### PR TITLE
feat: add opt-in plan-first orchestrator mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ Run one prompt:
 cargo run -p pi-coding-agent -- --prompt "Summarize src/lib.rs"
 ```
 
+Run one prompt with plan-first orchestration:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --prompt "Summarize src/lib.rs" \
+  --orchestrator-mode plan-first \
+  --orchestrator-max-plan-steps 8
+```
+
 Run one prompt from a file:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use clap::{ArgAction, Parser};
 
 use crate::{
-    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliOrchestratorMode,
+    CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset,
+    CliWebhookSignatureAlgorithm,
 };
 
 #[derive(Debug, Parser)]
@@ -409,6 +410,23 @@ pub(crate) struct Cli {
 
     #[arg(long, help = "Run one prompt and exit")]
     pub(crate) prompt: Option<String>,
+
+    #[arg(
+        long = "orchestrator-mode",
+        env = "PI_ORCHESTRATOR_MODE",
+        value_enum,
+        default_value_t = CliOrchestratorMode::Off,
+        help = "Optional orchestration mode for prompt execution"
+    )]
+    pub(crate) orchestrator_mode: CliOrchestratorMode,
+
+    #[arg(
+        long = "orchestrator-max-plan-steps",
+        env = "PI_ORCHESTRATOR_MAX_PLAN_STEPS",
+        default_value_t = 8,
+        help = "Maximum planner step count allowed in plan-first orchestrator mode"
+    )]
+    pub(crate) orchestrator_max_plan_steps: usize,
 
     #[arg(
         long,

