### PR TITLE
Add extension manifest validation preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,13 @@ cargo run -p pi-coding-agent -- \
 
 Inspect now reports artifact health counters (records, invalid index lines, active/expired), and repair also purges expired artifacts plus invalid artifact index rows.
 
+Validate an extension manifest JSON and exit:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --extension-validate .pi/extensions/issue-assistant/extension.json
+```
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -528,6 +528,14 @@ pub(crate) struct Cli {
     pub(crate) channel_store_repair: Option<String>,
 
     #[arg(
+        long = "extension-validate",
+        env = "PI_EXTENSION_VALIDATE",
+        value_name = "path",
+        help = "Validate an extension manifest JSON file and exit"
+    )]
+    pub(crate) extension_validate: Option<PathBuf>,
+
+    #[arg(
         long = "package-validate",
         env = "PI_PACKAGE_VALIDATE",
         conflicts_with = "package_show",

--- a/crates/pi-coding-agent/src/extension_manifest.rs
+++ b/crates/pi-coding-agent/src/extension_manifest.rs
@@ -1,0 +1,289 @@
+use std::{
+    collections::HashSet,
+    hash::Hash,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::Cli;
+
+const EXTENSION_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const EXTENSION_TIMEOUT_MS_DEFAULT: u64 = 5_000;
+const EXTENSION_TIMEOUT_MS_MAX: u64 = 300_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ExtensionManifestSummary {
+    pub manifest_path: PathBuf,
+    pub id: String,
+    pub version: String,
+    pub runtime: String,
+    pub entrypoint: String,
+    pub hook_count: usize,
+    pub permission_count: usize,
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExtensionManifest {
+    schema_version: u32,
+    id: String,
+    version: String,
+    runtime: ExtensionRuntime,
+    entrypoint: String,
+    #[serde(default)]
+    hooks: Vec<ExtensionHook>,
+    #[serde(default)]
+    permissions: Vec<ExtensionPermission>,
+    #[serde(default = "default_extension_timeout_ms")]
+    timeout_ms: u64,
+}
+
+fn default_extension_timeout_ms() -> u64 {
+    EXTENSION_TIMEOUT_MS_DEFAULT
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum ExtensionRuntime {
+    Process,
+    Wasm,
+}
+
+impl ExtensionRuntime {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Wasm => "wasm",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+enum ExtensionHook {
+    RunStart,
+    RunEnd,
+    PreToolCall,
+    PostToolCall,
+    MessageTransform,
+    PolicyOverride,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+enum ExtensionPermission {
+    ReadFiles,
+    WriteFiles,
+    RunCommands,
+    Network,
+}
+
+pub(crate) fn execute_extension_validate_command(cli: &Cli) -> Result<()> {
+    let Some(path) = cli.extension_validate.as_ref() else {
+        return Ok(());
+    };
+    let summary = validate_extension_manifest(path)?;
+    println!(
+        "extension validate: path={} id={} version={} runtime={} entrypoint={} hooks={} permissions={} timeout_ms={}",
+        summary.manifest_path.display(),
+        summary.id,
+        summary.version,
+        summary.runtime,
+        summary.entrypoint,
+        summary.hook_count,
+        summary.permission_count,
+        summary.timeout_ms
+    );
+    Ok(())
+}
+
+pub(crate) fn validate_extension_manifest(path: &Path) -> Result<ExtensionManifestSummary> {
+    let manifest = load_extension_manifest(path)?;
+    validate_manifest_schema(&manifest)?;
+    validate_manifest_identifiers(&manifest)?;
+    validate_entrypoint_path(&manifest.entrypoint)?;
+    validate_unique(&manifest.hooks, "hooks")?;
+    validate_unique(&manifest.permissions, "permissions")?;
+    validate_timeout_ms(manifest.timeout_ms)?;
+    Ok(ExtensionManifestSummary {
+        manifest_path: path.to_path_buf(),
+        id: manifest.id,
+        version: manifest.version,
+        runtime: manifest.runtime.as_str().to_string(),
+        entrypoint: manifest.entrypoint,
+        hook_count: manifest.hooks.len(),
+        permission_count: manifest.permissions.len(),
+        timeout_ms: manifest.timeout_ms,
+    })
+}
+
+fn load_extension_manifest(path: &Path) -> Result<ExtensionManifest> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read extension manifest {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse extension manifest {}", path.display()))
+}
+
+fn validate_manifest_schema(manifest: &ExtensionManifest) -> Result<()> {
+    if manifest.schema_version != EXTENSION_MANIFEST_SCHEMA_VERSION {
+        bail!(
+            "unsupported extension manifest schema '{}': expected {}",
+            manifest.schema_version,
+            EXTENSION_MANIFEST_SCHEMA_VERSION
+        );
+    }
+    Ok(())
+}
+
+fn validate_manifest_identifiers(manifest: &ExtensionManifest) -> Result<()> {
+    validate_non_empty_field("id", &manifest.id)?;
+    validate_non_empty_field("version", &manifest.version)?;
+    Ok(())
+}
+
+fn validate_non_empty_field(name: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("extension manifest '{}' must not be empty", name);
+    }
+    Ok(())
+}
+
+fn validate_entrypoint_path(entrypoint: &str) -> Result<()> {
+    let trimmed = entrypoint.trim();
+    if trimmed.is_empty() {
+        bail!("extension manifest 'entrypoint' must not be empty");
+    }
+    let path = Path::new(trimmed);
+    if path.is_absolute() {
+        bail!(
+            "extension manifest entrypoint '{}' must be relative",
+            trimmed
+        );
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                bail!(
+                    "extension manifest entrypoint '{}' must not contain parent traversals",
+                    trimmed
+                );
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                bail!(
+                    "extension manifest entrypoint '{}' must be relative",
+                    trimmed
+                );
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_unique<T>(entries: &[T], field_name: &str) -> Result<()>
+where
+    T: Eq + Hash,
+{
+    let mut seen = HashSet::new();
+    for entry in entries {
+        if !seen.insert(entry) {
+            bail!(
+                "extension manifest '{}' contains duplicate entries",
+                field_name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_timeout_ms(timeout_ms: u64) -> Result<()> {
+    if timeout_ms == 0 {
+        bail!("extension manifest 'timeout_ms' must be greater than 0");
+    }
+    if timeout_ms > EXTENSION_TIMEOUT_MS_MAX {
+        bail!(
+            "extension manifest 'timeout_ms' must be <= {}",
+            EXTENSION_TIMEOUT_MS_MAX
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_extension_manifest;
+    use tempfile::tempdir;
+
+    #[test]
+    fn unit_validate_extension_manifest_accepts_minimal_schema() {
+        let temp = tempdir().expect("tempdir");
+        let manifest_path = temp.path().join("extension.json");
+        std::fs::write(
+            &manifest_path,
+            r#"{
+  "schema_version": 1,
+  "id": "issue-assistant",
+  "version": "0.1.0",
+  "runtime": "process",
+  "entrypoint": "bin/assistant"
+}"#,
+        )
+        .expect("write manifest");
+
+        let summary = validate_extension_manifest(&manifest_path).expect("valid manifest");
+        assert_eq!(summary.id, "issue-assistant");
+        assert_eq!(summary.version, "0.1.0");
+        assert_eq!(summary.runtime, "process");
+        assert_eq!(summary.entrypoint, "bin/assistant");
+        assert_eq!(summary.hook_count, 0);
+        assert_eq!(summary.permission_count, 0);
+        assert_eq!(summary.timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn regression_validate_extension_manifest_rejects_parent_dir_entrypoint() {
+        let temp = tempdir().expect("tempdir");
+        let manifest_path = temp.path().join("extension.json");
+        std::fs::write(
+            &manifest_path,
+            r#"{
+  "schema_version": 1,
+  "id": "issue-assistant",
+  "version": "0.1.0",
+  "runtime": "process",
+  "entrypoint": "../escape.sh"
+}"#,
+        )
+        .expect("write manifest");
+
+        let error =
+            validate_extension_manifest(&manifest_path).expect_err("parent traversal should fail");
+        assert!(error
+            .to_string()
+            .contains("must not contain parent traversals"));
+    }
+
+    #[test]
+    fn regression_validate_extension_manifest_rejects_duplicate_hooks() {
+        let temp = tempdir().expect("tempdir");
+        let manifest_path = temp.path().join("extension.json");
+        std::fs::write(
+            &manifest_path,
+            r#"{
+  "schema_version": 1,
+  "id": "issue-assistant",
+  "version": "0.1.0",
+  "runtime": "process",
+  "entrypoint": "bin/assistant",
+  "hooks": ["run-start", "run-start"]
+}"#,
+        )
+        .expect("write manifest");
+
+        let error =
+            validate_extension_manifest(&manifest_path).expect_err("duplicate hooks should fail");
+        assert!(error.to_string().contains("contains duplicate entries"));
+    }
+}

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -10,6 +10,7 @@ mod commands;
 mod credentials;
 mod diagnostics_commands;
 mod events;
+mod extension_manifest;
 mod github_issues;
 mod macro_profile_commands;
 mod model_catalog;
@@ -124,6 +125,7 @@ use crate::events::{
     ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
     EventWebhookIngestConfig,
 };
+pub(crate) use crate::extension_manifest::execute_extension_validate_command;
 pub(crate) use crate::macro_profile_commands::{
     default_macro_config_path, default_profile_store_path, execute_macro_command,
     execute_profile_command,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -11,6 +11,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.extension_validate.is_some() {
+        execute_extension_validate_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.package_validate.is_some() {
         execute_package_validate_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add extension manifest schema v1 support with strict validator (`id`, `version`, `runtime`, `entrypoint`, hooks/permissions uniqueness, timeout bounds)
- add `--extension-validate` / `PI_EXTENSION_VALIDATE` startup preflight command path
- reject unsafe extension entrypoints (absolute paths and parent traversal) with deterministic fail-closed errors
- wire startup preflight dispatch and CLI parsing for extension manifest validation
- document extension validation usage in README

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent extension_manifest -- --nocapture
- cargo test -p pi-coding-agent extension_validate -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #318
