### PR TITLE
feat: remote skills cache and offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Implemented now:
 - Remote skill fetch/install with optional checksum verification
 - Registry-based skill installation (`--skill-registry-url`, `--install-skill-from-registry`)
 - Signed registry skill installation with trust roots (`--skill-trust-root`, `--require-signed-skills`)
+- Remote/registry download cache with offline replay (`--skills-cache-dir`, `--skills-offline`)
 - Skills lockfile write/sync workflow (`--skills-lock-write`, `--skills-sync`)
 - Unit tests for serialization, tool loop, renderer diffing, and tool behaviors
 
@@ -207,12 +208,49 @@ cargo run -p pi-coding-agent -- \
   --skill review
 ```
 
+Warm the remote skill cache, then replay installs offline:
+
+```bash
+# Online warm-cache run
+cargo run -p pi-coding-agent -- \
+  --prompt "Audit this module" \
+  --skills-dir .pi/skills \
+  --skills-cache-dir .pi/skills-cache \
+  --install-skill-url https://example.com/skills/review.md \
+  --install-skill-sha256 2f7d0... \
+  --skill review
+
+# Offline replay run (no remote fetches; requires cache hit)
+cargo run -p pi-coding-agent -- \
+  --prompt "Audit this module" \
+  --skills-dir .pi/skills \
+  --skills-cache-dir .pi/skills-cache \
+  --skills-offline \
+  --install-skill-url https://example.com/skills/review.md \
+  --install-skill-sha256 2f7d0... \
+  --skill review
+```
+
 Install skills from a remote registry manifest:
 
 ```bash
 cargo run -p pi-coding-agent -- \
   --prompt "Audit this module" \
   --skills-dir .pi/skills \