--- a/crates/pi-coding-agent/src/cli_types.rs
+++ b/crates/pi-coding-agent/src/cli_types.rs
@@ -119,3 +119,9 @@ pub(crate) enum CliCredentialStoreEncryptionMode {
     None,
     Keyed,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliOrchestratorMode {
+    Off,
+    PlanFirst,
+}

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -14,6 +14,7 @@ mod github_issues;
 mod macro_profile_commands;
 mod model_catalog;
 mod observability_loggers;
+mod orchestrator;
 mod provider_auth;
 mod provider_client;
 mod provider_credentials;
@@ -78,8 +79,9 @@ use crate::channel_store::ChannelStore;
 pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
-    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliOrchestratorMode,
+    CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset,
+    CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
@@ -141,6 +143,9 @@ pub(crate) use crate::model_catalog::{
 #[cfg(test)]
 pub(crate) use crate::observability_loggers::tool_audit_event_json;
 pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLogger};
+#[cfg(test)]
+pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
+pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,
     missing_provider_api_key_message, provider_api_key_candidates,

--- a/crates/pi-coding-agent/src/orchestrator.rs
+++ b/crates/pi-coding-agent/src/orchestrator.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+pub(crate) async fn run_plan_first_prompt(
+    agent: &mut Agent,
+    session_runtime: &mut Option<SessionRuntime>,
+    user_prompt: &str,
+    turn_timeout_ms: u64,
+    render_options: RenderOptions,
+    max_plan_steps: usize,
+) -> Result<()> {
+    let planner_prompt = build_plan_first_planner_prompt(user_prompt, max_plan_steps);
+    let planner_render_options = RenderOptions {
+        stream_output: false,
+        stream_delay_ms: 0,
+    };
+    let planner_status = run_prompt_with_cancellation(
+        agent,
+        session_runtime,
+        &planner_prompt,
+        turn_timeout_ms,
+        tokio::signal::ctrl_c(),
+        planner_render_options,
+    )
+    .await?;
+    report_prompt_status_internal(planner_status);
+    if planner_status != PromptRunStatus::Completed {
+        return Ok(());
+    }
+
+    let plan_text = latest_assistant_text(agent).ok_or_else(|| {
+        anyhow!("plan-first orchestrator failed: planner produced no text output")
+    })?;
+    let plan_steps = parse_numbered_plan_steps(&plan_text);
+    if plan_steps.is_empty() {
+        bail!("plan-first orchestrator failed: planner response did not include numbered steps");
+    }
+    if plan_steps.len() > max_plan_steps {
+        bail!(
+            "plan-first orchestrator failed: planner produced {} steps (max allowed {})",
+            plan_steps.len(),
+            max_plan_steps
+        );
+    }
+
+    println!(
+        "orchestrator trace: mode=plan-first phase=planner approved_steps={} max_steps={}",
+        plan_steps.len(),
+        max_plan_steps
+    );
+    for (index, step) in plan_steps.iter().enumerate() {
+        println!(
+            "orchestrator trace: phase=planner step={} text={}",
+            index + 1,
+            flatten_whitespace(step)
+        );
+    }
+    println!("orchestrator trace: mode=plan-first phase=executor");
+
+    let execution_prompt = build_plan_first_execution_prompt(user_prompt, &plan_steps);
+    let execution_status = run_prompt_with_cancellation(
+        agent,
+        session_runtime,
+        &execution_prompt,
+        turn_timeout_ms,
+        tokio::signal::ctrl_c(),
+        render_options,
+    )
+    .await?;
+    report_prompt_status_internal(execution_status);
+    Ok(())
+}
+
+pub(crate) fn parse_numbered_plan_steps(plan: &str) -> Vec<String> {
+    let mut steps = Vec::new();
+    for line in plan.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let digit_prefix_len = trimmed
+            .chars()
+            .take_while(|character| character.is_ascii_digit())
+            .count();
+        if digit_prefix_len == 0 {
+            continue;
+        }
+        let remainder = trimmed[digit_prefix_len..].trim_start();
+        let Some(remainder) = remainder
+            .strip_prefix('.')
+            .or_else(|| remainder.strip_prefix(')'))
+        else {
+            continue;
+        };
+        let step = remainder.trim();
+        if step.is_empty() {
+            continue;
+        }
+        steps.push(step.to_string());
+    }
+    steps
+}
+
+fn latest_assistant_text(agent: &Agent) -> Option<String> {
+    agent
+        .messages()
+        .iter()
+        .rev()
+        .find(|message| message.role == MessageRole::Assistant)
+        .map(|message| message.text_content())
+}
+
+fn build_plan_first_planner_prompt(user_prompt: &str, max_plan_steps: usize) -> String {
+    format!(
+        "ORCHESTRATOR_PLANNER_PHASE\nYou are operating in plan-first orchestration mode.\nCreate a numbered implementation plan with at most {} steps.\nUse exactly one line per step in the format '1. <step>'.\nDo not execute anything.\n\nUser request:\n{}",
+        max_plan_steps, user_prompt
+    )
+}
+
+fn build_plan_first_execution_prompt(user_prompt: &str, plan_steps: &[String]) -> String {
+    let numbered_steps = plan_steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| format!("{}. {}", index + 1, step))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "ORCHESTRATOR_EXECUTION_PHASE\nExecute the user request using the approved plan.\n\nApproved plan:\n{}\n\nUser request:\n{}\n\nProvide the final response.",
+        numbered_steps, user_prompt
+    )
+}
+
+fn flatten_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn report_prompt_status_internal(status: PromptRunStatus) {
+    if status == PromptRunStatus::Cancelled {
+        println!("\nrequest cancelled\n");
+    } else if status == PromptRunStatus::TimedOut {
+        println!("\nrequest timed out\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_numbered_plan_steps;
+
+    #[test]
+    fn unit_parse_numbered_plan_steps_extracts_dot_and_paren_prefixes() {
+        let steps = parse_numbered_plan_steps(
+            "1. Inspect current behavior\n2) Design fix\n3. Add tests\nDone",
+        );
+        assert_eq!(
+            steps,
+            vec![
+                "Inspect current behavior".to_string(),
+                "Design fix".to_string(),
+                "Add tests".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn regression_parse_numbered_plan_steps_ignores_unstructured_lines() {
+        let steps = parse_numbered_plan_steps("- inspect\n* patch\nstep three");
+        assert!(steps.is_empty());
+    }
+}

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -69,14 +69,26 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     }
 
     if let Some(prompt) = resolve_prompt_input(cli)? {
-        run_prompt(
-            &mut agent,
-            &mut session_runtime,
-            &prompt,
-            cli.turn_timeout_ms,
-            render_options,
-        )
-        .await?;
+        if cli.orchestrator_mode == CliOrchestratorMode::PlanFirst {
+            run_plan_first_prompt(
+                &mut agent,
+                &mut session_runtime,
+                &prompt,
+                cli.turn_timeout_ms,
+                render_options,
+                cli.orchestrator_max_plan_steps,
+            )
+            .await?;
+        } else {
+            run_prompt(
+                &mut agent,
+                &mut session_runtime,
+                &prompt,
+                cli.turn_timeout_ms,
+                render_options,
+            )
+            .await?;
+        }
         return Ok(());
     }
 

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -39,48 +39,50 @@ use super::{
     is_retryable_provider_error, load_branch_aliases, load_credential_store, load_macro_file,
     load_profile_store, load_session_bookmarks, load_trust_root_records, parse_auth_command,
     parse_branch_alias_command, parse_command, parse_command_file, parse_doctor_command_args,
-    parse_integration_auth_command, parse_macro_command, parse_profile_command,
-    parse_sandbox_command_tokens, parse_session_bookmark_command, parse_session_diff_args,
-    parse_session_search_args, parse_session_stats_args, parse_skills_lock_diff_args,
-    parse_skills_prune_args, parse_skills_search_args, parse_skills_trust_list_args,
-    parse_skills_trust_mutation_args, parse_skills_verify_args, parse_trust_rotation_spec,
-    parse_trusted_root_spec, percentile_duration_ms, provider_auth_capability,
-    refresh_provider_access_token, render_audit_summary, render_command_help, render_doctor_report,
-    render_doctor_report_json, render_help_overview, render_macro_list, render_macro_show,
-    render_profile_diffs, render_profile_list, render_profile_show, render_session_diff,
-    render_session_graph_dot, render_session_graph_mermaid, render_session_stats,
-    render_session_stats_json, render_skills_list, render_skills_lock_diff_drift,
-    render_skills_lock_diff_in_sync, render_skills_lock_write_success, render_skills_search,
-    render_skills_show, render_skills_sync_drift_details, render_skills_trust_list,
-    render_skills_verify_report, resolve_credential_store_encryption_mode, resolve_fallback_models,
-    resolve_prompt_input, resolve_prunable_skill_file_name, resolve_secret_from_cli_or_store_id,
+    parse_integration_auth_command, parse_macro_command, parse_numbered_plan_steps,
+    parse_profile_command, parse_sandbox_command_tokens, parse_session_bookmark_command,
+    parse_session_diff_args, parse_session_search_args, parse_session_stats_args,
+    parse_skills_lock_diff_args, parse_skills_prune_args, parse_skills_search_args,
+    parse_skills_trust_list_args, parse_skills_trust_mutation_args, parse_skills_verify_args,
+    parse_trust_rotation_spec, parse_trusted_root_spec, percentile_duration_ms,
+    provider_auth_capability, refresh_provider_access_token, render_audit_summary,
+    render_command_help, render_doctor_report, render_doctor_report_json, render_help_overview,
+    render_macro_list, render_macro_show, render_profile_diffs, render_profile_list,
+    render_profile_show, render_session_diff, render_session_graph_dot,
+    render_session_graph_mermaid, render_session_stats, render_session_stats_json,
+    render_skills_list, render_skills_lock_diff_drift, render_skills_lock_diff_in_sync,
+    render_skills_lock_write_success, render_skills_search, render_skills_show,
+    render_skills_sync_drift_details, render_skills_trust_list, render_skills_verify_report,
+    resolve_credential_store_encryption_mode, resolve_fallback_models, resolve_prompt_input,
+    resolve_prunable_skill_file_name, resolve_secret_from_cli_or_store_id,
     resolve_session_graph_format, resolve_skill_trust_roots, resolve_skills_lock_path,
     resolve_store_backed_provider_credential, resolve_system_prompt, run_doctor_checks,
-    run_prompt_with_cancellation, save_branch_aliases, save_credential_store, save_macro_file,
-    save_profile_store, save_session_bookmarks, search_session_entries,
-    session_bookmark_path_for_session, session_message_preview, shared_lineage_prefix_depth,
-    stream_text_chunks, summarize_audit_file, tool_audit_event_json, tool_policy_to_json,
-    trust_record_status, unknown_command_message, validate_branch_alias_name,
+    run_plan_first_prompt, run_prompt_with_cancellation, save_branch_aliases,
+    save_credential_store, save_macro_file, save_profile_store, save_session_bookmarks,
+    search_session_entries, session_bookmark_path_for_session, session_message_preview,
+    shared_lineage_prefix_depth, stream_text_chunks, summarize_audit_file, tool_audit_event_json,
+    tool_policy_to_json, trust_record_status, unknown_command_message, validate_branch_alias_name,
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_macro_command_entry, validate_macro_name,
     validate_profile_name, validate_session_file, validate_skills_prune_file_name,
     validate_slack_bridge_cli, AuthCommand, AuthCommandConfig, BranchAliasCommand, BranchAliasFile,
     Cli, CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
-    CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset,
-    CliWebhookSignatureAlgorithm, ClientRoute, CommandAction, CommandExecutionContext,
-    CommandFileEntry, CommandFileReport, CredentialStoreData, CredentialStoreEncryptionMode,
-    DoctorCheckResult, DoctorCommandConfig, DoctorCommandOutputFormat, DoctorProviderKeyStatus,
-    DoctorStatus, FallbackRoutingClient, IntegrationAuthCommand, IntegrationCredentialStoreRecord,
-    MacroCommand, MacroFile, ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus,
-    PromptTelemetryLogger, ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions,
-    SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry, SessionDiffReport,
-    SessionGraphFormat, SessionRuntime, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
-    SkillsPruneMode, SkillsSyncCommandConfig, SkillsVerifyEntry, SkillsVerifyReport,
-    SkillsVerifyStatus, SkillsVerifySummary, SkillsVerifyTrustSummary, ToolAuditLogger,
-    TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION,
-    MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
-    SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
-    SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute, CommandAction,
+    CommandExecutionContext, CommandFileEntry, CommandFileReport, CredentialStoreData,
+    CredentialStoreEncryptionMode, DoctorCheckResult, DoctorCommandConfig,
+    DoctorCommandOutputFormat, DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient,
+    IntegrationAuthCommand, IntegrationCredentialStoreRecord, MacroCommand, MacroFile,
+    ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
+    ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions, SessionBookmarkCommand,
+    SessionBookmarkFile, SessionDiffEntry, SessionDiffReport, SessionGraphFormat, SessionRuntime,
+    SessionSearchArgs, SessionStats, SessionStatsOutputFormat, SkillsPruneMode,
+    SkillsSyncCommandConfig, SkillsVerifyEntry, SkillsVerifyReport, SkillsVerifyStatus,
+    SkillsVerifySummary, SkillsVerifyTrustSummary, ToolAuditLogger, TrustedRootRecord,
+    BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION, MACRO_USAGE,
+    PROFILE_SCHEMA_VERSION, PROFILE_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION, SESSION_BOOKMARK_USAGE,
+    SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS, SKILLS_PRUNE_USAGE,
+    SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
 };
 use crate::provider_api_key_candidates_with_inputs;
 use crate::resolve_api_key;
@@ -233,6 +235,8 @@ fn test_cli() -> Cli {
         stream_output: true,
         stream_delay_ms: 0,
         prompt: None,
+        orchestrator_mode: CliOrchestratorMode::Off,
+        orchestrator_max_plan_steps: 8,
         prompt_file: None,
         command_file: None,
         command_file_error_mode: CliCommandFileErrorMode::FailFast,
@@ -496,6 +500,26 @@ fn functional_cli_model_catalog_flags_accept_overrides() {
     assert_eq!(cli.model_catalog_cache, PathBuf::from("/tmp/catalog.json"));
     assert!(cli.model_catalog_offline);
     assert_eq!(cli.model_catalog_stale_after_hours, 48);
+}
+
+#[test]
+fn unit_cli_orchestrator_flags_default_values_are_stable() {
+    let cli = Cli::parse_from(["pi-rs"]);
+    assert_eq!(cli.orchestrator_mode, CliOrchestratorMode::Off);
+    assert_eq!(cli.orchestrator_max_plan_steps, 8);
+}
+
+#[test]
+fn functional_cli_orchestrator_flags_accept_overrides() {
+    let cli = Cli::parse_from([
+        "pi-rs",
+        "--orchestrator-mode",
+        "plan-first",
+        "--orchestrator-max-plan-steps",
+        "5",
+    ]);
+    assert_eq!(cli.orchestrator_mode, CliOrchestratorMode::PlanFirst);
+    assert_eq!(cli.orchestrator_max_plan_steps, 5);
 }
 
 #[test]
@@ -6956,6 +6980,104 @@ async fn integration_run_prompt_with_cancellation_completes_when_not_cancelled()
     assert_eq!(agent.messages().len(), 3);
     assert_eq!(agent.messages()[1].role, MessageRole::User);
     assert_eq!(agent.messages()[2].role, MessageRole::Assistant);
+}
+
+#[test]
+fn unit_parse_numbered_plan_steps_accepts_deterministic_step_format() {
+    let steps = parse_numbered_plan_steps("1. Gather context\n2) Implement fix\n3. Verify");
+    assert_eq!(
+        steps,
+        vec![
+            "Gather context".to_string(),
+            "Implement fix".to_string(),
+            "Verify".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn functional_run_plan_first_prompt_executes_planner_then_executor() {
+    let planner_response = ChatResponse {
+        message: Message::assistant_text("1. Inspect constraints\n2. Apply change"),
+        finish_reason: Some("stop".to_string()),
+        usage: ChatUsage::default(),
+    };
+    let executor_response = ChatResponse {
+        message: Message::assistant_text("final implementation response"),
+        finish_reason: Some("stop".to_string()),
+        usage: ChatUsage::default(),
+    };
+    let mut agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(VecDeque::from([
+                Ok(planner_response),
+                Ok(executor_response),
+            ])),
+        }),
+        AgentConfig::default(),
+    );
+    let mut runtime = None;
+
+    run_plan_first_prompt(
+        &mut agent,
+        &mut runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        4,
+    )
+    .await
+    .expect("plan-first prompt should succeed");
+
+    assert_eq!(agent.messages().len(), 5);
+    assert_eq!(
+        agent
+            .messages()
+            .last()
+            .expect("assistant response")
+            .text_content(),
+        "final implementation response"
+    );
+}
+
+#[tokio::test]
+async fn regression_run_plan_first_prompt_rejects_overlong_plans_before_executor_phase() {
+    let planner_response = ChatResponse {
+        message: Message::assistant_text("1. Step one\n2. Step two\n3. Step three"),
+        finish_reason: Some("stop".to_string()),
+        usage: ChatUsage::default(),
+    };
+    let executor_response = ChatResponse {
+        message: Message::assistant_text("should not execute"),
+        finish_reason: Some("stop".to_string()),
+        usage: ChatUsage::default(),
+    };
+    let mut agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(VecDeque::from([
+                Ok(planner_response),
+                Ok(executor_response),
+            ])),
+        }),
+        AgentConfig::default(),
+    );
+    let mut runtime = None;
+
+    let error = run_plan_first_prompt(
+        &mut agent,
+        &mut runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        2,
+    )
+    .await
+    .expect_err("overlong plan should fail");
+    assert!(error.to_string().contains("planner produced 3 steps"));
+    assert!(!agent
+        .messages()
+        .iter()
+        .any(|message| message.text_content() == "should not execute"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add an opt-in orchestrator mode (`off` | `plan-first`) with configurable planner step bounds
- add plan-first orchestration flow: planner phase -> validated numbered plan -> executor phase
- enforce fail-closed behavior for malformed or overlong planner output
- emit deterministic orchestration trace lines for planner/executor transitions and approved steps
- add unit, functional, integration, and regression coverage for orchestrator parsing/flow and CLI behavior

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #258
