### PR TITLE
feat(package): add package activation preflight with conflict policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ cargo run -p pi-coding-agent -- \
   --package-conflicts-root .pi/packages
 ```
 
+Materialize installed package components into an activation destination with explicit conflict policy:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-activate \
+  --package-activate-root .pi/packages \
+  --package-activate-destination .pi/packages-active \
+  --package-activate-conflict-policy keep-first
+```
+
 List installed package bundles from a package root:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -518,6 +518,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "path",
         help = "Validate a package manifest JSON file and exit"
     )]
@@ -533,6 +534,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "path",
         help = "Print package manifest metadata and component inventory"
     )]
@@ -548,6 +550,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "path",
         help = "Install a local package manifest bundle and exit"
     )]
@@ -573,6 +576,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "path",
         help = "Update an already installed package bundle from a manifest and exit"
     )]
@@ -595,6 +599,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         default_value_t = false,
         help = "List installed package bundles from a package root and exit"
     )]
@@ -620,6 +625,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_rollback",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "name@version",
         help = "Remove one installed package bundle by coordinate and exit"
     )]
@@ -645,6 +651,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_conflicts",
+        conflicts_with = "package_activate",
         value_name = "name@version",
         help = "Rollback one package to a target installed version and remove sibling versions"
     )]
@@ -670,6 +677,7 @@ pub(crate) struct Cli {
         conflicts_with = "package_list",
         conflicts_with = "package_remove",
         conflicts_with = "package_rollback",
+        conflicts_with = "package_activate",
         default_value_t = false,
         help = "Audit installed package component path conflicts and exit"
     )]
@@ -684,6 +692,52 @@ pub(crate) struct Cli {
         help = "Source root containing installed package bundles for conflict audit"
     )]
     pub(crate) package_conflicts_root: PathBuf,
+
+    #[arg(
+        long = "package-activate",
+        env = "PI_PACKAGE_ACTIVATE",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_update",
+        conflicts_with = "package_list",
+        conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
+        default_value_t = false,
+        help = "Materialize installed package components into an activation destination and exit"
+    )]
+    pub(crate) package_activate: bool,
+
+    #[arg(
+        long = "package-activate-root",
+        env = "PI_PACKAGE_ACTIVATE_ROOT",
+        default_value = ".pi/packages",
+        requires = "package_activate",
+        value_name = "path",
+        help = "Source root containing installed package bundles for activation"
+    )]
+    pub(crate) package_activate_root: PathBuf,
+
+    #[arg(
+        long = "package-activate-destination",
+        env = "PI_PACKAGE_ACTIVATE_DESTINATION",
+        default_value = ".pi/packages-active",
+        requires = "package_activate",
+        value_name = "path",
+        help = "Destination root where resolved package components are materialized"
+    )]
+    pub(crate) package_activate_destination: PathBuf,
+
+    #[arg(
+        long = "package-activate-conflict-policy",
+        env = "PI_PACKAGE_ACTIVATE_CONFLICT_POLICY",
+        default_value = "error",
+        requires = "package_activate",
+        value_name = "error|keep-first|keep-last",
+        help = "Conflict strategy when multiple packages contain the same kind/path component"
+    )]
+    pub(crate) package_activate_conflict_policy: String,
 
     #[arg(
         long = "rpc-capabilities",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,9 +150,10 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_conflicts_command, execute_package_install_command,
-    execute_package_list_command, execute_package_remove_command, execute_package_rollback_command,
-    execute_package_show_command, execute_package_update_command, execute_package_validate_command,
+    execute_package_activate_command, execute_package_conflicts_command,
+    execute_package_install_command, execute_package_list_command, execute_package_remove_command,
+    execute_package_rollback_command, execute_package_show_command, execute_package_update_command,
+    execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -51,6 +51,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.package_activate {
+        execute_package_activate_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.rpc_capabilities {
         execute_rpc_capabilities_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add `--package-activate` preflight command and activation options:
  - `--package-activate-root`
  - `--package-activate-destination`
  - `--package-activate-conflict-policy` (`error|keep-first|keep-last`)
- implement deterministic package activation materialization from installed bundles
- enforce explicit conflict policy for overlapping component kind/path ownership
- fail closed when invalid installed manifests are present during activation
- add deterministic activation reporting and README docs
- extend unit/functional/integration/regression coverage across package core, command layer, and CLI integration

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent package_activate -- --nocapture`
- `cargo test -p pi-coding-agent activate_installed_packages -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #306
