### PR TITLE
feat(package): startup activation wiring for runtime skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,17 @@ cargo run -p pi-coding-agent -- \
   --package-activate-conflict-policy keep-first
 ```
 
+Activate installed package components during normal startup (without exiting), then run with activated package skills:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --package-activate-on-startup \
+  --package-activate-root .pi/packages \
+  --package-activate-destination .pi/packages-active \
+  --package-activate-conflict-policy keep-first \
+  --skill checks
+```
+
 List installed package bundles from a package root:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -696,6 +696,7 @@ pub(crate) struct Cli {
     #[arg(
         long = "package-activate",
         env = "PI_PACKAGE_ACTIVATE",
+        conflicts_with = "package_activate_on_startup",
         conflicts_with = "package_validate",
         conflicts_with = "package_show",
         conflicts_with = "package_install",
@@ -710,10 +711,26 @@ pub(crate) struct Cli {
     pub(crate) package_activate: bool,
 
     #[arg(
+        long = "package-activate-on-startup",
+        env = "PI_PACKAGE_ACTIVATE_ON_STARTUP",
+        conflicts_with = "package_activate",
+        conflicts_with = "package_validate",
+        conflicts_with = "package_show",
+        conflicts_with = "package_install",
+        conflicts_with = "package_update",
+        conflicts_with = "package_list",
+        conflicts_with = "package_remove",
+        conflicts_with = "package_rollback",
+        conflicts_with = "package_conflicts",
+        default_value_t = false,
+        help = "Activate installed package components during startup before runtime execution"
+    )]
+    pub(crate) package_activate_on_startup: bool,
+
+    #[arg(
         long = "package-activate-root",
         env = "PI_PACKAGE_ACTIVATE_ROOT",
         default_value = ".pi/packages",
-        requires = "package_activate",
         value_name = "path",
         help = "Source root containing installed package bundles for activation"
     )]
@@ -723,7 +740,6 @@ pub(crate) struct Cli {
         long = "package-activate-destination",
         env = "PI_PACKAGE_ACTIVATE_DESTINATION",
         default_value = ".pi/packages-active",
-        requires = "package_activate",
         value_name = "path",
         help = "Destination root where resolved package components are materialized"
     )]
@@ -733,7 +749,6 @@ pub(crate) struct Cli {
         long = "package-activate-conflict-policy",
         env = "PI_PACKAGE_ACTIVATE_CONFLICT_POLICY",
         default_value = "error",
-        requires = "package_activate",
         value_name = "error|keep-first|keep-last",
         help = "Conflict strategy when multiple packages contain the same kind/path component"
     )]

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -150,10 +150,10 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::package_manifest::{
-    execute_package_activate_command, execute_package_conflicts_command,
-    execute_package_install_command, execute_package_list_command, execute_package_remove_command,
-    execute_package_rollback_command, execute_package_show_command, execute_package_update_command,
-    execute_package_validate_command,
+    execute_package_activate_command, execute_package_activate_on_startup,
+    execute_package_conflicts_command, execute_package_install_command,
+    execute_package_list_command, execute_package_remove_command, execute_package_rollback_command,
+    execute_package_show_command, execute_package_update_command, execute_package_validate_command,
 };
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,

--- a/crates/pi-coding-agent/src/startup_dispatch.rs
+++ b/crates/pi-coding-agent/src/startup_dispatch.rs
@@ -14,8 +14,15 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
 
     let client = build_client_with_fallbacks(&cli, &model_ref, &fallback_model_refs)?;
     let skills_bootstrap = run_startup_skills_bootstrap(&cli).await?;
-    let skills_lock_path = skills_bootstrap.skills_lock_path;
-    let system_prompt = compose_startup_system_prompt(&cli)?;
+    let startup_package_activation = execute_package_activate_on_startup(&cli)?;
+    let effective_skills_dir =
+        resolve_runtime_skills_dir(&cli, startup_package_activation.is_some());
+    let skills_lock_path = resolve_runtime_skills_lock_path(
+        &cli,
+        &skills_bootstrap.skills_lock_path,
+        &effective_skills_dir,
+    );
+    let system_prompt = compose_startup_system_prompt(&cli, &effective_skills_dir)?;
     let StartupPolicyBundle {
         tool_policy,
         tool_policy_json,
@@ -44,7 +51,31 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
         tool_policy,
         tool_policy_json: &tool_policy_json,
         render_options,
+        skills_dir: &effective_skills_dir,
         skills_lock_path: &skills_lock_path,
     })
     .await
+}
+
+fn resolve_runtime_skills_dir(cli: &Cli, activation_applied: bool) -> PathBuf {
+    if !activation_applied {
+        return cli.skills_dir.clone();
+    }
+    let activated_skills_dir = cli.package_activate_destination.join("skills");
+    if activated_skills_dir.is_dir() {
+        return activated_skills_dir;
+    }
+    cli.skills_dir.clone()
+}
+
+fn resolve_runtime_skills_lock_path(
+    cli: &Cli,
+    bootstrap_lock_path: &Path,
+    effective_skills_dir: &Path,
+) -> PathBuf {
+    if effective_skills_dir == cli.skills_dir {
+        bootstrap_lock_path.to_path_buf()
+    } else {
+        default_skills_lock_path(effective_skills_dir)
+    }
 }

--- a/crates/pi-coding-agent/src/startup_prompt_composition.rs
+++ b/crates/pi-coding-agent/src/startup_prompt_composition.rs
@@ -1,9 +1,11 @@
+use std::path::Path;
+
 use super::*;
 
-pub(crate) fn compose_startup_system_prompt(cli: &Cli) -> Result<String> {
+pub(crate) fn compose_startup_system_prompt(cli: &Cli, skills_dir: &Path) -> Result<String> {
     let base_system_prompt = resolve_system_prompt(cli)?;
-    let catalog = load_catalog(&cli.skills_dir)
-        .with_context(|| format!("failed to load skills from {}", cli.skills_dir.display()))?;
+    let catalog = load_catalog(skills_dir)
+        .with_context(|| format!("failed to load skills from {}", skills_dir.display()))?;
     let selected_skills = resolve_selected_skills(&catalog, &cli.skills)?;
     Ok(augment_system_prompt(&base_system_prompt, &selected_skills))
 }


### PR DESCRIPTION
## Summary
- add `--package-activate-on-startup` to activate installed package bundles during normal startup (without exiting)
- wire startup dispatch/runtime to use activated skills directory (`<destination>/skills`) when startup activation runs and activated skills are present
- add runtime-friendly alias materialization for package skill-style paths (`skills/<name>/SKILL.md` -> `skills/<name>.md`) so existing skill catalog loading remains compatible
- update README package usage docs with startup activation example

## Risks / Compatibility
- `--package-activate-root`, `--package-activate-destination`, and `--package-activate-conflict-policy` are now accepted outside one-shot `--package-activate` flows; they are only acted on when `--package-activate` or `--package-activate-on-startup` is enabled
- startup activation now prints the same deterministic activation summary line used by one-shot activation mode
- package activation writes an additional skill alias file for `SKILL.md`-style package skill entries; original nested file paths are still materialized unchanged

## Validation
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent package_activate -- --nocapture`
- `cargo test --workspace`

Closes #308
