### PR TITLE
feat: enforce extension policy-override in bash tool path

### DIFF
--- a/crates/pi-coding-agent/src/tool_policy_config.rs
+++ b/crates/pi-coding-agent/src/tool_policy_config.rs
@@ -46,6 +46,9 @@ pub(crate) fn build_tool_policy(cli: &Cli) -> Result<ToolPolicy> {
     if cli.tool_policy_trace {
         policy.tool_policy_trace = true;
     }
+    if cli.extension_runtime_hooks {
+        policy.extension_policy_override_root = Some(cli.extension_runtime_root.clone());
+    }
     if !cli.allow_command.is_empty() {
         for command in &cli.allow_command {
             let command = command.trim();
@@ -104,5 +107,9 @@ pub(crate) fn tool_policy_to_json(policy: &ToolPolicy) -> serde_json::Value {
         "enforce_regular_files": policy.enforce_regular_files,
         "bash_dry_run": policy.bash_dry_run,
         "tool_policy_trace": policy.tool_policy_trace,
+        "extension_policy_override_root": policy
+            .extension_policy_override_root
+            .as_ref()
+            .map(|path| path.display().to_string()),
     })
 }


### PR DESCRIPTION
## Summary
- add `policy-override` evaluation support in extension runtime with strict response parsing and fail-closed behavior
- enforce extension policy overrides in bash tool execution before command spawn, including deterministic deny payload and policy-trace entries
- wire override root through tool policy config when `--extension-runtime-hooks` is enabled and expose it via policy JSON
- expand unit/functional/integration/regression coverage for parser behavior, runtime evaluation, bash enforcement, and policy wiring
- harden extension hook tests by using deterministic shell shebang paths

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #332
