### PR TITLE
feat(session): add /branch-alias command suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session-graph-export /tmp/session-graph.mmd
 /branches
 
+# Persist and use named aliases for fast branch navigation
+/branch-alias set hotfix 12
+/branch-alias list
+/branch-alias use hotfix
+
 # Switch to an older entry and fork a new branch
 /branch 12
 


### PR DESCRIPTION
## Summary
- add interactive `/branch-alias` command family with deterministic `set`, `list`, and `use` flows
- persist aliases in a JSON sidecar next to the active session and validate alias name/id inputs
- mark stale aliases in list output and fail safely on unknown IDs or malformed alias files
- document command usage in README and command help coverage

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p pi-coding-agent branch_alias
- cargo test --workspace

Closes #71