### PR TITLE
feat: add interactive /skills-trust-list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /skills-prune
 /skills-prune /tmp/custom-skills.lock.json --apply
 
+# Inspect trust-root keys from configured or explicit trust-root file
+/skills-trust-list
+/skills-trust-list /tmp/trust-roots.json
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- add interactive `/skills-trust-list [trust_root_file]` command metadata, help wiring, and command-loop handling
- add trust-root inspection rendering with deterministic key-id sorting and status output (`active`/`revoked`/`expired`) including `revoked`, `expires_unix`, and `rotated_from`
- wire command defaults to configured `--skill-trust-root-file` while allowing explicit per-command file overrides, with non-fatal parse/error handling
- add unit, functional, integration, and regression coverage across core command logic and interactive CLI behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #67