### PR TITLE
Add plan-first executor response budget guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ Run interactive mode with plan-first orchestration on each user turn:
 cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
   --orchestrator-mode plan-first \
-  --orchestrator-max-plan-steps 8
+  --orchestrator-max-plan-steps 8 \
+  --orchestrator-max-executor-response-chars 20000
 ```
 
-Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `review`, and `consolidation` phases.
+Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `review`, and `consolidation` phases, including executor response budget metadata and accept/reject consolidation decisions.
 
 Use Anthropic:
 
@@ -199,7 +200,8 @@ Run one prompt with plan-first orchestration:
 cargo run -p pi-coding-agent -- \
   --prompt "Summarize src/lib.rs" \
   --orchestrator-mode plan-first \
-  --orchestrator-max-plan-steps 8
+  --orchestrator-max-plan-steps 8 \
+  --orchestrator-max-executor-response-chars 20000
 ```
 
 Run one prompt from a file:

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -8,6 +8,16 @@ use crate::{
     CliWebhookSignatureAlgorithm,
 };
 
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|error| format!("failed to parse integer: {error}"))?;
+    if parsed == 0 {
+        return Err("value must be greater than 0".to_string());
+    }
+    Ok(parsed)
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "pi-rs",
@@ -435,6 +445,15 @@ pub(crate) struct Cli {
         help = "Maximum planner step count allowed in plan-first orchestrator mode"
     )]
     pub(crate) orchestrator_max_plan_steps: usize,
+
+    #[arg(
+        long = "orchestrator-max-executor-response-chars",
+        env = "PI_ORCHESTRATOR_MAX_EXECUTOR_RESPONSE_CHARS",
+        default_value_t = 20000,
+        value_parser = parse_positive_usize,
+        help = "Maximum executor response length (characters) allowed in plan-first orchestrator mode"
+    )]
+    pub(crate) orchestrator_max_executor_response_chars: usize,
 
     #[arg(
         long,

--- a/crates/pi-coding-agent/src/runtime_loop.rs
+++ b/crates/pi-coding-agent/src/runtime_loop.rs
@@ -33,6 +33,7 @@ pub(crate) struct InteractiveRuntimeConfig<'a> {
     pub(crate) render_options: RenderOptions,
     pub(crate) orchestrator_mode: CliOrchestratorMode,
     pub(crate) orchestrator_max_plan_steps: usize,
+    pub(crate) orchestrator_max_executor_response_chars: usize,
     pub(crate) command_context: CommandExecutionContext<'a>,
 }
 
@@ -105,6 +106,7 @@ pub(crate) async fn run_interactive(
                 config.turn_timeout_ms,
                 config.render_options,
                 config.orchestrator_max_plan_steps,
+                config.orchestrator_max_executor_response_chars,
             )
             .await?;
         } else {

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -79,6 +79,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 cli.turn_timeout_ms,
                 render_options,
                 cli.orchestrator_max_plan_steps,
+                cli.orchestrator_max_executor_response_chars,
             )
             .await?;
         } else {
@@ -121,6 +122,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         render_options,
         orchestrator_mode: cli.orchestrator_mode,
         orchestrator_max_plan_steps: cli.orchestrator_max_plan_steps,
+        orchestrator_max_executor_response_chars: cli.orchestrator_max_executor_response_chars,
         command_context,
     };
     if let Some(command_file_path) = cli.command_file.as_deref() {


### PR DESCRIPTION
## Summary
- add a configurable plan-first executor response budget via `--orchestrator-max-executor-response-chars` / `PI_ORCHESTRATOR_MAX_EXECUTOR_RESPONSE_CHARS`
- enforce fail-closed rejection when executor output exceeds configured character budget
- include budget metadata in `review` traces and emit explicit consolidation accept/reject decisions
- wire the budget through prompt and interactive runtime paths
- document the new orchestrator budget option in README examples

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent plan_first -- --nocapture
- cargo test -p pi-coding-agent cli_orchestrator_flags -- --nocapture
- cargo test -p pi-coding-agent executor_response_budget_rejects_zero -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #316
