### PR TITLE
Refactor: extract shared time utilities module

### DIFF
--- a/crates/pi-coding-agent/src/time_utils.rs
+++ b/crates/pi-coding-agent/src/time_utils.rs
@@ -1,0 +1,19 @@
+pub(crate) fn current_unix_timestamp_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+pub(crate) fn current_unix_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+pub(crate) fn is_expired_unix(expires_unix: Option<u64>, now_unix: u64) -> bool {
+    matches!(expires_unix, Some(value) if value <= now_unix)
+}


### PR DESCRIPTION
## Summary
- extract unix timestamp/expiry helpers from `main.rs` into `time_utils.rs`
- move `current_unix_timestamp_ms`, `current_unix_timestamp`, and `is_expired_unix`
- preserve behavior and callsites via `pub(crate)` re-exports from `main.rs`

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #202
