### PR TITLE
feat(rpc): add ndjson batch dispatch preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,13 @@ cargo run -p pi-coding-agent -- \
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.
 
+Dispatch newline-delimited RPC request frames (NDJSON) and emit one response JSON line per input frame:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --rpc-dispatch-ndjson-file /tmp/rpc-frames.ndjson
+```
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -533,6 +533,14 @@ pub(crate) struct Cli {
     pub(crate) rpc_dispatch_frame_file: Option<PathBuf>,
 
     #[arg(
+        long = "rpc-dispatch-ndjson-file",
+        env = "PI_RPC_DISPATCH_NDJSON_FILE",
+        value_name = "path",
+        help = "Dispatch newline-delimited RPC request frames and print one response JSON line per frame"
+    )]
+    pub(crate) rpc_dispatch_ndjson_file: Option<PathBuf>,
+
+    #[arg(
         long = "events-runner",
         env = "PI_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -173,7 +173,8 @@ pub(crate) use crate::rpc_capabilities::rpc_capabilities_payload;
 #[cfg(test)]
 pub(crate) use crate::rpc_protocol::validate_rpc_frame_file;
 pub(crate) use crate::rpc_protocol::{
-    execute_rpc_dispatch_frame_command, execute_rpc_validate_frame_command,
+    execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
+    execute_rpc_validate_frame_command,
 };
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -31,6 +31,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.rpc_dispatch_ndjson_file.is_some() {
+        execute_rpc_dispatch_ndjson_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli


### PR DESCRIPTION
## Summary
- add `--rpc-dispatch-ndjson-file` startup preflight command for newline-delimited RPC request dispatch
- process non-empty non-comment lines in order and emit one response JSON line per input line
- continue dispatch after malformed lines by emitting structured error envelopes, then exit non-zero if any errors occurred
- add docs and broad test coverage (unit/functional/integration/regression)

Closes #286

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests:: --quiet
- cargo test -p pi-coding-agent rpc_dispatch_ndjson_file --quiet
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
