### PR TITLE
Add run.status RPC primitive for serve lifecycle introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
-In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id`, `run.status` reports active/inactive state for that `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/src/rpc_capabilities.rs
+++ b/crates/pi-coding-agent/src/rpc_capabilities.rs
@@ -10,6 +10,7 @@ const RPC_CAPABILITIES: &[&str] = &[
     "errors.structured",
     "run.cancel",
     "run.start",
+    "run.status",
     "run.stream.assistant_text",
     "run.stream.tool_events",
 ];
@@ -67,6 +68,7 @@ mod tests {
                 "errors.structured",
                 "run.cancel",
                 "run.start",
+                "run.status",
                 "run.stream.assistant_text",
                 "run.stream.tool_events",
             ]


### PR DESCRIPTION
## Summary
- add new RPC request kind `run.status` for lifecycle introspection
- return deterministic run status envelopes in stateless dispatch mode (`active=false`, `known=false`)
- return stateful run status envelopes in `--rpc-serve-ndjson` based on active serve-session runs
- advertise `run.status` in capabilities and document behavior in README
- add unit, functional, integration, and regression test coverage across protocol and CLI

Closes #355

## Validation
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
