### PR TITLE
feat: schema-version extension hook payload envelopes

### DIFF
--- a/crates/pi-coding-agent/src/extension_manifest.rs
+++ b/crates/pi-coding-agent/src/extension_manifest.rs
@@ -18,6 +18,7 @@ use crate::Cli;
 const EXTENSION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const EXTENSION_TIMEOUT_MS_DEFAULT: u64 = 5_000;
 const EXTENSION_TIMEOUT_MS_MAX: u64 = 300_000;
+const EXTENSION_HOOK_PAYLOAD_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ExtensionManifestSummary {
@@ -641,7 +642,13 @@ pub(crate) fn apply_extension_message_transforms(
 
         result.executed += 1;
         let payload = serde_json::json!({
+            "schema_version": EXTENSION_HOOK_PAYLOAD_SCHEMA_VERSION,
+            "hook": hook.as_str(),
+            "emitted_at_ms": crate::current_unix_timestamp_ms(),
             "prompt": result.prompt.clone(),
+            "data": {
+                "prompt": result.prompt.clone(),
+            },
         });
         match execute_extension_process_hook_with_loaded(
             &loaded_manifest.manifest,

--- a/crates/pi-coding-agent/src/tests.rs
+++ b/crates/pi-coding-agent/src/tests.rs
@@ -8588,9 +8588,15 @@ async fn integration_tool_hook_subscriber_dispatches_pre_and_post_tool_call_hook
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["hook"], "pre-tool-call");
     assert_eq!(rows[1]["hook"], "post-tool-call");
-    assert_eq!(rows[0]["payload"]["tool_name"], "read");
-    assert_eq!(rows[1]["payload"]["tool_name"], "read");
-    assert_eq!(rows[1]["payload"]["result"]["is_error"], false);
+    assert_eq!(rows[0]["payload"]["schema_version"], 1);
+    assert_eq!(rows[1]["payload"]["schema_version"], 1);
+    assert_eq!(rows[0]["payload"]["hook"], "pre-tool-call");
+    assert_eq!(rows[1]["payload"]["hook"], "post-tool-call");
+    assert!(rows[0]["payload"]["emitted_at_ms"].as_u64().is_some());
+    assert!(rows[1]["payload"]["emitted_at_ms"].as_u64().is_some());
+    assert_eq!(rows[0]["payload"]["data"]["tool_name"], "read");
+    assert_eq!(rows[1]["payload"]["data"]["tool_name"], "read");
+    assert_eq!(rows[1]["payload"]["data"]["result"]["is_error"], false);
 }
 
 #[tokio::test]

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -3202,8 +3202,14 @@ fn extension_runtime_hooks_wrap_prompt_with_run_start_and_run_end() {
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["hook"], "run-start");
     assert_eq!(rows[1]["hook"], "run-end");
-    assert_eq!(rows[0]["payload"]["prompt"], "hello runtime hooks");
-    assert_eq!(rows[1]["payload"]["status"], "completed");
+    assert_eq!(rows[0]["payload"]["schema_version"], 1);
+    assert_eq!(rows[1]["payload"]["schema_version"], 1);
+    assert_eq!(rows[0]["payload"]["hook"], "run-start");
+    assert_eq!(rows[1]["payload"]["hook"], "run-end");
+    assert!(rows[0]["payload"]["emitted_at_ms"].as_u64().is_some());
+    assert!(rows[1]["payload"]["emitted_at_ms"].as_u64().is_some());
+    assert_eq!(rows[0]["payload"]["data"]["prompt"], "hello runtime hooks");
+    assert_eq!(rows[1]["payload"]["data"]["status"], "completed");
 
     openai.assert_calls(1);
 }


### PR DESCRIPTION
## Summary
- add schema-versioned envelopes to runtime extension hook payloads (`run-start`/`run-end`)
- add schema-versioned envelopes to pre-tool-call/post-tool-call event hook payloads
- add schema metadata to message-transform payload inputs
- preserve backward compatibility by keeping legacy top-level payload keys alongside nested `data`
- update unit/integration/regression assertions for new payload contract shape

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #338
