### PR TITLE
feat(slack): emit run artifacts with metadata footer and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ In Slack bridge mode:
 - duplicate deliveries are deduplicated via persisted event keys
 - stale events are skipped based on `--slack-max-event-age-seconds`
 - attached files are downloaded into channel-local attachment folders and surfaced in prompt context
+- each completed run emits a markdown artifact + metadata under `channel-store/channels/slack/<channel>/artifacts/`
 
 Inspect or repair ChannelStore state for a specific channel:
 


### PR DESCRIPTION
## Summary
- extend Slack bridge runs to emit one markdown artifact per run into channel-store artifacts
- include artifact metadata in Slack outbound channel logs
- include artifact path/checksum/size in Slack response footer metadata
- add Slack-focused artifact rendering tests and integration assertions
- document Slack artifact emission in README

## Test Matrix
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent slack::tests --quiet`
- `cargo test -p pi-coding-agent --quiet`
- `cargo test --workspace`

## Coverage Highlights
- Unit: slack response rendering includes artifact metadata footer
- Functional: slack artifact markdown rendering includes stable event/run metadata
- Integration: slack runtime writes artifact index and outbound log artifact metadata
- Regression: existing transport behavior remains stable with artifact metadata additions

Closes #266
