### PR TITLE
feat: add tool policy evaluation trace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ cargo run -p pi-coding-agent -- \
   --max-command-length 2048 \
   --bash-profile strict \
   --bash-dry-run false \
+  --tool-policy-trace false \
   --allow-command python,cargo-nextest* \
   --print-tool-policy \
   --os-sandbox-mode auto \

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -796,6 +796,7 @@ fn tool_policy_preset_and_bash_dry_run_flags_are_accepted_in_prompt_mode() {
         "--tool-policy-preset",
         "hardened",
         "--bash-dry-run",
+        "--tool-policy-trace",
         "--print-tool-policy",
         "--no-session",
     ]);
@@ -804,6 +805,7 @@ fn tool_policy_preset_and_bash_dry_run_flags_are_accepted_in_prompt_mode() {
         .success()
         .stdout(predicate::str::contains("\"preset\":\"hardened\""))
         .stdout(predicate::str::contains("\"bash_dry_run\":true"))
+        .stdout(predicate::str::contains("\"tool_policy_trace\":true"))
         .stdout(predicate::str::contains("preset dry-run ok"));
 
     openai.assert_calls(1);


### PR DESCRIPTION
## Summary
- add `--tool-policy-trace` to enable structured policy evaluation traces for bash tool decisions
- add trace metadata in policy JSON output (`tool_policy_trace`)
- extend bash tool results with decision attribution when trace is enabled:
  - `policy_decision` (`allow`/`deny`)
  - `policy_trace` step list with check/outcome/detail
- keep backward compatibility when trace mode is disabled (no trace payload)
- retain existing `policy_rule` deny attribution and dry-run behavior

## Testing Matrix
- Unit:
  - policy build/json includes trace flag
  - policy trace helper paths covered via tools tests
- Functional:
  - build policy enables trace when CLI flag set
  - dry-run + trace allow decision payload
- Integration:
  - deny path includes structured trace and deny decision
  - CLI accepts preset + dry-run + trace and prints expected policy JSON
- Regression:
  - non-trace deny path still includes `policy_rule` and omits `policy_trace`
  - full existing workspace suite remains green

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #32
Refs #13
Refs #20
