### PR TITLE
feat: add runtime message-transform hook pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ cargo run -p pi-coding-agent -- \
   --extension-runtime-root .pi/extensions
 ```
 
+For `message-transform` hooks, extension responses can return a replacement prompt via `{"prompt":"..."}`.
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -126,8 +126,8 @@ use crate::events::{
     EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
-    dispatch_extension_runtime_hook, execute_extension_exec_command,
-    execute_extension_list_command, execute_extension_show_command,
+    apply_extension_message_transforms, dispatch_extension_runtime_hook,
+    execute_extension_exec_command, execute_extension_list_command, execute_extension_show_command,
     execute_extension_validate_command,
 };
 pub(crate) use crate::macro_profile_commands::{


### PR DESCRIPTION
## Summary
- add deterministic runtime message-transform pipeline for extension hooks (`message-transform`)
- allow transform extensions to rewrite prompt text via response contract `{ "prompt": "..." }`
- apply transformed prompt across standard prompt execution and plan-first wrapper paths
- preserve fail-isolated behavior: malformed transform output emits diagnostics and keeps original prompt
- add unit/functional/integration/regression coverage and README usage note

Closes #330
