### PR TITLE
feat(skills): add interactive trust mutation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,11 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /skills-trust-list
 /skills-trust-list /tmp/trust-roots.json
 
+# Mutate trust-root keys interactively (uses configured trust-root path by default)
+/skills-trust-add root-v2=AbC...
+/skills-trust-revoke root-v1
+/skills-trust-rotate root-v1:root-v2=AbC...
+
 # List currently installed skills
 /skills-list
 


### PR DESCRIPTION
## Summary
- adds interactive trust mutation commands:
  - `/skills-trust-add <id=base64_key> [trust_root_file]`
  - `/skills-trust-revoke <id> [trust_root_file]`
  - `/skills-trust-rotate <old_id:new_id=base64_key> [trust_root_file]`
- reuses existing trust mutation validation and lifecycle logic used by startup flags
- wires commands into help/catalog and README examples
- updates trust-root persistence writes to atomic file updates
- ensures mutations are reflected immediately in `/skills-trust-list`

## Risks and Compatibility
- additive command surface; existing commands/flags remain compatible
- trust-root persistence now uses atomic writes (safer behavior) and keeps same schema payload format
- command errors are deterministic for malformed specs, missing trust-root path, and unknown ids

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #95
