### PR TITLE
feat(package): add explicit package update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ cargo run -p pi-coding-agent -- \
   --skill-trust-root publisher=BASE64_PUBLIC_KEY
 ```
 
+Update an already installed package bundle from a manifest (fails if target version is not installed):
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-update ./examples/starter/package.json \
+  --package-update-root .pi/packages
+```
+
 List installed package bundles from a package root:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -513,6 +513,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_VALIDATE",
         conflicts_with = "package_show",
         conflicts_with = "package_install",
+        conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
@@ -526,6 +527,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_SHOW",
         conflicts_with = "package_validate",
         conflicts_with = "package_install",
+        conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
@@ -539,6 +541,7 @@ pub(crate) struct Cli {
         env = "PI_PACKAGE_INSTALL",
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
+        conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
@@ -558,8 +561,33 @@ pub(crate) struct Cli {
     pub(crate) package_install_root: PathBuf,
 
     #[arg(
+        long = "package-update",
+        env = "PI_PACKAGE_UPDATE",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_list",
+        conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
+        value_name = "path",
+        help = "Update an already installed package bundle from a manifest and exit"
+    )]
+    pub(crate) package_update: Option<PathBuf>,
+
+    #[arg(
+        long = "package-update-root",
+        env = "PI_PACKAGE_UPDATE_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_update",
+        value_name = "path",
+        help = "Destination root containing installed package bundles for update"
+    )]
+    pub(crate) package_update_root: PathBuf,
+
+    #[arg(
         long = "package-list",
         env = "PI_PACKAGE_LIST",
+        conflicts_with = "package_update",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         default_value_t = false,
@@ -583,6 +611,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
         conflicts_with = "package_install",
+        conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_rollback",
         value_name = "name@version",
@@ -606,6 +635,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
         conflicts_with = "package_install",
+        conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         value_name = "name@version",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -151,7 +151,7 @@ pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
     execute_package_install_command, execute_package_list_command, execute_package_remove_command,
-    execute_package_rollback_command, execute_package_show_command,
+    execute_package_rollback_command, execute_package_show_command, execute_package_update_command,
     execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -26,6 +26,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_update.is_some() {
+        execute_package_update_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.package_list {
         execute_package_list_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add `--package-update <manifest_path>` and `--package-update-root <path>` CLI flags
- wire update into startup preflight dispatch and command exports
- implement update workflow that requires target `name/version` to already be installed
- reuse manifest validation and signature/trust policy enforcement for update paths
- add deterministic `package update:` reporting
- extend README and tests across unit/functional/integration/regression layers

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent package_update -- --nocapture`
- `cargo test -p pi-coding-agent update_package_manifest_with_policy -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #302
