### PR TITLE
feat(rpc): add capabilities handshake preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ cargo run -p pi-coding-agent -- \
   --package-validate .pi/packages/starter/package.json
 ```
 
+Print versioned RPC protocol capabilities JSON and exit:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --rpc-capabilities
+```
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -509,6 +509,14 @@ pub(crate) struct Cli {
     pub(crate) package_validate: Option<PathBuf>,
 
     #[arg(
+        long = "rpc-capabilities",
+        env = "PI_RPC_CAPABILITIES",
+        default_value_t = false,
+        help = "Print versioned RPC protocol capabilities JSON and exit"
+    )]
+    pub(crate) rpc_capabilities: bool,
+
+    #[arg(
         long = "events-runner",
         env = "PI_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -20,6 +20,7 @@ mod provider_auth;
 mod provider_client;
 mod provider_credentials;
 mod provider_fallback;
+mod rpc_capabilities;
 mod runtime_cli_validation;
 mod runtime_loop;
 mod runtime_output;
@@ -165,6 +166,9 @@ pub(crate) use crate::provider_fallback::{build_client_with_fallbacks, resolve_f
 pub(crate) use crate::provider_fallback::{
     is_retryable_provider_error, ClientRoute, FallbackRoutingClient,
 };
+pub(crate) use crate::rpc_capabilities::execute_rpc_capabilities_command;
+#[cfg(test)]
+pub(crate) use crate::rpc_capabilities::rpc_capabilities_payload;
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_slack_bridge_cli,

--- a/crates/pi-coding-agent/src/rpc_capabilities.rs
+++ b/crates/pi-coding-agent/src/rpc_capabilities.rs
@@ -1,0 +1,93 @@
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+
+use crate::Cli;
+
+pub(crate) const RPC_CAPABILITIES_SCHEMA_VERSION: u32 = 1;
+pub(crate) const RPC_PROTOCOL_VERSION: &str = "0.1.0";
+
+const RPC_CAPABILITIES: &[&str] = &[
+    "errors.structured",
+    "run.cancel",
+    "run.start",
+    "run.stream.assistant_text",
+    "run.stream.tool_events",
+];
+
+pub(crate) fn rpc_capabilities_payload() -> Value {
+    json!({
+        "schema_version": RPC_CAPABILITIES_SCHEMA_VERSION,
+        "protocol_version": RPC_PROTOCOL_VERSION,
+        "capabilities": RPC_CAPABILITIES,
+    })
+}
+
+pub(crate) fn execute_rpc_capabilities_command(cli: &Cli) -> Result<()> {
+    if !cli.rpc_capabilities {
+        return Ok(());
+    }
+
+    let payload = serde_json::to_string_pretty(&rpc_capabilities_payload())
+        .context("failed to serialize rpc capabilities payload")?;
+    println!("{payload}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{rpc_capabilities_payload, RPC_CAPABILITIES_SCHEMA_VERSION, RPC_PROTOCOL_VERSION};
+
+    #[test]
+    fn unit_rpc_capabilities_payload_has_expected_schema_and_version() {
+        let payload = rpc_capabilities_payload();
+        assert_eq!(
+            payload["schema_version"].as_u64(),
+            Some(RPC_CAPABILITIES_SCHEMA_VERSION as u64)
+        );
+        assert_eq!(
+            payload["protocol_version"].as_str(),
+            Some(RPC_PROTOCOL_VERSION)
+        );
+    }
+
+    #[test]
+    fn functional_rpc_capabilities_payload_includes_deterministic_capabilities() {
+        let payload = rpc_capabilities_payload();
+        let capabilities = payload["capabilities"]
+            .as_array()
+            .expect("capabilities should be an array")
+            .iter()
+            .map(|value| value.as_str().expect("capability should be string"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            capabilities,
+            vec![
+                "errors.structured",
+                "run.cancel",
+                "run.start",
+                "run.stream.assistant_text",
+                "run.stream.tool_events",
+            ]
+        );
+    }
+
+    #[test]
+    fn regression_rpc_capabilities_payload_has_unique_entries() {
+        let payload = rpc_capabilities_payload();
+        let capabilities = payload["capabilities"]
+            .as_array()
+            .expect("capabilities should be an array")
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .expect("capability should be string")
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        let unique = capabilities.iter().cloned().collect::<BTreeSet<_>>();
+        assert_eq!(unique.len(), capabilities.len());
+    }
+}

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -16,6 +16,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.rpc_capabilities {
+        execute_rpc_capabilities_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -2800,6 +2800,29 @@ fn regression_package_validate_flag_rejects_invalid_manifest() {
 }
 
 #[test]
+fn rpc_capabilities_flag_outputs_versioned_json_and_exits() {
+    let mut cmd = binary_command();
+    cmd.arg("--rpc-capabilities");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"schema_version\": 1"))
+        .stdout(predicate::str::contains("\"protocol_version\": \"0.1.0\""))
+        .stdout(predicate::str::contains("\"run.cancel\""));
+}
+
+#[test]
+fn regression_rpc_capabilities_flag_takes_preflight_precedence_over_prompt() {
+    let mut cmd = binary_command();
+    cmd.args(["--rpc-capabilities", "--prompt", "ignored prompt"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"schema_version\": 1"))
+        .stderr(predicate::str::contains("OPENAI_API_KEY").not());
+}
+
+#[test]
 fn prompt_file_flag_runs_one_shot_prompt() {
     let server = MockServer::start();
     let openai = server.mock(|when, then| {


### PR DESCRIPTION
## Summary
- add `--rpc-capabilities` startup preflight flag for versioned machine-readable RPC capability discovery
- add `rpc_capabilities` module with stable schema/protocol constants and deterministic capability ordering
- wire command into startup preflight and document usage in README
- add unit/functional/integration/regression test coverage for payload invariants and CLI behavior

Closes #278

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_capabilities --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
