### PR TITLE
feat: add extension process-hook execution preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 jsonschema = "0.41"
 sha2 = "0.10"
+wait-timeout = "0.2"

--- a/README.md
+++ b/README.md
@@ -326,6 +326,15 @@ cargo run -p pi-coding-agent -- \
   --extension-list-root .pi/extensions
 ```
 
+Execute one declared process-runtime extension hook with a JSON payload:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --extension-exec-manifest .pi/extensions/issue-assistant/extension.json \
+  --extension-exec-hook run-start \
+  --extension-exec-payload-file .pi/extensions/issue-assistant/payload.json
+```
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/Cargo.toml
+++ b/crates/pi-coding-agent/Cargo.toml
@@ -26,6 +26,7 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+wait-timeout.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -528,8 +528,40 @@ pub(crate) struct Cli {
     pub(crate) channel_store_repair: Option<String>,
 
     #[arg(
+        long = "extension-exec-manifest",
+        env = "PI_EXTENSION_EXEC_MANIFEST",
+        conflicts_with = "extension_validate",
+        conflicts_with = "extension_list",
+        conflicts_with = "extension_show",
+        requires = "extension_exec_hook",
+        requires = "extension_exec_payload_file",
+        value_name = "path",
+        help = "Execute one process-runtime extension hook from a manifest and exit"
+    )]
+    pub(crate) extension_exec_manifest: Option<PathBuf>,
+
+    #[arg(
+        long = "extension-exec-hook",
+        env = "PI_EXTENSION_EXEC_HOOK",
+        requires = "extension_exec_manifest",
+        value_name = "hook",
+        help = "Hook name used by --extension-exec-manifest (for example run-start)"
+    )]
+    pub(crate) extension_exec_hook: Option<String>,
+
+    #[arg(
+        long = "extension-exec-payload-file",
+        env = "PI_EXTENSION_EXEC_PAYLOAD_FILE",
+        requires = "extension_exec_manifest",
+        value_name = "path",
+        help = "JSON payload file for --extension-exec-manifest hook invocation"
+    )]
+    pub(crate) extension_exec_payload_file: Option<PathBuf>,
+
+    #[arg(
         long = "extension-validate",
         env = "PI_EXTENSION_VALIDATE",
+        conflicts_with = "extension_exec_manifest",
         conflicts_with = "extension_list",
         conflicts_with = "extension_show",
         value_name = "path",
@@ -540,6 +572,7 @@ pub(crate) struct Cli {
     #[arg(
         long = "extension-list",
         env = "PI_EXTENSION_LIST",
+        conflicts_with = "extension_exec_manifest",
         conflicts_with = "extension_validate",
         conflicts_with = "extension_show",
         help = "List discovered extension manifests from a root path and exit"
@@ -559,6 +592,7 @@ pub(crate) struct Cli {
     #[arg(
         long = "extension-show",
         env = "PI_EXTENSION_SHOW",
+        conflicts_with = "extension_exec_manifest",
         conflicts_with = "extension_list",
         conflicts_with = "extension_validate",
         value_name = "path",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -126,7 +126,7 @@ use crate::events::{
     EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
-    execute_extension_list_command, execute_extension_show_command,
+    execute_extension_exec_command, execute_extension_list_command, execute_extension_show_command,
     execute_extension_validate_command,
 };
 pub(crate) use crate::macro_profile_commands::{

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -11,6 +11,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.extension_exec_manifest.is_some() {
+        execute_extension_exec_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.extension_list {
         execute_extension_list_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add startup preflight flags for extension process-hook execution (`--extension-exec-manifest`, `--extension-exec-hook`, `--extension-exec-payload-file`)
- execute process-runtime extension hooks with strict manifest/payload validation and fail-closed timeout handling
- enforce CLI conflict/requirement guards and document usage in README
- add unit, functional, integration, and regression tests for success/failure/timeout/invalid JSON paths

Closes #324
