### PR TITLE
feat(cli): add --command-file batch execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Pipe a one-shot prompt from stdin:
 printf "Summarize src/main.rs" | cargo run -p pi-coding-agent -- --prompt-file -
 ```
 
+Execute a slash-command script and exit:
+
+```bash
+# Fail-fast on first malformed/failing line (default)
+cargo run -p pi-coding-agent -- --no-session --command-file .pi/commands/checks.commands
+
+# Continue past malformed/failing lines and report a final summary
+cargo run -p pi-coding-agent -- --no-session \
+  --command-file .pi/commands/checks.commands \
+  --command-file-error-mode continue-on-error
+```
+
 Load the base system prompt from a file:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `--command-file <path>` startup flag for non-interactive slash-command batch workflows
- add `--command-file-error-mode <fail-fast|continue-on-error>` execution policy
- parse command files deterministically (skip blank/comment lines, preserve line numbers)
- execute commands sequentially through the existing command pipeline
- print deterministic per-error diagnostics and a final execution summary
- keep default behavior fail-fast and preserve existing interactive/prompt flows

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent command_file
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #74
