### PR TITLE
refactor(agent): extract startup policy assembly module (#238)

### DIFF
--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -33,6 +33,7 @@ mod startup_config;
 mod startup_dispatch;
 mod startup_local_runtime;
 mod startup_model_resolution;
+mod startup_policy;
 mod startup_preflight;
 mod startup_prompt_composition;
 mod startup_resolution;
@@ -233,6 +234,7 @@ pub(crate) use crate::startup_config::{
 use crate::startup_dispatch::run_cli;
 pub(crate) use crate::startup_local_runtime::{run_local_runtime, LocalRuntimeConfig};
 pub(crate) use crate::startup_model_resolution::{resolve_startup_models, StartupModelResolution};
+pub(crate) use crate::startup_policy::{resolve_startup_policy, StartupPolicyBundle};
 pub(crate) use crate::startup_preflight::execute_startup_preflight;
 pub(crate) use crate::startup_prompt_composition::compose_startup_system_prompt;
 pub(crate) use crate::startup_resolution::{

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -14,12 +14,10 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
     let skills_bootstrap = run_startup_skills_bootstrap(&cli).await?;
     let skills_lock_path = skills_bootstrap.skills_lock_path;
     let system_prompt = compose_startup_system_prompt(&cli)?;
-
-    let tool_policy = build_tool_policy(&cli)?;
-    let tool_policy_json = tool_policy_to_json(&tool_policy);
-    if cli.print_tool_policy {
-        println!("{tool_policy_json}");
-    }
+    let StartupPolicyBundle {
+        tool_policy,
+        tool_policy_json,
+    } = resolve_startup_policy(&cli)?;
     let render_options = RenderOptions::from_cli(&cli);
     if run_transport_mode_if_requested(
         &cli,

--- a/crates/pi-coding-agent/src/startup_policy.rs
+++ b/crates/pi-coding-agent/src/startup_policy.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+pub(crate) struct StartupPolicyBundle {
+    pub(crate) tool_policy: ToolPolicy,
+    pub(crate) tool_policy_json: Value,
+}
+
+pub(crate) fn resolve_startup_policy(cli: &Cli) -> Result<StartupPolicyBundle> {
+    let tool_policy = build_tool_policy(cli)?;
+    let tool_policy_json = tool_policy_to_json(&tool_policy);
+    if cli.print_tool_policy {
+        println!("{tool_policy_json}");
+    }
+    Ok(StartupPolicyBundle {
+        tool_policy,
+        tool_policy_json,
+    })
+}


### PR DESCRIPTION
## Summary
- add `startup_policy` module with `resolve_startup_policy(cli)` and `StartupPolicyBundle`
- extract startup policy setup from `startup_dispatch`:
  - effective policy assembly
  - policy JSON render
  - optional `--print-tool-policy` output
- keep startup behavior unchanged while reducing dispatch responsibilities

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #238
