### PR TITLE
refactor(agent): extract startup preflight module (#226)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -31,6 +31,7 @@ mod skills_commands;
 mod slack;
 mod startup_config;
 mod startup_dispatch;
+mod startup_preflight;
 mod startup_resolution;
 mod time_utils;
 mod tool_policy_config;
@@ -225,6 +226,7 @@ pub(crate) use crate::startup_config::{
     build_auth_command_config, build_profile_defaults, default_provider_auth_method,
 };
 use crate::startup_dispatch::run_cli;
+pub(crate) use crate::startup_preflight::execute_startup_preflight;
 pub(crate) use crate::startup_resolution::{
     ensure_non_empty_text, resolve_skill_trust_roots, resolve_system_prompt,
 };

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -1,44 +1,7 @@
 use super::*;
 
 pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
-    if cli.session_validate {
-        validate_session_file(&cli)?;
-        return Ok(());
-    }
-    if cli.channel_store_inspect.is_some() || cli.channel_store_repair.is_some() {
-        execute_channel_store_admin_command(&cli)?;
-        return Ok(());
-    }
-    if cli.event_webhook_ingest_file.is_some() {
-        validate_event_webhook_ingest_cli(&cli)?;
-        let payload_file = cli
-            .event_webhook_ingest_file
-            .clone()
-            .ok_or_else(|| anyhow!("--event-webhook-ingest-file is required"))?;
-        let channel_ref = cli
-            .event_webhook_channel
-            .clone()
-            .ok_or_else(|| anyhow!("--event-webhook-channel is required"))?;
-        let event_webhook_secret = resolve_secret_from_cli_or_store_id(
-            &cli,
-            cli.event_webhook_secret.as_deref(),
-            cli.event_webhook_secret_id.as_deref(),
-            "--event-webhook-secret-id",
-        )?;
-        ingest_webhook_immediate_event(&EventWebhookIngestConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            channel_ref,
-            payload_file,
-            prompt_prefix: cli.event_webhook_prompt_prefix.clone(),
-            debounce_key: cli.event_webhook_debounce_key.clone(),
-            debounce_window_seconds: cli.event_webhook_debounce_window_seconds,
-            signature: cli.event_webhook_signature.clone(),
-            timestamp: cli.event_webhook_timestamp.clone(),
-            secret: event_webhook_secret,
-            signature_algorithm: cli.event_webhook_signature_algorithm.map(Into::into),
-            signature_max_skew_seconds: cli.event_webhook_signature_max_skew_seconds,
-        })?;
+    if execute_startup_preflight(&cli)? {
         return Ok(());
     }
 

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
+    if cli.session_validate {
+        validate_session_file(cli)?;
+        return Ok(true);
+    }
+
+    if cli.channel_store_inspect.is_some() || cli.channel_store_repair.is_some() {
+        execute_channel_store_admin_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.event_webhook_ingest_file.is_some() {
+        validate_event_webhook_ingest_cli(cli)?;
+        let payload_file = cli
+            .event_webhook_ingest_file
+            .clone()
+            .ok_or_else(|| anyhow!("--event-webhook-ingest-file is required"))?;
+        let channel_ref = cli
+            .event_webhook_channel
+            .clone()
+            .ok_or_else(|| anyhow!("--event-webhook-channel is required"))?;
+        let event_webhook_secret = resolve_secret_from_cli_or_store_id(
+            cli,
+            cli.event_webhook_secret.as_deref(),
+            cli.event_webhook_secret_id.as_deref(),
+            "--event-webhook-secret-id",
+        )?;
+        ingest_webhook_immediate_event(&EventWebhookIngestConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            channel_ref,
+            payload_file,
+            prompt_prefix: cli.event_webhook_prompt_prefix.clone(),
+            debounce_key: cli.event_webhook_debounce_key.clone(),
+            debounce_window_seconds: cli.event_webhook_debounce_window_seconds,
+            signature: cli.event_webhook_signature.clone(),
+            timestamp: cli.event_webhook_timestamp.clone(),
+            secret: event_webhook_secret,
+            signature_algorithm: cli.event_webhook_signature_algorithm.map(Into::into),
+            signature_max_skew_seconds: cli.event_webhook_signature_max_skew_seconds,
+        })?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
## Summary
- add `startup_preflight` module with `execute_startup_preflight(cli)`
- move startup-only preflight paths out of `startup_dispatch::run_cli`:
  - `--session-validate`
  - channel store inspect/repair flags
  - webhook ingest mode
- keep startup dispatch focused on runtime orchestration and preserve existing behavior

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #226
