### PR TITLE
feat(cli): add /doctor diagnostics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session
 /session-search retry budget
 /session-stats
+/doctor
 /session-graph-export /tmp/session-graph.mmd
 /branches
 


### PR DESCRIPTION
## Summary
- add a new interactive `/doctor` command for runtime diagnostics
- include deterministic checks for model/provider key status, session path, skills directory, lockfile readability, and trust-root readability
- add structured pass/warn/fail output with actionable remediation hints
- wire doctor configuration from CLI model/fallback/provider context and skills/session paths
- document `/doctor` in README interactive examples

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Validation Matrix
- Unit: doctor config construction and report rendering
- Functional: deterministic check ordering and command output sections
- Integration: mixed healthy/unhealthy diagnostics and session-runtime preservation
- Regression: type mismatches/readability failures and CLI usage-error behavior

Closes #75
