### PR TITLE
test(auth): add conformance/security harness with CI path gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +36,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Detect auth/runtime changes
+        id: auth_changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            auth_runtime:
+              - 'crates/pi-coding-agent/src/**'
+              - 'crates/pi-ai/src/**'
+              - 'crates/pi-agent-core/src/**'
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -49,6 +61,12 @@ jobs:
 
       - name: Lint
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run auth conformance and security regression suite
+        if: github.event_name != 'pull_request' || steps.auth_changes.outputs.auth_runtime == 'true'
+        run: |
+          cargo test -p pi-coding-agent auth_conformance_ -- --nocapture
+          cargo test -p pi-coding-agent auth_security_ -- --nocapture
 
       - name: Run workspace tests
         run: cargo test --workspace


### PR DESCRIPTION
## Summary
- add explicit auth conformance matrix tests covering provider/mode capability support and status contracts
- add store-backed auth regression tests for stale/revoked/missing token states with secret non-leak assertions
- add unsupported-mode bypass regression matrix for login command
- add CI path filter + targeted auth conformance/security suite execution for auth/runtime path changes

## Coverage Added
- Unit: provider capability matrix support/reason contract
- Functional: status output contract matrix across provider/mode combinations
- Integration: store-backed stale token state handling and leak-resistant outputs
- Regression: unsupported mode bypass attempts across provider/mode matrix

## Testing
- `cargo fmt --all`
- `cargo test -p pi-coding-agent auth_conformance_ -- --nocapture`
- `cargo test -p pi-coding-agent auth_security_ -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #109
