### PR TITLE
feat: dispatch extension run-start/run-end hooks during prompt runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,17 @@ cargo run -p pi-coding-agent -- \
   --extension-exec-payload-file .pi/extensions/issue-assistant/payload.json
 ```
 
+Enable runtime lifecycle hook dispatch (`run-start` / `run-end`) for prompt turns:
+
+```bash
+cargo run -p pi-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --openai-api-key "$OPENAI_API_KEY" \
+  --prompt "Summarize open issues" \
+  --extension-runtime-hooks \
+  --extension-runtime-root .pi/extensions
+```
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -601,6 +601,24 @@ pub(crate) struct Cli {
     pub(crate) extension_show: Option<PathBuf>,
 
     #[arg(
+        long = "extension-runtime-hooks",
+        env = "PI_EXTENSION_RUNTIME_HOOKS",
+        default_value_t = false,
+        help = "Enable runtime run-start/run-end extension hook dispatch for prompt turns"
+    )]
+    pub(crate) extension_runtime_hooks: bool,
+
+    #[arg(
+        long = "extension-runtime-root",
+        env = "PI_EXTENSION_RUNTIME_ROOT",
+        default_value = ".pi/extensions",
+        requires = "extension_runtime_hooks",
+        value_name = "path",
+        help = "Root directory scanned for runtime extension hooks when --extension-runtime-hooks is enabled"
+    )]
+    pub(crate) extension_runtime_root: PathBuf,
+
+    #[arg(
         long = "package-validate",
         env = "PI_PACKAGE_VALIDATE",
         conflicts_with = "package_show",

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -126,7 +126,8 @@ use crate::events::{
     EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
-    execute_extension_exec_command, execute_extension_list_command, execute_extension_show_command,
+    dispatch_extension_runtime_hook, execute_extension_exec_command,
+    execute_extension_list_command, execute_extension_show_command,
     execute_extension_validate_command,
 };
 pub(crate) use crate::macro_profile_commands::{
@@ -191,8 +192,9 @@ pub(crate) use crate::runtime_cli_validation::{
     validate_github_issues_bridge_cli, validate_slack_bridge_cli,
 };
 pub(crate) use crate::runtime_loop::{
-    resolve_prompt_input, run_interactive, run_prompt, run_prompt_with_cancellation,
-    InteractiveRuntimeConfig, PromptRunStatus,
+    resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
+    run_prompt_with_cancellation, InteractiveRuntimeConfig, PromptRunStatus,
+    RuntimeExtensionHooksConfig,
 };
 #[cfg(test)]
 pub(crate) use crate::runtime_output::stream_text_chunks;

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -69,10 +69,14 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
             println!("{value}");
         });
     }
+    let extension_runtime_hooks = RuntimeExtensionHooksConfig {
+        enabled: cli.extension_runtime_hooks,
+        root: cli.extension_runtime_root.clone(),
+    };
 
     if let Some(prompt) = resolve_prompt_input(cli)? {
         if cli.orchestrator_mode == CliOrchestratorMode::PlanFirst {
-            run_plan_first_prompt(
+            run_plan_first_prompt_with_runtime_hooks(
                 &mut agent,
                 &mut session_runtime,
                 &prompt,
@@ -80,6 +84,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 render_options,
                 cli.orchestrator_max_plan_steps,
                 cli.orchestrator_max_executor_response_chars,
+                &extension_runtime_hooks,
             )
             .await?;
         } else {
@@ -89,6 +94,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 &prompt,
                 cli.turn_timeout_ms,
                 render_options,
+                &extension_runtime_hooks,
             )
             .await?;
         }
@@ -120,6 +126,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     let interactive_config = InteractiveRuntimeConfig {
         turn_timeout_ms: cli.turn_timeout_ms,
         render_options,
+        extension_runtime_hooks: &extension_runtime_hooks,
         orchestrator_mode: cli.orchestrator_mode,
         orchestrator_max_plan_steps: cli.orchestrator_max_plan_steps,
         orchestrator_max_executor_response_chars: cli.orchestrator_max_executor_response_chars,

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -265,6 +265,8 @@ fn test_cli() -> Cli {
         extension_list: false,
         extension_list_root: PathBuf::from(".pi/extensions"),
         extension_show: None,
+        extension_runtime_hooks: false,
+        extension_runtime_root: PathBuf::from(".pi/extensions"),
         package_validate: None,
         package_show: None,
         package_install: None,
@@ -559,6 +561,8 @@ fn unit_cli_extension_validate_flag_defaults_to_none() {
     assert!(!cli.extension_list);
     assert_eq!(cli.extension_list_root, PathBuf::from(".pi/extensions"));
     assert!(cli.extension_show.is_none());
+    assert!(!cli.extension_runtime_hooks);
+    assert_eq!(cli.extension_runtime_root, PathBuf::from(".pi/extensions"));
 }
 
 #[test]
@@ -614,6 +618,18 @@ fn functional_cli_extension_list_flag_accepts_root_override() {
 }
 
 #[test]
+fn functional_cli_extension_runtime_hook_flags_accept_root_override() {
+    let cli = Cli::parse_from([
+        "pi-rs",
+        "--extension-runtime-hooks",
+        "--extension-runtime-root",
+        "extensions",
+    ]);
+    assert!(cli.extension_runtime_hooks);
+    assert_eq!(cli.extension_runtime_root, PathBuf::from("extensions"));
+}
+
+#[test]
 fn regression_cli_extension_show_and_validate_conflict() {
     let parse = Cli::try_parse_from([
         "pi-rs",
@@ -646,6 +662,15 @@ fn regression_cli_extension_exec_requires_hook_and_payload() {
         "extensions/issue.json",
     ]);
     let error = parse.expect_err("exec manifest should require hook and payload");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn regression_cli_extension_runtime_root_requires_runtime_hooks_flag() {
+    let parse = Cli::try_parse_from(["pi-rs", "--extension-runtime-root", "extensions"]);
+    let error = parse.expect_err("runtime root should require runtime hooks flag");
     assert!(error
         .to_string()
         .contains("required arguments were not provided"));


### PR DESCRIPTION
## Summary
- add opt-in runtime extension hook flags (`--extension-runtime-hooks`, `--extension-runtime-root`)
- wire `run-start`/`run-end` hook dispatch around one-shot, interactive, and plan-first prompt execution paths
- introduce deterministic runtime extension discovery and execution ordering with fail-isolated diagnostics
- preserve prompt runtime success when extension hooks fail/timeout and document runtime hook usage in README
- extend test coverage across unit, functional, integration, and regression suites

Closes #326
