### PR TITLE
feat: add session export and validation primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
 # Compact to the active lineage and prune inactive branches
 /session-compact
+
+# Export the active lineage snapshot to a new JSONL file
+/session-export /tmp/session-snapshot.jsonl
 ```
 
 Tune session lock behavior for shared/concurrent workflows:
@@ -266,6 +269,14 @@ cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
   --session-lock-wait-ms 15000 \
   --session-lock-stale-ms 60000
+```
+
+Validate a session graph and exit:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --session .pi/sessions/default.jsonl \
+  --session-validate
 ```
 
 Tool policy controls:


### PR DESCRIPTION
## Summary
- add `SessionStore::validation_report()` with duplicate/invalid-parent/cycle accounting
- add `SessionStore::lineage_entries()` and `SessionStore::export_lineage()` for deterministic active-lineage snapshot export
- add interactive `/session-export <path>` command
- add one-shot `--session-validate` mode that validates session integrity and exits
- update interactive command help/docs and README session workflows

Closes #24

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Test Matrix
- Unit: validation report semantics, command parsing, session validation failures
- Functional: lineage export snapshot behavior, session validation success, session-export command behavior
- Integration: CLI `--session-validate` success/failure flows, interactive command flows
- Regression: no-session validation rejection, existing command/session behavior retained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session graph traversal and persistence paths (new export + validation logic), which could impact session correctness if lineage resolution or atomic writes regress; changes are well-covered by new tests.
> 
> **Overview**
> Adds **session integrity tooling** to `pi-coding-agent`: a one-shot `--session-validate` mode that loads the session file, reports duplicate/invalid-parent/cycle counts, and exits non-zero if the graph is invalid.
> 
> Adds **active-lineage snapshot export** via a new interactive `/session-export <path>` command backed by `SessionStore::lineage_entries()` and `SessionStore::export_lineage()`, ensuring only the current active lineage (with schema metadata) is written to a new JSONL file. README/help output and unit/functional/integration tests are updated to cover the new CLI flag and command behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c502b5690f7ac570dff73a56aa3873ed3e3e2d12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->