### PR TITLE
refactor(agent): extract local runtime bootstrap module (#230)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -31,6 +31,7 @@ mod skills_commands;
 mod slack;
 mod startup_config;
 mod startup_dispatch;
+mod startup_local_runtime;
 mod startup_preflight;
 mod startup_resolution;
 mod startup_transport_modes;
@@ -227,6 +228,7 @@ pub(crate) use crate::startup_config::{
     build_auth_command_config, build_profile_defaults, default_provider_auth_method,
 };
 use crate::startup_dispatch::run_cli;
+pub(crate) use crate::startup_local_runtime::{run_local_runtime, LocalRuntimeConfig};
 pub(crate) use crate::startup_preflight::execute_startup_preflight;
 pub(crate) use crate::startup_resolution::{
     ensure_non_empty_text, resolve_skill_trust_roots, resolve_system_prompt,

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -125,93 +125,16 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    let mut agent = Agent::new(
-        client.clone(),
-        AgentConfig {
-            model: model_ref.model.clone(),
-            system_prompt: system_prompt.clone(),
-            max_turns: cli.max_turns,
-            temperature: Some(0.0),
-            max_tokens: None,
-        },
-    );
-    tools::register_builtin_tools(&mut agent, tool_policy);
-    if let Some(path) = cli.tool_audit_log.clone() {
-        let logger = ToolAuditLogger::open(path)?;
-        agent.subscribe(move |event| {
-            if let Err(error) = logger.log_event(event) {
-                eprintln!("tool audit logger error: {error}");
-            }
-        });
-    }
-    if let Some(path) = cli.telemetry_log.clone() {
-        let logger =
-            PromptTelemetryLogger::open(path, model_ref.provider.as_str(), &model_ref.model)?;
-        agent.subscribe(move |event| {
-            if let Err(error) = logger.log_event(event) {
-                eprintln!("telemetry logger error: {error}");
-            }
-        });
-    }
-    let mut session_runtime = if cli.no_session {
-        None
-    } else {
-        Some(initialize_session(&mut agent, &cli, &system_prompt)?)
-    };
-
-    if cli.json_events {
-        agent.subscribe(|event| {
-            let value = event_to_json(event);
-            println!("{value}");
-        });
-    }
-
-    if let Some(prompt) = resolve_prompt_input(&cli)? {
-        run_prompt(
-            &mut agent,
-            &mut session_runtime,
-            &prompt,
-            cli.turn_timeout_ms,
-            render_options,
-        )
-        .await?;
-        return Ok(());
-    }
-
-    let skills_sync_command_config = SkillsSyncCommandConfig {
-        skills_dir: cli.skills_dir.clone(),
-        default_lock_path: skills_lock_path.clone(),
-        default_trust_root_path: cli.skill_trust_root_file.clone(),
-        doctor_config: build_doctor_command_config(
-            &cli,
-            &model_ref,
-            &fallback_model_refs,
-            &skills_lock_path,
-        ),
-    };
-    let profile_defaults = build_profile_defaults(&cli);
-    let auth_command_config = build_auth_command_config(&cli);
-    let command_context = CommandExecutionContext {
+    run_local_runtime(LocalRuntimeConfig {
+        cli: &cli,
+        client,
+        model_ref: &model_ref,
+        fallback_model_refs: &fallback_model_refs,
+        system_prompt: &system_prompt,
+        tool_policy,
         tool_policy_json: &tool_policy_json,
-        session_import_mode: cli.session_import_mode.into(),
-        profile_defaults: &profile_defaults,
-        skills_command_config: &skills_sync_command_config,
-        auth_command_config: &auth_command_config,
-    };
-    let interactive_config = InteractiveRuntimeConfig {
-        turn_timeout_ms: cli.turn_timeout_ms,
         render_options,
-        command_context,
-    };
-    if let Some(command_file_path) = cli.command_file.as_deref() {
-        execute_command_file(
-            command_file_path,
-            cli.command_file_error_mode,
-            &mut agent,
-            &mut session_runtime,
-            command_context,
-        )?;
-        return Ok(());
-    }
-    run_interactive(agent, session_runtime, interactive_config).await
+        skills_lock_path: &skills_lock_path,
+    })
+    .await
 }

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+pub(crate) struct LocalRuntimeConfig<'a> {
+    pub(crate) cli: &'a Cli,
+    pub(crate) client: Arc<dyn LlmClient>,
+    pub(crate) model_ref: &'a ModelRef,
+    pub(crate) fallback_model_refs: &'a [ModelRef],
+    pub(crate) system_prompt: &'a str,
+    pub(crate) tool_policy: ToolPolicy,
+    pub(crate) tool_policy_json: &'a Value,
+    pub(crate) render_options: RenderOptions,
+    pub(crate) skills_lock_path: &'a Path,
+}
+
+pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<()> {
+    let LocalRuntimeConfig {
+        cli,
+        client,
+        model_ref,
+        fallback_model_refs,
+        system_prompt,
+        tool_policy,
+        tool_policy_json,
+        render_options,
+        skills_lock_path,
+    } = config;
+
+    let mut agent = Agent::new(
+        client,
+        AgentConfig {
+            model: model_ref.model.clone(),
+            system_prompt: system_prompt.to_string(),
+            max_turns: cli.max_turns,
+            temperature: Some(0.0),
+            max_tokens: None,
+        },
+    );
+    tools::register_builtin_tools(&mut agent, tool_policy);
+    if let Some(path) = cli.tool_audit_log.clone() {
+        let logger = ToolAuditLogger::open(path)?;
+        agent.subscribe(move |event| {
+            if let Err(error) = logger.log_event(event) {
+                eprintln!("tool audit logger error: {error}");
+            }
+        });
+    }
+    if let Some(path) = cli.telemetry_log.clone() {
+        let logger =
+            PromptTelemetryLogger::open(path, model_ref.provider.as_str(), &model_ref.model)?;
+        agent.subscribe(move |event| {
+            if let Err(error) = logger.log_event(event) {
+                eprintln!("telemetry logger error: {error}");
+            }
+        });
+    }
+    let mut session_runtime = if cli.no_session {
+        None
+    } else {
+        Some(initialize_session(&mut agent, cli, system_prompt)?)
+    };
+
+    if cli.json_events {
+        agent.subscribe(|event| {
+            let value = event_to_json(event);
+            println!("{value}");
+        });
+    }
+
+    if let Some(prompt) = resolve_prompt_input(cli)? {
+        run_prompt(
+            &mut agent,
+            &mut session_runtime,
+            &prompt,
+            cli.turn_timeout_ms,
+            render_options,
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let skills_sync_command_config = SkillsSyncCommandConfig {
+        skills_dir: cli.skills_dir.clone(),
+        default_lock_path: skills_lock_path.to_path_buf(),
+        default_trust_root_path: cli.skill_trust_root_file.clone(),
+        doctor_config: build_doctor_command_config(
+            cli,
+            model_ref,
+            fallback_model_refs,
+            skills_lock_path,
+        ),
+    };
+    let profile_defaults = build_profile_defaults(cli);
+    let auth_command_config = build_auth_command_config(cli);
+    let command_context = CommandExecutionContext {
+        tool_policy_json,
+        session_import_mode: cli.session_import_mode.into(),
+        profile_defaults: &profile_defaults,
+        skills_command_config: &skills_sync_command_config,
+        auth_command_config: &auth_command_config,
+    };
+    let interactive_config = InteractiveRuntimeConfig {
+        turn_timeout_ms: cli.turn_timeout_ms,
+        render_options,
+        command_context,
+    };
+    if let Some(command_file_path) = cli.command_file.as_deref() {
+        execute_command_file(
+            command_file_path,
+            cli.command_file_error_mode,
+            &mut agent,
+            &mut session_runtime,
+            command_context,
+        )?;
+        return Ok(());
+    }
+    run_interactive(agent, session_runtime, interactive_config).await
+}


### PR DESCRIPTION
## Summary
- add `startup_local_runtime` module with `run_local_runtime(LocalRuntimeConfig)`
- extract local runtime bootstrap/loop wiring out of `startup_dispatch`:
  - agent creation + tool registration
  - telemetry/audit subscriptions
  - session runtime init
  - prompt mode handling
  - command-file and interactive loop dispatch
- keep `startup_dispatch` focused on high-level startup orchestration

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #230
