### PR TITLE
refactor(agent): extract startup model resolution module (#236)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -32,6 +32,7 @@ mod slack;
 mod startup_config;
 mod startup_dispatch;
 mod startup_local_runtime;
+mod startup_model_resolution;
 mod startup_preflight;
 mod startup_prompt_composition;
 mod startup_resolution;
@@ -231,6 +232,7 @@ pub(crate) use crate::startup_config::{
 };
 use crate::startup_dispatch::run_cli;
 pub(crate) use crate::startup_local_runtime::{run_local_runtime, LocalRuntimeConfig};
+pub(crate) use crate::startup_model_resolution::{resolve_startup_models, StartupModelResolution};
 pub(crate) use crate::startup_preflight::execute_startup_preflight;
 pub(crate) use crate::startup_prompt_composition::compose_startup_system_prompt;
 pub(crate) use crate::startup_resolution::{

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -5,13 +5,10 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    if cli.no_session && cli.branch_from.is_some() {
-        bail!("--branch-from cannot be used together with --no-session");
-    }
-
-    let model_ref = ModelRef::parse(&cli.model)
-        .map_err(|error| anyhow!("failed to parse --model '{}': {error}", cli.model))?;
-    let fallback_model_refs = resolve_fallback_models(&cli, &model_ref)?;
+    let StartupModelResolution {
+        model_ref,
+        fallback_model_refs,
+    } = resolve_startup_models(&cli)?;
 
     let client = build_client_with_fallbacks(&cli, &model_ref, &fallback_model_refs)?;
     let skills_bootstrap = run_startup_skills_bootstrap(&cli).await?;

--- a/crates/pi-coding-agent/src/startup_model_resolution.rs
+++ b/crates/pi-coding-agent/src/startup_model_resolution.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+pub(crate) struct StartupModelResolution {
+    pub(crate) model_ref: ModelRef,
+    pub(crate) fallback_model_refs: Vec<ModelRef>,
+}
+
+pub(crate) fn resolve_startup_models(cli: &Cli) -> Result<StartupModelResolution> {
+    if cli.no_session && cli.branch_from.is_some() {
+        bail!("--branch-from cannot be used together with --no-session");
+    }
+
+    let model_ref = ModelRef::parse(&cli.model)
+        .map_err(|error| anyhow!("failed to parse --model '{}': {error}", cli.model))?;
+    let fallback_model_refs = resolve_fallback_models(cli, &model_ref)?;
+
+    Ok(StartupModelResolution {
+        model_ref,
+        fallback_model_refs,
+    })
+}


### PR DESCRIPTION
## Summary
- add `startup_model_resolution` module with `resolve_startup_models(cli)`
- extract startup model concerns from `startup_dispatch`:
  - `--no-session` and `--branch-from` compatibility guard
  - primary model parsing
  - fallback model resolution
- keep startup dispatch focused on orchestration and preserve existing behavior

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #236
