### PR TITLE
feat(rpc): add frame dispatch preflight responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,13 @@ cargo run -p pi-coding-agent -- \
   --rpc-validate-frame-file /tmp/rpc-frame.json
 ```
 
+Dispatch one RPC request frame JSON into a response frame JSON and exit:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --rpc-dispatch-frame-file /tmp/rpc-frame.json
+```
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -525,6 +525,14 @@ pub(crate) struct Cli {
     pub(crate) rpc_validate_frame_file: Option<PathBuf>,
 
     #[arg(
+        long = "rpc-dispatch-frame-file",
+        env = "PI_RPC_DISPATCH_FRAME_FILE",
+        value_name = "path",
+        help = "Dispatch one RPC request frame JSON file and print a response frame JSON"
+    )]
+    pub(crate) rpc_dispatch_frame_file: Option<PathBuf>,
+
+    #[arg(
         long = "events-runner",
         env = "PI_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -170,9 +170,11 @@ pub(crate) use crate::provider_fallback::{
 pub(crate) use crate::rpc_capabilities::execute_rpc_capabilities_command;
 #[cfg(test)]
 pub(crate) use crate::rpc_capabilities::rpc_capabilities_payload;
-pub(crate) use crate::rpc_protocol::execute_rpc_validate_frame_command;
 #[cfg(test)]
 pub(crate) use crate::rpc_protocol::validate_rpc_frame_file;
+pub(crate) use crate::rpc_protocol::{
+    execute_rpc_dispatch_frame_command, execute_rpc_validate_frame_command,
+};
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_slack_bridge_cli,

--- a/crates/pi-coding-agent/src/rpc_protocol.rs
+++ b/crates/pi-coding-agent/src/rpc_protocol.rs
@@ -1,12 +1,14 @@
 use std::{path::Path, str::FromStr};
 
-use anyhow::{bail, Context, Result};
-use serde::Deserialize;
-use serde_json::Value;
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
+use crate::rpc_capabilities::{rpc_capabilities_payload, RPC_PROTOCOL_VERSION};
 use crate::Cli;
 
 pub(crate) const RPC_FRAME_SCHEMA_VERSION: u32 = 1;
