### PR TITLE
ci: reduce Actions spend by removing redundant push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,15 @@ on:
     paths-ignore:
       - "**/*.md"
       - "docs/**"
-  push:
-    branches:
-      - master
-      - main
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
   workflow_dispatch:
     inputs:
       run_coverage:
         description: "Run llvm-cov coverage job"
+        required: false
+        default: false
+        type: boolean
+      run_cross_platform:
+        description: "Run cross-platform compile smoke jobs"
         required: false
         default: false
         type: boolean
@@ -57,7 +55,7 @@ jobs:
 
   cross-platform-smoke:
     name: Cross-platform compile smoke (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' && inputs.run_cross_platform
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,13 +1,6 @@
 name: Security
 
 on:
-  push:
-    branches:
-      - master
-      - main
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
   schedule:
     - cron: "0 7 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- remove `push` trigger from CI workflow so expensive quality jobs do not re-run after merge
- add manual `run_cross_platform` input and gate cross-platform smoke to explicit opt-in
- remove `push` trigger from Security workflow so scans run on schedule/manual only

## Expected Cost Impact
- eliminates duplicate post-merge Linux quality jobs
- eliminates routine post-merge security jobs
- eliminates post-merge cross-platform smoke runs (macOS/Windows) unless manually requested

## Validation
- workflow YAML diff reviewed for event/job gating changes
- no runtime code paths changed

Closes #126
