### PR TITLE
feat(rpc): emit structured dispatch error envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
+For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash


### PR DESCRIPTION
## Summary
- add deterministic RPC dispatch error taxonomy and `kind: error` response envelope support
- emit machine-readable error frames for parse/validation/dispatch failures with stable `payload.code`
- preserve non-zero CLI exit status while printing JSON error envelope for client consumption
- add request-id best-effort extraction on parse failures and io-error envelope on unreadable files
- add docs plus unit/functional/integration/regression coverage

Closes #284

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests:: --quiet
- cargo test -p pi-coding-agent rpc_dispatch_frame_file --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
