### PR TITLE
Add extension inventory list preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ cargo run -p pi-coding-agent -- \
   --extension-show .pi/extensions/issue-assistant/extension.json
 ```
 
+List discovered extension manifests from an extension root (including invalid entries):
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --extension-list \
+  --extension-list-root .pi/extensions
+```
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -530,6 +530,7 @@ pub(crate) struct Cli {
     #[arg(
         long = "extension-validate",
         env = "PI_EXTENSION_VALIDATE",
+        conflicts_with = "extension_list",
         conflicts_with = "extension_show",
         value_name = "path",
         help = "Validate an extension manifest JSON file and exit"
@@ -537,8 +538,28 @@ pub(crate) struct Cli {
     pub(crate) extension_validate: Option<PathBuf>,
 
     #[arg(
+        long = "extension-list",
+        env = "PI_EXTENSION_LIST",
+        conflicts_with = "extension_validate",
+        conflicts_with = "extension_show",
+        help = "List discovered extension manifests from a root path and exit"
+    )]
+    pub(crate) extension_list: bool,
+
+    #[arg(
+        long = "extension-list-root",
+        env = "PI_EXTENSION_LIST_ROOT",
+        default_value = ".pi/extensions",
+        requires = "extension_list",
+        value_name = "path",
+        help = "Root directory scanned by --extension-list"
+    )]
+    pub(crate) extension_list_root: PathBuf,
+
+    #[arg(
         long = "extension-show",
         env = "PI_EXTENSION_SHOW",
+        conflicts_with = "extension_list",
         conflicts_with = "extension_validate",
         value_name = "path",
         help = "Print extension manifest metadata and inventory"

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -126,7 +126,8 @@ use crate::events::{
     EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
-    execute_extension_show_command, execute_extension_validate_command,
+    execute_extension_list_command, execute_extension_show_command,
+    execute_extension_validate_command,
 };
 pub(crate) use crate::macro_profile_commands::{
     default_macro_config_path, default_profile_store_path, execute_macro_command,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -11,6 +11,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.extension_list {
+        execute_extension_list_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.extension_show.is_some() {
         execute_extension_show_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add extension inventory preflight via `--extension-list` / `--extension-list-root`
- scan extension roots deterministically and validate discovered manifests
- render stable list output with valid entries and invalid-manifest diagnostics
- treat missing roots as empty inventory and fail clearly for non-directory roots
- add CLI conflict guards between extension list/show/validate flags
- document extension list usage in README

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent extension_list -- --nocapture
- cargo test -p pi-coding-agent extension_manifest -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #322
