### PR TITLE
feat(security): signed webhook verification and replay protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -932,6 +933,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1622,6 +1632,7 @@ dependencies = [
  "cron",
  "ed25519-dalek",
  "futures-util",
+ "hmac",
  "httpmock",
  "pi-agent-core",
  "pi-ai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono-tz = "0.10"
 cron = "0.15"
 ed25519-dalek = "2.1"
 futures-util = "0.3"
+hmac = "0.12"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ cargo run -p pi-coding-agent -- \
   --event-webhook-debounce-window-seconds 60
 ```
 
+Queue a signed webhook payload with verification and replay protection:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --events-dir .pi/events \
+  --events-state-path .pi/events/state.json \
+  --event-webhook-ingest-file /tmp/webhook.json \
+  --event-webhook-channel github/owner/repo#42 \
+  --event-webhook-signature "$X_HUB_SIGNATURE_256" \
+  --event-webhook-secret "$WEBHOOK_SECRET" \
+  --event-webhook-signature-algorithm github-sha256 \
+  --event-webhook-signature-max-skew-seconds 300
+```
+
 Load the base system prompt from a file:
 
 ```bash

--- a/crates/pi-coding-agent/Cargo.toml
+++ b/crates/pi-coding-agent/Cargo.toml
@@ -14,6 +14,7 @@ clap.workspace = true
 cron.workspace = true
 ed25519-dalek.workspace = true
 futures-util.workspace = true
+hmac.workspace = true
 pi-agent-core = { path = "../pi-agent-core" }
 pi-ai = { path = "../pi-ai" }
 reqwest.workspace = true


### PR DESCRIPTION
## Summary
- harden webhook ingest mode with optional signature verification for:
  - `github-sha256` (`sha256=<hex>`)
  - `slack-v0` (`v0=<hex>` with timestamp binding)
- add timestamp skew enforcement and signature replay protection cache to event runner state
- add secure webhook CLI options:
  - `--event-webhook-signature`
  - `--event-webhook-timestamp`
  - `--event-webhook-secret`
  - `--event-webhook-signature-algorithm`
  - `--event-webhook-signature-max-skew-seconds`
- add strict CLI validation for signed ingest combinations
- add unit/functional/integration/regression coverage for signature verification and replay rejection
- document signed webhook ingest usage in README

## Testing
- cargo fmt --all --check
- cargo test -p pi-coding-agent webhook_ingest_ -- --nocapture
- cargo test -p pi-coding-agent
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Part of #137
