### PR TITLE
feat: Azure OpenAI compatibility mode for OpenAI runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ export XAI_API_KEY=...your-xai-key...
 # Mistral (OpenAI-compatible alias path)
 export MISTRAL_API_KEY=...your-mistral-key...
 
+# Azure OpenAI (OpenAI-compatible runtime with Azure auth/query mode)
+export AZURE_OPENAI_API_KEY=...your-azure-openai-key...
+
 # Anthropic
 export ANTHROPIC_API_KEY=...your-key...
 
@@ -146,6 +149,15 @@ Use Mistral via OpenAI-compatible endpoint:
 cargo run -p pi-coding-agent -- \
   --model mistral/mistral-large-latest \
   --api-base https://api.mistral.ai/v1
+```
+
+Use Azure OpenAI deployment endpoint:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --model azure/gpt-4o-mini \
+  --api-base https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT \
+  --azure-openai-api-version 2024-10-21
 ```
 
 Run one prompt:

--- a/crates/pi-ai/src/lib.rs
+++ b/crates/pi-ai/src/lib.rs
@@ -7,7 +7,7 @@ mod types;
 
 pub use anthropic::{AnthropicClient, AnthropicConfig};
 pub use google::{GoogleClient, GoogleConfig};
-pub use openai::{OpenAiClient, OpenAiConfig};
+pub use openai::{OpenAiAuthScheme, OpenAiClient, OpenAiConfig};
 pub use provider::{ModelRef, ModelRefParseError, Provider};
 pub use types::{
     ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole, PiAiError,

--- a/crates/pi-ai/src/provider.rs
+++ b/crates/pi-ai/src/provider.rs
@@ -29,7 +29,7 @@ impl fmt::Display for Provider {
 pub enum ModelRefParseError {
     #[error("missing model identifier")]
     MissingModel,
-    #[error("unsupported provider '{0}'. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), anthropic, google")]
+    #[error("unsupported provider '{0}'. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), azure/azure-openai (alias), anthropic, google")]
     UnsupportedProvider(String),
 }
 
@@ -39,7 +39,9 @@ impl FromStr for Provider {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let normalized = value.trim().to_ascii_lowercase();
         match normalized.as_str() {
-            "openai" | "openrouter" | "groq" | "xai" | "mistral" => Ok(Provider::OpenAi),
+            "openai" | "openrouter" | "groq" | "xai" | "mistral" | "azure" | "azure-openai" => {
+                Ok(Provider::OpenAi)
+            }
             "anthropic" => Ok(Provider::Anthropic),
             "google" | "gemini" => Ok(Provider::Google),
             _ => Err(ModelRefParseError::UnsupportedProvider(value.to_string())),
@@ -123,6 +125,13 @@ mod tests {
         let parsed = ModelRef::parse("mistral/mistral-large-latest").expect("valid model ref");
         assert_eq!(parsed.provider, Provider::OpenAi);
         assert_eq!(parsed.model, "mistral-large-latest");
+    }
+
+    #[test]
+    fn parses_azure_openai_as_openai_alias() {
+        let parsed = ModelRef::parse("azure/gpt-4o").expect("valid model ref");
+        assert_eq!(parsed.provider, Provider::OpenAi);
+        assert_eq!(parsed.model, "gpt-4o");
     }
 
     #[test]

--- a/crates/pi-ai/tests/provider_contract_conformance.rs
+++ b/crates/pi-ai/tests/provider_contract_conformance.rs
@@ -1,7 +1,7 @@
 use httpmock::prelude::*;
 use pi_ai::{
     AnthropicClient, AnthropicConfig, ChatRequest, ChatResponse, GoogleClient, GoogleConfig,
-    LlmClient, Message, OpenAiClient, OpenAiConfig, PiAiError, ToolDefinition,
+    LlmClient, Message, OpenAiAuthScheme, OpenAiClient, OpenAiConfig, PiAiError, ToolDefinition,
 };
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
@@ -88,6 +88,8 @@ fn openai_client(api_base: String) -> OpenAiClient {
         max_retries: 1,
         retry_budget_ms: 0,
         retry_jitter: false,
+        auth_scheme: OpenAiAuthScheme::Bearer,
+        api_version: None,
     })
     .expect("openai client should be created")
 }

--- a/crates/pi-coding-agent/src/auth_commands.rs
+++ b/crates/pi-coding-agent/src/auth_commands.rs
@@ -37,11 +37,13 @@ pub(crate) struct AuthStatusRow {
 
 pub(crate) fn parse_auth_provider(token: &str) -> Result<Provider> {
     match token.trim().to_ascii_lowercase().as_str() {
-        "openai" | "openrouter" | "groq" | "xai" | "mistral" => Ok(Provider::OpenAi),
+        "openai" | "openrouter" | "groq" | "xai" | "mistral" | "azure" | "azure-openai" => {
+            Ok(Provider::OpenAi)
+        }
         "anthropic" => Ok(Provider::Anthropic),
         "google" => Ok(Provider::Google),
         other => bail!(
-            "unknown provider '{}'; supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), anthropic, google",
+            "unknown provider '{}'; supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), azure/azure-openai (alias), anthropic, google",
             other
         ),
     }

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -18,7 +18,7 @@ pub(crate) struct Cli {
         long,
         env = "PI_MODEL",
         default_value = "openai/gpt-4o-mini",
-        help = "Model in provider/model format. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), anthropic, google."
+        help = "Model in provider/model format. Supported providers: openai, openrouter (alias), groq (alias), xai (alias), mistral (alias), azure/azure-openai (alias), anthropic, google."
     )]
     pub(crate) model: String,
 
@@ -37,6 +37,14 @@ pub(crate) struct Cli {
         help = "Base URL for OpenAI-compatible APIs"
     )]
     pub(crate) api_base: String,
+
+    #[arg(
+        long = "azure-openai-api-version",
+        env = "PI_AZURE_OPENAI_API_VERSION",
+        default_value = "2024-10-21",
+        help = "Azure OpenAI api-version query value used when --api-base points to an Azure deployment endpoint"
+    )]
+    pub(crate) azure_openai_api_version: String,
 
     #[arg(
         long,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -60,8 +60,8 @@ use clap::Parser;
 use pi_agent_core::{Agent, AgentConfig, AgentEvent};
 use pi_ai::{
     AnthropicClient, AnthropicConfig, ChatRequest, ChatResponse, GoogleClient, GoogleConfig,
-    LlmClient, Message, MessageRole, ModelRef, OpenAiClient, OpenAiConfig, PiAiError, Provider,
-    StreamDeltaHandler,
+    LlmClient, Message, MessageRole, ModelRef, OpenAiAuthScheme, OpenAiClient, OpenAiConfig,
+    PiAiError, Provider, StreamDeltaHandler,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/pi-coding-agent/src/provider_auth.rs
+++ b/crates/pi-coding-agent/src/provider_auth.rs
@@ -129,7 +129,7 @@ pub(crate) fn provider_auth_mode_flag(provider: Provider) -> &'static str {
 pub(crate) fn missing_provider_api_key_message(provider: Provider) -> &'static str {
     match provider {
         Provider::OpenAi => {
-            "missing OpenAI-compatible API key. Set OPENAI_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY, XAI_API_KEY, MISTRAL_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
+            "missing OpenAI-compatible API key. Set OPENAI_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY, XAI_API_KEY, MISTRAL_API_KEY, AZURE_OPENAI_API_KEY, PI_API_KEY, --openai-api-key, or --api-key"
         }
         Provider::Anthropic => {
             "missing Anthropic API key. Set ANTHROPIC_API_KEY, PI_API_KEY, --anthropic-api-key, or --api-key"
@@ -159,6 +159,10 @@ pub(crate) fn provider_api_key_candidates_with_inputs(
             ("GROQ_API_KEY", std::env::var("GROQ_API_KEY").ok()),
             ("XAI_API_KEY", std::env::var("XAI_API_KEY").ok()),
             ("MISTRAL_API_KEY", std::env::var("MISTRAL_API_KEY").ok()),
+            (
+                "AZURE_OPENAI_API_KEY",
+                std::env::var("AZURE_OPENAI_API_KEY").ok(),
+            ),
             ("PI_API_KEY", std::env::var("PI_API_KEY").ok()),
         ],
         Provider::Anthropic => vec![

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -184,6 +184,7 @@ fn test_cli() -> Cli {
         model: "openai/gpt-4o-mini".to_string(),
         fallback_model: vec![],
         api_base: "https://api.openai.com/v1".to_string(),
+        azure_openai_api_version: "2024-10-21".to_string(),
         anthropic_api_base: "https://api.anthropic.com/v1".to_string(),
         google_api_base: "https://generativelanguage.googleapis.com/v1beta".to_string(),
         api_key: None,
@@ -618,6 +619,16 @@ fn unit_parse_auth_command_supports_login_status_logout_and_json() {
         parse_auth_command("login mistral --mode api-key").expect("parse mistral login");
     assert_eq!(
         mistral_login,
+        AuthCommand::Login {
+            provider: Provider::OpenAi,
+            mode: Some(ProviderAuthMethod::ApiKey),
+            json_output: false,
+        }
+    );
+
+    let azure_login = parse_auth_command("login azure --mode api-key").expect("parse azure login");
+    assert_eq!(
+        azure_login,
         AuthCommand::Login {
             provider: Provider::OpenAi,
             mode: Some(ProviderAuthMethod::ApiKey),
@@ -1484,7 +1495,7 @@ fn resolve_api_key_returns_none_when_all_candidates_are_empty() {
 }
 
 #[test]
-fn functional_openai_api_key_candidates_include_openrouter_groq_xai_and_mistral_env_slots() {
+fn functional_openai_api_key_candidates_include_openrouter_groq_xai_mistral_and_azure_env_slots() {
     let candidates =
         provider_api_key_candidates_with_inputs(Provider::OpenAi, None, None, None, None);
     assert!(candidates
@@ -1499,6 +1510,9 @@ fn functional_openai_api_key_candidates_include_openrouter_groq_xai_and_mistral_
     assert!(candidates
         .iter()
         .any(|(source, _)| *source == "MISTRAL_API_KEY"));
+    assert!(candidates
+        .iter()
+        .any(|(source, _)| *source == "AZURE_OPENAI_API_KEY"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Azure OpenAI compatibility mode to OpenAI runtime
- detect Azure deployment endpoints and switch auth to `api-key` header
- append configurable `api-version` query parameter for Azure endpoints
- add `azure` and `azure-openai` model/auth aliases and key candidate support
- document Azure OpenAI usage in README

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #254