### PR TITLE
feat(session): add /session-stats --json output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session
 /session-search retry budget
 /session-stats
+/session-stats --json
 /doctor
 /doctor --json
 /session-graph-export /tmp/session-graph.mmd

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -442,7 +442,7 @@ fn integration_interactive_session_stats_command_reports_branched_summary() {
         "--session",
         session.to_str().expect("utf8 path"),
     ])
-    .write_stdin("/session-stats\n/quit\n");
+    .write_stdin("/session-stats\n/session-stats --json\n/quit\n");
 
     cmd.assert()
         .success()
@@ -454,7 +454,11 @@ fn integration_interactive_session_stats_command_reports_branched_summary() {
         ))
         .stdout(predicate::str::contains("depth: active=2 latest=2"))
         .stdout(predicate::str::contains("role: system=1"))
-        .stdout(predicate::str::contains("role: user=2"));
+        .stdout(predicate::str::contains("role: user=2"))
+        .stdout(predicate::str::contains("\"entries\":3"))
+        .stdout(predicate::str::contains("\"branch_tips\":2"))
+        .stdout(predicate::str::contains("\"role_counts\""))
+        .stdout(predicate::str::contains("\"user\":2"));
 }
 
 #[test]
@@ -491,9 +495,9 @@ fn regression_interactive_session_stats_command_with_args_prints_usage_and_conti
 
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("usage: /session-stats"))
+        .stdout(predicate::str::contains("usage: /session-stats [--json]"))
         .stdout(predicate::str::contains("command: /session-stats"))
-        .stdout(predicate::str::contains("usage: /session-stats"));
+        .stdout(predicate::str::contains("usage: /session-stats [--json]"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--json` mode for `/session-stats` with deterministic machine-readable output
- introduce explicit argument parser for `/session-stats [--json]`
- preserve existing text output as default behavior
- add JSON rendering for success payloads and JSON error payloads for malformed session graphs
- update command help and README interactive examples

## Risks and Compatibility
- Backward compatible: `/session-stats` text output remains unchanged by default
- New mode is additive (`--json`) and read-only

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Validation Matrix
- Unit: stats arg parsing and JSON render field assertions
- Functional: command help/usage and text rendering behavior
- Integration: branched session parity checks for text and JSON output
- Regression: invalid args and malformed session graph error behavior in text/JSON modes

Closes #94
