### PR TITLE
Enforce stateful run lifecycle in RPC serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 
 ```bash


### PR DESCRIPTION
## Summary
- make rpc serve NDJSON mode enforce a stateful run lifecycle
- have run.start responses include run_id and track active runs in serve mode
- return structured invalid_payload errors for unknown cancels, duplicate active run ids, and invalid optional run_id
- document serve lifecycle semantics in the README
- add unit, functional, regression, and integration coverage for the new behavior

Closes #353

## Validation
- cargo fmt --all
- cargo test -p pi-coding-agent -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1