### PR TITLE
feat(github): add /pi artifacts purge lifecycle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ In bridge mode:
 - duplicate deliveries are deduplicated using persisted event keys and response footers
 - bot replies include run/model/token metadata in the issue comment footer
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
-- `/pi artifacts` posts the current issue artifact inventory (active entries + index corruption count)
+- `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:
 


### PR DESCRIPTION
## Summary
- extend GitHub issue command parsing for artifact lifecycle control:
  - `/pi artifacts` (list)
  - `/pi artifacts purge` (remove expired artifacts)
- wire purge flow through ChannelStore purge primitives and return deterministic lifecycle counters (`expired_removed`, `invalid_removed`, `active_remaining`)
- keep artifact listing behavior unchanged for `/pi artifacts`
- update README bridge docs to include purge mode

## Test Matrix
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent github_issues::tests --quiet`
- `cargo test -p pi-coding-agent --quiet`
- `cargo test --workspace`

## Coverage Highlights
- Unit: parser coverage for list vs purge plus invalid forms
- Integration: `/pi artifacts purge` removes expired artifacts and reports counts
- Regression: no-op purge path remains stable with zero expired artifacts

Closes #264
