### PR TITLE
feat(cli): add prompt template file rendering with variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ Run one prompt from a file:
 cargo run -p pi-coding-agent -- --prompt-file .pi/prompts/review.txt
 ```
 
+Run one prompt from a template file with variables:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --prompt-template-file .pi/prompts/review.template.txt \
+  --prompt-template-var module=src/main.rs \
+  --prompt-template-var focus=\"error handling\"
+```
+
 Pipe a one-shot prompt from stdin:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -432,15 +432,34 @@ pub(crate) struct Cli {
         long,
         env = "PI_PROMPT_FILE",
         conflicts_with = "prompt",
+        conflicts_with = "prompt_template_file",
         help = "Read one prompt from a UTF-8 text file and exit"
     )]
     pub(crate) prompt_file: Option<PathBuf>,
 
     #[arg(
         long,
+        env = "PI_PROMPT_TEMPLATE_FILE",
+        conflicts_with = "prompt",
+        conflicts_with = "prompt_file",
+        help = "Read one prompt template from a UTF-8 text file and render placeholders like {{name}} before executing"
+    )]
+    pub(crate) prompt_template_file: Option<PathBuf>,
+
+    #[arg(
+        long = "prompt-template-var",
+        value_name = "key=value",
+        requires = "prompt_template_file",
+        help = "Template variable assignment for --prompt-template-file (repeatable)"
+    )]
+    pub(crate) prompt_template_var: Vec<String>,
+
+    #[arg(
+        long,
         env = "PI_COMMAND_FILE",
         conflicts_with = "prompt",
         conflicts_with = "prompt_file",
+        conflicts_with = "prompt_template_file",
         help = "Execute slash commands from a UTF-8 file and exit"
     )]
     pub(crate) command_file: Option<PathBuf>,

--- a/crates/pi-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/pi-coding-agent/src/runtime_cli_validation.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 fn has_prompt_or_command_input(cli: &Cli) -> bool {
-    cli.prompt.is_some() || cli.prompt_file.is_some() || cli.command_file.is_some()
+    cli.prompt.is_some()
+        || cli.prompt_file.is_some()
+        || cli.prompt_template_file.is_some()
+        || cli.command_file.is_some()
 }
 
 pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
@@ -11,7 +14,7 @@ pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
 
     if has_prompt_or_command_input(cli) {
         bail!(
-            "--github-issues-bridge cannot be combined with --prompt, --prompt-file, or --command-file"
+            "--github-issues-bridge cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file"
         );
     }
     if cli.no_session {
@@ -54,7 +57,7 @@ pub(crate) fn validate_slack_bridge_cli(cli: &Cli) -> Result<()> {
     }
 
     if has_prompt_or_command_input(cli) {
-        bail!("--slack-bridge cannot be combined with --prompt, --prompt-file, or --command-file");
+        bail!("--slack-bridge cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
     }
     if cli.no_session {
         bail!("--slack-bridge cannot be used together with --no-session");
@@ -99,7 +102,7 @@ pub(crate) fn validate_events_runner_cli(cli: &Cli) -> Result<()> {
     }
 
     if has_prompt_or_command_input(cli) {
-        bail!("--events-runner cannot be combined with --prompt, --prompt-file, or --command-file");
+        bail!("--events-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
     }
     if cli.no_session {
         bail!("--events-runner cannot be used together with --no-session");


### PR DESCRIPTION
## Summary
- add one-shot prompt template support via:
  - `--prompt-template-file <path>`
  - `--prompt-template-var key=value` (repeatable)
- integrate template rendering into prompt resolution flow with `{{key}}` placeholders
- enforce fail-closed validation for template input:
  - invalid `key=value` specs
  - duplicate keys
  - missing placeholder bindings
  - unused provided variables
  - unterminated/empty placeholders
- update transport/event-mode prompt conflict validation to include `--prompt-template-file`
- add README usage examples

## Test Matrix
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent unit_resolve_prompt_input_uses_inline_prompt --quiet`
- `cargo test -p pi-coding-agent prompt_template_file_flag_renders_and_runs_one_shot_prompt --quiet`
- `cargo test -p pi-coding-agent --quiet`
- `cargo test --workspace`

## Coverage Highlights
- Unit/Functional: template rendering in prompt resolution with deterministic interpolation rules
- Integration: CLI one-shot prompt template execution reaches provider with rendered prompt
- Regression: missing/invalid/unused template variables fail fast; bridge/events prompt conflict guards include template mode

Closes #270
