### PR TITLE
Refactor: extract startup config builder helpers

### DIFF
--- a/crates/pi-coding-agent/src/startup_config.rs
+++ b/crates/pi-coding-agent/src/startup_config.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+pub(crate) fn default_provider_auth_method() -> ProviderAuthMethod {
+    ProviderAuthMethod::ApiKey
+}
+
+pub(crate) fn build_auth_command_config(cli: &Cli) -> AuthCommandConfig {
+    AuthCommandConfig {
+        credential_store: cli.credential_store.clone(),
+        credential_store_key: cli.credential_store_key.clone(),
+        credential_store_encryption: resolve_credential_store_encryption_mode(cli),
+        api_key: cli.api_key.clone(),
+        openai_api_key: cli.openai_api_key.clone(),
+        anthropic_api_key: cli.anthropic_api_key.clone(),
+        google_api_key: cli.google_api_key.clone(),
+        openai_auth_mode: cli.openai_auth_mode.into(),
+        anthropic_auth_mode: cli.anthropic_auth_mode.into(),
+        google_auth_mode: cli.google_auth_mode.into(),
+    }
+}
+
+pub(crate) fn build_profile_defaults(cli: &Cli) -> ProfileDefaults {
+    ProfileDefaults {
+        model: cli.model.clone(),
+        fallback_models: cli.fallback_model.clone(),
+        session: ProfileSessionDefaults {
+            enabled: !cli.no_session,
+            path: if cli.no_session {
+                None
+            } else {
+                Some(cli.session.display().to_string())
+            },
+            import_mode: format!("{:?}", cli.session_import_mode).to_lowercase(),
+        },
+        policy: ProfilePolicyDefaults {
+            tool_policy_preset: format!("{:?}", cli.tool_policy_preset).to_lowercase(),
+            bash_profile: format!("{:?}", cli.bash_profile).to_lowercase(),
+            bash_dry_run: cli.bash_dry_run,
+            os_sandbox_mode: format!("{:?}", cli.os_sandbox_mode).to_lowercase(),
+            enforce_regular_files: cli.enforce_regular_files,
+            bash_timeout_ms: cli.bash_timeout_ms,
+            max_command_length: cli.max_command_length,
+            max_tool_output_bytes: cli.max_tool_output_bytes,
+            max_file_read_bytes: cli.max_file_read_bytes,
+            max_file_write_bytes: cli.max_file_write_bytes,
+            allow_command_newlines: cli.allow_command_newlines,
+        },
+        auth: ProfileAuthDefaults {
+            openai: cli.openai_auth_mode.into(),
+            anthropic: cli.anthropic_auth_mode.into(),
+            google: cli.google_auth_mode.into(),
+        },
+    }
+}


### PR DESCRIPTION
## Summary
- extract startup config helper logic from `main.rs` into `startup_config.rs`
- move `default_provider_auth_method`, `build_auth_command_config`, and `build_profile_defaults`
- preserve behavior and callsites (including serde defaults) via `pub(crate)` re-exports from `main.rs`

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #206
