### PR TITLE
feat(session): add /session-diff lineage comparison command

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /session-search retry budget
 /session-stats
 /session-stats --json
+/session-diff
+/session-diff 12 24
 /doctor
 /doctor --json
 /session-graph-export /tmp/session-graph.mmd


### PR DESCRIPTION
## Summary
- adds interactive `/session-diff` command with two modes:
  - default heads: `/session-diff` compares active head vs latest head
  - explicit heads: `/session-diff <left-id> <right-id>`
- adds deterministic diff output with shared lineage rows plus left/right divergent rows including id, parent, role, and preview text
- updates command catalog/help/README with usage examples
- adds comprehensive tests across unit, functional, integration, and regression layers (runtime + CLI integration)

## Risks and Compatibility
- additive command only; no behavior change to existing commands
- read-only command; does not mutate session state
- malformed/unknown-id graph states now surface deterministic `session diff error` messages

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #92
