### PR TITLE
feat(session): add /session-bookmark command suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /branch-alias list
 /branch-alias use hotfix
 
+# Persist and use named bookmarks for investigation checkpoints
+/session-bookmark set investigation 12
+/session-bookmark list
+/session-bookmark use investigation
+/session-bookmark delete investigation
+
 # Switch to an older entry and fork a new branch
 /branch 12
 


### PR DESCRIPTION
## Summary
- adds `/session-bookmark` command suite:
  - `/session-bookmark set <name> <id>`
  - `/session-bookmark list`
  - `/session-bookmark use <name>`
  - `/session-bookmark delete <name>`
- persists bookmarks in project-local metadata (`<session>.bookmarks.json`) with schema versioning
- reuses existing alias name validation conventions for bookmark names
- integrates bookmark `use` with active-head switching and agent lineage reload
- updates command help catalog and README examples

## Risks and Compatibility
- additive command only; existing command behavior remains unchanged
- bookmark operations are session-local metadata writes; no session graph mutations
- malformed bookmark file and stale id cases return deterministic errors without crashing the loop

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #93
