### PR TITLE
feat: add interactive help and command suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ Session branching and resume:
 # Persist to the default session file (.pi/sessions/default.jsonl)
 cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
+# Show interactive command help
+/help
+/help branch
+
 # Resume latest branch (default behavior), inspect session state
 /session
 /branches

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -90,6 +90,26 @@ fn no_session_and_branch_from_combination_fails_fast() {
 }
 
 #[test]
+fn interactive_help_and_unknown_command_suggestions_work() {
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--no-session",
+    ])
+    .write_stdin("/help\n/help branch\n/help polciy\n/polciy\n/quit\n");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("commands:"))
+        .stdout(predicate::str::contains("usage: /branch <id>"))
+        .stdout(predicate::str::contains("unknown help topic: /polciy"))
+        .stdout(predicate::str::contains("did you mean /policy?"));
+}
+
+#[test]
 fn openai_prompt_persists_session_and_supports_branch_from() {
     let server = MockServer::start();
     let openai = server.mock(|when, then| {


### PR DESCRIPTION
## Summary
- add interactive `/help` with full command catalog and usage descriptions
- add command-specific help via `/help <command>` with normalized topic parsing (`/help branch` and `/help /branch`)
- normalize slash command parsing with whitespace-tolerant handling
- add unknown-command and unknown-help-topic suggestion messages using closest-match heuristics
- keep all existing command behaviors while adding usage guidance for invalid argument forms
- update README interactive command examples

Closes #11

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Test Matrix
- Unit: command parsing, suggestion logic, non-empty parsing behavior
- Functional: help overview rendering, command-specific help rendering, help command behavior
- Integration: interactive stdin flow (`/help`, `/help branch`, typo suggestions, `/quit`)
- Regression: unknown-command suggestion stability, non-command parse rejection, branch command whitespace handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CLI UX changes around command parsing and messaging; no changes to provider calls, tool execution, or session persistence semantics beyond stricter argument validation.
> 
> **Overview**
> Adds an interactive `/help` command to `pi-coding-agent` that prints a command catalog and supports command-specific help via `/help <command>` with normalized topics.
> 
> Refactors command handling to use a whitespace-tolerant parser (`parse_command`) plus canonicalization (`/exit` -> `/quit`), adds usage validation for commands that should not accept args, and improves unknown-command/help-topic output with prefix/Levenshtein-based suggestions.
> 
> Updates the README with the new help examples and adds unit + integration tests covering parsing, help rendering, typo suggestions, and interactive stdin flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba263c93b6dedea2056f9fb221b6279b69ae3b5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->