### PR TITLE
feat: enforce run-commands permission across extension hooks

### DIFF
--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -7051,6 +7051,7 @@ fn functional_execute_extension_exec_command_runs_process_hook() {
   "runtime": "process",
   "entrypoint": "bin/hook.sh",
   "hooks": ["run-start"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -7087,6 +7088,7 @@ fn regression_execute_extension_exec_command_rejects_undeclared_hook() {
   "runtime": "process",
   "entrypoint": "bin/hook.sh",
   "hooks": ["run-end"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -7124,6 +7126,7 @@ fn regression_execute_extension_exec_command_enforces_timeout() {
   "runtime": "process",
   "entrypoint": "bin/slow.sh",
   "hooks": ["run-start"],
+  "permissions": ["run-commands"],
   "timeout_ms": 20
 }"#,
     )
@@ -7161,6 +7164,7 @@ fn regression_execute_extension_exec_command_rejects_invalid_json_response() {
   "runtime": "process",
   "entrypoint": "bin/bad.sh",
   "hooks": ["run-start"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -8523,6 +8527,7 @@ async fn integration_tool_hook_subscriber_dispatches_pre_and_post_tool_call_hook
   "runtime": "process",
   "entrypoint": "hook.sh",
   "hooks": ["pre-tool-call", "post-tool-call"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -8613,6 +8618,7 @@ async fn regression_tool_hook_subscriber_timeout_does_not_fail_prompt() {
   "runtime": "process",
   "entrypoint": "hook.sh",
   "hooks": ["pre-tool-call", "post-tool-call"],
+  "permissions": ["run-commands"],
   "timeout_ms": 20
 }"#,
     )

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -3044,6 +3044,7 @@ fn extension_exec_flag_runs_process_hook_and_reports_success() {
   "runtime": "process",
   "entrypoint": "bin/hook.sh",
   "hooks": ["run-start"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -3098,6 +3099,7 @@ fn regression_extension_exec_flag_rejects_invalid_response() {
   "runtime": "process",
   "entrypoint": "bin/bad.sh",
   "hooks": ["run-start"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -3154,6 +3156,7 @@ fn extension_runtime_hooks_wrap_prompt_with_run_start_and_run_end() {
   "runtime": "process",
   "entrypoint": "hook.sh",
   "hooks": ["run-start", "run-end"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -3235,6 +3238,7 @@ fn regression_extension_runtime_hook_timeout_does_not_fail_prompt() {
   "runtime": "process",
   "entrypoint": "hook.sh",
   "hooks": ["run-start", "run-end"],
+  "permissions": ["run-commands"],
   "timeout_ms": 20
 }"#,
     )
@@ -3305,6 +3309,7 @@ fn extension_message_transform_hook_rewrites_prompt_before_model_request() {
   "runtime": "process",
   "entrypoint": "transform.sh",
   "hooks": ["message-transform"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )
@@ -3376,6 +3381,7 @@ fn regression_extension_message_transform_invalid_response_falls_back_to_origina
   "runtime": "process",
   "entrypoint": "transform.sh",
   "hooks": ["message-transform"],
+  "permissions": ["run-commands"],
   "timeout_ms": 5000
 }"#,
     )


### PR DESCRIPTION
## Summary
- require `run-commands` permission for all process hook execution paths (`run-start`, `run-end`, `pre-tool-call`, `post-tool-call`, `message-transform`, `policy-override`)
- add permission-denied counters/diagnostics in runtime hook dispatch and message-transform reports
- preserve fail-closed behavior for policy override while adding deterministic diagnostics for missing permission
- update extension fixtures/tests to declare required permissions where execution is expected

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #336
