### PR TITLE
feat(artifacts): configurable GitHub/Slack artifact retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ cargo run -p pi-coding-agent -- \
   --github-repo owner/repo \
   --github-bot-login your-bot-login \
   --github-state-dir .pi/github-issues \
-  --github-poll-interval-seconds 30
+  --github-poll-interval-seconds 30 \
+  --github-artifact-retention-days 30
 ```
 
 In bridge mode:
@@ -254,6 +255,7 @@ In bridge mode:
 - duplicate deliveries are deduplicated using persisted event keys and response footers
 - bot replies include run/model/token metadata in the issue comment footer
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
+- set `--github-artifact-retention-days 0` to disable artifact expiration
 - `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts show <artifact_id>` shows one artifact record; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:
@@ -266,6 +268,7 @@ cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
   --slack-bridge \
   --slack-state-dir .pi/slack \
+  --slack-artifact-retention-days 30 \
   --slack-thread-detail-output true \
   --slack-thread-detail-threshold-chars 1500
 ```
@@ -279,6 +282,7 @@ In Slack bridge mode:
 - stale events are skipped based on `--slack-max-event-age-seconds`
 - attached files are downloaded into channel-local attachment folders and surfaced in prompt context
 - each completed run emits a markdown artifact + metadata under `channel-store/channels/slack/<channel>/artifacts/`
+- set `--slack-artifact-retention-days 0` to disable artifact expiration
 
 Inspect or repair ChannelStore state for a specific channel:
 

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -1002,6 +1002,15 @@ pub(crate) struct Cli {
     pub(crate) github_poll_interval_seconds: u64,
 
     #[arg(
+        long = "github-artifact-retention-days",
+        env = "PI_GITHUB_ARTIFACT_RETENTION_DAYS",
+        default_value_t = 30,
+        requires = "github_issues_bridge",
+        help = "Retention window for GitHub bridge artifacts in days (0 disables expiration)"
+    )]
+    pub(crate) github_artifact_retention_days: u64,
+
+    #[arg(
         long = "github-include-issue-body",
         env = "PI_GITHUB_INCLUDE_ISSUE_BODY",
         default_value_t = false,
@@ -1115,6 +1124,15 @@ pub(crate) struct Cli {
         help = "Directory for slack bridge state/session/event logs"
     )]
     pub(crate) slack_state_dir: PathBuf,
+
+    #[arg(
+        long = "slack-artifact-retention-days",
+        env = "PI_SLACK_ARTIFACT_RETENTION_DAYS",
+        default_value_t = 30,
+        requires = "slack_bridge",
+        help = "Retention window for Slack bridge artifacts in days (0 disables expiration)"
+    )]
+    pub(crate) slack_artifact_retention_days: u64,
 
     #[arg(
         long = "slack-thread-detail-output",

--- a/crates/pi-coding-agent/src/startup_transport_modes.rs
+++ b/crates/pi-coding-agent/src/startup_transport_modes.rs
@@ -49,6 +49,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_event_cap: cli.github_processed_event_cap.max(1),
             retry_max_attempts: cli.github_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.github_retry_base_delay_ms.max(1),
+            artifact_retention_days: cli.github_artifact_retention_days,
         })
         .await?;
         return Ok(true);
@@ -100,6 +101,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             reconnect_delay: Duration::from_millis(cli.slack_reconnect_delay_ms.max(1)),
             retry_max_attempts: cli.slack_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.slack_retry_base_delay_ms.max(1),
+            artifact_retention_days: cli.slack_artifact_retention_days,
         })
         .await?;
         return Ok(true);

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -301,6 +301,7 @@ fn test_cli() -> Cli {
         github_api_base: "https://api.github.com".to_string(),
         github_state_dir: PathBuf::from(".pi/github-issues"),
         github_poll_interval_seconds: 30,
+        github_artifact_retention_days: 30,
         github_include_issue_body: false,
         github_include_edited_comments: true,
         github_processed_event_cap: 10_000,
@@ -314,6 +315,7 @@ fn test_cli() -> Cli {
         slack_bot_user_id: None,
         slack_api_base: "https://slack.com/api".to_string(),
         slack_state_dir: PathBuf::from(".pi/slack"),
+        slack_artifact_retention_days: 30,
         slack_thread_detail_output: true,
         slack_thread_detail_threshold_chars: 1500,
         slack_processed_event_cap: 10_000,
@@ -648,6 +650,28 @@ fn functional_cli_integration_secret_id_flags_accept_explicit_values() {
     assert_eq!(cli.github_token_id.as_deref(), Some("github-token"));
     assert_eq!(cli.slack_app_token_id.as_deref(), Some("slack-app-token"));
     assert_eq!(cli.slack_bot_token_id.as_deref(), Some("slack-bot-token"));
+}
+
+#[test]
+fn unit_cli_artifact_retention_flags_default_to_30_days() {
+    let cli = Cli::parse_from(["pi-rs"]);
+    assert_eq!(cli.github_artifact_retention_days, 30);
+    assert_eq!(cli.slack_artifact_retention_days, 30);
+}
+
+#[test]
+fn functional_cli_artifact_retention_flags_accept_explicit_values() {
+    let cli = Cli::parse_from([
+        "pi-rs",
+        "--github-issues-bridge",
+        "--slack-bridge",
+        "--github-artifact-retention-days",
+        "14",
+        "--slack-artifact-retention-days",
+        "0",
+    ]);
+    assert_eq!(cli.github_artifact_retention_days, 14);
+    assert_eq!(cli.slack_artifact_retention_days, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add CLI flags for bridge artifact retention control:
  - `--github-artifact-retention-days`
  - `--slack-artifact-retention-days`
- wire retention settings through startup transport config into GitHub/Slack runtime artifact writes
- support `0` retention as no-expiration (`expires_unix_ms = null`)
- add runtime tests covering default retention (expiry present) and zero retention (no expiry + still active/listable)
- document the new flags in README bridge examples and notes

## Risks / Compatibility
- default behavior remains unchanged at 30-day retention for both bridges
- new CLI flags are bridge-mode scoped via existing `requires = bridge` guards
- zero-retention artifacts will no longer age out automatically and must be managed via manual lifecycle controls

## Validation
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent artifact_retention -- --nocapture`
- `cargo test -p pi-coding-agent sets_expiry_with_default_retention -- --nocapture`
- `cargo test -p pi-coding-agent zero_retention_disables_expiry -- --nocapture`
- `cargo test --workspace`

Closes #310
