### PR TITLE
feat(github): add channel artifact index and /pi artifacts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ In bridge mode:
 - inbound/outbound event payloads are persisted as JSONL logs for replay/debugging
 - duplicate deliveries are deduplicated using persisted event keys and response footers
 - bot replies include run/model/token metadata in the issue comment footer
+- each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
+- `/pi artifacts` posts the current issue artifact inventory (active entries + index corruption count)
 
 Run as a Slack Socket Mode conversational transport:
 


### PR DESCRIPTION
## Summary
- add channel artifact lifecycle primitives in `ChannelStore`:
  - artifact metadata schema and index persistence (`artifacts/index.jsonl`)
  - text artifact writer with checksum/size/path/timestamps/visibility
  - strict and tolerant loaders, active listing, and expired purge support
- extend GitHub Issues bridge run flow to emit one markdown artifact per run and include artifact metadata in outbound channel logs and issue footer metadata
- add `/pi artifacts` command to report active artifacts for an issue channel (including ignored malformed-index line count)
- document bridge artifact behavior and `/pi artifacts` in README

## Why
This delivers the first concrete slice of Story #143 by turning run outputs into durable, auditable artifacts rather than only transient comments.

## Test Matrix
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent --quiet`
- `cargo test --workspace`

## Coverage Highlights
- Unit:
  - `/pi artifacts` command parsing and usage-path regressions
- Functional:
  - channel artifact create/load/list roundtrip
- Integration:
  - GitHub bridge run emits artifact + index + footer metadata
  - `/pi artifacts` command posts seeded artifact listings
- Regression:
  - tolerant artifact index loading skips malformed lines without runtime failure
  - `/pi artifacts` empty-state + malformed-index reporting remains stable

Closes #262
