### PR TITLE
feat: support stdin one-shot prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Run one prompt from a file:
 cargo run -p pi-coding-agent -- --prompt-file .pi/prompts/review.txt
 ```
 
+Pipe a one-shot prompt from stdin:
+
+```bash
+printf "Summarize src/main.rs" | cargo run -p pi-coding-agent -- --prompt-file -
+```
+
 Load the base system prompt from a file:
 
 ```bash


### PR DESCRIPTION
## Summary
- extend `--prompt-file` to accept `-` and read one-shot prompts from stdin
- add shared non-empty text validation used by prompt/system prompt resolution paths
- preserve existing prompt-file and system-prompt-file error messages while adding explicit `stdin prompt is empty` handling
- add unit/regression tests for text validation and integration tests for stdin prompt success/failure
- document stdin prompt piping usage in `README.md`

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI input-path change limited to one-shot prompt resolution, with added validation and regression tests to prevent empty/whitespace prompts.
> 
> **Overview**
> Adds support for piping one-shot prompts via `--prompt-file -`, reading the prompt from stdin instead of a file.
> 
> Refactors prompt/system prompt loading to share a single `ensure_non_empty_text` validator (including a dedicated `stdin prompt is empty` error path), and adds unit + CLI integration tests covering stdin success/blank input and the refactored validation. Updates the README with the new piping example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cda0fff560267096a575cea258966a2ba4a42669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->