### PR TITLE
feat: add package manifest show preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ cargo run -p pi-coding-agent -- \
   --package-validate .pi/packages/starter/package.json
 ```
 
+Inspect package manifest metadata and component inventory:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-show .pi/packages/starter/package.json
+```
+
 Print versioned RPC protocol capabilities JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -503,10 +503,20 @@ pub(crate) struct Cli {
     #[arg(
         long = "package-validate",
         env = "PI_PACKAGE_VALIDATE",
+        conflicts_with = "package_show",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
     pub(crate) package_validate: Option<PathBuf>,
+
+    #[arg(
+        long = "package-show",
+        env = "PI_PACKAGE_SHOW",
+        conflicts_with = "package_validate",
+        value_name = "path",
+        help = "Print package manifest metadata and component inventory"
+    )]
+    pub(crate) package_show: Option<PathBuf>,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -149,7 +149,9 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 #[cfg(test)]
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
-pub(crate) use crate::package_manifest::execute_package_validate_command;
+pub(crate) use crate::package_manifest::{
+    execute_package_show_command, execute_package_validate_command,
+};
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,
     missing_provider_api_key_message, provider_api_key_candidates,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -16,6 +16,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_show.is_some() {
+        execute_package_show_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add `--package-show <path>` preflight command to print manifest metadata and component inventory
- refactor package manifest loading/validation so validate and show share one strict loader
- wire CLI/startup routing and add README usage docs

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent package_show_flag_reports_manifest_inventory_and_exits --quiet
- cargo test --workspace

Closes #288
