### PR TITLE
Issue #137: integration credential lifecycle + bridge secret-id resolution

### DIFF
--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -103,7 +103,7 @@ fn regression_github_issues_bridge_requires_token() {
     ]);
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "--github-token (or GITHUB_TOKEN) is required",
+        "--github-token (or --github-token-id) is required",
     ));
 }
 


### PR DESCRIPTION
## Summary
- extend credential store with encrypted integration entries (`integrations`) while preserving backward compatibility for legacy provider-only files
- add `/integration-auth` lifecycle commands: `set`, `status`, `rotate`, `revoke`
- add integration secret-id CLI flags:
  - `--event-webhook-secret-id`
  - `--github-token-id`
  - `--slack-app-token-id`
  - `--slack-bot-token-id`
- resolve GitHub/Slack/webhook secrets from the credential store when id flags are provided
- update validations to accept either direct secrets or secret-id flags
- add and update unit/functional/integration/regression tests for parser/executor, encrypted persistence, compatibility, and CLI validation paths

## Testing
- `cargo fmt`
- `cargo test -p pi-coding-agent`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #137
