### PR TITLE
feat: add interactive /skills-show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Import a snapshot into the current session (mode defaults to merge)
 /session-import /tmp/session-snapshot.jsonl
 
+# Show a specific installed skill by name
+/skills-show checklist
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- add interactive `/skills-show <name>` command to inspect installed skill metadata and content
- wire command into help/command discovery and deterministic output rendering
- keep unknown skill and filesystem failure paths non-fatal to interactive loop
- add README interactive usage example

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #63
