### PR TITLE
feat: add interactive /skills-prune command

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /skills-lock-diff
 /skills-lock-diff /tmp/custom-skills.lock.json --json
 
+# Preview and apply prune of untracked local skills
+/skills-prune
+/skills-prune /tmp/custom-skills.lock.json --apply
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- add interactive `/skills-prune [lockfile_path] [--dry-run|--apply]` command metadata, help wiring, and command-loop handling
- implement safe prune planning/execution with deterministic candidate listing, default dry-run mode, and explicit `--apply` deletion
- add lockfile/file path safety guards and end-to-end coverage for unit, functional, integration, and regression behaviors

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #66