### PR TITLE
feat(runtime): extend plan-first orchestrator to interactive turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Run interactive mode:
 cargo run -p pi-coding-agent -- --model openai/gpt-4o-mini
 ```
 
+Run interactive mode with plan-first orchestration on each user turn:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --orchestrator-mode plan-first \
+  --orchestrator-max-plan-steps 8
+```
+
 Use Anthropic:
 
 ```bash

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -116,6 +116,8 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     let interactive_config = InteractiveRuntimeConfig {
         turn_timeout_ms: cli.turn_timeout_ms,
         render_options,
+        orchestrator_mode: cli.orchestrator_mode,
+        orchestrator_max_plan_steps: cli.orchestrator_max_plan_steps,
         command_context,
     };
     if let Some(command_file_path) = cli.command_file.as_deref() {

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -562,6 +562,85 @@ fn regression_prompt_plan_first_mode_fails_closed_on_overlong_plan() {
 }
 
 #[test]
+fn integration_interactive_plan_first_mode_runs_planner_and_executor_per_turn() {
+    let server = MockServer::start();
+    let planner = server.mock(|when, then| {
+        when.method(POST).path("/v1/chat/completions");
+        then.status(200).json_body(json!({
+            "choices": [{
+                "message": {"content": "1. Inspect requirements\n2. Apply implementation"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 6, "total_tokens": 16}
+        }));
+    });
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--orchestrator-mode",
+        "plan-first",
+        "--orchestrator-max-plan-steps",
+        "4",
+        "--no-session",
+    ])
+    .write_stdin("interactive request\n/quit\n");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "orchestrator trace: mode=plan-first phase=planner approved_steps=2",
+        ))
+        .stdout(predicate::str::contains(
+            "orchestrator trace: mode=plan-first phase=executor",
+        ));
+
+    planner.assert_calls(2);
+}
+
+#[test]
+fn regression_interactive_plan_first_mode_overlong_plan_fails_before_executor() {
+    let server = MockServer::start();
+    let planner = server.mock(|when, then| {
+        when.method(POST).path("/v1/chat/completions");
+        then.status(200).json_body(json!({
+            "choices": [{
+                "message": {"content": "1. Step one\n2. Step two\n3. Step three"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 6, "total_tokens": 16}
+        }));
+    });
+
+    let mut cmd = binary_command();
+    cmd.args([
+        "--model",
+        "openai/gpt-4o-mini",
+        "--openai-api-key",
+        "test-openai-key",
+        "--api-base",
+        &format!("{}/v1", server.base_url()),
+        "--orchestrator-mode",
+        "plan-first",
+        "--orchestrator-max-plan-steps",
+        "2",
+        "--no-session",
+    ])
+    .write_stdin("interactive request\n");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("planner produced 3 steps"));
+
+    planner.assert_calls(1);
+}
+
+#[test]
 fn integration_interactive_session_search_command_finds_results_across_branches() {
     let temp = tempdir().expect("tempdir");
     let session = temp.path().join("session-search.jsonl");


### PR DESCRIPTION
## Summary
- route interactive non-command prompt turns through the plan-first orchestrator when `--orchestrator-mode plan-first` is enabled
- keep existing interactive behavior unchanged when orchestrator mode is `off`
- pass orchestrator configuration into `InteractiveRuntimeConfig` from startup wiring
- document interactive plan-first invocation in README

## Test Matrix
- unit: `cargo test -p pi-coding-agent --quiet`
- functional: `cargo test -p pi-coding-agent --quiet`
- integration: `cargo test -p pi-coding-agent --quiet`
- regression: `cargo test -p pi-coding-agent --quiet`
- full workspace regression sweep: `cargo test --workspace`
- lint/style gate: `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`

## Validation Notes
- Added integration coverage for per-turn planner/executor flow in interactive mode
- Added regression coverage for overlong plan fail-closed behavior before executor invocation in interactive mode

Closes #260
