### PR TITLE
feat: dispatch extension pre/post tool-call hooks from runtime events

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ cargo run -p pi-coding-agent -- \
   --extension-exec-payload-file .pi/extensions/issue-assistant/payload.json
 ```
 
-Enable runtime lifecycle hook dispatch (`run-start` / `run-end`) for prompt turns:
+Enable runtime lifecycle hook dispatch (`run-start`, `run-end`, `pre-tool-call`, `post-tool-call`) for prompt turns:
 
 ```bash
 cargo run -p pi-coding-agent -- \

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -271,6 +271,8 @@ pub(crate) use crate::startup_config::{
     build_auth_command_config, build_profile_defaults, default_provider_auth_method,
 };
 use crate::startup_dispatch::run_cli;
+#[cfg(test)]
+pub(crate) use crate::startup_local_runtime::register_runtime_extension_tool_hook_subscriber;
 pub(crate) use crate::startup_local_runtime::{run_local_runtime, LocalRuntimeConfig};
 pub(crate) use crate::startup_model_catalog::{
     resolve_startup_model_catalog, validate_startup_model_catalog,


### PR DESCRIPTION
## Summary
- register a runtime extension tool-hook subscriber when `--extension-runtime-hooks` is enabled
- dispatch `pre-tool-call` and `post-tool-call` extension hooks from `AgentEvent::ToolExecutionStart/End`
- emit stable payload shapes containing tool call identity, arguments, and execution result content
- preserve fail-isolated behavior by surfacing diagnostics without failing prompt execution
- add unit and integration/regression tests for payload mapping and timeout isolation

Closes #328
