### PR TITLE
feat: add package list preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ cargo run -p pi-coding-agent -- \
   --package-install-root .pi/packages
 ```
 
+List installed package bundles from a package root:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-list \
+  --package-list-root .pi/packages
+```
+
 Print versioned RPC protocol capabilities JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -505,6 +505,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_VALIDATE",
         conflicts_with = "package_show",
         conflicts_with = "package_install",
+        conflicts_with = "package_list",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -515,6 +516,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_SHOW",
         conflicts_with = "package_validate",
         conflicts_with = "package_install",
+        conflicts_with = "package_list",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
@@ -525,6 +527,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_INSTALL",
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
+        conflicts_with = "package_list",
         value_name = "path",
         help = "Install a local package manifest bundle and exit"
     )]
@@ -539,6 +542,24 @@ pub(crate) struct Cli {
         help = "Destination root for installed package bundles"
     )]
     pub(crate) package_install_root: PathBuf,
+
+    #[arg(
+        long = "package-list",
+        env = "PI_PACKAGE_LIST",
+        default_value_t = false,
+        help = "List installed package bundles from a package root and exit"
+    )]
+    pub(crate) package_list: bool,
+
+    #[arg(
+        long = "package-list-root",
+        env = "PI_PACKAGE_LIST_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_list",
+        value_name = "path",
+        help = "Source root to scan for installed package bundles"
+    )]
+    pub(crate) package_list_root: PathBuf,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,7 +150,8 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_install_command, execute_package_show_command, execute_package_validate_command,
+    execute_package_install_command, execute_package_list_command, execute_package_show_command,
+    execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -26,6 +26,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_list {
+        execute_package_list_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -27,15 +27,15 @@ use super::{
     encrypt_credential_store_secret, ensure_non_empty_text, escape_graph_label,
     execute_auth_command, execute_branch_alias_command, execute_channel_store_admin_command,
     execute_command_file, execute_doctor_command, execute_integration_auth_command,
-    execute_macro_command, execute_package_install_command, execute_package_show_command,
-    execute_package_validate_command, execute_profile_command, execute_rpc_capabilities_command,
-    execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
-    execute_rpc_validate_frame_command, execute_session_bookmark_command,
-    execute_session_diff_command, execute_session_graph_export_command,
-    execute_session_search_command, execute_session_stats_command, execute_skills_list_command,
-    execute_skills_lock_diff_command, execute_skills_lock_write_command,
-    execute_skills_prune_command, execute_skills_search_command, execute_skills_show_command,
-    execute_skills_sync_command, execute_skills_trust_add_command,
+    execute_macro_command, execute_package_install_command, execute_package_list_command,
+    execute_package_show_command, execute_package_validate_command, execute_profile_command,
+    execute_rpc_capabilities_command, execute_rpc_dispatch_frame_command,
+    execute_rpc_dispatch_ndjson_command, execute_rpc_validate_frame_command,
+    execute_session_bookmark_command, execute_session_diff_command,
+    execute_session_graph_export_command, execute_session_search_command,
+    execute_session_stats_command, execute_skills_list_command, execute_skills_lock_diff_command,
+    execute_skills_lock_write_command, execute_skills_prune_command, execute_skills_search_command,
+    execute_skills_show_command, execute_skills_sync_command, execute_skills_trust_add_command,
     execute_skills_trust_list_command, execute_skills_trust_revoke_command,
     execute_skills_trust_rotate_command, execute_skills_verify_command, format_id_list,
     format_remap_ids, handle_command, handle_command_with_session_import_mode, initialize_session,
@@ -252,6 +252,8 @@ fn test_cli() -> Cli {
         package_show: None,
         package_install: None,
         package_install_root: PathBuf::from(".pi/packages"),
+        package_list: false,
+        package_list_root: PathBuf::from(".pi/packages"),
         rpc_capabilities: false,
         rpc_validate_frame_file: None,
         rpc_dispatch_frame_file: None,
@@ -6816,6 +6818,50 @@ fn regression_execute_package_install_command_rejects_missing_component_source()
     cli.package_install_root = temp.path().join("installed");
     let error = execute_package_install_command(&cli).expect_err("missing source should fail");
     assert!(error.to_string().contains("does not exist"));
+}
+
+#[test]
+fn functional_execute_package_list_command_reports_installed_packages() {
+    let temp = tempdir().expect("tempdir");
+    let package_root = temp.path().join("bundle");
+    std::fs::create_dir_all(package_root.join("templates")).expect("create templates dir");
+    std::fs::write(package_root.join("templates/review.txt"), "template")
+        .expect("write template source");
+    let manifest_path = package_root.join("package.json");
+    std::fs::write(
+        &manifest_path,
+        r#"{
+  "schema_version": 1,
+  "name": "starter-bundle",
+  "version": "1.0.0",
+  "templates": [{"id":"review","path":"templates/review.txt"}]
+}"#,
+    )
+    .expect("write manifest");
+
+    let install_root = temp.path().join("installed");
+    let mut install_cli = test_cli();
+    install_cli.package_install = Some(manifest_path);
+    install_cli.package_install_root = install_root.clone();
+    execute_package_install_command(&install_cli).expect("package install should succeed");
+
+    let mut list_cli = test_cli();
+    list_cli.package_list = true;
+    list_cli.package_list_root = install_root;
+    execute_package_list_command(&list_cli).expect("package list should succeed");
+}
+
+#[test]
+fn regression_execute_package_list_command_rejects_non_directory_root() {
+    let temp = tempdir().expect("tempdir");
+    let root_file = temp.path().join("not-a-directory.txt");
+    std::fs::write(&root_file, "file root").expect("write root file");
+
+    let mut cli = test_cli();
+    cli.package_list = true;
+    cli.package_list_root = root_file;
+    let error = execute_package_list_command(&cli).expect_err("non-directory root should fail");
+    assert!(error.to_string().contains("is not a directory"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add package list preflight command (`--package-list`) with configurable scan root (`--package-list-root`)
- scan deterministic package install layout and render sorted package inventory entries
- keep listing resilient by surfacing invalid/corrupt installed manifests as explicit invalid entries
- wire startup preflight routing, CLI options, and README docs for package list mode

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent package_list --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #292
