### PR TITLE
refactor(agent): extract startup prompt composition module (#234)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -33,6 +33,7 @@ mod startup_config;
 mod startup_dispatch;
 mod startup_local_runtime;
 mod startup_preflight;
+mod startup_prompt_composition;
 mod startup_resolution;
 mod startup_skills_bootstrap;
 mod startup_transport_modes;
@@ -231,6 +232,7 @@ pub(crate) use crate::startup_config::{
 use crate::startup_dispatch::run_cli;
 pub(crate) use crate::startup_local_runtime::{run_local_runtime, LocalRuntimeConfig};
 pub(crate) use crate::startup_preflight::execute_startup_preflight;
+pub(crate) use crate::startup_prompt_composition::compose_startup_system_prompt;
 pub(crate) use crate::startup_resolution::{
     ensure_non_empty_text, resolve_skill_trust_roots, resolve_system_prompt,
 };

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -16,11 +16,7 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
     let client = build_client_with_fallbacks(&cli, &model_ref, &fallback_model_refs)?;
     let skills_bootstrap = run_startup_skills_bootstrap(&cli).await?;
     let skills_lock_path = skills_bootstrap.skills_lock_path;
-    let base_system_prompt = resolve_system_prompt(&cli)?;
-    let catalog = load_catalog(&cli.skills_dir)
-        .with_context(|| format!("failed to load skills from {}", cli.skills_dir.display()))?;
-    let selected_skills = resolve_selected_skills(&catalog, &cli.skills)?;
-    let system_prompt = augment_system_prompt(&base_system_prompt, &selected_skills);
+    let system_prompt = compose_startup_system_prompt(&cli)?;
 
     let tool_policy = build_tool_policy(&cli)?;
     let tool_policy_json = tool_policy_to_json(&tool_policy);

--- a/crates/pi-coding-agent/src/startup_prompt_composition.rs
+++ b/crates/pi-coding-agent/src/startup_prompt_composition.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub(crate) fn compose_startup_system_prompt(cli: &Cli) -> Result<String> {
+    let base_system_prompt = resolve_system_prompt(cli)?;
+    let catalog = load_catalog(&cli.skills_dir)
+        .with_context(|| format!("failed to load skills from {}", cli.skills_dir.display()))?;
+    let selected_skills = resolve_selected_skills(&catalog, &cli.skills)?;
+    Ok(augment_system_prompt(&base_system_prompt, &selected_skills))
+}


### PR DESCRIPTION
## Summary
- add `startup_prompt_composition` module with `compose_startup_system_prompt(cli)`
- move startup prompt composition logic out of `startup_dispatch`:
  - resolve base system prompt
  - load skills catalog
  - resolve selected skills
  - augment final system prompt
- keep behavior and errors unchanged while making dispatch thinner

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #234
