### PR TITLE
feat: add local package install preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ cargo run -p pi-coding-agent -- \
   --package-show .pi/packages/starter/package.json
 ```
 
+Install a local package manifest bundle into a versioned package root:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-install ./examples/starter/package.json \
+  --package-install-root .pi/packages
+```
+
 Print versioned RPC protocol capabilities JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -504,6 +504,7 @@ pub(crate) struct Cli {
         long = "package-validate",
         env = "PI_PACKAGE_VALIDATE",
         conflicts_with = "package_show",
+        conflicts_with = "package_install",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -513,10 +514,31 @@ pub(crate) struct Cli {
         long = "package-show",
         env = "PI_PACKAGE_SHOW",
         conflicts_with = "package_validate",
+        conflicts_with = "package_install",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
     pub(crate) package_show: Option<PathBuf>,
+
+    #[arg(
+        long = "package-install",
+        env = "PI_PACKAGE_INSTALL",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        value_name = "path",
+        help = "Install a local package manifest bundle and exit"
+    )]
+    pub(crate) package_install: Option<PathBuf>,
+
+    #[arg(
+        long = "package-install-root",
+        env = "PI_PACKAGE_INSTALL_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_install",
+        value_name = "path",
+        help = "Destination root for installed package bundles"
+    )]
+    pub(crate) package_install_root: PathBuf,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,7 +150,7 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_show_command, execute_package_validate_command,
+    execute_package_install_command, execute_package_show_command, execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -21,6 +21,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_install.is_some() {
+        execute_package_install_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add `--package-install <manifest_path>` preflight command and `--package-install-root` destination support
- install validated package bundles into deterministic versioned layout (`<root>/<name>/<version>/...`) preserving component paths
- enforce strict source safety checks (missing source rejection, regular-file requirement, symlink escape rejection)
- provide idempotent upsert accounting (`installed`, `updated`, `skipped`) and deterministic install reporting
- wire docs and startup preflight routing for package install mode

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent functional_execute_package_install_command_succeeds_for_valid_manifest --quiet
- cargo test -p pi-coding-agent regression_execute_package_install_command_rejects_missing_component_source --quiet
- cargo test -p pi-coding-agent package_install_flag_installs_bundle_files_and_exits --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #290
