### PR TITLE
feat: enforce signed package install policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,16 @@ cargo run -p pi-coding-agent -- \
   --package-install-root .pi/packages
 ```
 
+Require package signatures during install (trusted keys come from skill trust roots):
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-install ./examples/starter/package.json \
+  --package-install-root .pi/packages \
+  --require-signed-packages \
+  --skill-trust-root publisher=BASE64_PUBLIC_KEY
+```
+
 List installed package bundles from a package root:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -322,6 +322,14 @@ pub(crate) struct Cli {
     pub(crate) require_signed_skills: bool,
 
     #[arg(
+        long = "require-signed-packages",
+        env = "PI_REQUIRE_SIGNED_PACKAGES",
+        default_value_t = false,
+        help = "Require package manifests to provide signing metadata and validate against trusted roots"
+    )]
+    pub(crate) require_signed_packages: bool,
+
+    #[arg(
         long = "skills-lock-file",
         env = "PI_SKILLS_LOCK_FILE",
         help = "Path to skills lockfile (defaults to <skills-dir>/skills.lock.json)"


### PR DESCRIPTION
## Summary
- add package signing metadata support (`signing_key`, `signature_file`) to manifest validation
- add `--require-signed-packages` policy flag and enforce signed install behavior when enabled
- reuse trusted root resolution (`--skill-trust-root` / `--skill-trust-root-file`) for package signature verification
- verify package manifest signatures with Ed25519 over raw manifest bytes using trusted keys
- add signed/unsigned policy docs and broad unit/functional/integration/regression test coverage

## Testing
- cargo fmt --all -- --check
- cargo test -p pi-coding-agent package_manifest::tests --quiet
- cargo test -p pi-coding-agent regression_execute_package_install_command_rejects_unsigned_when_required --quiet
- cargo test -p pi-coding-agent package_install_flag_accepts_valid_signed_manifest_when_required --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #298
