### PR TITLE
feat(package): add package conflict audit preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,14 @@ cargo run -p pi-coding-agent -- \
   --package-update-root .pi/packages
 ```
 
+Audit installed package bundles for deterministic component path conflicts:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-conflicts \
+  --package-conflicts-root .pi/packages
+```
+
 List installed package bundles from a package root:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -517,6 +517,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -531,6 +532,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
@@ -545,6 +547,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         value_name = "path",
         help = "Install a local package manifest bundle and exit"
     )]
@@ -569,6 +572,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         value_name = "path",
         help = "Update an already installed package bundle from a manifest and exit"
     )]
@@ -590,6 +594,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_update",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         default_value_t = false,
         help = "List installed package bundles from a package root and exit"
     )]
@@ -614,6 +619,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
         value_name = "name@version",
         help = "Remove one installed package bundle by coordinate and exit"
     )]
@@ -638,6 +644,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_update",
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
+        conflicts_with = "package_conflicts",
         value_name = "name@version",
         help = "Rollback one package to a target installed version and remove sibling versions"
     )]
@@ -652,6 +659,31 @@ pub(crate) struct Cli {
         help = "Source root containing installed package versions for rollback"
     )]
     pub(crate) package_rollback_root: PathBuf,
+
+    #[arg(
+        long = "package-conflicts",
+        env = "PI_PACKAGE_CONFLICTS",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_update",
+        conflicts_with = "package_list",
+        conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
+        default_value_t = false,
+        help = "Audit installed package component path conflicts and exit"
+    )]
+    pub(crate) package_conflicts: bool,
+
+    #[arg(
+        long = "package-conflicts-root",
+        env = "PI_PACKAGE_CONFLICTS_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_conflicts",
+        value_name = "path",
+        help = "Source root containing installed package bundles for conflict audit"
+    )]
+    pub(crate) package_conflicts_root: PathBuf,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,9 +150,9 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_install_command, execute_package_list_command, execute_package_remove_command,
-    execute_package_rollback_command, execute_package_show_command, execute_package_update_command,
-    execute_package_validate_command,
+    execute_package_conflicts_command, execute_package_install_command,
+    execute_package_list_command, execute_package_remove_command, execute_package_rollback_command,
+    execute_package_show_command, execute_package_update_command, execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -46,6 +46,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_conflicts {
+        execute_package_conflicts_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add `--package-conflicts` and `--package-conflicts-root` preflight CLI flags
- wire conflict audit into startup preflight command dispatch
- implement deterministic installed-package conflict scanning by component kind/path
- include invalid installed-manifest entries in audit output without crashing
- add deterministic conflict report rendering and README usage docs
- extend unit/functional/integration/regression coverage in package + CLI tests

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent package_conflicts -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #304
