### PR TITLE
feat(observability): add artifact health counters to channel-store inspect/repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ cargo run -p pi-coding-agent -- \
   --channel-store-repair slack/C123
 ```
 
+Inspect now reports artifact health counters (records, invalid index lines, active/expired), and repair also purges expired artifacts plus invalid artifact index rows.
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/channel_store_admin.rs
+++ b/crates/pi-coding-agent/src/channel_store_admin.rs
@@ -10,7 +10,7 @@ pub(crate) fn execute_channel_store_admin_command(cli: &Cli) -> Result<()> {
         )?;
         let report = store.inspect()?;
         println!(
-            "channel store inspect: transport={} channel_id={} dir={} log_records={} context_records={} invalid_log_lines={} invalid_context_lines={} memory_exists={} memory_bytes={}",
+            "channel store inspect: transport={} channel_id={} dir={} log_records={} context_records={} invalid_log_lines={} invalid_context_lines={} artifact_records={} invalid_artifact_lines={} active_artifacts={} expired_artifacts={} memory_exists={} memory_bytes={}",
             report.transport,
             report.channel_id,
             report.channel_dir.display(),
@@ -18,6 +18,10 @@ pub(crate) fn execute_channel_store_admin_command(cli: &Cli) -> Result<()> {
             report.context_records,
             report.invalid_log_lines,
             report.invalid_context_lines,
+            report.artifact_records,
+            report.invalid_artifact_lines,
+            report.active_artifacts,
+            report.expired_artifacts,
             report.memory_exists,
             report.memory_bytes,
         );
@@ -33,11 +37,13 @@ pub(crate) fn execute_channel_store_admin_command(cli: &Cli) -> Result<()> {
         )?;
         let report = store.repair()?;
         println!(
-            "channel store repair: transport={} channel_id={} log_removed_lines={} context_removed_lines={} log_backup_path={} context_backup_path={}",
+            "channel store repair: transport={} channel_id={} log_removed_lines={} context_removed_lines={} artifact_expired_removed={} artifact_invalid_removed={} log_backup_path={} context_backup_path={}",
             channel_ref.transport,
             channel_ref.channel_id,
             report.log_removed_lines,
             report.context_removed_lines,
+            report.artifact_expired_removed,
+            report.artifact_invalid_removed,
             report
                 .log_backup_path
                 .as_ref()


### PR DESCRIPTION
## Summary
- extend `ChannelInspectReport` with artifact health counters:
  - `artifact_records`
  - `invalid_artifact_lines`
  - `active_artifacts`
  - `expired_artifacts`
- extend `ChannelRepairReport` with artifact cleanup counters:
  - `artifact_expired_removed`
  - `artifact_invalid_removed`
- update channel-store inspect/repair admin output to print artifact metrics
- run artifact purge as part of `ChannelStore::repair` so expired artifact files and invalid index lines are cleaned
- add/expand unit, functional, integration, and regression tests for channel-store + admin command coverage
- document new inspect/repair artifact behavior in README

## Test Matrix
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent channel_store::tests --quiet`
- `cargo test -p pi-coding-agent channel_store_admin --quiet`
- `cargo test -p pi-coding-agent --quiet`
- `cargo test --workspace`

## Coverage Highlights
- Unit/Functional: inspect and report fields now include artifact counters
- Integration: repair removes expired artifacts and normalizes index state
- Regression: malformed artifact index lines are tolerated and repaired without runtime failure

Closes #268
