### PR TITLE
feat: add delegated output budgets for plan-first orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ cargo run -p pi-coding-agent -- \
   --orchestrator-mode plan-first \
   --orchestrator-delegate-steps \
   --orchestrator-max-plan-steps 8 \
-  --orchestrator-max-executor-response-chars 20000
+  --orchestrator-max-executor-response-chars 20000 \
+  --orchestrator-max-delegated-step-response-chars 20000 \
+  --orchestrator-max-delegated-total-response-chars 160000
 ```
 
 Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `delegated-step` (when enabled), `review`, and `consolidation` phases, including response budget metadata and accept/reject consolidation decisions.
@@ -203,7 +205,9 @@ cargo run -p pi-coding-agent -- \
   --orchestrator-mode plan-first \
   --orchestrator-delegate-steps \
   --orchestrator-max-plan-steps 8 \
-  --orchestrator-max-executor-response-chars 20000
+  --orchestrator-max-executor-response-chars 20000 \
+  --orchestrator-max-delegated-step-response-chars 20000 \
+  --orchestrator-max-delegated-total-response-chars 160000
 ```
 
 Run one prompt from a file:

--- a/crates/pi-coding-agent/src/cli_args.rs
+++ b/crates/pi-coding-agent/src/cli_args.rs
@@ -456,6 +456,24 @@ pub(crate) struct Cli {
     pub(crate) orchestrator_max_executor_response_chars: usize,
 
     #[arg(
+        long = "orchestrator-max-delegated-step-response-chars",
+        env = "PI_ORCHESTRATOR_MAX_DELEGATED_STEP_RESPONSE_CHARS",
+        default_value_t = 20000,
+        value_parser = parse_positive_usize,
+        help = "Maximum delegated step response length (characters) allowed when --orchestrator-delegate-steps is enabled"
+    )]
+    pub(crate) orchestrator_max_delegated_step_response_chars: usize,
+
+    #[arg(
+        long = "orchestrator-max-delegated-total-response-chars",
+        env = "PI_ORCHESTRATOR_MAX_DELEGATED_TOTAL_RESPONSE_CHARS",
+        default_value_t = 160000,
+        value_parser = parse_positive_usize,
+        help = "Maximum cumulative delegated response length (characters) allowed when --orchestrator-delegate-steps is enabled"
+    )]
+    pub(crate) orchestrator_max_delegated_total_response_chars: usize,
+
+    #[arg(
         long = "orchestrator-delegate-steps",
         env = "PI_ORCHESTRATOR_DELEGATE_STEPS",
         default_value_t = false,

--- a/crates/pi-coding-agent/src/runtime_loop.rs
+++ b/crates/pi-coding-agent/src/runtime_loop.rs
@@ -64,6 +64,8 @@ pub(crate) struct InteractiveRuntimeConfig<'a> {
     pub(crate) orchestrator_mode: CliOrchestratorMode,
     pub(crate) orchestrator_max_plan_steps: usize,
     pub(crate) orchestrator_max_executor_response_chars: usize,
+    pub(crate) orchestrator_max_delegated_step_response_chars: usize,
+    pub(crate) orchestrator_max_delegated_total_response_chars: usize,
     pub(crate) orchestrator_delegate_steps: bool,
     pub(crate) command_context: CommandExecutionContext<'a>,
 }
@@ -141,6 +143,8 @@ pub(crate) async fn run_interactive(
                 config.render_options,
                 config.orchestrator_max_plan_steps,
                 config.orchestrator_max_executor_response_chars,
+                config.orchestrator_max_delegated_step_response_chars,
+                config.orchestrator_max_delegated_total_response_chars,
                 config.orchestrator_delegate_steps,
                 config.extension_runtime_hooks,
             )
@@ -238,6 +242,8 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
     render_options: RenderOptions,
     orchestrator_max_plan_steps: usize,
     orchestrator_max_executor_response_chars: usize,
+    orchestrator_max_delegated_step_response_chars: usize,
+    orchestrator_max_delegated_total_response_chars: usize,
     orchestrator_delegate_steps: bool,
     extension_runtime_hooks: &RuntimeExtensionHooksConfig,
 ) -> Result<()> {
@@ -256,6 +262,8 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
         render_options,
         orchestrator_max_plan_steps,
         orchestrator_max_executor_response_chars,
+        orchestrator_max_delegated_step_response_chars,
+        orchestrator_max_delegated_total_response_chars,
         orchestrator_delegate_steps,
     )
     .await;

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -112,6 +112,8 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 render_options,
                 cli.orchestrator_max_plan_steps,
                 cli.orchestrator_max_executor_response_chars,
+                cli.orchestrator_max_delegated_step_response_chars,
+                cli.orchestrator_max_delegated_total_response_chars,
                 cli.orchestrator_delegate_steps,
                 &extension_runtime_hooks,
             )
@@ -160,6 +162,10 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         orchestrator_mode: cli.orchestrator_mode,
         orchestrator_max_plan_steps: cli.orchestrator_max_plan_steps,
         orchestrator_max_executor_response_chars: cli.orchestrator_max_executor_response_chars,
+        orchestrator_max_delegated_step_response_chars: cli
+            .orchestrator_max_delegated_step_response_chars,
+        orchestrator_max_delegated_total_response_chars: cli
+            .orchestrator_max_delegated_total_response_chars,
         orchestrator_delegate_steps: cli.orchestrator_delegate_steps,
         command_context,
     };


### PR DESCRIPTION
## Summary\n- add delegated output budget controls to plan-first orchestrator CLI/runtime wiring\n- enforce fail-closed delegated per-step and cumulative response budgets with deterministic trace rejection reasons\n- add unit/functional/integration/regression coverage for delegated budget parsing and runtime rejection paths\n- document new delegated budget flags in README plan-first examples\n\n## Linked Issue\n- closes #348\n\n## Validation\n- cargo fmt --all\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test -p pi-coding-agent -- --test-threads=1\n- cargo test --workspace -- --test-threads=1\n