### PR TITLE
Add extension manifest show preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,13 @@ cargo run -p pi-coding-agent -- \
   --extension-validate .pi/extensions/issue-assistant/extension.json
 ```
 
+Inspect extension manifest metadata and declared inventory:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --extension-show .pi/extensions/issue-assistant/extension.json
+```
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -530,10 +530,20 @@ pub(crate) struct Cli {
     #[arg(
         long = "extension-validate",
         env = "PI_EXTENSION_VALIDATE",
+        conflicts_with = "extension_show",
         value_name = "path",
         help = "Validate an extension manifest JSON file and exit"
     )]
     pub(crate) extension_validate: Option<PathBuf>,
+
+    #[arg(
+        long = "extension-show",
+        env = "PI_EXTENSION_SHOW",
+        conflicts_with = "extension_validate",
+        value_name = "path",
+        help = "Print extension manifest metadata and inventory"
+    )]
+    pub(crate) extension_show: Option<PathBuf>,
 
     #[arg(
         long = "package-validate",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -125,7 +125,9 @@ use crate::events::{
     ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
     EventWebhookIngestConfig,
 };
-pub(crate) use crate::extension_manifest::execute_extension_validate_command;
+pub(crate) use crate::extension_manifest::{
+    execute_extension_show_command, execute_extension_validate_command,
+};
 pub(crate) use crate::macro_profile_commands::{
     default_macro_config_path, default_profile_store_path, execute_macro_command,
     execute_profile_command,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -11,6 +11,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.extension_show.is_some() {
+        execute_extension_show_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.extension_validate.is_some() {
         execute_extension_validate_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add extension manifest inspect preflight command via `--extension-show` / `PI_EXTENSION_SHOW`
- render deterministic extension metadata with hook and permission inventory
- enforce mutual exclusion between extension show/validate flags
- reuse strict manifest validation before rendering show output
- document extension show usage in README

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent extension_show -- --nocapture
- cargo test -p pi-coding-agent extension_manifest -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #320
