### PR TITLE
feat(github): add /pi artifacts run filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ In bridge mode:
 - duplicate deliveries are deduplicated using persisted event keys and response footers
 - bot replies include run/model/token metadata in the issue comment footer
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
-- `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts purge` removes expired entries and reports lifecycle counts
+- `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:
 


### PR DESCRIPTION
## Summary
- extend GitHub issue command grammar with `/pi artifacts run <run_id>`
- add run-scoped artifact rendering and explicit empty-state messaging for unknown runs
- keep existing `/pi artifacts` and `/pi artifacts purge` behavior, update usage/help text and README
- add unit, functional, integration, and regression coverage for parser and bridge behavior

Closes #274

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent github_issues::tests:: --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
