### PR TITLE
Provider resilience phase-2: fallback model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ cargo run -p pi-coding-agent -- --prompt "Hello" --provider-retry-budget-ms 1500
 
 # Disable jitter to use deterministic exponential backoff
 cargo run -p pi-coding-agent -- --prompt "Hello" --provider-retry-jitter false
+
+# Configure fallback models (attempted in order on retriable provider failures)
+cargo run -p pi-coding-agent -- --prompt "Hello" \
+  --model openai/gpt-4o-mini \
+  --fallback-model openai/gpt-4o,anthropic/claude-sonnet-4-20250514
 ```
 
 Load reusable skills into the system prompt:


### PR DESCRIPTION
## Summary
- add fallback model chain support via `--fallback-model`
- add resilient routing wrapper that fails over only on retriable provider errors
- support cross-provider fallbacks by reusing/building provider clients per route
- emit `provider_fallback` JSON metadata events when `--json-events` is enabled
- add unit/functional/integration/regression tests for fallback eligibility and routing behavior
- add CLI integration test validating fallback failover with mocked HTTP provider responses
- document fallback usage in README

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #36
Progresses #14
Progresses #20
