### PR TITLE
feat: add one-shot prompt file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Run one prompt:
 cargo run -p pi-coding-agent -- --prompt "Summarize src/lib.rs"
 ```
 
+Run one prompt from a file:
+
+```bash
+cargo run -p pi-coding-agent -- --prompt-file .pi/prompts/review.txt
+```
+
 Cancel an in-flight prompt (interactive or one-shot) with `Ctrl+C`. The pending turn is discarded and session history remains consistent.
 
 Control output streaming behavior:


### PR DESCRIPTION
## Summary
- add `--prompt-file` (env: `PI_PROMPT_FILE`) for one-shot prompt execution from UTF-8 text files
- add prompt-source resolution that supports inline `--prompt` or file input and rejects empty prompt files
- add unit, functional, and regression tests for prompt resolution behavior in `pi-coding-agent`
- add CLI integration coverage for successful prompt-file execution and empty prompt-file failure
- document prompt-file usage in `README.md`

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, isolated CLI input path (file read) plus validation and test coverage, without changing core agent/tool execution behavior.
> 
> **Overview**
> Adds one-shot prompt execution from a UTF-8 text file via `--prompt-file` (env `PI_PROMPT_FILE`), mutually exclusive with `--prompt`, and routes one-shot mode through a new `resolve_prompt_input` helper.
> 
> The helper reads the file, errors with a clear message on read failure, and rejects empty/whitespace-only prompt files. Updates README usage docs and adds unit + CLI integration tests covering successful file prompts and fast-fail behavior for empty files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1808d28c126764cb11330691eb819fec3bcf2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->