### PR TITLE
feat: lock signer metadata and strict skills-sync validation

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -1344,12 +1344,18 @@ async fn main() -> Result<()> {
             } else {
                 report.changed.join(",")
             };
+            let metadata = if report.metadata_mismatch.is_empty() {
+                "none".to_string()
+            } else {
+                report.metadata_mismatch.join(";")
+            };
             bail!(
-                "skills sync drift detected: path={} missing={} extra={} changed={}",
+                "skills sync drift detected: path={} missing={} extra={} changed={} metadata={}",
                 skills_lock_path.display(),
                 missing,
                 extra,
-                changed
+                changed,
+                metadata
             );
         }
     }


### PR DESCRIPTION
## Summary
- extends lockfile source metadata with:
  - `signing_key_id`
  - `signature_sha256`
- ensures registry-resolved sources preserve `signing_key_id`
- adds strict metadata consistency validation in `--skills-sync`
  - validates `expected_sha256` against lockfile file hash
  - validates `signature_sha256` against signature payload
- surfaces metadata mismatch details in sync drift errors
- adds signed-registry lockfile integration assertions in both crate tests and CLI integration tests

## Risks and Compatibility
- backward-compatible parsing: new metadata fields are optional for existing lockfiles
- stricter sync checks may fail previously inconsistent lockfiles, with explicit actionable reasons
- lockfile behavior remains opt-in behind lockfile flags

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Testing Matrix Coverage
- Unit: metadata digest behavior and lock schema validation
- Functional: source metadata capture and sync mismatch checks
- Integration: signed registry install + lock write + sync success
- Regression: metadata mismatch detection and existing drift checks

Closes #48
Part of #16
