### PR TITLE
Provider streaming phase-1: OpenAI incremental transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ name = "pi-ai"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures-util",
  "httpmock",
  "reqwest 0.12.28",
  "serde",
@@ -1906,6 +1907,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1925,12 +1927,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2850,6 +2854,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive", "env"] }
 ed25519-dalek = "2.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shell-words = "1.1"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ cargo run -p pi-coding-agent -- --prompt "Hello" --stream-output false
 cargo run -p pi-coding-agent -- --prompt "Hello" --stream-delay-ms 20
 ```
 
+When using OpenAI-compatible models with `--stream-output true`, the client uses provider-side incremental streaming when available.
+
 Control provider and turn timeouts:
 
 ```bash

--- a/crates/pi-ai/Cargo.toml
+++ b/crates/pi-ai/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+futures-util.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/pi-ai/src/lib.rs
+++ b/crates/pi-ai/src/lib.rs
@@ -11,5 +11,5 @@ pub use openai::{OpenAiClient, OpenAiConfig};
 pub use provider::{ModelRef, ModelRefParseError, Provider};
 pub use types::{
     ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole, PiAiError,
-    ToolCall, ToolDefinition,
+    StreamDeltaHandler, ToolCall, ToolDefinition,
 };

--- a/crates/pi-ai/src/types.rs
+++ b/crates/pi-ai/src/types.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -184,9 +185,20 @@ pub enum PiAiError {
     InvalidResponse(String),
 }
 
+pub type StreamDeltaHandler = Arc<dyn Fn(String) + Send + Sync>;
+
 #[async_trait]
 pub trait LlmClient: Send + Sync {
     async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, PiAiError>;
+
+    async fn complete_with_stream(
+        &self,
+        request: ChatRequest,
+        on_delta: Option<StreamDeltaHandler>,
+    ) -> Result<ChatResponse, PiAiError> {
+        let _ = on_delta;
+        self.complete(request).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- extend `pi-ai` client interface with optional stream callback support
- add true OpenAI incremental streaming transport + SSE parser/state assembly
- add compatibility fallback for non-event-stream responses under stream mode
- wire stream callback propagation through `pi-agent-core` (`prompt_with_stream`) and CLI prompt execution
- keep fallback routing client stream-aware for failover paths
- add tests for stream parser, agent callback propagation, and OpenAI mocked streaming integration
- document true provider streaming behavior in README

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #38
Progresses #15
Progresses #20
