### PR TITLE
feat: add /session-search interactive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
 # Resume latest branch (default behavior), inspect session state
 /session
+/session-search retry budget
 /branches
 
 # Switch to an older entry and fork a new branch


### PR DESCRIPTION
## Summary
- add interactive `/session-search <query>` command metadata, help wiring, and command-loop handling
- implement case-insensitive role/text search across all session entries (including branches) with deterministic id ordering, preview snippets, and result caps
- add unit, functional, integration, and regression tests for query parsing, matching, preview behavior, branch-aware results, empty-query handling, and huge-session caps

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #68