### PR TITLE
Provider resilience phase-1: jittered retries and retry budget controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ cargo run -p pi-coding-agent -- --prompt "Hello" --request-timeout-ms 60000
 cargo run -p pi-coding-agent -- --prompt "Hello" --turn-timeout-ms 20000
 ```
 
+Control provider retry resilience behavior:
+
+```bash
+# Retry retryable provider errors up to 4 times
+cargo run -p pi-coding-agent -- --prompt "Hello" --provider-max-retries 4
+
+# Enforce a 1500ms cumulative backoff budget for retries (0 disables)
+cargo run -p pi-coding-agent -- --prompt "Hello" --provider-retry-budget-ms 1500
+
+# Disable jitter to use deterministic exponential backoff
+cargo run -p pi-coding-agent -- --prompt "Hello" --provider-retry-jitter false
+```
+
 Load reusable skills into the system prompt:
 
 ```bash

--- a/crates/pi-ai/src/anthropic.rs
+++ b/crates/pi-ai/src/anthropic.rs
@@ -6,7 +6,8 @@ use tokio::time::sleep;
 
 use crate::{
     retry::{
-        is_retryable_http_error, new_request_id, next_backoff_ms, should_retry_status, MAX_RETRIES,
+        is_retryable_http_error, new_request_id, next_backoff_ms_with_jitter,
+        retry_budget_allows_delay, should_retry_status,
     },
     ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole, PiAiError,
     ToolDefinition,
@@ -17,6 +18,9 @@ pub struct AnthropicConfig {
     pub api_base: String,
     pub api_key: String,
     pub request_timeout_ms: u64,
+    pub max_retries: usize,
+    pub retry_budget_ms: u64,
+    pub retry_jitter: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -65,8 +69,10 @@ impl LlmClient for AnthropicClient {
     async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, PiAiError> {
         let body = build_messages_request_body(&request);
         let url = self.messages_url();
+        let started = std::time::Instant::now();
+        let max_retries = self.config.max_retries;
 
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=max_retries {
             let request_id = new_request_id();
             let response = self
                 .client
@@ -85,9 +91,18 @@ impl LlmClient for AnthropicClient {
                         return parse_messages_response(&raw);
                     }
 
-                    if attempt < MAX_RETRIES && should_retry_status(status.as_u16()) {
-                        sleep(std::time::Duration::from_millis(next_backoff_ms(attempt))).await;
-                        continue;
+                    if attempt < max_retries && should_retry_status(status.as_u16()) {
+                        let backoff_ms =
+                            next_backoff_ms_with_jitter(attempt, self.config.retry_jitter);
+                        let elapsed_ms = started.elapsed().as_millis() as u64;
+                        if retry_budget_allows_delay(
+                            elapsed_ms,
+                            backoff_ms,
+                            self.config.retry_budget_ms,
+                        ) {
+                            sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                            continue;
+                        }
                     }
 
                     return Err(PiAiError::HttpStatus {
@@ -96,9 +111,18 @@ impl LlmClient for AnthropicClient {
                     });
                 }
                 Err(error) => {
-                    if attempt < MAX_RETRIES && is_retryable_http_error(&error) {
-                        sleep(std::time::Duration::from_millis(next_backoff_ms(attempt))).await;
-                        continue;
+                    if attempt < max_retries && is_retryable_http_error(&error) {
+                        let backoff_ms =
+                            next_backoff_ms_with_jitter(attempt, self.config.retry_jitter);
+                        let elapsed_ms = started.elapsed().as_millis() as u64;
+                        if retry_budget_allows_delay(
+                            elapsed_ms,
+                            backoff_ms,
+                            self.config.retry_budget_ms,
+                        ) {
+                            sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                            continue;
+                        }
                     }
                     return Err(PiAiError::Http(error));
                 }

--- a/crates/pi-ai/src/google.rs
+++ b/crates/pi-ai/src/google.rs
@@ -5,7 +5,8 @@ use tokio::time::sleep;
 
 use crate::{
     retry::{
-        is_retryable_http_error, new_request_id, next_backoff_ms, should_retry_status, MAX_RETRIES,
+        is_retryable_http_error, new_request_id, next_backoff_ms_with_jitter,
+        retry_budget_allows_delay, should_retry_status,
     },
     ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole, PiAiError,
     ToolDefinition,
@@ -16,6 +17,9 @@ pub struct GoogleConfig {
     pub api_base: String,
     pub api_key: String,
     pub request_timeout_ms: u64,
+    pub max_retries: usize,
+    pub retry_budget_ms: u64,
+    pub retry_jitter: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -54,8 +58,10 @@ impl LlmClient for GoogleClient {
     async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, PiAiError> {
         let body = build_generate_content_body(&request);
         let url = self.generate_content_url(&request.model);
+        let started = std::time::Instant::now();
+        let max_retries = self.config.max_retries;
 
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=max_retries {
             let request_id = new_request_id();
             let response = self
                 .client
@@ -75,9 +81,18 @@ impl LlmClient for GoogleClient {
                         return parse_generate_content_response(&raw);
                     }
 
-                    if attempt < MAX_RETRIES && should_retry_status(status.as_u16()) {
-                        sleep(std::time::Duration::from_millis(next_backoff_ms(attempt))).await;
-                        continue;
+                    if attempt < max_retries && should_retry_status(status.as_u16()) {
+                        let backoff_ms =
+                            next_backoff_ms_with_jitter(attempt, self.config.retry_jitter);
+                        let elapsed_ms = started.elapsed().as_millis() as u64;
+                        if retry_budget_allows_delay(
+                            elapsed_ms,
+                            backoff_ms,
+                            self.config.retry_budget_ms,
+                        ) {
+                            sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                            continue;
+                        }
                     }
 
                     return Err(PiAiError::HttpStatus {
@@ -86,9 +101,18 @@ impl LlmClient for GoogleClient {
                     });
                 }
                 Err(error) => {
-                    if attempt < MAX_RETRIES && is_retryable_http_error(&error) {
-                        sleep(std::time::Duration::from_millis(next_backoff_ms(attempt))).await;
-                        continue;
+                    if attempt < max_retries && is_retryable_http_error(&error) {
+                        let backoff_ms =
+                            next_backoff_ms_with_jitter(attempt, self.config.retry_jitter);
+                        let elapsed_ms = started.elapsed().as_millis() as u64;
+                        if retry_budget_allows_delay(
+                            elapsed_ms,
+                            backoff_ms,
+                            self.config.retry_budget_ms,
+                        ) {
+                            sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                            continue;
+                        }
                     }
                     return Err(PiAiError::Http(error));
                 }

--- a/crates/pi-ai/src/retry.rs
+++ b/crates/pi-ai/src/retry.rs
@@ -1,10 +1,10 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub const MAX_RETRIES: usize = 2;
 pub const BASE_BACKOFF_MS: u64 = 200;
 
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+static JITTER_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 pub fn should_retry_status(status: u16) -> bool {
     status == 408 || status == 409 || status == 425 || status == 429 || status >= 500
@@ -13,6 +13,32 @@ pub fn should_retry_status(status: u16) -> bool {
 pub fn next_backoff_ms(attempt: usize) -> u64 {
     let shift = attempt.min(6);
     BASE_BACKOFF_MS.saturating_mul(1_u64 << shift)
+}
+
+pub fn next_backoff_ms_with_jitter(attempt: usize, jitter_enabled: bool) -> u64 {
+    let base = next_backoff_ms(attempt);
+    if !jitter_enabled || base <= 1 {
+        return base;
+    }
+
+    // Bounded jitter in [50%, 100%] of the deterministic backoff.
+    let low = base / 2;
+    let width = base.saturating_sub(low);
+    let seed = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mixed = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).rotate_left(17) ^ 0xA24B_AED4_963E_E407;
+    let jitter = if width == 0 {
+        0
+    } else {
+        mixed % width.saturating_add(1)
+    };
+    low.saturating_add(jitter)
+}
+
+pub fn retry_budget_allows_delay(elapsed_ms: u64, delay_ms: u64, retry_budget_ms: u64) -> bool {
+    if retry_budget_ms == 0 {
+        return true;
+    }
+    elapsed_ms.saturating_add(delay_ms) <= retry_budget_ms
 }
 
 pub fn is_retryable_http_error(error: &reqwest::Error) -> bool {
@@ -30,7 +56,10 @@ pub fn new_request_id() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{new_request_id, next_backoff_ms, should_retry_status};
+    use super::{
+        new_request_id, next_backoff_ms, next_backoff_ms_with_jitter, retry_budget_allows_delay,
+        should_retry_status,
+    };
 
     #[test]
     fn retry_status_selection_is_correct() {
@@ -45,6 +74,25 @@ mod tests {
         assert_eq!(next_backoff_ms(0), 200);
         assert_eq!(next_backoff_ms(1), 400);
         assert_eq!(next_backoff_ms(2), 800);
+    }
+
+    #[test]
+    fn jittered_backoff_stays_within_expected_bounds() {
+        let attempt = 3;
+        let base = next_backoff_ms(attempt);
+        let low = base / 2;
+        for _ in 0..64 {
+            let value = next_backoff_ms_with_jitter(attempt, true);
+            assert!(value >= low, "expected {value} >= {low}");
+            assert!(value <= base, "expected {value} <= {base}");
+        }
+    }
+
+    #[test]
+    fn retry_budget_math_respects_zero_and_bounded_budgets() {
+        assert!(retry_budget_allows_delay(50, 100, 0));
+        assert!(retry_budget_allows_delay(50, 50, 100));
+        assert!(!retry_budget_allows_delay(50, 60, 100));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add bounded retry jitter and retry-budget gating in `pi-ai` retry utilities
- apply provider retry controls across OpenAI, Anthropic, and Google clients
- add CLI flags for provider retry behavior (`--provider-max-retries`, `--provider-retry-budget-ms`, `--provider-retry-jitter`) and parser tests
- extend provider HTTP integration coverage with retry-budget regression test
- document provider retry controls in README usage

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #34
Progresses #14
Progresses #20