### PR TITLE
feat(package): remote source install with checksum validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,24 @@ cargo run -p pi-coding-agent -- \
   --package-install-root .pi/packages
 ```
 
+Package components can also source content from remote HTTP(S) URLs with optional checksum pinning:
+
+```json
+{
+  "schema_version": 1,
+  "name": "starter-bundle",
+  "version": "1.0.0",
+  "templates": [
+    {
+      "id": "review",
+      "path": "templates/review.txt",
+      "url": "https://example.com/templates/review.txt",
+      "sha256": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ]
+}
+```
+
 Require package signatures during install (trusted keys come from skill trust roots):
 
 ```bash


### PR DESCRIPTION
## Summary
- add remote package component source support via `url` metadata in package manifests
- enforce optional component checksum validation via `sha256` metadata (`sha256:<64-hex>` or raw 64-hex)
- preserve signed-package policy behavior and validate remote + signed flows
- extend package preflight tests and CLI integration tests for remote success/failure scenarios
- document remote source manifest shape in README

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent remote_ -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #300
