### PR TITLE
feat: add interactive /skills-sync command with lockfile drift reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Import a snapshot into the current session (mode defaults to merge)
 /session-import /tmp/session-snapshot.jsonl
 
+# Validate installed skills against lockfile drift without restarting
+/skills-sync
+/skills-sync /tmp/custom-skills.lock.json
+
 # Repair/import output includes affected IDs and remap pairs for diagnostics
 ```
 


### PR DESCRIPTION
## Summary\n- add interactive `/skills-sync [lockfile_path]` command in `pi-coding-agent`\n- default to `<skills-dir>/skills.lock.json` when the path argument is omitted\n- reuse deterministic lockfile drift formatting across startup `--skills-sync` and interactive command paths\n- keep interactive behavior non-fatal by printing actionable diagnostics on drift/error and continuing\n- add README interactive command usage examples\n\n## Testing\n- cargo fmt --all\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace\n\nCloses #54