### PR TITLE
feat: add interactive /skills-list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Import a snapshot into the current session (mode defaults to merge)
 /session-import /tmp/session-snapshot.jsonl
 
+# List currently installed skills
+/skills-list
+
 # Write/update skills lockfile from currently installed skills
 /skills-lock-write
 /skills-lock-write /tmp/custom-skills.lock.json


### PR DESCRIPTION
## Summary
- add interactive /skills-list command to inspect installed skill inventory
- keep command read-only and non-fatal with deterministic success/error output
- include command metadata and help integration
- add README interactive usage example

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #58