+  --skill-registry-url https://example.com/registry.json \
+  --skill-registry-sha256 3ac10... \
+  --install-skill-from-registry review \
+  --skill review
+```
+
+Replay registry installs offline from cache:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --prompt "Audit this module" \
+  --skills-dir .pi/skills \
+  --skills-cache-dir .pi/skills-cache \
+  --skills-offline \
   --skill-registry-url https://example.com/registry.json \
   --skill-registry-sha256 3ac10... \
   --install-skill-from-registry review \

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -3888,6 +3888,122 @@ fn install_skill_url_with_sha256_verification_works_end_to_end() {
 }
 
 #[test]
+fn integration_install_skill_url_offline_replay_uses_cache_without_network() {
+    let server = MockServer::start();
+    let remote_body = "Remote cached skill";
+    let checksum = format!("{:x}", Sha256::digest(remote_body.as_bytes()));
+
+    let remote = server.mock(|when, then| {
+        when.method(GET).path("/skills/cached.md");
+        then.status(200).body(remote_body);
+    });
+
+    let openai = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/chat/completions")
+            .header("authorization", "Bearer test-openai-key");
+        then.status(200).json_body(json!({
+            "choices": [{
+                "message": {"content": "ok remote cache"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 1, "total_tokens": 8}
+        }));
+    });
+
+    let temp = tempdir().expect("tempdir");
+    let skills_dir = temp.path().join("skills");
+    let cache_dir = temp.path().join("skills-cache");
+
+    let mut warm = binary_command();
+    warm.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--system-prompt",
+        "base",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-cache-dir",
+        cache_dir.to_str().expect("utf8 path"),
+        "--install-skill-url",
+        &format!("{}/skills/cached.md", server.base_url()),
+        "--install-skill-sha256",
+        &checksum,
+        "--skill",
+        "cached",
+        "--no-session",
+    ]);
+    warm.assert().success();
+
+    let mut replay = binary_command();
+    replay.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--system-prompt",
+        "base",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-cache-dir",
+        cache_dir.to_str().expect("utf8 path"),
+        "--skills-offline",
+        "--install-skill-url",
+        &format!("{}/skills/cached.md", server.base_url()),
+        "--install-skill-sha256",
+        &checksum,
+        "--skill",
+        "cached",
+        "--no-session",
+    ]);
+    replay
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("remote skills install:"));
+
+    remote.assert_calls(1);
+    openai.assert_calls(2);
+}
+
+#[test]
+fn regression_skills_offline_mode_without_warm_remote_cache_fails() {
+    let temp = tempdir().expect("tempdir");
+    let skills_dir = temp.path().join("skills");
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-offline",
+        "--install-skill-url",
+        "https://example.com/skills/missing.md",
+        "--install-skill-sha256",
+        "deadbeef",
+        "--no-session",
+    ]);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("offline cache miss for skill URL"));
+}
+
+#[test]
 fn install_skill_from_registry_works_end_to_end() {
     let server = MockServer::start();
     let skill_body = "Registry-driven skill";
@@ -3971,6 +4087,140 @@ fn install_skill_from_registry_works_end_to_end() {
     registry.assert_calls(1);
     remote.assert_calls(1);
     openai.assert_calls(1);
+}
+
+#[test]
+fn integration_install_skill_from_registry_offline_replay_uses_cache_without_network() {
+    let server = MockServer::start();
+    let skill_body = "Registry cached skill";
+    let skill_sha = format!("{:x}", Sha256::digest(skill_body.as_bytes()));
+    let registry_body = json!({
+        "version": 1,
+        "skills": [{
+            "name": "reg-cache",
+            "url": format!("{}/skills/reg-cache.md", server.base_url()),
+            "sha256": skill_sha
+        }]
+    })
+    .to_string();
+    let registry_sha = format!("{:x}", Sha256::digest(registry_body.as_bytes()));
+
+    let registry = server.mock(|when, then| {
+        when.method(GET).path("/registry-cache.json");
+        then.status(200).body(registry_body);
+    });
+    let remote = server.mock(|when, then| {
+        when.method(GET).path("/skills/reg-cache.md");
+        then.status(200).body(skill_body);
+    });
+    let openai = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/chat/completions")
+            .header("authorization", "Bearer test-openai-key");
+        then.status(200).json_body(json!({
+            "choices": [{
+                "message": {"content": "ok registry cache"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 1, "total_tokens": 9}
+        }));
+    });
+
+    let temp = tempdir().expect("tempdir");
+    let skills_dir = temp.path().join("skills");
+    let cache_dir = temp.path().join("skills-cache");
+
+    let mut warm = binary_command();
+    warm.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--system-prompt",
+        "base",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-cache-dir",
+        cache_dir.to_str().expect("utf8 path"),
+        "--skill-registry-url",
+        &format!("{}/registry-cache.json", server.base_url()),
+        "--skill-registry-sha256",
+        &registry_sha,
+        "--install-skill-from-registry",
+        "reg-cache",
+        "--skill",
+        "reg-cache",
+        "--no-session",
+    ]);
+    warm.assert().success();
+
+    let mut replay = binary_command();
+    replay.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--system-prompt",
+        "base",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-cache-dir",
+        cache_dir.to_str().expect("utf8 path"),
+        "--skills-offline",
+        "--skill-registry-url",
+        &format!("{}/registry-cache.json", server.base_url()),
+        "--skill-registry-sha256",
+        &registry_sha,
+        "--install-skill-from-registry",
+        "reg-cache",
+        "--skill",
+        "reg-cache",
+        "--no-session",
+    ]);
+    replay
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("registry skills install:"));
+
+    registry.assert_calls(1);
+    remote.assert_calls(1);
+    openai.assert_calls(2);
+}
+
+#[test]
+fn regression_skills_offline_mode_without_warm_registry_cache_fails() {
+    let temp = tempdir().expect("tempdir");
+    let skills_dir = temp.path().join("skills");
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--prompt",
+        "hello",
+        "--skills-dir",
+        skills_dir.to_str().expect("utf8 path"),
+        "--skills-offline",
+        "--skill-registry-url",
+        "https://example.com/registry.json",
+        "--install-skill-from-registry",
+        "review",
+        "--no-session",
+    ]);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("offline cache miss for registry"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add cache-aware remote skill artifact downloads and registry manifest fetches
- add offline replay support for remote and registry installs via `--skills-offline`
- add configurable cache location via `--skills-cache-dir` (default: `<skills-dir>/.cache`)
- retain checksum/signature validation for cached payload reuse and enforce deterministic cache-miss failures in offline mode
- extend README and add broad test coverage across unit, functional, integration, and regression layers

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #97
