### PR TITLE
feat: add skills lockfile write/sync workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Implemented now:
 - Remote skill fetch/install with optional checksum verification
 - Registry-based skill installation (`--skill-registry-url`, `--install-skill-from-registry`)
 - Signed registry skill installation with trust roots (`--skill-trust-root`, `--require-signed-skills`)
+- Skills lockfile write/sync workflow (`--skills-lock-write`, `--skills-sync`)
 - Unit tests for serialization, tool loop, renderer diffing, and tool behaviors
 
 ## Build & Test
@@ -217,6 +218,26 @@ cargo run -p pi-coding-agent -- \
   --skill-trust-root root=Gf7... \
   --require-signed-skills \
   --skill review
+```
+
+Write a deterministic skills lockfile after installs:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --prompt "Audit this module" \
+  --skills-dir .pi/skills \
+  --install-skill /tmp/review.md \
+  --skills-lock-write \
+  --skill review
+```
+
+Verify installed skills match the lockfile (fails on drift):
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --skills-dir .pi/skills \
+  --skills-sync \
+  --no-session
 ```
 
 Manage trust lifecycle in a trust-root file:


### PR DESCRIPTION
## Summary
- adds a versioned skills lockfile format at `.pi/skills/skills.lock.json`
- adds lockfile metadata capture for local, remote, and registry installs
- adds CLI flags:
  - `--skills-lock-write` to generate/update lockfile from installed skills
  - `--skills-sync` to verify lockfile drift and fail on mismatch
  - `--skills-lock-file` to override lockfile path
- adds sync drift reporting for missing/extra/changed skill files
- preserves backward compatibility when lockfile flags are not used
- documents lockfile workflow in `README.md`

## Risks and Compatibility
- lockfile behavior is opt-in and off by default
- existing install and prompt flows are unchanged without lockfile flags
- sync failures are explicit and include drift categories to avoid silent mismatch

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Testing Matrix Coverage
- Unit: lockfile path/flag parsing and source metadata hinting
- Functional: lockfile write/load roundtrip and metadata capture
- Integration: remote install + lockfile write + sync success, CLI lockfile generation
- Regression: drift detection and unsupported lockfile schema handling

Closes #46
Part of #16
