### PR TITLE
Provider streaming phase-3: Google incremental transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cargo run -p pi-coding-agent -- --prompt "Hello" --stream-output false
 cargo run -p pi-coding-agent -- --prompt "Hello" --stream-delay-ms 20
 ```
 
-When using OpenAI-compatible or Anthropic models with `--stream-output true`, the client uses provider-side incremental streaming when available.
+When using OpenAI-compatible, Anthropic, or Google models with `--stream-output true`, the client uses provider-side incremental streaming when available.
 
 Control provider and turn timeouts:
 


### PR DESCRIPTION
## Summary
- add Google `complete_with_stream` implementation with incremental SSE chunk parsing
- route stream mode to `:streamGenerateContent` with `alt=sse`
- emit incremental text deltas and assemble function-call blocks from stream chunks
- preserve compatibility fallback for non-event-stream payloads in stream mode
- add Google stream unit/integration coverage plus CLI integration alignment with new default streaming behavior
- document Google provider-side streaming support in README

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #42
Progresses #15
Progresses #20
