### PR TITLE
feat: add session diagnostics IDs and roundtrip coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
 # Import a snapshot into the current session (mode defaults to merge)
 /session-import /tmp/session-snapshot.jsonl
+
+# Repair/import output includes affected IDs and remap pairs for diagnostics
 ```
 
 Tune session lock behavior for shared/concurrent workflows:

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -265,7 +265,8 @@ fn interactive_session_import_merge_remaps_collisions_by_default() {
         .success()
         .stdout(predicate::str::contains("session import complete"))
         .stdout(predicate::str::contains("mode=merge"))
-        .stdout(predicate::str::contains("remapped_entries=2"));
+        .stdout(predicate::str::contains("remapped_entries=2"))
+        .stdout(predicate::str::contains("remapped_ids=1->2,2->3"));
 
     let entries = parse_session_entries(&target);
     assert_eq!(entries.len(), 3);
@@ -358,6 +359,7 @@ fn integration_interactive_session_import_replace_mode_overwrites_target() {
         .success()
         .stdout(predicate::str::contains("session import complete"))
         .stdout(predicate::str::contains("mode=replace"))
+        .stdout(predicate::str::contains("remapped_ids=none"))
         .stdout(predicate::str::contains("replaced_entries=2"));
 
     let entries = parse_session_entries(&target);
@@ -366,6 +368,95 @@ fn integration_interactive_session_import_replace_mode_overwrites_target() {
     assert_eq!(entries[0].parent_id, None);
     assert_eq!(entries[1].id, 11);
     assert_eq!(entries[1].parent_id, Some(10));
+}
+
+#[test]
+fn regression_session_repair_reports_removed_ids() {
+    let temp = tempdir().expect("tempdir");
+    let session = temp.path().join("repair-session.jsonl");
+
+    let raw = [
+        json!({"record_type":"meta","schema_version":1}).to_string(),
+        json!({
+            "record_type":"entry",
+            "id":1,
+            "parent_id":null,
+            "message":{
+                "role":"system",
+                "content":[{"type":"text","text":"root"}],
+                "is_error":false
+            }
+        })
+        .to_string(),
+        json!({
+            "record_type":"entry",
+            "id":2,
+            "parent_id":99,
+            "message":{
+                "role":"user",
+                "content":[{"type":"text","text":"invalid-parent"}],
+                "is_error":false
+            }
+        })
+        .to_string(),
+        json!({
+            "record_type":"entry",
+            "id":3,
+            "parent_id":4,
+            "message":{
+                "role":"user",
+                "content":[{"type":"text","text":"cycle-a"}],
+                "is_error":false
+            }
+        })
+        .to_string(),
+        json!({
+            "record_type":"entry",
+            "id":4,
+            "parent_id":3,
+            "message":{
+                "role":"assistant",
+                "content":[{"type":"text","text":"cycle-b"}],
+                "is_error":false
+            }
+        })
+        .to_string(),
+        json!({
+            "record_type":"entry",
+            "id":5,
+            "parent_id":1,
+            "message":{
+                "role":"user",
+                "content":[{"type":"text","text":"healthy-head"}],
+                "is_error":false
+            }
+        })
+        .to_string(),
+    ]
+    .join("\n");
+    fs::write(&session, format!("{raw}\n")).expect("write malformed session");
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--session",
+        session.to_str().expect("utf8 session path"),
+    ])
+    .write_stdin("/session-repair\n/quit\n");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("repair complete"))
+        .stdout(predicate::str::contains("invalid_parent_ids=2"))
+        .stdout(predicate::str::contains("cycle_ids=3,4"));
+
+    let entries = parse_session_entries(&session);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].id, 1);
+    assert_eq!(entries[1].id, 5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend session repair diagnostics with explicit ID lists:
  - `duplicate_ids`
  - `invalid_parent_ids`
  - `cycle_ids`
- extend session import diagnostics with collision remap pairs (`from->to`)
- surface diagnostic IDs in interactive command output:
  - `/session-repair`
  - `/session-import`
- add export/import roundtrip coverage for merge and replace flows
- add CLI integration regression for repair diagnostics output and on-disk result

## Testing Matrix
- Unit:
  - format helpers for ID list/remap rendering
  - import/repair report field assertions
- Functional:
  - export/import roundtrip replace behavior
  - command-level import flow assertions
- Integration:
  - export/import roundtrip merge behavior
  - interactive CLI replace + repair diagnostics path
- Regression:
  - malformed import rejection preserves target
  - repair diagnostics for invalid parent/cycle IDs

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #28
Refs #12
Refs #20
