### PR TITLE
feat: add interactive /skills-lock-write command

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Import a snapshot into the current session (mode defaults to merge)
 /session-import /tmp/session-snapshot.jsonl
 
+# Write/update skills lockfile from currently installed skills
+/skills-lock-write
+/skills-lock-write /tmp/custom-skills.lock.json
+
 # Validate installed skills against lockfile drift without restarting
 /skills-sync
 /skills-sync /tmp/custom-skills.lock.json


### PR DESCRIPTION
## Summary
- add interactive /skills-lock-write [lockfile_path] command in pi-coding-agent
- default lock path to <skills-dir>/skills.lock.json when no argument is passed
- reuse shared lock-path resolution and deterministic output rendering for startup and interactive workflows
- keep interactive behavior non-fatal by printing actionable lock write errors and continuing command loop
- document interactive lock write usage in README

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #56