+const RPC_STUB_MODE: &str = "preflight";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RpcFrameKind {
@@ -16,7 +18,7 @@ pub(crate) enum RpcFrameKind {
 }
 
 impl RpcFrameKind {
-    fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::CapabilitiesRequest => "capabilities.request",
             Self::RunStart => "run.start",
@@ -48,6 +50,14 @@ pub(crate) struct RpcFrame {
     pub payload: serde_json::Map<String, Value>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct RpcResponseFrame {
+    pub schema_version: u32,
+    pub request_id: String,
+    pub kind: String,
+    pub payload: Value,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct RawRpcFrame {
     schema_version: u32,
@@ -74,7 +84,7 @@ pub(crate) fn parse_rpc_frame(raw: &str) -> Result<RpcFrame> {
     let payload = frame
         .payload
         .as_object()
-        .ok_or_else(|| anyhow::anyhow!("rpc frame payload must be a JSON object"))?
+        .ok_or_else(|| anyhow!("rpc frame payload must be a JSON object"))?
         .clone();
     Ok(RpcFrame {
         request_id: request_id.to_string(),
@@ -87,6 +97,57 @@ pub(crate) fn validate_rpc_frame_file(path: &Path) -> Result<RpcFrame> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read rpc frame file {}", path.display()))?;
     parse_rpc_frame(&raw)
+}
+
+pub(crate) fn dispatch_rpc_frame(frame: &RpcFrame) -> Result<RpcResponseFrame> {
+    match frame.kind {
+        RpcFrameKind::CapabilitiesRequest => {
+            let capabilities = rpc_capabilities_payload();
+            let capability_list = capabilities["capabilities"]
+                .as_array()
+                .cloned()
+                .ok_or_else(|| anyhow!("rpc capabilities payload is missing capabilities array"))?;
+            Ok(build_response_frame(
+                &frame.request_id,
+                "capabilities.response",
+                json!({
+                    "protocol_version": RPC_PROTOCOL_VERSION,
+                    "capabilities": capability_list,
+                }),
+            ))
+        }
+        RpcFrameKind::RunStart => {
+            let prompt =
+                require_non_empty_payload_string(&frame.payload, "prompt", frame.kind.as_str())?;
+            Ok(build_response_frame(
+                &frame.request_id,
+                "run.accepted",
+                json!({
+                    "status": "accepted",
+                    "mode": RPC_STUB_MODE,
+                    "prompt_chars": prompt.chars().count(),
+                }),
+            ))
+        }
+        RpcFrameKind::RunCancel => {
+            let run_id =
+                require_non_empty_payload_string(&frame.payload, "run_id", frame.kind.as_str())?;
+            Ok(build_response_frame(
+                &frame.request_id,
+                "run.cancelled",
+                json!({
+                    "status": "cancelled",
+                    "mode": RPC_STUB_MODE,
+                    "run_id": run_id,
+                }),
+            ))
+        }
+    }
+}
+
+pub(crate) fn dispatch_rpc_frame_file(path: &Path) -> Result<RpcResponseFrame> {
+    let frame = validate_rpc_frame_file(path)?;
+    dispatch_rpc_frame(&frame)
 }
 
 pub(crate) fn execute_rpc_validate_frame_command(cli: &Cli) -> Result<()> {
@@ -104,11 +165,54 @@ pub(crate) fn execute_rpc_validate_frame_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn execute_rpc_dispatch_frame_command(cli: &Cli) -> Result<()> {
+    let Some(path) = cli.rpc_dispatch_frame_file.as_ref() else {
+        return Ok(());
+    };
+    let response = dispatch_rpc_frame_file(path)?;
+    let payload = serde_json::to_string_pretty(&response)
+        .context("failed to serialize rpc response frame")?;
+    println!("{payload}");
+    Ok(())
+}
+
+fn build_response_frame(request_id: &str, kind: &str, payload: Value) -> RpcResponseFrame {
+    RpcResponseFrame {
+        schema_version: RPC_FRAME_SCHEMA_VERSION,
+        request_id: request_id.to_string(),
+        kind: kind.to_string(),
+        payload,
+    }
+}
+
+fn require_non_empty_payload_string(
+    payload: &serde_json::Map<String, Value>,
+    key: &str,
+    kind: &str,
+) -> Result<String> {
+    let value = payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "rpc frame kind '{}' requires non-empty payload field '{}'",
+                kind,
+                key
+            )
+        })?;
+    Ok(value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
 
-    use super::{parse_rpc_frame, validate_rpc_frame_file, RpcFrameKind};
+    use super::{
+        dispatch_rpc_frame, dispatch_rpc_frame_file, parse_rpc_frame, validate_rpc_frame_file,
+        RpcFrameKind,
+    };
 
     #[test]
     fn unit_parse_rpc_frame_accepts_supported_kind_and_payload_object() {
@@ -124,6 +228,51 @@ mod tests {
         assert_eq!(frame.request_id, "req-1");
         assert_eq!(frame.kind, RpcFrameKind::RunStart);
         assert_eq!(frame.payload.len(), 1);
+    }
+
+    #[test]
+    fn unit_dispatch_rpc_frame_maps_supported_kinds_to_response_envelopes() {
+        let capabilities = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-cap",
+  "kind": "capabilities.request",
+  "payload": {}
+}"#,
+        )
+        .expect("parse capabilities");
+        let capabilities_response = dispatch_rpc_frame(&capabilities).expect("dispatch");
+        assert_eq!(capabilities_response.kind, "capabilities.response");
+        assert_eq!(
+            capabilities_response.payload["protocol_version"].as_str(),
+            Some("0.1.0")
+        );
+
+        let start = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-start",
+  "kind": "run.start",
+  "payload": {"prompt":"hello world"}
+}"#,
+        )
+        .expect("parse start");
+        let start_response = dispatch_rpc_frame(&start).expect("dispatch start");
+        assert_eq!(start_response.kind, "run.accepted");
+        assert_eq!(start_response.payload["prompt_chars"].as_u64(), Some(11));
+
+        let cancel = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-cancel",
+  "kind": "run.cancel",
+  "payload": {"run_id":"run-1"}
+}"#,
+        )
+        .expect("parse cancel");
+        let cancel_response = dispatch_rpc_frame(&cancel).expect("dispatch cancel");
+        assert_eq!(cancel_response.kind, "run.cancelled");
+        assert_eq!(cancel_response.payload["run_id"].as_str(), Some("run-1"));
     }
 
     #[test]
@@ -144,6 +293,26 @@ mod tests {
         let frame = validate_rpc_frame_file(&frame_path).expect("validate frame");
         assert_eq!(frame.request_id, "req-cap");
         assert_eq!(frame.kind, RpcFrameKind::CapabilitiesRequest);
+    }
+
+    #[test]
+    fn integration_dispatch_rpc_frame_file_returns_response_frame() {
+        let temp = tempdir().expect("tempdir");
+        let frame_path = temp.path().join("frame.json");
+        std::fs::write(
+            &frame_path,
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-dispatch",
+  "kind": "run.cancel",
+  "payload": {"run_id":"run-42"}
+}"#,
+        )
+        .expect("write frame");
+
+        let response = dispatch_rpc_frame_file(&frame_path).expect("dispatch frame");
+        assert_eq!(response.request_id, "req-dispatch");
+        assert_eq!(response.kind, "run.cancelled");
     }
 
     #[test]
@@ -186,5 +355,36 @@ mod tests {
         assert!(payload_error
             .to_string()
             .contains("rpc frame payload must be a JSON object"));
+    }
+
+    #[test]
+    fn regression_dispatch_rpc_frame_rejects_missing_required_payload_fields() {
+        let start = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-start",
+  "kind": "run.start",
+  "payload": {}
+}"#,
+        )
+        .expect("parse start");
+        let start_error = dispatch_rpc_frame(&start).expect_err("missing prompt should fail");
+        assert!(start_error
+            .to_string()
+            .contains("requires non-empty payload field 'prompt'"));
+
+        let cancel = parse_rpc_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-cancel",
+  "kind": "run.cancel",
+  "payload": {}
+}"#,
+        )
+        .expect("parse cancel");
+        let cancel_error = dispatch_rpc_frame(&cancel).expect_err("missing run_id should fail");
+        assert!(cancel_error
+            .to_string()
+            .contains("requires non-empty payload field 'run_id'"));
     }
 }

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -26,6 +26,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.rpc_dispatch_frame_file.is_some() {
+        execute_rpc_dispatch_frame_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli


### PR DESCRIPTION
## Summary
- extend RPC protocol support with a request-frame dispatcher and structured response envelopes
- add `--rpc-dispatch-frame-file <path>` startup preflight command that prints response JSON and exits
- map supported request kinds to responses:
  - `capabilities.request` -> `capabilities.response`
  - `run.start` -> `run.accepted`
  - `run.cancel` -> `run.cancelled`
- validate required payload fields for run commands with deterministic diagnostics
- add README docs and unit/functional/integration/regression coverage

Closes #282

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests:: --quiet
- cargo test -p pi-coding-agent rpc_dispatch_frame_file --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
