### PR TITLE
refactor(cli): extract doctor config assembly helpers (#182)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -70,7 +70,8 @@ pub(crate) use crate::credentials::{
 #[cfg(test)]
 pub(crate) use crate::diagnostics_commands::execute_doctor_command;
 pub(crate) use crate::diagnostics_commands::{
-    execute_audit_summary_command, execute_doctor_cli_command, execute_policy_command,
+    build_doctor_command_config, execute_audit_summary_command, execute_doctor_cli_command,
+    execute_policy_command,
 };
 #[cfg(test)]
 pub(crate) use crate::diagnostics_commands::{
@@ -3389,73 +3390,6 @@ fn build_profile_defaults(cli: &Cli) -> ProfileDefaults {
             anthropic: cli.anthropic_auth_mode.into(),
             google: cli.google_auth_mode.into(),
         },
-    }
-}
-
-fn provider_key_env_var(provider: Provider) -> &'static str {
-    match provider {
-        Provider::OpenAi => "OPENAI_API_KEY",
-        Provider::Anthropic => "ANTHROPIC_API_KEY",
-        Provider::Google => "GEMINI_API_KEY",
-    }
-}
-
-fn provider_key_present(cli: &Cli, provider: Provider) -> bool {
-    match provider {
-        Provider::OpenAi => {
-            resolve_api_key(vec![cli.openai_api_key.clone(), cli.api_key.clone()]).is_some()
-        }
-        Provider::Anthropic => {
-            resolve_api_key(vec![cli.anthropic_api_key.clone(), cli.api_key.clone()]).is_some()
-        }
-        Provider::Google => {
-            resolve_api_key(vec![cli.google_api_key.clone(), cli.api_key.clone()]).is_some()
-        }
-    }
-}
-
-fn build_doctor_command_config(
-    cli: &Cli,
-    primary_model: &ModelRef,
-    fallback_models: &[ModelRef],
-    skills_lock_path: &Path,
-) -> DoctorCommandConfig {
-    let mut providers = Vec::new();
-    providers.push(primary_model.provider);
-    for model in fallback_models {
-        if !providers.contains(&model.provider) {
-            providers.push(model.provider);
-        }
-    }
-    providers.sort_by_key(|provider| provider.as_str().to_string());
-    let provider_keys = providers
-        .into_iter()
-        .map(|provider| {
-            let auth_mode = configured_provider_auth_method(cli, provider);
-            let capability = provider_auth_capability(provider, auth_mode);
-            DoctorProviderKeyStatus {
-                provider_kind: provider,
-                provider: provider.as_str().to_string(),
-                key_env_var: provider_key_env_var(provider).to_string(),
-                present: provider_key_present(cli, provider),
-                auth_mode,
-                mode_supported: capability.supported,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    DoctorCommandConfig {
-        model: format!(
-            "{}/{}",
-            primary_model.provider.as_str(),
-            primary_model.model
-        ),
-        provider_keys,
-        session_enabled: !cli.no_session,
-        session_path: cli.session.clone(),
-        skills_dir: cli.skills_dir.clone(),
-        skills_lock_path: skills_lock_path.to_path_buf(),
-        trust_root_path: cli.skill_trust_root_file.clone(),
     }
 }
 


### PR DESCRIPTION
## Summary
- move doctor/provider status config assembly helpers (`provider_key_env_var`, `provider_key_present`, `build_doctor_command_config`) from `main.rs` into `diagnostics_commands.rs`
- keep doctor diagnostics wiring and behavior unchanged while reducing `main.rs` coupling
- re-export `build_doctor_command_config` from `main.rs` to preserve existing test imports/contracts

## Testing
- cargo fmt
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #182
