### PR TITLE
feat(cli): add /macro show-delete lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 # Save/list/run repeatable command macros (project-local .pi/macros.json)
 /macro save quick-check /tmp/quick-check.commands
 /macro list
+/macro show quick-check
 /macro run quick-check --dry-run
 /macro run quick-check
+/macro delete quick-check
 
 # Save/load runtime defaults profiles (project-local .pi/profiles.json)
 /profile save baseline


### PR DESCRIPTION
## Summary
- extend `/macro` lifecycle with `show` and `delete` subcommands
- keep save/run/list behavior intact while broadening parser/help usage coverage
- add deterministic macro inspection output (`command: index=<n> value=<cmd>`)
- allow deletion of stale/broken macros for recovery workflows
- update README interactive examples and CLI integration tests

## Risks and Compatibility
- Backward compatible with existing `macros.json` schema and existing save/run/list flows
- `delete` intentionally mutates macro store; all other new macro lifecycle operations are read-only

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Validation Matrix
- Unit: parser and macro render helper coverage
- Functional: help/usage and deterministic output behavior
- Integration: save/show/run/delete/list lifecycle roundtrip
- Regression: malformed args, unknown macros, corrupt store handling

Closes #90
