### PR TITLE
feat(github): add /pi artifacts show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ In bridge mode:
 - duplicate deliveries are deduplicated using persisted event keys and response footers
 - bot replies include run/model/token metadata in the issue comment footer
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
-- `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts purge` removes expired entries and reports lifecycle counts
+- `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts show <artifact_id>` shows one artifact record; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:
 


### PR DESCRIPTION
## Summary
- extend `/pi artifacts` command grammar with `show <artifact_id>`
- add issue-scoped artifact detail rendering with explicit `active`, `expired`, and `not found` states
- preserve and validate compatibility for existing `artifacts`, `artifacts run`, and `artifacts purge` commands
- update README and add unit/functional/integration/regression coverage

Closes #276

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent github_issues::tests:: --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
