### PR TITLE
feat: add tool audit logging and modernize test compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,12 @@ cargo run -p pi-coding-agent -- \
   --os-sandbox-command bwrap,--die-with-parent,--new-session,--unshare-all,--proc,/proc,--dev,/dev,--tmpfs,/tmp,--bind,{cwd},{cwd},--chdir,{cwd},{shell},-lc,{command} \
   --enforce-regular-files true
 ```
+
+Emit structured tool audit events to JSONL:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --prompt "Inspect repo status" \
+  --tool-audit-log .pi/audit/tools.jsonl
+```

--- a/crates/pi-ai/tests/provider_http_integration.rs
+++ b/crates/pi-ai/tests/provider_http_integration.rs
@@ -15,7 +15,7 @@ async fn openai_client_sends_expected_http_request() {
             .header("authorization", "Bearer test-openai-key")
             .header_exists("x-pi-request-id")
             .header("x-pi-retry-attempt", "0")
-            .json_body_partial(
+            .json_body_includes(
                 json!({
                     "model": "gpt-4o-mini",
                     "messages": [{"role": "system"}, {"role": "user"}],
@@ -79,7 +79,7 @@ async fn anthropic_client_sends_expected_http_request() {
             .header("anthropic-version", "2023-06-01")
             .header_exists("x-pi-request-id")
             .header("x-pi-retry-attempt", "0")
-            .json_body_partial(
+            .json_body_includes(
                 json!({
                     "model": "claude-sonnet-4-20250514",
                     "system": "system",
@@ -138,7 +138,7 @@ async fn google_client_sends_expected_http_request() {
             .query_param("key", "test-google-key")
             .header_exists("x-pi-request-id")
             .header("x-pi-retry-attempt", "0")
-            .json_body_partial(
+            .json_body_includes(
                 json!({
                     "contents": [{"role": "user"}],
                     "tools": [{"functionDeclarations": [{"name": "read"}]}]
@@ -274,8 +274,8 @@ async fn openai_client_retries_on_rate_limit_then_succeeds() {
         .expect("retry should eventually succeed");
 
     assert_eq!(response.message.text_content(), "ok after retry");
-    first.assert_hits(1);
-    second.assert_hits(1);
+    first.assert_calls(1);
+    second.assert_calls(1);
 }
 
 #[tokio::test]

--- a/crates/pi-coding-agent/src/skills.rs
+++ b/crates/pi-coding-agent/src/skills.rs
@@ -792,7 +792,7 @@ mod tests {
             std::fs::read_to_string(destination.join("review.md")).expect("read installed"),
             body
         );
-        remote.assert_hits(1);
+        remote.assert_calls(1);
     }
 
     #[tokio::test]
@@ -818,7 +818,7 @@ mod tests {
         .expect_err("checksum mismatch should fail");
 
         assert!(error.to_string().contains("sha256 mismatch"));
-        remote.assert_hits(1);
+        remote.assert_calls(1);
     }
 
     #[tokio::test]
@@ -858,7 +858,7 @@ mod tests {
             std::fs::read_to_string(destination.join("sync.md")).expect("read updated"),
             "v2"
         );
-        remote.assert_hits(1);
+        remote.assert_calls(1);
     }
 
     #[tokio::test]
@@ -886,7 +886,7 @@ mod tests {
         .expect("fetch should succeed");
         assert_eq!(manifest.version, 1);
         assert_eq!(manifest.skills.len(), 1);
-        registry.assert_hits(1);
+        registry.assert_calls(1);
     }
 
     #[test]
@@ -964,8 +964,8 @@ mod tests {
             std::fs::read_to_string(destination.join("skill.md")).expect("read skill"),
             skill_body
         );
-        registry.assert_hits(1);
-        skill.assert_hits(1);
+        registry.assert_calls(1);
+        skill.assert_calls(1);
     }
 
     #[tokio::test]
@@ -998,7 +998,7 @@ mod tests {
         assert!(error
             .to_string()
             .contains("signature verification failed for"));
-        remote.assert_hits(1);
+        remote.assert_calls(1);
     }
 
     #[tokio::test]
@@ -1082,8 +1082,8 @@ mod tests {
             std::fs::read_to_string(destination.join("secure.md")).expect("read skill"),
             skill_body
         );
-        registry.assert_hits(1);
-        skill.assert_hits(1);
+        registry.assert_calls(1);
+        skill.assert_calls(1);
     }
 
     #[test]

--- a/crates/pi-tui/benches/render_bench.rs
+++ b/crates/pi-tui/benches/render_bench.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use pi_tui::{apply_overlay, Component, DiffRenderer, EditorBuffer, EditorView, LumaImage};
 
 fn benchmark_renderer_diff(c: &mut Criterion) {


### PR DESCRIPTION
## Summary
- add optional JSONL tool execution audit logging via `--tool-audit-log`
- record structured `tool_execution_start` / `tool_execution_end` events with timestamps, durations, and payload sizes
- add unit/integration coverage for audit event shaping and file persistence
- refresh compatibility for current dependency APIs (`httpmock 0.8` and criterion `black_box`)

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Notes
This wave continues operational hardening with auditable runtime tool behavior and keeps all workspace quality gates green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new file I/O and shared-state tracking on the agent event path, which could affect runtime stability/performance if logging is enabled, but it is opt-in and well-covered by tests.
> 
> **Overview**
> Adds optional JSONL tool audit logging to `pi-coding-agent` via `--tool-audit-log`/`PI_TOOL_AUDIT_LOG`, subscribing to `AgentEvent` tool start/end events and writing structured records (timestamp, duration, error flag, and payload size counters).
> 
> Updates docs/tests accordingly: README gains usage example; new unit/integration coverage validates event shaping and JSONL persistence; and existing tests/benches are modernized for dependency API changes (`httpmock` matcher/assertion updates and Criterion’s `black_box`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea844d6c130216d5eb4546ad4f150cbc2549c0da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->