### PR TITLE
refactor(agent): extract transport mode dispatch module (#228)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -33,6 +33,7 @@ mod startup_config;
 mod startup_dispatch;
 mod startup_preflight;
 mod startup_resolution;
+mod startup_transport_modes;
 mod time_utils;
 mod tool_policy_config;
 mod tools;
@@ -230,6 +231,7 @@ pub(crate) use crate::startup_preflight::execute_startup_preflight;
 pub(crate) use crate::startup_resolution::{
     ensure_non_empty_text, resolve_skill_trust_roots, resolve_system_prompt,
 };
+pub(crate) use crate::startup_transport_modes::run_transport_mode_if_requested;
 pub(crate) use crate::time_utils::{
     current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix,
 };

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -112,113 +112,17 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
         println!("{tool_policy_json}");
     }
     let render_options = RenderOptions::from_cli(&cli);
-    validate_github_issues_bridge_cli(&cli)?;
-    validate_slack_bridge_cli(&cli)?;
-    validate_events_runner_cli(&cli)?;
-    if cli.github_issues_bridge {
-        let repo_slug = cli.github_repo.clone().ok_or_else(|| {
-            anyhow!("--github-repo is required when --github-issues-bridge is set")
-        })?;
-        let token = resolve_secret_from_cli_or_store_id(
-            &cli,
-            cli.github_token.as_deref(),
-            cli.github_token_id.as_deref(),
-            "--github-token-id",
-        )?
-        .ok_or_else(|| {
-            anyhow!(
-                "--github-token (or --github-token-id) is required when --github-issues-bridge is set"
-            )
-        })?;
-        return run_github_issues_bridge(GithubIssuesBridgeRuntimeConfig {
-            client: client.clone(),
-            model: model_ref.model.clone(),
-            system_prompt: system_prompt.clone(),
-            max_turns: cli.max_turns,
-            tool_policy: tool_policy.clone(),
-            turn_timeout_ms: cli.turn_timeout_ms,
-            request_timeout_ms: cli.request_timeout_ms,
-            render_options,
-            session_lock_wait_ms: cli.session_lock_wait_ms,
-            session_lock_stale_ms: cli.session_lock_stale_ms,
-            state_dir: cli.github_state_dir.clone(),
-            repo_slug,
-            api_base: cli.github_api_base.clone(),
-            token,
-            bot_login: cli.github_bot_login.clone(),
-            poll_interval: Duration::from_secs(cli.github_poll_interval_seconds.max(1)),
-            include_issue_body: cli.github_include_issue_body,
-            include_edited_comments: cli.github_include_edited_comments,
-            processed_event_cap: cli.github_processed_event_cap.max(1),
-            retry_max_attempts: cli.github_retry_max_attempts.max(1),
-            retry_base_delay_ms: cli.github_retry_base_delay_ms.max(1),
-        })
-        .await;
-    }
-    if cli.slack_bridge {
-        let app_token = resolve_secret_from_cli_or_store_id(
-            &cli,
-            cli.slack_app_token.as_deref(),
-            cli.slack_app_token_id.as_deref(),
-            "--slack-app-token-id",
-        )?
-        .ok_or_else(|| {
-            anyhow!("--slack-app-token (or --slack-app-token-id) is required when --slack-bridge is set")
-        })?;
-        let bot_token = resolve_secret_from_cli_or_store_id(
-            &cli,
-            cli.slack_bot_token.as_deref(),
-            cli.slack_bot_token_id.as_deref(),
-            "--slack-bot-token-id",
-        )?
-        .ok_or_else(|| {
-            anyhow!("--slack-bot-token (or --slack-bot-token-id) is required when --slack-bridge is set")
-        })?;
-        return run_slack_bridge(SlackBridgeRuntimeConfig {
-            client: client.clone(),
-            model: model_ref.model.clone(),
-            system_prompt: system_prompt.clone(),
-            max_turns: cli.max_turns,
-            tool_policy: tool_policy.clone(),
-            turn_timeout_ms: cli.turn_timeout_ms,
-            request_timeout_ms: cli.request_timeout_ms,
-            render_options,
-            session_lock_wait_ms: cli.session_lock_wait_ms,
-            session_lock_stale_ms: cli.session_lock_stale_ms,
-            state_dir: cli.slack_state_dir.clone(),
-            api_base: cli.slack_api_base.clone(),
-            app_token,
-            bot_token,
-            bot_user_id: cli.slack_bot_user_id.clone(),
-            detail_thread_output: cli.slack_thread_detail_output,
-            detail_thread_threshold_chars: cli.slack_thread_detail_threshold_chars.max(1),
-            processed_event_cap: cli.slack_processed_event_cap.max(1),
-            max_event_age_seconds: cli.slack_max_event_age_seconds,
-            reconnect_delay: Duration::from_millis(cli.slack_reconnect_delay_ms.max(1)),
-            retry_max_attempts: cli.slack_retry_max_attempts.max(1),
-            retry_base_delay_ms: cli.slack_retry_base_delay_ms.max(1),
-        })
-        .await;
-    }
-    if cli.events_runner {
-        return run_event_scheduler(EventSchedulerConfig {
-            client: client.clone(),
-            model: model_ref.model.clone(),
-            system_prompt: system_prompt.clone(),
-            max_turns: cli.max_turns,
-            tool_policy: tool_policy.clone(),
-            turn_timeout_ms: cli.turn_timeout_ms,
-            render_options,
-            session_lock_wait_ms: cli.session_lock_wait_ms,
-            session_lock_stale_ms: cli.session_lock_stale_ms,
-            channel_store_root: cli.channel_store_root.clone(),
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            poll_interval: Duration::from_millis(cli.events_poll_interval_ms.max(1)),
-            queue_limit: cli.events_queue_limit.max(1),
-            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
-        })
-        .await;
+    if run_transport_mode_if_requested(
+        &cli,
+        &client,
+        &model_ref,
+        &system_prompt,
+        &tool_policy,
+        render_options,
+    )
+    .await?
+    {
+        return Ok(());
     }
 
     let mut agent = Agent::new(

--- a/crates/pi-coding-agent/src/startup_transport_modes.rs
+++ b/crates/pi-coding-agent/src/startup_transport_modes.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+pub(crate) async fn run_transport_mode_if_requested(
+    cli: &Cli,
+    client: &Arc<dyn LlmClient>,
+    model_ref: &ModelRef,
+    system_prompt: &str,
+    tool_policy: &ToolPolicy,
+    render_options: RenderOptions,
+) -> Result<bool> {
+    validate_github_issues_bridge_cli(cli)?;
+    validate_slack_bridge_cli(cli)?;
+    validate_events_runner_cli(cli)?;
+
+    if cli.github_issues_bridge {
+        let repo_slug = cli.github_repo.clone().ok_or_else(|| {
+            anyhow!("--github-repo is required when --github-issues-bridge is set")
+        })?;
+        let token = resolve_secret_from_cli_or_store_id(
+            cli,
+            cli.github_token.as_deref(),
+            cli.github_token_id.as_deref(),
+            "--github-token-id",
+        )?
+        .ok_or_else(|| {
+            anyhow!(
+                "--github-token (or --github-token-id) is required when --github-issues-bridge is set"
+            )
+        })?;
+        run_github_issues_bridge(GithubIssuesBridgeRuntimeConfig {
+            client: client.clone(),
+            model: model_ref.model.clone(),
+            system_prompt: system_prompt.to_string(),
+            max_turns: cli.max_turns,
+            tool_policy: tool_policy.clone(),
+            turn_timeout_ms: cli.turn_timeout_ms,
+            request_timeout_ms: cli.request_timeout_ms,
+            render_options,
+            session_lock_wait_ms: cli.session_lock_wait_ms,
+            session_lock_stale_ms: cli.session_lock_stale_ms,
+            state_dir: cli.github_state_dir.clone(),
+            repo_slug,
+            api_base: cli.github_api_base.clone(),
+            token,
+            bot_login: cli.github_bot_login.clone(),
+            poll_interval: Duration::from_secs(cli.github_poll_interval_seconds.max(1)),
+            include_issue_body: cli.github_include_issue_body,
+            include_edited_comments: cli.github_include_edited_comments,
+            processed_event_cap: cli.github_processed_event_cap.max(1),
+            retry_max_attempts: cli.github_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.github_retry_base_delay_ms.max(1),
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.slack_bridge {
+        let app_token = resolve_secret_from_cli_or_store_id(
+            cli,
+            cli.slack_app_token.as_deref(),
+            cli.slack_app_token_id.as_deref(),
+            "--slack-app-token-id",
+        )?
+        .ok_or_else(|| {
+            anyhow!(
+                "--slack-app-token (or --slack-app-token-id) is required when --slack-bridge is set"
+            )
+        })?;
+        let bot_token = resolve_secret_from_cli_or_store_id(
+            cli,
+            cli.slack_bot_token.as_deref(),
+            cli.slack_bot_token_id.as_deref(),
+            "--slack-bot-token-id",
+        )?
+        .ok_or_else(|| {
+            anyhow!(
+                "--slack-bot-token (or --slack-bot-token-id) is required when --slack-bridge is set"
+            )
+        })?;
+        run_slack_bridge(SlackBridgeRuntimeConfig {
+            client: client.clone(),
+            model: model_ref.model.clone(),
+            system_prompt: system_prompt.to_string(),
+            max_turns: cli.max_turns,
+            tool_policy: tool_policy.clone(),
+            turn_timeout_ms: cli.turn_timeout_ms,
+            request_timeout_ms: cli.request_timeout_ms,
+            render_options,
+            session_lock_wait_ms: cli.session_lock_wait_ms,
+            session_lock_stale_ms: cli.session_lock_stale_ms,
+            state_dir: cli.slack_state_dir.clone(),
+            api_base: cli.slack_api_base.clone(),
+            app_token,
+            bot_token,
+            bot_user_id: cli.slack_bot_user_id.clone(),
+            detail_thread_output: cli.slack_thread_detail_output,
+            detail_thread_threshold_chars: cli.slack_thread_detail_threshold_chars.max(1),
+            processed_event_cap: cli.slack_processed_event_cap.max(1),
+            max_event_age_seconds: cli.slack_max_event_age_seconds,
+            reconnect_delay: Duration::from_millis(cli.slack_reconnect_delay_ms.max(1)),
+            retry_max_attempts: cli.slack_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.slack_retry_base_delay_ms.max(1),
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.events_runner {
+        run_event_scheduler(EventSchedulerConfig {
+            client: client.clone(),
+            model: model_ref.model.clone(),
+            system_prompt: system_prompt.to_string(),
+            max_turns: cli.max_turns,
+            tool_policy: tool_policy.clone(),
+            turn_timeout_ms: cli.turn_timeout_ms,
+            render_options,
+            session_lock_wait_ms: cli.session_lock_wait_ms,
+            session_lock_stale_ms: cli.session_lock_stale_ms,
+            channel_store_root: cli.channel_store_root.clone(),
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            poll_interval: Duration::from_millis(cli.events_poll_interval_ms.max(1)),
+            queue_limit: cli.events_queue_limit.max(1),
+            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
## Summary
- add `startup_transport_modes` module with `run_transport_mode_if_requested(...)`
- move transport runtime mode validation and dispatch out of `startup_dispatch`:
  - GitHub issues bridge
  - Slack bridge
  - events scheduler
- keep `startup_dispatch::run_cli` focused on high-level orchestration with early-return when a transport mode is executed

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #228
