### PR TITLE
ci: reduce PR runtime cost with codex-light mode (#346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,26 +32,25 @@ jobs:
   quality-linux:
     name: Quality (fmt + clippy + tests)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Detect auth/runtime changes
-        id: auth_changes
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            auth_runtime:
-              - 'crates/pi-coding-agent/src/**'
-              - 'crates/pi-ai/src/**'
-              - 'crates/pi-agent-core/src/**'
-            transport_conformance:
-              - 'crates/pi-coding-agent/src/events.rs'
-              - 'crates/pi-coding-agent/src/github_issues.rs'
-              - 'crates/pi-coding-agent/src/slack.rs'
-              - 'crates/pi-coding-agent/src/transport_conformance.rs'
-              - 'crates/pi-coding-agent/testdata/transport-replay/**'
+      - name: Determine quality mode
+        id: quality_mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          mode="full"
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.head_ref }}" == codex/* ]]; then
+            mode="codex-light"
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Quality Mode"
+            echo "- Mode: ${mode}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -68,17 +66,12 @@ jobs:
       - name: Lint
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Run auth conformance and security regression suite
-        if: github.event_name != 'pull_request' || steps.auth_changes.outputs.auth_runtime == 'true'
-        run: |
-          cargo test -p pi-coding-agent auth_conformance_ -- --nocapture
-          cargo test -p pi-coding-agent auth_security_ -- --nocapture
-
-      - name: Run transport conformance replay suite
-        if: github.event_name != 'pull_request' || steps.auth_changes.outputs.transport_conformance == 'true'
-        run: cargo test -p pi-coding-agent transport_conformance_ -- --nocapture
+      - name: Run codex light smoke tests
+        if: steps.quality_mode.outputs.mode == 'codex-light'
+        run: cargo test --workspace --lib --bins
 
       - name: Run workspace tests
+        if: steps.quality_mode.outputs.mode != 'codex-light'
         run: cargo test --workspace
 
   cross-platform-smoke:
@@ -158,53 +151,3 @@ jobs:
           path: |
             coverage/lcov.info
             coverage/summary.txt
-
-  report:
-    name: CI Summary
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - quality-linux
-      - cross-platform-smoke
-      - coverage
-    env:
-      QUALITY_RESULT: ${{ needs.quality-linux.result }}
-      CROSS_PLATFORM_RESULT: ${{ needs.cross-platform-smoke.result }}
-      COVERAGE_RESULT: ${{ needs.coverage.result }}
-      COVERAGE_PCT: ${{ needs.coverage.outputs.line_coverage }}
-    steps:
-      - name: Publish summary and annotate failures
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          {
-            echo "### CI Suite Summary"
-            echo ""
-            echo "| Suite | Result |"
-            echo "| --- | --- |"
-            echo "| Linux quality (fmt + clippy + workspace tests) | ${QUALITY_RESULT} |"
-            echo "| Cross-platform smoke | ${CROSS_PLATFORM_RESULT} |"
-            echo "| Coverage | ${COVERAGE_RESULT} |"
-            if [[ "${COVERAGE_RESULT}" == "success" ]]; then
-              echo ""
-              echo "Coverage: ${COVERAGE_PCT}%"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          failed=0
-          for suite in \
-            "Linux quality:${QUALITY_RESULT}" \
-            "Cross-platform smoke:${CROSS_PLATFORM_RESULT}" \
-            "Coverage:${COVERAGE_RESULT}"; do
-            name="${suite%%:*}"
-            result="${suite##*:}"
-            if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
-              echo "::error title=CI suite failed::${name} returned ${result}"
-              failed=1
-            fi
-          done
-
-          if [[ "${failed}" -ne 0 ]]; then
-            exit 1
-          fi


### PR DESCRIPTION
## Summary
- reduce CI Linux minutes for frequent codex PR iterations
- remove duplicate targeted auth/transport test stages from PR CI
- add codex-light quality mode for pull_request branches prefixed codex/
- codex-light mode runs fmt + clippy + smoke tests (cargo test --workspace --lib --bins)
- non-codex branches and workflow_dispatch continue to run full workspace tests
- remove separate CI Summary job to avoid extra runner startup minutes

## Why this is safe
- local development workflow already runs full fmt/clippy/workspace tests before merge
- CI still enforces compile/lint/test guardrails on every PR
- non-codex PRs keep full test execution in CI

## Validation
- ruby YAML parse: .github/workflows/ci.yml
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #346