### PR TITLE
feat: add system prompt file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Run one prompt from a file:
 cargo run -p pi-coding-agent -- --prompt-file .pi/prompts/review.txt
 ```
 
+Load the base system prompt from a file:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --system-prompt-file .pi/prompts/system.txt \
+  --prompt "Review src/main.rs"
+```
+
 Cancel an in-flight prompt (interactive or one-shot) with `Ctrl+C`. The pending turn is discarded and session history remains consistent.
 
 Control output streaming behavior:


### PR DESCRIPTION
## Summary
- add `--system-prompt-file` (env: `PI_SYSTEM_PROMPT_FILE`) to load the base system prompt from UTF-8 files
- resolve system prompt at startup with empty-file validation and use it before skill augmentation
- add unit, functional, and regression tests for system prompt resolution in `pi-coding-agent`
- add CLI integration coverage for system-prompt-file override and empty-file failure
- document system-prompt-file usage in `README.md`

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI input change (file read + validation) with no security-sensitive logic changes; main risk is altered startup behavior if the flag/env is set or the file is missing/empty.
> 
> **Overview**
> Adds `--system-prompt-file` (and `PI_SYSTEM_PROMPT_FILE`) to `pi-coding-agent` to load the *base* system prompt from a UTF-8 text file, overriding `--system-prompt`.
> 
> Startup now resolves the base system prompt once (with empty-file validation) before augmenting it with selected skills, and this behavior is covered by new unit tests plus CLI integration tests. README usage docs are updated with an example invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b8abe45f24749bccd27884092f6258c6ce50025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->