### PR TITLE
refactor: extract shared runtime/config data types from main.rs

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -19,6 +19,7 @@ mod provider_fallback;
 mod runtime_cli_validation;
 mod runtime_loop;
 mod runtime_output;
+mod runtime_types;
 mod session;
 mod session_commands;
 mod session_graph_commands;
@@ -150,6 +151,11 @@ pub(crate) use crate::runtime_loop::{
 pub(crate) use crate::runtime_output::stream_text_chunks;
 pub(crate) use crate::runtime_output::{
     event_to_json, persist_messages, print_assistant_messages, summarize_message,
+};
+pub(crate) use crate::runtime_types::{
+    AuthCommandConfig, CommandExecutionContext, DoctorCommandConfig, DoctorProviderKeyStatus,
+    ProfileAuthDefaults, ProfileDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
+    RenderOptions, SessionRuntime, SkillsSyncCommandConfig,
 };
 use crate::session::{SessionImportMode, SessionStore};
 #[cfg(test)]
@@ -1231,131 +1237,6 @@ struct Cli {
         help = "Require read/edit targets and existing write targets to be regular files (reject symlink targets)"
     )]
     enforce_regular_files: bool,
-}
-
-#[derive(Debug)]
-struct SessionRuntime {
-    store: SessionStore,
-    active_head: Option<u64>,
-}
-
-#[derive(Debug, Clone)]
-struct SkillsSyncCommandConfig {
-    skills_dir: PathBuf,
-    default_lock_path: PathBuf,
-    default_trust_root_path: Option<PathBuf>,
-    doctor_config: DoctorCommandConfig,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DoctorProviderKeyStatus {
-    provider_kind: Provider,
-    provider: String,
-    key_env_var: String,
-    present: bool,
-    auth_mode: ProviderAuthMethod,
-    mode_supported: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DoctorCommandConfig {
-    model: String,
-    provider_keys: Vec<DoctorProviderKeyStatus>,
-    session_enabled: bool,
-    session_path: PathBuf,
-    skills_dir: PathBuf,
-    skills_lock_path: PathBuf,
-    trust_root_path: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct ProfileSessionDefaults {
-    enabled: bool,
-    path: Option<String>,
-    import_mode: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct ProfilePolicyDefaults {
-    tool_policy_preset: String,
-    bash_profile: String,
-    bash_dry_run: bool,
-    os_sandbox_mode: String,
-    enforce_regular_files: bool,
-    bash_timeout_ms: u64,
-    max_command_length: usize,
-    max_tool_output_bytes: usize,
-    max_file_read_bytes: usize,
-    max_file_write_bytes: usize,
-    allow_command_newlines: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct ProfileAuthDefaults {
-    #[serde(default = "default_provider_auth_method")]
-    openai: ProviderAuthMethod,
-    #[serde(default = "default_provider_auth_method")]
-    anthropic: ProviderAuthMethod,
-    #[serde(default = "default_provider_auth_method")]
-    google: ProviderAuthMethod,
-}
-
-impl Default for ProfileAuthDefaults {
-    fn default() -> Self {
-        Self {
-            openai: default_provider_auth_method(),
-            anthropic: default_provider_auth_method(),
-            google: default_provider_auth_method(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct ProfileDefaults {
-    model: String,
-    fallback_models: Vec<String>,
-    session: ProfileSessionDefaults,
-    policy: ProfilePolicyDefaults,
-    #[serde(default)]
-    auth: ProfileAuthDefaults,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct RenderOptions {
-    stream_output: bool,
-    stream_delay_ms: u64,
-}
-
-impl RenderOptions {
-    fn from_cli(cli: &Cli) -> Self {
-        Self {
-            stream_output: cli.stream_output,
-            stream_delay_ms: cli.stream_delay_ms,
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-struct CommandExecutionContext<'a> {
-    tool_policy_json: &'a serde_json::Value,
-    session_import_mode: SessionImportMode,
-    profile_defaults: &'a ProfileDefaults,
-    skills_command_config: &'a SkillsSyncCommandConfig,
-    auth_command_config: &'a AuthCommandConfig,
-}
-
-#[derive(Debug, Clone)]
-struct AuthCommandConfig {
-    credential_store: PathBuf,
-    credential_store_key: Option<String>,
-    credential_store_encryption: CredentialStoreEncryptionMode,
-    api_key: Option<String>,
-    openai_api_key: Option<String>,
-    anthropic_api_key: Option<String>,
-    google_api_key: Option<String>,
-    openai_auth_mode: ProviderAuthMethod,
-    anthropic_auth_mode: ProviderAuthMethod,
-    google_auth_mode: ProviderAuthMethod,
 }
 
 #[tokio::main]

--- a/crates/pi-coding-agent/src/runtime_types.rs
+++ b/crates/pi-coding-agent/src/runtime_types.rs
@@ -1,0 +1,132 @@
+use std::path::PathBuf;
+
+use pi_ai::Provider;
+use serde::{Deserialize, Serialize};
+
+use crate::session::{SessionImportMode, SessionStore};
+use crate::{default_provider_auth_method, Cli, CredentialStoreEncryptionMode, ProviderAuthMethod};
+
+#[derive(Debug)]
+pub(crate) struct SessionRuntime {
+    pub(crate) store: SessionStore,
+    pub(crate) active_head: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SkillsSyncCommandConfig {
+    pub(crate) skills_dir: PathBuf,
+    pub(crate) default_lock_path: PathBuf,
+    pub(crate) default_trust_root_path: Option<PathBuf>,
+    pub(crate) doctor_config: DoctorCommandConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorProviderKeyStatus {
+    pub(crate) provider_kind: Provider,
+    pub(crate) provider: String,
+    pub(crate) key_env_var: String,
+    pub(crate) present: bool,
+    pub(crate) auth_mode: ProviderAuthMethod,
+    pub(crate) mode_supported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorCommandConfig {
+    pub(crate) model: String,
+    pub(crate) provider_keys: Vec<DoctorProviderKeyStatus>,
+    pub(crate) session_enabled: bool,
+    pub(crate) session_path: PathBuf,
+    pub(crate) skills_dir: PathBuf,
+    pub(crate) skills_lock_path: PathBuf,
+    pub(crate) trust_root_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ProfileSessionDefaults {
+    pub(crate) enabled: bool,
+    pub(crate) path: Option<String>,
+    pub(crate) import_mode: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ProfilePolicyDefaults {
+    pub(crate) tool_policy_preset: String,
+    pub(crate) bash_profile: String,
+    pub(crate) bash_dry_run: bool,
+    pub(crate) os_sandbox_mode: String,
+    pub(crate) enforce_regular_files: bool,
+    pub(crate) bash_timeout_ms: u64,
+    pub(crate) max_command_length: usize,
+    pub(crate) max_tool_output_bytes: usize,
+    pub(crate) max_file_read_bytes: usize,
+    pub(crate) max_file_write_bytes: usize,
+    pub(crate) allow_command_newlines: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ProfileAuthDefaults {
+    #[serde(default = "default_provider_auth_method")]
+    pub(crate) openai: ProviderAuthMethod,
+    #[serde(default = "default_provider_auth_method")]
+    pub(crate) anthropic: ProviderAuthMethod,
+    #[serde(default = "default_provider_auth_method")]
+    pub(crate) google: ProviderAuthMethod,
+}
+
+impl Default for ProfileAuthDefaults {
+    fn default() -> Self {
+        Self {
+            openai: default_provider_auth_method(),
+            anthropic: default_provider_auth_method(),
+            google: default_provider_auth_method(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ProfileDefaults {
+    pub(crate) model: String,
+    pub(crate) fallback_models: Vec<String>,
+    pub(crate) session: ProfileSessionDefaults,
+    pub(crate) policy: ProfilePolicyDefaults,
+    #[serde(default)]
+    pub(crate) auth: ProfileAuthDefaults,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RenderOptions {
+    pub(crate) stream_output: bool,
+    pub(crate) stream_delay_ms: u64,
+}
+
+impl RenderOptions {
+    pub(crate) fn from_cli(cli: &Cli) -> Self {
+        Self {
+            stream_output: cli.stream_output,
+            stream_delay_ms: cli.stream_delay_ms,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct CommandExecutionContext<'a> {
+    pub(crate) tool_policy_json: &'a serde_json::Value,
+    pub(crate) session_import_mode: SessionImportMode,
+    pub(crate) profile_defaults: &'a ProfileDefaults,
+    pub(crate) skills_command_config: &'a SkillsSyncCommandConfig,
+    pub(crate) auth_command_config: &'a AuthCommandConfig,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuthCommandConfig {
+    pub(crate) credential_store: PathBuf,
+    pub(crate) credential_store_key: Option<String>,
+    pub(crate) credential_store_encryption: CredentialStoreEncryptionMode,
+    pub(crate) api_key: Option<String>,
+    pub(crate) openai_api_key: Option<String>,
+    pub(crate) anthropic_api_key: Option<String>,
+    pub(crate) google_api_key: Option<String>,
+    pub(crate) openai_auth_mode: ProviderAuthMethod,
+    pub(crate) anthropic_auth_mode: ProviderAuthMethod,
+    pub(crate) google_auth_mode: ProviderAuthMethod,
+}


### PR DESCRIPTION
## Summary
- move shared runtime/config structs out of `main.rs` into `runtime_types` module
- extract session/runtime, doctor/profile defaults, render options, command context, and auth command config types
- re-export extracted types from crate root to preserve existing module and test call sites

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #220
