### PR TITLE
feat(rpc): accept legacy request schemas and advertise compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.response` includes both `response_schema_version` and `supported_request_schema_versions`.
+
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.
 
 Dispatch newline-delimited RPC request frames (NDJSON) and emit one response JSON line per input frame:


### PR DESCRIPTION
## Summary
- add bounded RPC request schema compatibility support (`schema_version` 0 and 1)
- keep response frames pinned to schema version 1
- extend `capabilities.response` payload with:
  - `response_schema_version`
  - `supported_request_schema_versions`
- preserve deterministic structured error envelopes for unsupported schema versions
- document compatibility behavior in README

## Risks / Compatibility
- backward compatibility improves for legacy request schema version 0 clients
- unsupported schema values still fail closed with `kind:error` and `payload.code=unsupported_schema`
- response schema remains stable at v1 to avoid introducing downstream response-shape drift

## Validation
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent rpc -- --nocapture`
- `cargo test --workspace`

Closes #312
