### PR TITLE
feat: add session import merge/replace workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Implemented now:
 - Interactive CLI and one-shot prompt mode
 - Token-by-token CLI output rendering controls
 - Persistent JSONL sessions with branch/resume support
-- Session repair and lineage compaction commands
+- Session repair, export/import, and lineage compaction commands
 - Built-in filesystem and shell tools
 - Theme loading and ANSI styling primitives in `pi-tui`
 - Overlay composition primitives in `pi-tui`
@@ -260,6 +260,9 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
 # Export the active lineage snapshot to a new JSONL file
 /session-export /tmp/session-snapshot.jsonl
+
+# Import a snapshot into the current session (mode defaults to merge)
+/session-import /tmp/session-snapshot.jsonl
 ```
 
 Tune session lock behavior for shared/concurrent workflows:
@@ -269,6 +272,11 @@ cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
   --session-lock-wait-ms 15000 \
   --session-lock-stale-ms 60000
+
+# Optional: use replace mode for /session-import
+cargo run -p pi-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --session-import-mode replace
 ```
 
 Validate a session graph and exit:


### PR DESCRIPTION
## Summary
- add session import primitives to `SessionStore` with explicit modes:
  - `merge`: append imported entries and remap colliding ids while preserving imported lineage
  - `replace`: replace current session entries with imported snapshot
- validate imported snapshots before applying (duplicates/invalid parents/cycles)
- add interactive `/session-import <path>` command and `--session-import-mode <merge|replace>` flag
- update command help/suggestions and README usage docs

## Testing Matrix
- Unit:
  - session import id remapping and report assertions
  - parsing/help/path behaviors remain covered
- Functional:
  - `/session-import` merge flow in command handler
  - replace flow semantics and active-head updates
  - interactive CLI merge path in integration suite
- Integration:
  - interactive CLI replace mode (`--session-import-mode replace`)
  - post-import append ID progression
- Regression:
  - invalid import snapshot is rejected and target session remains unchanged
  - existing session validate/export/repair/compact suites remain green

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #26
Refs #12
Refs #20
