### PR TITLE
feat(providers): add xai alias and env-key support (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ export OPENROUTER_API_KEY=...your-openrouter-key...
 # Groq (OpenAI-compatible alias path)
 export GROQ_API_KEY=...your-groq-key...
 
+# xAI (OpenAI-compatible alias path)
+export XAI_API_KEY=...your-xai-key...
+
 # Anthropic
 export ANTHROPIC_API_KEY=...your-key...
 
@@ -124,6 +127,14 @@ Use Groq via OpenAI-compatible endpoint:
 cargo run -p pi-coding-agent -- \
   --model groq/llama-3.3-70b \
   --api-base https://api.groq.com/openai/v1
+```
+
+Use xAI via OpenAI-compatible endpoint:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --model xai/grok-4 \
+  --api-base https://api.x.ai/v1
 ```
 
 Run one prompt:

--- a/crates/pi-ai/src/provider.rs
+++ b/crates/pi-ai/src/provider.rs
@@ -29,7 +29,7 @@ impl fmt::Display for Provider {
 pub enum ModelRefParseError {
     #[error("missing model identifier")]
     MissingModel,
-    #[error("unsupported provider '{0}'. Supported providers: openai, openrouter (alias), groq (alias), anthropic, google")]
+    #[error("unsupported provider '{0}'. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), anthropic, google")]
     UnsupportedProvider(String),
 }
 
@@ -39,7 +39,7 @@ impl FromStr for Provider {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let normalized = value.trim().to_ascii_lowercase();
         match normalized.as_str() {
-            "openai" | "openrouter" | "groq" => Ok(Provider::OpenAi),
+            "openai" | "openrouter" | "groq" | "xai" => Ok(Provider::OpenAi),
             "anthropic" => Ok(Provider::Anthropic),
             "google" | "gemini" => Ok(Provider::Google),
             _ => Err(ModelRefParseError::UnsupportedProvider(value.to_string())),
@@ -109,6 +109,13 @@ mod tests {
         let parsed = ModelRef::parse("groq/llama-3.3-70b").expect("valid model ref");
         assert_eq!(parsed.provider, Provider::OpenAi);
         assert_eq!(parsed.model, "llama-3.3-70b");
+    }
+
+    #[test]
+    fn parses_xai_as_openai_alias() {
+        let parsed = ModelRef::parse("xai/grok-4").expect("valid model ref");
+        assert_eq!(parsed.provider, Provider::OpenAi);
+        assert_eq!(parsed.model, "grok-4");
     }
 
     #[test]

--- a/crates/pi-coding-agent/src/auth_commands.rs
+++ b/crates/pi-coding-agent/src/auth_commands.rs
@@ -37,11 +37,11 @@ pub(crate) struct AuthStatusRow {
 
 pub(crate) fn parse_auth_provider(token: &str) -> Result<Provider> {
     match token.trim().to_ascii_lowercase().as_str() {
-        "openai" | "openrouter" | "groq" => Ok(Provider::OpenAi),
+        "openai" | "openrouter" | "groq" | "xai" => Ok(Provider::OpenAi),
         "anthropic" => Ok(Provider::Anthropic),
         "google" => Ok(Provider::Google),
         other => bail!(
-            "unknown provider '{}'; supported providers: openai, openrouter (alias), groq (alias), anthropic, google",
+            "unknown provider '{}'; supported providers: openai, openrouter (alias), groq (alias), xai (alias), anthropic, google",
             other
         ),
     }

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -18,7 +18,7 @@ pub(crate) struct Cli {
         long,
         env = "PI_MODEL",
         default_value = "openai/gpt-4o-mini",
-        help = "Model in provider/model format. Supported providers: openai, openrouter (alias), groq (alias), anthropic, google."
+        help = "Model in provider/model format. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), anthropic, google."
     )]
     pub(crate) model: String,
 

--- a/crates/pi-coding-agent/src/provider_auth.rs
+++ b/crates/pi-coding-agent/src/provider_auth.rs
@@ -129,7 +129,7 @@ pub(crate) fn provider_auth_mode_flag(provider: Provider) -> &'static str {
 pub(crate) fn missing_provider_api_key_message(provider: Provider) -> &'static str {
     match provider {
         Provider::OpenAi => {
-            "missing OpenAI-compatible API key. Set OPENAI_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
+            "missing OpenAI-compatible API key. Set OPENAI_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY, XAI_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
         }
         Provider::Anthropic => {
             "missing Anthropic API key. Set ANTHROPIC_API_KEY, PI_API_KEY, --anthropic-api-key, or --api-key"
@@ -157,6 +157,7 @@ pub(crate) fn provider_api_key_candidates_with_inputs(
                 std::env::var("OPENROUTER_API_KEY").ok(),
             ),
             ("GROQ_API_KEY", std::env::var("GROQ_API_KEY").ok()),
+            ("XAI_API_KEY", std::env::var("XAI_API_KEY").ok()),
             ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
         ],
         Provider::Anthropic => vec![

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -603,6 +603,16 @@ fn unit_parse_auth_command_supports_login_status_logout_and_json() {
             json_output: false,
         }
     );
+
+    let xai_login = parse_auth_command("login xai --mode api-key").expect("parse xai login");
+    assert_eq!(
+        xai_login,
+        AuthCommand::Login {
+            provider: Provider::OpenAi,
+            mode: Some(ProviderAuthMethod::ApiKey),
+            json_output: false,
+        }
+    );
 }
 
 #[test]
@@ -1463,7 +1473,7 @@ fn resolve_api_key_returns_none_when_all_candidates_are_empty() {
 }
 
 #[test]
-fn functional_openai_api_key_candidates_include_openrouter_and_groq_env_slots() {
+fn functional_openai_api_key_candidates_include_openrouter_groq_and_xai_env_slots() {
     let candidates =
         provider_api_key_candidates_with_inputs(Provider::OpenAi, None, None, None, None);
     assert!(candidates
@@ -1472,6 +1482,9 @@ fn functional_openai_api_key_candidates_include_openrouter_and_groq_env_slots() 
     assert!(candidates
         .iter()
         .any(|(source, _)| *source == "GROQ_API_KEY"));
+    assert!(candidates
+        .iter()
+        .any(|(source, _)| *source == "XAI_API_KEY"));
 }
 
 #[test]

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -2032,6 +2032,38 @@ fn integration_groq_alias_uses_openai_compatible_runtime_with_env_key() {
 }
 
 #[test]
+fn integration_xai_alias_uses_openai_compatible_runtime_with_env_key() {
+    let server = MockServer::start();
+    let xai = server.mock(|_, then| {
+        then.status(200).json_body(json!({
+            "choices": [{
+                "message": {"content": "integration xai response"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11}
+        }));
+    });
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "xai/grok-4",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--prompt",
+        "hello",
+        "--no-session",
+    ])
+    .env("XAI_API_KEY", "test-xai-key");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("integration xai response"));
+
+    xai.assert_calls(1);
+}
+
+#[test]
 fn anthropic_prompt_works_end_to_end() {
     let server = MockServer::start();
     let anthropic = server.mock(|when, then| {


### PR DESCRIPTION
## Summary
- add `xai/*` model/provider alias support through the OpenAI-compatible runtime path
- allow `/auth` provider parsing for `xai` alias token
- include `XAI_API_KEY` in OpenAI-compatible API key candidate resolution
- update CLI/help/docs text for xAI alias usage
- add unit/functional/integration coverage for alias parsing and runtime behavior

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #250
