### PR TITLE
feat(rpc): add long-running ndjson stdio serve mode (#342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,12 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-ndjson-file /tmp/rpc-frames.ndjson
 ```
 
+Run long-lived RPC NDJSON server mode over stdin/stdout:
+
+```bash
+cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
+```
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -897,6 +897,18 @@ pub(crate) struct Cli {
     pub(crate) rpc_dispatch_ndjson_file: Option<PathBuf>,
 
     #[arg(
+        long = "rpc-serve-ndjson",
+        env = "PI_RPC_SERVE_NDJSON",
+        default_value_t = false,
+        conflicts_with = "rpc_capabilities",
+        conflicts_with = "rpc_validate_frame_file",
+        conflicts_with = "rpc_dispatch_frame_file",
+        conflicts_with = "rpc_dispatch_ndjson_file",
+        help = "Run long-lived RPC NDJSON server mode over stdin/stdout"
+    )]
+    pub(crate) rpc_serve_ndjson: bool,
+
+    #[arg(
         long = "events-runner",
         env = "PI_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -185,7 +185,7 @@ pub(crate) use crate::rpc_capabilities::rpc_capabilities_payload;
 pub(crate) use crate::rpc_protocol::validate_rpc_frame_file;
 pub(crate) use crate::rpc_protocol::{
     execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
-    execute_rpc_validate_frame_command,
+    execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
 };
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,

--- a/crates/pi-coding-agent/src/startup_preflight.rs
+++ b/crates/pi-coding-agent/src/startup_preflight.rs
@@ -96,6 +96,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.rpc_serve_ndjson {
+        execute_rpc_serve_ndjson_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -4912,6 +4912,62 @@ not-json
 }
 
 #[test]
+fn rpc_serve_ndjson_flag_streams_ordered_response_lines() {
+    let mut cmd = binary_command();
+    cmd.arg("--rpc-serve-ndjson").write_stdin(
+        r#"{"schema_version":1,"request_id":"req-cap","kind":"capabilities.request","payload":{}}
+{"schema_version":1,"request_id":"req-cancel","kind":"run.cancel","payload":{"run_id":"run-1"}}
+"#,
+    );
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"request_id\":\"req-cap\""))
+        .stdout(predicate::str::contains(
+            "\"kind\":\"capabilities.response\"",
+        ))
+        .stdout(predicate::str::contains("\"request_id\":\"req-cancel\""))
+        .stdout(predicate::str::contains("\"kind\":\"run.cancelled\""));
+}
+
+#[test]
+fn regression_rpc_serve_ndjson_continues_after_error_and_exits_failure() {
+    let mut cmd = binary_command();
+    cmd.arg("--rpc-serve-ndjson").write_stdin(
+        r#"{"schema_version":1,"request_id":"req-ok","kind":"run.cancel","payload":{"run_id":"run-1"}}
+not-json
+{"schema_version":1,"request_id":"req-ok-2","kind":"run.start","payload":{"prompt":"x"}}
+"#,
+    );
+
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("\"request_id\":\"req-ok\""))
+        .stdout(predicate::str::contains("\"kind\":\"run.cancelled\""))
+        .stdout(predicate::str::contains("\"kind\":\"error\""))
+        .stdout(predicate::str::contains("\"code\":\"invalid_json\""))
+        .stdout(predicate::str::contains("\"request_id\":\"req-ok-2\""))
+        .stdout(predicate::str::contains("\"kind\":\"run.accepted\""))
+        .stderr(predicate::str::contains(
+            "rpc ndjson serve completed with 1 error frame(s)",
+        ));
+}
+
+#[test]
+fn regression_rpc_serve_ndjson_takes_preflight_precedence_over_prompt() {
+    let mut cmd = binary_command();
+    cmd.args(["--rpc-serve-ndjson", "--prompt", "ignored prompt"])
+        .write_stdin(r#"{"schema_version":1,"request_id":"req-cap","kind":"capabilities.request","payload":{}}"#);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"kind\":\"capabilities.response\"",
+        ))
+        .stderr(predicate::str::contains("OPENAI_API_KEY").not());
+}
+
+#[test]
 fn prompt_file_flag_runs_one_shot_prompt() {
     let server = MockServer::start();
     let openai = server.mock(|when, then| {


### PR DESCRIPTION
## Summary
- add --rpc-serve-ndjson CLI mode for long-running stdio NDJSON RPC serving
- process one input frame per line from stdin and emit one response frame per line to stdout
- keep serving after malformed frames and return deterministic non-zero exit when any error frame is emitted
- wire serve mode into startup preflight and document usage in README
- add unit, functional, integration, and regression tests for parser behavior and runtime behavior

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #342