### PR TITLE
feat(extension): register runtime tools and slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,46 @@ cargo run -p pi-coding-agent -- \
 
 For `message-transform` hooks, extension responses can return a replacement prompt via `{"prompt":"..."}`.
 
+When `--extension-runtime-hooks` is enabled, process extensions can also declare runtime tools and slash commands:
+
+```json
+{
+  "schema_version": 1,
+  "id": "issue-assistant",
+  "version": "1.0.0",
+  "runtime": "process",
+  "entrypoint": "runtime.sh",
+  "permissions": ["run-commands"],
+  "tools": [
+    {
+      "name": "issue_triage",
+      "description": "Classify and label issues",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" }
+        },
+        "required": ["title"],
+        "additionalProperties": false
+      }
+    }
+  ],
+  "commands": [
+    {
+      "name": "/triage-now",
+      "description": "Run triage pipeline",
+      "usage": "/triage-now <issue-number>"
+    }
+  ]
+}
+```
+
+Runtime tool response contract:
+- return JSON object with `content` (any JSON) and optional `is_error` boolean.
+
+Runtime slash-command response contract:
+- return JSON object with optional `output` (or `message`) string and optional `action` of `continue` or `exit`.
+
 Validate a reusable package manifest JSON and exit:
 
 ```bash

--- a/crates/pi-coding-agent/src/macro_profile_commands.rs
+++ b/crates/pi-coding-agent/src/macro_profile_commands.rs
@@ -338,6 +338,7 @@ pub(crate) fn execute_macro_command(
                     command_context.skills_command_config,
                     command_context.auth_command_config,
                     command_context.model_catalog,
+                    command_context.extension_commands,
                 ) {
                     Ok(CommandAction::Continue) => {}
                     Ok(CommandAction::Exit) => {

--- a/crates/pi-coding-agent/src/runtime_loop.rs
+++ b/crates/pi-coding-agent/src/runtime_loop.rs
@@ -123,6 +123,7 @@ pub(crate) async fn run_interactive(
                 config.command_context.skills_command_config,
                 config.command_context.auth_command_config,
                 config.command_context.model_catalog,
+                config.command_context.extension_commands,
             )? == CommandAction::Exit
             {
                 break;

--- a/crates/pi-coding-agent/src/runtime_types.rs
+++ b/crates/pi-coding-agent/src/runtime_types.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use pi_ai::Provider;
 use serde::{Deserialize, Serialize};
 
+use crate::extension_manifest::ExtensionRegisteredCommand;
 use crate::session::{SessionImportMode, SessionStore};
 use crate::{
     default_provider_auth_method, Cli, CredentialStoreEncryptionMode, ModelCatalog,
@@ -119,6 +120,7 @@ pub(crate) struct CommandExecutionContext<'a> {
     pub(crate) skills_command_config: &'a SkillsSyncCommandConfig,
     pub(crate) auth_command_config: &'a AuthCommandConfig,
     pub(crate) model_catalog: &'a ModelCatalog,
+    pub(crate) extension_commands: &'a [ExtensionRegisteredCommand],
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- extend extension manifests with optional `tools` and `commands` registration blocks
- add runtime discovery/registration for extension-backed tools and slash commands with deterministic conflict diagnostics
- wire extension tool registration into agent startup and extension command dispatch into interactive, macro, and command-file command paths
- keep command failures fail-isolated (report and continue) and enforce explicit `run-commands` permission for command/tool registrations
- add docs and full test coverage across unit/functional/integration/regression paths

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #340
