### PR TITLE
refactor(providers): extract shared provider auth helpers module (#180)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -6,6 +6,7 @@ mod diagnostics_commands;
 mod events;
 mod github_issues;
 mod macro_profile_commands;
+mod provider_auth;
 mod runtime_loop;
 mod session;
 mod session_commands;
@@ -92,6 +93,12 @@ pub(crate) use crate::macro_profile_commands::{
     render_profile_show, save_macro_file, save_profile_store, validate_macro_command_entry,
     validate_macro_name, validate_profile_name, MacroCommand, MacroFile, ProfileCommand,
     ProfileStoreFile, MACRO_SCHEMA_VERSION, MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE,
+};
+pub(crate) use crate::provider_auth::{
+    configured_provider_auth_method, configured_provider_auth_method_from_config,
+    missing_provider_api_key_message, provider_api_key_candidates,
+    provider_api_key_candidates_with_inputs, provider_auth_capability, provider_auth_mode_flag,
+    resolve_api_key,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_prompt, run_prompt_with_cancellation,
@@ -3014,189 +3021,6 @@ fn resolve_store_backed_provider_credential(
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ProviderAuthCapability {
-    method: ProviderAuthMethod,
-    supported: bool,
-    reason: &'static str,
-}
-
-const OPENAI_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::ApiKey,
-        supported: true,
-        reason: "supported",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::OauthToken,
-        supported: true,
-        reason: "supported",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::Adc,
-        supported: false,
-        reason: "not_implemented",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::SessionToken,
-        supported: true,
-        reason: "supported",
-    },
-];
-
-const ANTHROPIC_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::ApiKey,
-        supported: true,
-        reason: "supported",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::OauthToken,
-        supported: false,
-        reason: "not_implemented",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::Adc,
-        supported: false,
-        reason: "not_implemented",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::SessionToken,
-        supported: false,
-        reason: "unsupported",
-    },
-];
-
-const GOOGLE_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::ApiKey,
-        supported: true,
-        reason: "supported",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::OauthToken,
-        supported: false,
-        reason: "not_implemented",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::Adc,
-        supported: false,
-        reason: "not_implemented",
-    },
-    ProviderAuthCapability {
-        method: ProviderAuthMethod::SessionToken,
-        supported: false,
-        reason: "unsupported",
-    },
-];
-
-fn provider_auth_capabilities(provider: Provider) -> &'static [ProviderAuthCapability] {
-    match provider {
-        Provider::OpenAi => OPENAI_AUTH_CAPABILITIES,
-        Provider::Anthropic => ANTHROPIC_AUTH_CAPABILITIES,
-        Provider::Google => GOOGLE_AUTH_CAPABILITIES,
-    }
-}
-
-fn provider_auth_capability(
-    provider: Provider,
-    method: ProviderAuthMethod,
-) -> ProviderAuthCapability {
-    provider_auth_capabilities(provider)
-        .iter()
-        .find(|capability| capability.method == method)
-        .copied()
-        .unwrap_or(ProviderAuthCapability {
-            method,
-            supported: false,
-            reason: "unknown",
-        })
-}
-
-fn configured_provider_auth_method(cli: &Cli, provider: Provider) -> ProviderAuthMethod {
-    match provider {
-        Provider::OpenAi => cli.openai_auth_mode.into(),
-        Provider::Anthropic => cli.anthropic_auth_mode.into(),
-        Provider::Google => cli.google_auth_mode.into(),
-    }
-}
-
-fn configured_provider_auth_method_from_config(
-    config: &AuthCommandConfig,
-    provider: Provider,
-) -> ProviderAuthMethod {
-    match provider {
-        Provider::OpenAi => config.openai_auth_mode,
-        Provider::Anthropic => config.anthropic_auth_mode,
-        Provider::Google => config.google_auth_mode,
-    }
-}
-
-fn provider_auth_mode_flag(provider: Provider) -> &'static str {
-    match provider {
-        Provider::OpenAi => "--openai-auth-mode",
-        Provider::Anthropic => "--anthropic-auth-mode",
-        Provider::Google => "--google-auth-mode",
-    }
-}
-
-fn missing_provider_api_key_message(provider: Provider) -> &'static str {
-    match provider {
-        Provider::OpenAi => {
-            "missing OpenAI API key. Set OPENAI_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
-        }
-        Provider::Anthropic => {
-            "missing Anthropic API key. Set ANTHROPIC_API_KEY, PI_API_KEY, --anthropic-api-key, or --api-key"
-        }
-        Provider::Google => {
-            "missing Google API key. Set GEMINI_API_KEY, GOOGLE_API_KEY, PI_API_KEY, --google-api-key, or --api-key"
-        }
-    }
-}
-
-fn provider_api_key_candidates_with_inputs(
-    provider: Provider,
-    api_key: Option<String>,
-    openai_api_key: Option<String>,
-    anthropic_api_key: Option<String>,
-    google_api_key: Option<String>,
-) -> Vec<(&'static str, Option<String>)> {
-    match provider {
-        Provider::OpenAi => vec![
-            ("--openai-api-key", openai_api_key),
-            ("--api-key", api_key),
-            ("OPENAI_API_KEY", std::env::var("OPENAI_API_KEY").ok()),
-            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
-        ],
-        Provider::Anthropic => vec![
-            ("--anthropic-api-key", anthropic_api_key),
-            ("--api-key", api_key),
-            ("ANTHROPIC_API_KEY", std::env::var("ANTHROPIC_API_KEY").ok()),
-            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
-        ],
-        Provider::Google => vec![
-            ("--google-api-key", google_api_key),
-            ("--api-key", api_key),
-            ("GEMINI_API_KEY", std::env::var("GEMINI_API_KEY").ok()),
-            ("GOOGLE_API_KEY", std::env::var("GOOGLE_API_KEY").ok()),
-            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
-        ],
-    }
-}
-
-fn provider_api_key_candidates(
-    cli: &Cli,
-    provider: Provider,
-) -> Vec<(&'static str, Option<String>)> {
-    provider_api_key_candidates_with_inputs(
-        provider,
-        cli.api_key.clone(),
-        cli.openai_api_key.clone(),
-        cli.anthropic_api_key.clone(),
-        cli.google_api_key.clone(),
-    )
-}
-
 fn resolve_non_empty_secret_with_source(
     candidates: Vec<(&'static str, Option<String>)>,
 ) -> Option<(String, String)> {
@@ -3425,13 +3249,6 @@ fn build_provider_client(cli: &Cli, provider: Provider) -> Result<Arc<dyn LlmCli
             Ok(Arc::new(client))
         }
     }
