### PR TITLE
feat: add package remove preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,14 @@ cargo run -p pi-coding-agent -- \
   --package-list-root .pi/packages
 ```
 
+Remove one installed package bundle from a package root:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-remove starter-bundle@1.0.0 \
+  --package-remove-root .pi/packages
+```
+
 Print versioned RPC protocol capabilities JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -506,6 +506,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_show",
         conflicts_with = "package_install",
         conflicts_with = "package_list",
+        conflicts_with = "package_remove",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -517,6 +518,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_validate",
         conflicts_with = "package_install",
         conflicts_with = "package_list",
+        conflicts_with = "package_remove",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
@@ -528,6 +530,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
         conflicts_with = "package_list",
+        conflicts_with = "package_remove",
         value_name = "path",
         help = "Install a local package manifest bundle and exit"
     )]
@@ -546,6 +549,7 @@ pub(crate) struct Cli {
     #[arg(
         long = "package-list",
         env = "PI_PACKAGE_LIST",
+        conflicts_with = "package_remove",
         default_value_t = false,
         help = "List installed package bundles from a package root and exit"
     )]
@@ -560,6 +564,28 @@ pub(crate) struct Cli {
         help = "Source root to scan for installed package bundles"
     )]
     pub(crate) package_list_root: PathBuf,
+
+    #[arg(
+        long = "package-remove",
+        env = "PI_PACKAGE_REMOVE",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_list",
+        value_name = "name@version",
+        help = "Remove one installed package bundle by coordinate and exit"
+    )]
+    pub(crate) package_remove: Option<String>,
+
+    #[arg(
+        long = "package-remove-root",
+        env = "PI_PACKAGE_REMOVE_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_remove",
+        value_name = "path",
+        help = "Source root containing installed package bundles for removal"
+    )]
+    pub(crate) package_remove_root: PathBuf,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,8 +150,8 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_install_command, execute_package_list_command, execute_package_show_command,
-    execute_package_validate_command,
+    execute_package_install_command, execute_package_list_command, execute_package_remove_command,
+    execute_package_show_command, execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -31,6 +31,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_remove.is_some() {
+        execute_package_remove_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add package remove preflight command (`--package-remove <name@version>`) with configurable source root (`--package-remove-root`)
- add strict package coordinate parsing and validation for remove flows
- remove deterministic installed bundle path and cleanup empty package parent directories
- render deterministic remove result status (`removed` or `not_found`) and wire startup preflight/CLI/docs support

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent package_remove --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #294
