### PR TITLE
feat(orchestrator): add delegated step execution mode (#344)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ Run interactive mode with plan-first orchestration on each user turn:
 cargo run -p pi-coding-agent -- \
   --model openai/gpt-4o-mini \
   --orchestrator-mode plan-first \
+  --orchestrator-delegate-steps \
   --orchestrator-max-plan-steps 8 \
   --orchestrator-max-executor-response-chars 20000
 ```
 
-Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `review`, and `consolidation` phases, including executor response budget metadata and accept/reject consolidation decisions.
+Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `delegated-step` (when enabled), `review`, and `consolidation` phases, including response budget metadata and accept/reject consolidation decisions.
 
 Use Anthropic:
 
@@ -200,6 +201,7 @@ Run one prompt with plan-first orchestration:
 cargo run -p pi-coding-agent -- \
   --prompt "Summarize src/lib.rs" \
   --orchestrator-mode plan-first \
+  --orchestrator-delegate-steps \
   --orchestrator-max-plan-steps 8 \
   --orchestrator-max-executor-response-chars 20000
 ```

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -456,6 +456,14 @@ pub(crate) struct Cli {
     pub(crate) orchestrator_max_executor_response_chars: usize,
 
     #[arg(
+        long = "orchestrator-delegate-steps",
+        env = "PI_ORCHESTRATOR_DELEGATE_STEPS",
+        default_value_t = false,
+        help = "Enable delegated step execution and final consolidation in plan-first orchestrator mode"
+    )]
+    pub(crate) orchestrator_delegate_steps: bool,
+
+    #[arg(
         long,
         env = "PI_PROMPT_FILE",
         conflicts_with = "prompt",

--- a/crates/pi-coding-agent/src/runtime_loop.rs
+++ b/crates/pi-coding-agent/src/runtime_loop.rs
@@ -64,6 +64,7 @@ pub(crate) struct InteractiveRuntimeConfig<'a> {
     pub(crate) orchestrator_mode: CliOrchestratorMode,
     pub(crate) orchestrator_max_plan_steps: usize,
     pub(crate) orchestrator_max_executor_response_chars: usize,
+    pub(crate) orchestrator_delegate_steps: bool,
     pub(crate) command_context: CommandExecutionContext<'a>,
 }
 
@@ -140,6 +141,7 @@ pub(crate) async fn run_interactive(
                 config.render_options,
                 config.orchestrator_max_plan_steps,
                 config.orchestrator_max_executor_response_chars,
+                config.orchestrator_delegate_steps,
                 config.extension_runtime_hooks,
             )
             .await?;
@@ -236,6 +238,7 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
     render_options: RenderOptions,
     orchestrator_max_plan_steps: usize,
     orchestrator_max_executor_response_chars: usize,
+    orchestrator_delegate_steps: bool,
     extension_runtime_hooks: &RuntimeExtensionHooksConfig,
 ) -> Result<()> {
     let effective_prompt = apply_runtime_message_transform(extension_runtime_hooks, prompt);
@@ -253,6 +256,7 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
         render_options,
         orchestrator_max_plan_steps,
         orchestrator_max_executor_response_chars,
+        orchestrator_delegate_steps,
     )
     .await;
 

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -112,6 +112,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 render_options,
                 cli.orchestrator_max_plan_steps,
                 cli.orchestrator_max_executor_response_chars,
+                cli.orchestrator_delegate_steps,
                 &extension_runtime_hooks,
             )
             .await?;
@@ -159,6 +160,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         orchestrator_mode: cli.orchestrator_mode,
         orchestrator_max_plan_steps: cli.orchestrator_max_plan_steps,
         orchestrator_max_executor_response_chars: cli.orchestrator_max_executor_response_chars,
+        orchestrator_delegate_steps: cli.orchestrator_delegate_steps,
         command_context,
     };
     if let Some(command_file_path) = cli.command_file.as_deref() {


### PR DESCRIPTION
## Summary
- add optional plan-first delegated execution mode via --orchestrator-delegate-steps
- when enabled, execute one delegated turn per approved planner step and then run a consolidation turn
- keep existing non-delegated plan-first behavior unchanged when the flag is disabled
- enforce fail-closed behavior for empty delegated step output and empty consolidation output
- preserve response budget guardrails for final consolidation output with deterministic trace decisions
- add deterministic orchestration traces for delegated execution phases
- update README with delegated plan-first examples

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #344