### PR TITLE
feat: add package rollback preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ cargo run -p pi-coding-agent -- \
   --package-remove-root .pi/packages
 ```
 
+Rollback one package to a target installed version (removes sibling versions):
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-rollback starter-bundle@1.0.0 \
+  --package-rollback-root .pi/packages
+```
+
 Print versioned RPC protocol capabilities JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -507,6 +507,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_install",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -519,6 +520,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_install",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
@@ -531,6 +533,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_show",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
         value_name = "path",
         help = "Install a local package manifest bundle and exit"
     )]
@@ -550,6 +553,7 @@ pub(crate) struct Cli {
         long = "package-list",
         env = "PI_PACKAGE_LIST",
         conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
         default_value_t = false,
         help = "List installed package bundles from a package root and exit"
     )]
@@ -572,6 +576,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_show",
         conflicts_with = "package_install",
         conflicts_with = "package_list",
+        conflicts_with = "package_rollback",
         value_name = "name@version",
         help = "Remove one installed package bundle by coordinate and exit"
     )]
@@ -586,6 +591,29 @@ pub(crate) struct Cli {
         help = "Source root containing installed package bundles for removal"
     )]
     pub(crate) package_remove_root: PathBuf,
+
+    #[arg(
+        long = "package-rollback",
+        env = "PI_PACKAGE_ROLLBACK",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_list",
+        conflicts_with = "package_remove",
+        value_name = "name@version",
+        help = "Rollback one package to a target installed version and remove sibling versions"
+    )]
+    pub(crate) package_rollback: Option<String>,
+
+    #[arg(
+        long = "package-rollback-root",
+        env = "PI_PACKAGE_ROLLBACK_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_rollback",
+        value_name = "path",
+        help = "Source root containing installed package versions for rollback"
+    )]
+    pub(crate) package_rollback_root: PathBuf,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -151,7 +151,8 @@ pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
     execute_package_install_command, execute_package_list_command, execute_package_remove_command,
-    execute_package_show_command, execute_package_validate_command,
+    execute_package_rollback_command, execute_package_show_command,
+    execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -36,6 +36,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_rollback.is_some() {
+        execute_package_rollback_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add package rollback preflight command (`--package-rollback <name@version>`) with configurable source root (`--package-rollback-root`)
- implement rollback behavior that keeps target version and removes sibling installed semver versions
- emit deterministic rollback report with removed version details and status (`rolled_back` / `already_at_target`)
- wire CLI conflict routing/startup preflight/docs updates and broaden package lifecycle coverage

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent package_rollback --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #296
