### PR TITLE
docs(agent): add contributor code map and README pointer (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Implemented now:
 - Unit tests for serialization, tool loop, renderer diffing, and tool behaviors
 - Provider auth/login feasibility matrix and implementation gates (`docs/provider-auth/provider-auth-capability-matrix.md`)
 
+## Contributor Map
+
+- `pi-coding-agent` architecture and module guide: `docs/pi-coding-agent/code-map.md`
+
 ## Build & Test
 
 ```bash

--- a/docs/pi-coding-agent/code-map.md
+++ b/docs/pi-coding-agent/code-map.md
@@ -1,0 +1,156 @@
+# `pi-coding-agent` Contributor Code Map
+
+This guide maps the `pi-coding-agent` source tree to responsibility areas so contributors can land changes quickly and safely.
+
+## Entrypoint and Startup Pipeline
+
+- Entrypoint: `crates/pi-coding-agent/src/main.rs`
+- Startup orchestrator: `crates/pi-coding-agent/src/startup_dispatch.rs` (`run_cli`)
+
+`run_cli` executes startup in this order:
+
+1. `startup_preflight::execute_startup_preflight`
+2. `startup_model_resolution::resolve_startup_models`
+3. `provider_fallback::build_client_with_fallbacks`
+4. `startup_skills_bootstrap::run_startup_skills_bootstrap`
+5. `startup_prompt_composition::compose_startup_system_prompt`
+6. `startup_policy::resolve_startup_policy`
+7. `startup_transport_modes::run_transport_mode_if_requested`
+8. `startup_local_runtime::run_local_runtime`
+
+If a preflight or transport mode completes, runtime startup exits early.
+
+## Module Map by Concern
+
+### CLI surface and parsing
+
+- `cli_args.rs`: all CLI flags and clap definitions.
+- `cli_types.rs`: clap-facing enums and value types.
+- `runtime_types.rs`: shared runtime/config structs used across modules.
+
+Use this area when adding or changing flags, defaults, and typed CLI input behavior.
+
+### Command system
+
+- `commands.rs`: slash-command parsing/dispatch and command-file execution.
+- `session_commands.rs`: session stats, diff, search command behaviors.
+- `session_graph_commands.rs`: session graph export formats.
+- `session_navigation_commands.rs`: bookmarks and branch aliases.
+- `skills_commands.rs`: skills lifecycle commands.
+- `auth_commands.rs`: provider auth command handling.
+- `diagnostics_commands.rs`: doctor/audit/policy diagnostics commands.
+- `macro_profile_commands.rs`: macro/profile command workflows.
+
+Use this area when command UX, parser behavior, or command output changes.
+
+### Runtime and output
+
+- `runtime_loop.rs`: interactive loop, one-shot prompt execution, cancellation.
+- `runtime_output.rs`: rendering helpers, JSON event conversion, persistence helpers.
+- `startup_local_runtime.rs`: runtime assembly and handoff from startup.
+
+Use this area for prompt-loop behavior, output formatting, and turn execution changes.
+
+### Provider/auth and model routing
+
+- `provider_client.rs`: provider client construction.
+- `provider_fallback.rs`: model fallback routing and retry-aware client composition.
+- `provider_auth.rs`: auth mode resolution and API key candidate logic.
+- `provider_credentials.rs`: CLI/store-backed provider credential resolution.
+- `credentials.rs`: encrypted credential store and integration credential flows.
+- `startup_model_resolution.rs`: `--model` parse and fallback model resolution.
+
+Use this area for provider onboarding, credential behavior, or fallback policy updates.
+
+### Session and persistence
+
+- `session.rs`: session storage and lineage model.
+- `session_runtime_helpers.rs`: session initialization and reload helpers.
+- `atomic_io.rs`: safe atomic file writes.
+- `channel_store.rs`: channel-specific persisted logs/context state.
+- `channel_store_admin.rs`: inspect/repair operations for ChannelStore.
+
+Use this area for storage formats, integrity behavior, and session/channel durability.
+
+### Skills and trust roots
+
+- `skills.rs`: skill catalog loading, selection, install/sync, registry integration.
+- `startup_skills_bootstrap.rs`: startup installs/sync and lockfile orchestration.
+- `startup_prompt_composition.rs`: base prompt + selected skill prompt augmentation.
+- `trust_roots.rs`: signed skill trust root parsing/mutations/persistence.
+
+Use this area for skill packaging, verification, registry support, and lock workflows.
+
+### Transports and integrations
+
+- `github_issues.rs`: GitHub Issues bridge transport.
+- `slack.rs`: Slack Socket Mode bridge transport.
+- `events.rs`: scheduler runner and webhook immediate-event ingestion.
+- `runtime_cli_validation.rs`: validation for integration runtime flags.
+- `startup_transport_modes.rs`: transport mode dispatch entry.
+
+Use this area when adding a new integration channel or adjusting bridge behavior.
+
+### Tool policy and observability
+
+- `tools.rs`: built-in tool registration and tool policy primitives.
+- `tool_policy_config.rs`: CLI/preset/env policy assembly.
+- `observability_loggers.rs`: telemetry and tool audit log subscribers.
+- `startup_policy.rs`: startup policy packaging and optional policy printing.
+
+Use this area for tool permissions, audit semantics, and telemetry output changes.
+
+### Shared helpers
+
+- `startup_config.rs`: startup-time config bundles for auth/profile/doctor commands.
+- `startup_resolution.rs`: shared prompt/trust root resolution helpers.
+- `bootstrap_helpers.rs`: tracing bootstrap and CLI helper labels.
+- `time_utils.rs`: timestamp and expiration utilities.
+
+Use this area for narrow utility behavior reused across startup/runtime modules.
+
+### Test surfaces
+
+- `tests.rs`: large integration/regression suite for `pi-coding-agent`.
+- `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.
+- `#[cfg(test)]` exports in `main.rs`: test-only visibility for parser/helpers.
+
+Prefer adding tests next to the module behavior being changed, plus regression coverage in `tests.rs` when behavior spans modules.
+
+## Common Change Paths
+
+- Add a new CLI flag:
+  1. Update `cli_args.rs` (flag definition).
+  2. Add/adjust type in `cli_types.rs` if needed.
+  3. Wire behavior in the appropriate startup/runtime/command module.
+  4. Add unit tests for parsing + integration/regression tests for behavior.
+
+- Add a new slash command:
+  1. Add parser/dispatch hooks in `commands.rs`.
+  2. Implement command logic in a focused `*_commands.rs` module.
+  3. Add command rendering and error-path tests.
+  4. Add command-file coverage if command should work in `--command-file` mode.
+
+- Add a new transport/integration mode:
+  1. Add CLI flags in `cli_args.rs`.
+  2. Add validation in `runtime_cli_validation.rs`.
+  3. Add runtime config + bridge runner wiring in `startup_transport_modes.rs`.
+  4. Add conformance fixtures/tests in `transport_conformance.rs` and regression tests in `tests.rs`.
+
+- Change provider/auth behavior:
+  1. Update auth resolution in `provider_auth.rs` / `provider_credentials.rs` / `credentials.rs`.
+  2. Keep model and fallback behavior aligned in `startup_model_resolution.rs` and `provider_fallback.rs`.
+  3. Add regression coverage for required/missing credentials and fallback routing.
+
+## Quality Gate (Local)
+
+Run this repository matrix before opening a PR:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p pi-coding-agent --quiet
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+For transport-heavy changes, also run focused conformance tests in `transport_conformance.rs`.


### PR DESCRIPTION
## Summary
- add pi-coding-agent contributor code-map document
- map startup/runtime responsibilities and common change paths
- add README pointer to the new contributor map

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #240
