### PR TITLE
feat: add /skills-verify compliance diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 /skills-sync
 /skills-sync /tmp/custom-skills.lock.json
 
+# Run combined lockfile + trust/signature compliance diagnostics
+/skills-verify
+/skills-verify /tmp/custom-skills.lock.json /tmp/trust-roots.json --json
+
 # Repair/import output includes affected IDs and remap pairs for diagnostics
 ```
 


### PR DESCRIPTION
## Summary
- add a new `/skills-verify` interactive command to validate lockfile sync and signature trust posture
- support text and `--json` outputs with pass/warn/fail summaries, trust metadata, and drift diagnostics
- add command/help/README wiring and coverage for parser, renderer, runtime behavior, and CLI integration

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #96