### PR TITLE
feat: add tool policy presets and bash dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Tool policy controls:
 ```bash
 cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
+  --tool-policy-preset hardened \
   --allow-path /Users/me/project \
   --max-file-read-bytes 500000 \
   --max-file-write-bytes 500000 \
@@ -301,6 +302,7 @@ cargo run -p pi-coding-agent -- \
   --bash-timeout-ms 60000 \
   --max-command-length 2048 \
   --bash-profile strict \
+  --bash-dry-run false \
   --allow-command python,cargo-nextest* \
   --print-tool-policy \
   --os-sandbox-mode auto \


### PR DESCRIPTION
## Summary
- add tool policy presets with deterministic baseline config:
  - `permissive`, `balanced`, `strict`, `hardened`
- add CLI controls:
  - `--tool-policy-preset`
  - `--bash-dry-run`
- include policy metadata in policy JSON output:
  - `schema_version`
  - `preset`
  - `bash_dry_run`
- improve bash deny diagnostics with explicit `policy_rule` attribution
- add dry-run execution path in bash tool (validation only, no process execution)

## Testing Matrix
- Unit:
  - preset configuration mapping
  - policy JSON shape includes schema/preset metadata
- Functional:
  - preset + explicit profile override behavior
  - CLI flag acceptance in prompt mode
- Integration:
  - bash dry-run path verifies no command execution side effects
- Regression:
  - allowlist denial still enforced and now includes explicit policy rule
  - existing tool/session/provider tests remain green

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #30
Refs #13
Refs #20
