### PR TITLE
feat(cli): add /profile save-load defaults workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /macro run quick-check --dry-run
 /macro run quick-check
 
+# Save/load runtime defaults profiles (project-local .pi/profiles.json)
+/profile save baseline
+/profile load baseline
+
 # Persist and use named aliases for fast branch navigation
 /branch-alias set hotfix 12
 /branch-alias list


### PR DESCRIPTION
## Summary
- add interactive `/profile save <name>` and `/profile load <name>` commands
- persist profile snapshots in project-local `.pi/profiles.json` with schema versioning
- include model, fallback models, session defaults, and policy defaults in each profile snapshot
- validate profile names and schema/version compatibility during save/load flows
- load command reports deterministic diffs against current runtime defaults
- keep existing CLI flag behavior unchanged (profiles are additive and non-breaking)

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent profile
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #73
