### PR TITLE
feat(cli): add /doctor --json diagnostics mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session-search retry budget
 /session-stats
 /doctor
+/doctor --json
 /session-graph-export /tmp/session-graph.mmd
 /branches
 

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -539,7 +539,7 @@ fn integration_interactive_doctor_command_reports_runtime_diagnostics() {
         "--skill-trust-root-file",
         trust_root_path.to_str().expect("utf8 path"),
     ])
-    .write_stdin("/doctor\n/quit\n");
+    .write_stdin("/doctor\n/doctor --json\n/quit\n");
 
     cmd.assert()
         .success()
@@ -557,7 +557,10 @@ fn integration_interactive_doctor_command_reports_runtime_diagnostics() {
         ))
         .stdout(predicate::str::contains(
             "doctor check: key=trust_root status=pass code=readable",
-        ));
+        ))
+        .stdout(predicate::str::contains("\"summary\""))
+        .stdout(predicate::str::contains("\"checks\""))
+        .stdout(predicate::str::contains("\"provider_key.openai\""));
 }
 
 #[test]
@@ -570,11 +573,11 @@ fn regression_interactive_doctor_command_with_args_prints_usage_and_continues() 
         "test-openai-key",
         "--no-session",
     ])
-    .write_stdin("/doctor extra\n/help doctor\n/quit\n");
+    .write_stdin("/doctor --bad\n/help doctor\n/quit\n");
 
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("usage: /doctor"))
+        .stdout(predicate::str::contains("usage: /doctor [--json]"))
         .stdout(predicate::str::contains("command: /doctor"))
         .stdout(predicate::str::contains("example: /doctor"));
 }


### PR DESCRIPTION
## Summary
- add `--json` mode for `/doctor` to emit machine-readable diagnostics output
- introduce explicit doctor argument parser with deterministic usage handling (`/doctor [--json]`)
- keep default text diagnostics output unchanged
- add JSON report renderer with stable summary/check structures
- update help/README and CLI integration coverage for new mode

## Risks and Compatibility
- Backward compatible: `/doctor` without args retains existing text output
- `--json` adds a new output mode only; no runtime mutation behavior changed

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Validation Matrix
- Unit: doctor arg parsing and JSON renderer schema/count assertions
- Functional: text vs JSON execution paths and deterministic ordering
- Integration: interactive `/doctor` + `/doctor --json` command behavior
- Regression: invalid doctor flags and usage reporting paths

Closes #91