-}
-
-fn resolve_api_key(candidates: Vec<Option<String>>) -> Option<String> {
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|value| !value.trim().is_empty())
 }
 
 const TOOL_POLICY_SCHEMA_VERSION: u32 = 2;

--- a/crates/pi-coding-agent/src/provider_auth.rs
+++ b/crates/pi-coding-agent/src/provider_auth.rs
@@ -1,0 +1,191 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderAuthCapability {
+    pub(crate) method: ProviderAuthMethod,
+    pub(crate) supported: bool,
+    pub(crate) reason: &'static str,
+}
+
+const OPENAI_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::ApiKey,
+        supported: true,
+        reason: "supported",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::OauthToken,
+        supported: true,
+        reason: "supported",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::Adc,
+        supported: false,
+        reason: "not_implemented",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::SessionToken,
+        supported: true,
+        reason: "supported",
+    },
+];
+
+const ANTHROPIC_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::ApiKey,
+        supported: true,
+        reason: "supported",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::OauthToken,
+        supported: false,
+        reason: "not_implemented",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::Adc,
+        supported: false,
+        reason: "not_implemented",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::SessionToken,
+        supported: false,
+        reason: "unsupported",
+    },
+];
+
+const GOOGLE_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::ApiKey,
+        supported: true,
+        reason: "supported",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::OauthToken,
+        supported: false,
+        reason: "not_implemented",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::Adc,
+        supported: false,
+        reason: "not_implemented",
+    },
+    ProviderAuthCapability {
+        method: ProviderAuthMethod::SessionToken,
+        supported: false,
+        reason: "unsupported",
+    },
+];
+
+fn provider_auth_capabilities(provider: Provider) -> &'static [ProviderAuthCapability] {
+    match provider {
+        Provider::OpenAi => OPENAI_AUTH_CAPABILITIES,
+        Provider::Anthropic => ANTHROPIC_AUTH_CAPABILITIES,
+        Provider::Google => GOOGLE_AUTH_CAPABILITIES,
+    }
+}
+
+pub(crate) fn provider_auth_capability(
+    provider: Provider,
+    method: ProviderAuthMethod,
+) -> ProviderAuthCapability {
+    provider_auth_capabilities(provider)
+        .iter()
+        .find(|capability| capability.method == method)
+        .copied()
+        .unwrap_or(ProviderAuthCapability {
+            method,
+            supported: false,
+            reason: "unknown",
+        })
+}
+
+pub(crate) fn configured_provider_auth_method(cli: &Cli, provider: Provider) -> ProviderAuthMethod {
+    match provider {
+        Provider::OpenAi => cli.openai_auth_mode.into(),
+        Provider::Anthropic => cli.anthropic_auth_mode.into(),
+        Provider::Google => cli.google_auth_mode.into(),
+    }
+}
+
+pub(crate) fn configured_provider_auth_method_from_config(
+    config: &AuthCommandConfig,
+    provider: Provider,
+) -> ProviderAuthMethod {
+    match provider {
+        Provider::OpenAi => config.openai_auth_mode,
+        Provider::Anthropic => config.anthropic_auth_mode,
+        Provider::Google => config.google_auth_mode,
+    }
+}
+
+pub(crate) fn provider_auth_mode_flag(provider: Provider) -> &'static str {
+    match provider {
+        Provider::OpenAi => "--openai-auth-mode",
+        Provider::Anthropic => "--anthropic-auth-mode",
+        Provider::Google => "--google-auth-mode",
+    }
+}
+
+pub(crate) fn missing_provider_api_key_message(provider: Provider) -> &'static str {
+    match provider {
+        Provider::OpenAi => {
+            "missing OpenAI API key. Set OPENAI_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
+        }
+        Provider::Anthropic => {
+            "missing Anthropic API key. Set ANTHROPIC_API_KEY, PI_API_KEY, --anthropic-api-key, or --api-key"
+        }
+        Provider::Google => {
+            "missing Google API key. Set GEMINI_API_KEY, GOOGLE_API_KEY, PI_API_KEY, --google-api-key, or --api-key"
+        }
+    }
+}
+
+pub(crate) fn provider_api_key_candidates_with_inputs(
+    provider: Provider,
+    api_key: Option<String>,
+    openai_api_key: Option<String>,
+    anthropic_api_key: Option<String>,
+    google_api_key: Option<String>,
+) -> Vec<(&'static str, Option<String>)> {
+    match provider {
+        Provider::OpenAi => vec![
+            ("--openai-api-key", openai_api_key),
+            ("--api-key", api_key),
+            ("OPENAI_API_KEY", std::env::var("OPENAI_API_KEY").ok()),
+            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
+        ],
+        Provider::Anthropic => vec![
+            ("--anthropic-api-key", anthropic_api_key),
+            ("--api-key", api_key),
+            ("ANTHROPIC_API_KEY", std::env::var("ANTHROPIC_API_KEY").ok()),
+            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
+        ],
+        Provider::Google => vec![
+            ("--google-api-key", google_api_key),
+            ("--api-key", api_key),
+            ("GEMINI_API_KEY", std::env::var("GEMINI_API_KEY").ok()),
+            ("GOOGLE_API_KEY", std::env::var("GOOGLE_API_KEY").ok()),
+            ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
+        ],
+    }
+}
+
+pub(crate) fn provider_api_key_candidates(
+    cli: &Cli,
+    provider: Provider,
+) -> Vec<(&'static str, Option<String>)> {
+    provider_api_key_candidates_with_inputs(
+        provider,
+        cli.api_key.clone(),
+        cli.openai_api_key.clone(),
+        cli.anthropic_api_key.clone(),
+        cli.google_api_key.clone(),
+    )
+}
+
+pub(crate) fn resolve_api_key(candidates: Vec<Option<String>>) -> Option<String> {
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|value| !value.trim().is_empty())
+}


### PR DESCRIPTION
## Summary
- extract shared provider-auth capability/mode helper logic from `main.rs` into `provider_auth.rs`
- centralize capability matrix, auth mode flag mapping, provider key message/candidate helpers, and shared mode resolution helpers
- re-export moved helpers through `main.rs` so existing command/runtime/doctor flows and tests remain behavior-compatible

## Testing
- cargo fmt
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #180
