### PR TITLE
Emit deterministic run.stream frames in RPC serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
-In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id`, `run.status` reports active/inactive state for that `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5200,6 +5200,12 @@ fn rpc_serve_ndjson_flag_streams_ordered_response_lines() {
         .stdout(predicate::str::contains("\"request_id\":\"req-start\""))
         .stdout(predicate::str::contains("\"kind\":\"run.accepted\""))
         .stdout(predicate::str::contains(
+            "\"kind\":\"run.stream.tool_events\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"kind\":\"run.stream.assistant_text\"",
+        ))
+        .stdout(predicate::str::contains(
             "\"request_id\":\"req-status-active\"",
         ))
         .stdout(predicate::str::contains("\"kind\":\"run.status\""))


### PR DESCRIPTION
## Summary
- extend `--rpc-serve-ndjson` run.start handling to emit deterministic stream frames in order
- emit `run.stream.tool_events` and `run.stream.assistant_text` after `run.accepted`
- keep file-based dispatch modes unchanged and stateless
- preserve structured error envelopes and loop continuity on malformed/invalid frames
- document serve-mode stream emission behavior in README

Closes #357

## Validation
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_serve_ndjson -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
