### PR TITLE
feat: add interactive /skills-search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Show a specific installed skill by name
 /skills-show checklist
 
+# Search installed skills by name/content with optional result cap
+/skills-search checklist
+/skills-search checklist 10
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- add interactive `/skills-search <query> [max_results]` command with case-insensitive name/content matching
- rank results deterministically with name matches before content-only matches
- include robust argument validation and non-fatal error handling in interactive mode
- update README examples and command help surface

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #64
