### PR TITLE
feat(cli): add /macro save-run-list workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session-graph-export /tmp/session-graph.mmd
 /branches
 
+# Save/list/run repeatable command macros (project-local .pi/macros.json)
+/macro save quick-check /tmp/quick-check.commands
+/macro list
+/macro run quick-check --dry-run
+/macro run quick-check
+
 # Persist and use named aliases for fast branch navigation
 /branch-alias set hotfix 12
 /branch-alias list


### PR DESCRIPTION
## Summary
- add interactive `/macro` command family with deterministic `save`, `list`, and `run` flows
- persist macros in project-local `.pi/macros.json` with schema validation and stable ordering
- validate macro names and macro command entries before execution (blocks unknown, nested, and exit commands)
- support `/macro run <name> --dry-run` planning mode and apply mode execution through existing command pipeline
- extend README and help coverage for macro usage

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent macro
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #72
