### PR TITLE
feat(rpc): add frame schema validation preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,13 @@ cargo run -p pi-coding-agent -- \
   --rpc-capabilities
 ```
 
+Validate one RPC frame JSON request/command shape and exit:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --rpc-validate-frame-file /tmp/rpc-frame.json
+```
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -517,6 +517,14 @@ pub(crate) struct Cli {
     pub(crate) rpc_capabilities: bool,
 
     #[arg(
+        long = "rpc-validate-frame-file",
+        env = "PI_RPC_VALIDATE_FRAME_FILE",
+        value_name = "path",
+        help = "Validate one RPC frame JSON file and exit"
+    )]
+    pub(crate) rpc_validate_frame_file: Option<PathBuf>,
+
+    #[arg(
         long = "events-runner",
         env = "PI_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -21,6 +21,7 @@ mod provider_client;
 mod provider_credentials;
 mod provider_fallback;
 mod rpc_capabilities;
+mod rpc_protocol;
 mod runtime_cli_validation;
 mod runtime_loop;
 mod runtime_output;
@@ -169,6 +170,9 @@ pub(crate) use crate::provider_fallback::{
 pub(crate) use crate::rpc_capabilities::execute_rpc_capabilities_command;
 #[cfg(test)]
 pub(crate) use crate::rpc_capabilities::rpc_capabilities_payload;
+pub(crate) use crate::rpc_protocol::execute_rpc_validate_frame_command;
+#[cfg(test)]
+pub(crate) use crate::rpc_protocol::validate_rpc_frame_file;
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_slack_bridge_cli,

--- a/crates/pi-coding-agent/src/rpc_protocol.rs
+++ b/crates/pi-coding-agent/src/rpc_protocol.rs
@@ -1,0 +1,190 @@
+use std::{path::Path, str::FromStr};
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::Cli;
+
+pub(crate) const RPC_FRAME_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RpcFrameKind {
+    CapabilitiesRequest,
+    RunStart,
+    RunCancel,
+}
+
+impl RpcFrameKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::CapabilitiesRequest => "capabilities.request",
+            Self::RunStart => "run.start",
+            Self::RunCancel => "run.cancel",
+        }
+    }
+}
+
+impl FromStr for RpcFrameKind {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "capabilities.request" => Ok(Self::CapabilitiesRequest),
+            "run.start" => Ok(Self::RunStart),
+            "run.cancel" => Ok(Self::RunCancel),
+            other => bail!(
+                "unsupported rpc frame kind '{}'; supported kinds are capabilities.request, run.start, run.cancel",
+                other
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RpcFrame {
+    pub request_id: String,
+    pub kind: RpcFrameKind,
+    pub payload: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawRpcFrame {
+    schema_version: u32,
+    request_id: String,
+    kind: String,
+    payload: Value,
+}
+
+pub(crate) fn parse_rpc_frame(raw: &str) -> Result<RpcFrame> {
+    let frame =
+        serde_json::from_str::<RawRpcFrame>(raw).context("failed to parse rpc frame JSON")?;
+    if frame.schema_version != RPC_FRAME_SCHEMA_VERSION {
+        bail!(
+            "unsupported rpc frame schema: expected {}, found {}",
+            RPC_FRAME_SCHEMA_VERSION,
+            frame.schema_version
+        );
+    }
+    let request_id = frame.request_id.trim();
+    if request_id.is_empty() {
+        bail!("rpc frame request_id must be non-empty");
+    }
+    let kind = RpcFrameKind::from_str(frame.kind.trim())?;
+    let payload = frame
+        .payload
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("rpc frame payload must be a JSON object"))?
+        .clone();
+    Ok(RpcFrame {
+        request_id: request_id.to_string(),
+        kind,
+        payload,
+    })
+}
+
+pub(crate) fn validate_rpc_frame_file(path: &Path) -> Result<RpcFrame> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read rpc frame file {}", path.display()))?;
+    parse_rpc_frame(&raw)
+}
+
+pub(crate) fn execute_rpc_validate_frame_command(cli: &Cli) -> Result<()> {
+    let Some(path) = cli.rpc_validate_frame_file.as_ref() else {
+        return Ok(());
+    };
+    let frame = validate_rpc_frame_file(path)?;
+    println!(
+        "rpc frame validate: path={} request_id={} kind={} payload_keys={}",
+        path.display(),
+        frame.request_id,
+        frame.kind.as_str(),
+        frame.payload.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{parse_rpc_frame, validate_rpc_frame_file, RpcFrameKind};
+
+    #[test]
+    fn unit_parse_rpc_frame_accepts_supported_kind_and_payload_object() {
+        let frame = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-1",
+  "kind": "run.start",
+  "payload": {"prompt":"hello"}
+}"#,
+        )
+        .expect("parse frame");
+        assert_eq!(frame.request_id, "req-1");
+        assert_eq!(frame.kind, RpcFrameKind::RunStart);
+        assert_eq!(frame.payload.len(), 1);
+    }
+
+    #[test]
+    fn functional_validate_rpc_frame_file_reports_roundtrip() {
+        let temp = tempdir().expect("tempdir");
+        let frame_path = temp.path().join("frame.json");
+        std::fs::write(
+            &frame_path,
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-cap",
+  "kind": "capabilities.request",
+  "payload": {}
+}"#,
+        )
+        .expect("write frame");
+
+        let frame = validate_rpc_frame_file(&frame_path).expect("validate frame");
+        assert_eq!(frame.request_id, "req-cap");
+        assert_eq!(frame.kind, RpcFrameKind::CapabilitiesRequest);
+    }
+
+    #[test]
+    fn regression_parse_rpc_frame_rejects_unknown_kind_schema_and_payload_shape() {
+        let schema_error = parse_rpc_frame(
+            r#"{
+  "schema_version": 9,
+  "request_id": "req-2",
+  "kind": "run.start",
+  "payload": {}
+}"#,
+        )
+        .expect_err("schema mismatch should fail");
+        assert!(schema_error
+            .to_string()
+            .contains("unsupported rpc frame schema"));
+
+        let kind_error = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-2",
+  "kind": "run.unknown",
+  "payload": {}
+}"#,
+        )
+        .expect_err("unknown kind should fail");
+        assert!(kind_error
+            .to_string()
+            .contains("unsupported rpc frame kind"));
+
+        let payload_error = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-2",
+  "kind": "run.cancel",
+  "payload": []
+}"#,
+        )
+        .expect_err("non-object payload should fail");
+        assert!(payload_error
+            .to_string()
+            .contains("rpc frame payload must be a JSON object"));
+    }
+}

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -21,6 +21,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.rpc_validate_frame_file.is_some() {
+        execute_rpc_validate_frame_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -28,12 +28,12 @@ use super::{
     execute_auth_command, execute_branch_alias_command, execute_channel_store_admin_command,
     execute_command_file, execute_doctor_command, execute_integration_auth_command,
     execute_macro_command, execute_package_validate_command, execute_profile_command,
-    execute_rpc_capabilities_command, execute_session_bookmark_command,
-    execute_session_diff_command, execute_session_graph_export_command,
-    execute_session_search_command, execute_session_stats_command, execute_skills_list_command,
-    execute_skills_lock_diff_command, execute_skills_lock_write_command,
-    execute_skills_prune_command, execute_skills_search_command, execute_skills_show_command,
-    execute_skills_sync_command, execute_skills_trust_add_command,
+    execute_rpc_capabilities_command, execute_rpc_validate_frame_command,
+    execute_session_bookmark_command, execute_session_diff_command,
+    execute_session_graph_export_command, execute_session_search_command,
+    execute_session_stats_command, execute_skills_list_command, execute_skills_lock_diff_command,
+    execute_skills_lock_write_command, execute_skills_prune_command, execute_skills_search_command,
+    execute_skills_show_command, execute_skills_sync_command, execute_skills_trust_add_command,
     execute_skills_trust_list_command, execute_skills_trust_revoke_command,
     execute_skills_trust_rotate_command, execute_skills_verify_command, format_id_list,
     format_remap_ids, handle_command, handle_command_with_session_import_mode, initialize_session,
@@ -65,13 +65,13 @@ use super::{
     tool_policy_to_json, trust_record_status, unknown_command_message, validate_branch_alias_name,
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_macro_command_entry, validate_macro_name,
-    validate_profile_name, validate_session_file, validate_skills_prune_file_name,
-    validate_slack_bridge_cli, AuthCommand, AuthCommandConfig, BranchAliasCommand, BranchAliasFile,
-    Cli, CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
-    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
-    CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute, CommandAction,
-    CommandExecutionContext, CommandFileEntry, CommandFileReport, CredentialStoreData,
-    CredentialStoreEncryptionMode, DoctorCheckResult, DoctorCommandConfig,
+    validate_profile_name, validate_rpc_frame_file, validate_session_file,
+    validate_skills_prune_file_name, validate_slack_bridge_cli, AuthCommand, AuthCommandConfig,
+    BranchAliasCommand, BranchAliasFile, Cli, CliBashProfile, CliCommandFileErrorMode,
+    CliCredentialStoreEncryptionMode, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
+    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute,
+    CommandAction, CommandExecutionContext, CommandFileEntry, CommandFileReport,
+    CredentialStoreData, CredentialStoreEncryptionMode, DoctorCheckResult, DoctorCommandConfig,
     DoctorCommandOutputFormat, DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient,
     IntegrationAuthCommand, IntegrationCredentialStoreRecord, MacroCommand, MacroFile,
     ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
@@ -248,6 +248,7 @@ fn test_cli() -> Cli {
         channel_store_repair: None,
         package_validate: None,
         rpc_capabilities: false,
+        rpc_validate_frame_file: None,
         events_runner: false,
         events_dir: PathBuf::from(".pi/events"),
         events_state_path: PathBuf::from(".pi/events/state.json"),
@@ -6735,6 +6736,64 @@ fn functional_execute_rpc_capabilities_command_succeeds_when_enabled() {
 fn regression_execute_rpc_capabilities_command_is_noop_when_disabled() {
     let cli = test_cli();
     execute_rpc_capabilities_command(&cli).expect("disabled rpc capabilities should be noop");
+}
+
+#[test]
+fn unit_validate_rpc_frame_file_parses_supported_frame_shape() {
+    let temp = tempdir().expect("tempdir");
+    let frame_path = temp.path().join("frame.json");
+    std::fs::write(
+        &frame_path,
+        r#"{
+  "schema_version": 1,
+  "request_id": "req-1",
+  "kind": "run.start",
+  "payload": {"prompt":"hello"}
+}"#,
+    )
+    .expect("write frame");
+    let frame = validate_rpc_frame_file(&frame_path).expect("validate frame");
+    assert_eq!(frame.request_id, "req-1");
+    assert_eq!(frame.payload.len(), 1);
+}
+
+#[test]
+fn functional_execute_rpc_validate_frame_command_succeeds_for_valid_frame() {
+    let temp = tempdir().expect("tempdir");
+    let frame_path = temp.path().join("frame.json");
+    std::fs::write(
+        &frame_path,
+        r#"{
+  "schema_version": 1,
+  "request_id": "req-cancel",
+  "kind": "run.cancel",
+  "payload": {"run_id":"run-1"}
+}"#,
+    )
+    .expect("write frame");
+    let mut cli = test_cli();
+    cli.rpc_validate_frame_file = Some(frame_path);
+    execute_rpc_validate_frame_command(&cli).expect("rpc frame validate should succeed");
+}
+
+#[test]
+fn regression_execute_rpc_validate_frame_command_rejects_invalid_frame() {
+    let temp = tempdir().expect("tempdir");
+    let frame_path = temp.path().join("frame.json");
+    std::fs::write(
+        &frame_path,
+        r#"{
+  "schema_version": 1,
+  "request_id": "req-invalid",
+  "kind": "run.unknown",
+  "payload": {}
+}"#,
+    )
+    .expect("write frame");
+    let mut cli = test_cli();
+    cli.rpc_validate_frame_file = Some(frame_path);
+    let error = execute_rpc_validate_frame_command(&cli).expect_err("invalid kind should fail");
+    assert!(error.to_string().contains("unsupported rpc frame kind"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `rpc_protocol` module with strict versioned RPC frame parsing and validation
- add `--rpc-validate-frame-file <path>` startup preflight command with deterministic summary output
- enforce supported schema/kind/request id/payload-object validation and actionable errors
- document usage and add unit/functional/integration/regression coverage

Closes #280

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
