### PR TITLE
Refactor: extract runtime output helper module

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -13,6 +13,7 @@ mod provider_credentials;
 mod provider_fallback;
 mod runtime_cli_validation;
 mod runtime_loop;
+mod runtime_output;
 mod session;
 mod session_commands;
 mod session_graph_commands;
@@ -129,6 +130,11 @@ pub(crate) use crate::runtime_cli_validation::{
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_prompt, run_prompt_with_cancellation,
     InteractiveRuntimeConfig, PromptRunStatus,
+};
+#[cfg(test)]
+pub(crate) use crate::runtime_output::stream_text_chunks;
+pub(crate) use crate::runtime_output::{
+    event_to_json, persist_messages, print_assistant_messages, summarize_message,
 };
 use crate::session::{SessionImportMode, SessionStore};
 #[cfg(test)]
@@ -2095,139 +2101,6 @@ fn reload_agent_from_active_head(agent: &mut Agent, runtime: &SessionRuntime) ->
     let lineage = runtime.store.lineage_messages(runtime.active_head)?;
     agent.replace_messages(lineage);
     Ok(())
-}
-
-fn summarize_message(message: &Message) -> String {
-    let text = message.text_content().replace('\n', " ");
-    if text.trim().is_empty() {
-        return format!(
-            "{:?} (tool_calls={})",
-            message.role,
-            message.tool_calls().len()
-        );
-    }
-
-    let max = 60;
-    if text.chars().count() <= max {
-        text
-    } else {
-        let summary = text.chars().take(max).collect::<String>();
-        format!("{summary}...")
-    }
-}
-
-fn persist_messages(
-    session_runtime: &mut Option<SessionRuntime>,
-    new_messages: &[Message],
-) -> Result<()> {
-    let Some(runtime) = session_runtime.as_mut() else {
-        return Ok(());
-    };
-
-    runtime.active_head = runtime
-        .store
-        .append_messages(runtime.active_head, new_messages)?;
-    Ok(())
-}
-
-fn print_assistant_messages(
-    messages: &[Message],
-    render_options: RenderOptions,
-    suppress_first_streamed_text: bool,
-) {
-    let mut suppressed_once = false;
-    for message in messages {
-        if message.role != MessageRole::Assistant {
-            continue;
-        }
-
-        let text = message.text_content();
-        if !text.trim().is_empty() {
-            if render_options.stream_output && suppress_first_streamed_text && !suppressed_once {
-                suppressed_once = true;
-                println!("\n");
-                continue;
-            }
-            println!();
-            if render_options.stream_output {
-                let mut stdout = std::io::stdout();
-                for chunk in stream_text_chunks(&text) {
-                    print!("{chunk}");
-                    let _ = stdout.flush();
-                    if render_options.stream_delay_ms > 0 {
-                        std::thread::sleep(Duration::from_millis(render_options.stream_delay_ms));
-                    }
-                }
-                println!("\n");
-            } else {
-                println!("{text}\n");
-            }
-            continue;
-        }
-
-        let tool_calls = message.tool_calls();
-        if !tool_calls.is_empty() {
-            println!(
-                "\n[assistant requested {} tool call(s)]\n",
-                tool_calls.len()
-            );
-        }
-    }
-}
-
-fn stream_text_chunks(text: &str) -> Vec<&str> {
-    text.split_inclusive(char::is_whitespace).collect()
-}
-
-fn event_to_json(event: &AgentEvent) -> serde_json::Value {
-    match event {
-        AgentEvent::AgentStart => serde_json::json!({ "type": "agent_start" }),
-        AgentEvent::AgentEnd { new_messages } => {
-            serde_json::json!({ "type": "agent_end", "new_messages": new_messages })
-        }
-        AgentEvent::TurnStart { turn } => serde_json::json!({ "type": "turn_start", "turn": turn }),
-        AgentEvent::TurnEnd {
-            turn,
-            tool_results,
-            request_duration_ms,
-            usage,
-            finish_reason,
-        } => serde_json::json!({
-            "type": "turn_end",
-            "turn": turn,
-            "tool_results": tool_results,
-            "request_duration_ms": request_duration_ms,
-            "usage": usage,
-            "finish_reason": finish_reason,
-        }),
-        AgentEvent::MessageAdded { message } => serde_json::json!({
-            "type": "message_added",
-            "role": format!("{:?}", message.role).to_lowercase(),
-            "text": message.text_content(),
-            "tool_calls": message.tool_calls().len(),
-        }),
-        AgentEvent::ToolExecutionStart {
-            tool_call_id,
-            tool_name,
-            arguments,
-        } => serde_json::json!({
-            "type": "tool_execution_start",
-            "tool_call_id": tool_call_id,
-            "tool_name": tool_name,
-            "arguments": arguments,
-        }),
-        AgentEvent::ToolExecutionEnd {
-            tool_call_id,
-            tool_name,
-            result,
-        } => serde_json::json!({
-            "type": "tool_execution_end",
-            "tool_call_id": tool_call_id,
-            "tool_name": tool_name,
-            "is_error": result.is_error,
-            "content": result.content,
-        }),
-    }
 }
 
 fn build_profile_defaults(cli: &Cli) -> ProfileDefaults {

--- a/crates/pi-coding-agent/src/runtime_output.rs
+++ b/crates/pi-coding-agent/src/runtime_output.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+pub(crate) fn summarize_message(message: &Message) -> String {
+    let text = message.text_content().replace('\n', " ");
+    if text.trim().is_empty() {
+        return format!(
+            "{:?} (tool_calls={})",
+            message.role,
+            message.tool_calls().len()
+        );
+    }
+
+    let max = 60;
+    if text.chars().count() <= max {
+        text
+    } else {
+        let summary = text.chars().take(max).collect::<String>();
+        format!("{summary}...")
+    }
+}
+
+pub(crate) fn persist_messages(
+    session_runtime: &mut Option<SessionRuntime>,
+    new_messages: &[Message],
+) -> Result<()> {
+    let Some(runtime) = session_runtime.as_mut() else {
+        return Ok(());
+    };
+
+    runtime.active_head = runtime
+        .store
+        .append_messages(runtime.active_head, new_messages)?;
+    Ok(())
+}
+
+pub(crate) fn print_assistant_messages(
+    messages: &[Message],
+    render_options: RenderOptions,
+    suppress_first_streamed_text: bool,
+) {
+    let mut suppressed_once = false;
+    for message in messages {
+        if message.role != MessageRole::Assistant {
+            continue;
+        }
+
+        let text = message.text_content();
+        if !text.trim().is_empty() {
+            if render_options.stream_output && suppress_first_streamed_text && !suppressed_once {
+                suppressed_once = true;
+                println!("\n");
+                continue;
+            }
+            println!();
+            if render_options.stream_output {
+                let mut stdout = std::io::stdout();
+                for chunk in stream_text_chunks(&text) {
+                    print!("{chunk}");
+                    let _ = stdout.flush();
+                    if render_options.stream_delay_ms > 0 {
+                        std::thread::sleep(Duration::from_millis(render_options.stream_delay_ms));
+                    }
+                }
+                println!("\n");
+            } else {
+                println!("{text}\n");
+            }
+            continue;
+        }
+
+        let tool_calls = message.tool_calls();
+        if !tool_calls.is_empty() {
+            println!(
+                "\n[assistant requested {} tool call(s)]\n",
+                tool_calls.len()
+            );
+        }
+    }
+}
+
+pub(crate) fn stream_text_chunks(text: &str) -> Vec<&str> {
+    text.split_inclusive(char::is_whitespace).collect()
+}
+
+pub(crate) fn event_to_json(event: &AgentEvent) -> serde_json::Value {
+    match event {
+        AgentEvent::AgentStart => serde_json::json!({ "type": "agent_start" }),
+        AgentEvent::AgentEnd { new_messages } => {
+            serde_json::json!({ "type": "agent_end", "new_messages": new_messages })
+        }
+        AgentEvent::TurnStart { turn } => serde_json::json!({ "type": "turn_start", "turn": turn }),
+        AgentEvent::TurnEnd {
+            turn,
+            tool_results,
+            request_duration_ms,
+            usage,
+            finish_reason,
+        } => serde_json::json!({
+            "type": "turn_end",
+            "turn": turn,
+            "tool_results": tool_results,
+            "request_duration_ms": request_duration_ms,
+            "usage": usage,
+            "finish_reason": finish_reason,
+        }),
+        AgentEvent::MessageAdded { message } => serde_json::json!({
+            "type": "message_added",
+            "role": format!("{:?}", message.role).to_lowercase(),
+            "text": message.text_content(),
+            "tool_calls": message.tool_calls().len(),
+        }),
+        AgentEvent::ToolExecutionStart {
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => serde_json::json!({
+            "type": "tool_execution_start",
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+        }),
+        AgentEvent::ToolExecutionEnd {
+            tool_call_id,
+            tool_name,
+            result,
+        } => serde_json::json!({
+            "type": "tool_execution_end",
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "is_error": result.is_error,
+            "content": result.content,
+        }),
+    }
+}


### PR DESCRIPTION
## Summary
- extract runtime output helpers from `main.rs` into `runtime_output.rs`
- move message summarization, session persistence, assistant output rendering, stream chunking, and event JSON serialization helpers
- preserve behavior and existing imports via `pub(crate)` re-exports from `main.rs`

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #198
