### PR TITLE
feat: add interactive /skills-lock-diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /skills-search checklist
 /skills-search checklist 10
 
+# Inspect lockfile drift without enforcing sync (optional JSON output)
+/skills-lock-diff
+/skills-lock-diff /tmp/custom-skills.lock.json --json
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- add interactive `/skills-lock-diff [lockfile_path] [--json]` command
- provide non-fatal in-sync/drift/error inspection with deterministic human and JSON output
- add argument validation and parsing for optional path and JSON mode
- update README examples and help command surface

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #65
