### PR TITLE
feat: add /session-stats interactive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Resume latest branch (default behavior), inspect session state
 /session
 /session-search retry budget
+/session-stats
 /branches
 
 # Switch to an older entry and fork a new branch


### PR DESCRIPTION
## Summary
- add interactive `/session-stats` command metadata, help wiring, and command-loop handling
- compute deterministic session graph stats (entries, branch tips, roots, depth metrics, active/latest head indicators, role distribution)
- add malformed-graph-safe depth computation with explicit error reporting for missing parents/cycles/duplicates
- add unit, functional, integration, and regression coverage for stats calculations, rendering, branched scenarios, empty sessions, malformed graphs, and interactive usage behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #69