### PR TITLE
Add plan-first review/consolidation trace phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ cargo run -p pi-coding-agent -- \
   --orchestrator-max-plan-steps 8
 ```
 
+Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `review`, and `consolidation` phases.
+
 Use Anthropic:
 
 ```bash


### PR DESCRIPTION
## Summary
- add explicit review and consolidation trace lines in plan-first orchestration after executor output
- fail closed when the executor phase returns missing or empty assistant output
- add deterministic reviewed-step coverage scoring helpers and tests
- document planner/executor/review/consolidation trace phases in README

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p pi-coding-agent plan_first -- --nocapture
- cargo test --workspace

Closes #314
