### PR TITLE
feat: add /session-graph-export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session
 /session-search retry budget
 /session-stats
+/session-graph-export /tmp/session-graph.mmd
 /branches
 
 # Switch to an older entry and fork a new branch


### PR DESCRIPTION
## Summary
- add interactive `/session-graph-export <path>` command metadata, help wiring, and command-loop handling
- export deterministic session graph files with node ids and parent edges, supporting Mermaid by default and DOT when destination extension is `.dot`
- add graph label escaping and atomic destination writes with directory validation and non-fatal error reporting
- add unit, functional, integration, and regression coverage for rendering/escaping, export summaries, branched graphs, and invalid destination paths

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #70