### PR TITLE
refactor: extract atomic text write utility from main.rs

### DIFF
--- a/crates/pi-coding-agent/src/atomic_io.rs
+++ b/crates/pi-coding-agent/src/atomic_io.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use crate::current_unix_timestamp;
+
+pub(crate) fn write_text_atomic(path: &Path, content: &str) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        bail!("destination path cannot be empty");
+    }
+    if path.exists() && path.is_dir() {
+        bail!("destination path '{}' is a directory", path.display());
+    }
+
+    let parent_dir = path
+        .parent()
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent_dir)
+        .with_context(|| format!("failed to create {}", parent_dir.display()))?;
+
+    let temp_name = format!(
+        ".{}.tmp-{}-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("session-graph"),
+        std::process::id(),
+        current_unix_timestamp()
+    );
+    let temp_path = parent_dir.join(temp_name);
+    std::fs::write(&temp_path, content)
+        .with_context(|| format!("failed to write temporary file {}", temp_path.display()))?;
+    std::fs::rename(&temp_path, path).with_context(|| {
+        format!(
+            "failed to rename temporary graph file {} to {}",
+            temp_path.display(),
+            path.display()
+        )
+    })?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move `write_text_atomic` from `main.rs` into a new `atomic_io` module
- re-export `write_text_atomic` from crate root so persistence call sites remain unchanged
- keep behavior parity for empty path checks, parent directory creation, temp writes, and atomic rename

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #212
