### PR TITLE
feat(cli): extend /profile with list-show-delete lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 
 # Save/load runtime defaults profiles (project-local .pi/profiles.json)
 /profile save baseline
+/profile list
+/profile show baseline
 /profile load baseline
+/profile delete baseline
 
 # Persist and use named aliases for fast branch navigation
 /branch-alias set hotfix 12


### PR DESCRIPTION
## Summary
- extend `/profile` with lifecycle subcommands: `list`, `show`, and `delete`
- keep `save`/`load` behavior intact while expanding parser/help usage to cover all subcommands
- add deterministic renderers for profile inventory and full profile inspection output
- update interactive README examples for full profile lifecycle operations
- add CLI integration coverage for lifecycle and usage-error regression paths

## Risks and Compatibility
- Backward compatible with existing `profiles.json` schema and existing `save`/`load` workflows
- New `delete` path mutates profile store intentionally; all other new commands are read-only

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Validation Matrix
- Unit: profile parser/render helpers and deterministic output
- Functional: parse/help coverage for new subcommands
- Integration: save/list/show/load/delete lifecycle roundtrip
- Regression: invalid args, unknown profile handling, schema errors

Closes #89
