### PR TITLE
Add run.complete RPC primitive for deterministic lifecycle closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
-In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/src/rpc_capabilities.rs
+++ b/crates/pi-coding-agent/src/rpc_capabilities.rs
@@ -9,6 +9,7 @@ pub(crate) const RPC_PROTOCOL_VERSION: &str = "0.1.0";
 const RPC_CAPABILITIES: &[&str] = &[
     "errors.structured",
     "run.cancel",
+    "run.complete",
     "run.start",
     "run.status",
     "run.stream.assistant_text",
@@ -67,6 +68,7 @@ mod tests {
             vec![
                 "errors.structured",
                 "run.cancel",
+                "run.complete",
                 "run.start",
                 "run.status",
                 "run.stream.assistant_text",


### PR DESCRIPTION
## Summary
- add new RPC request kind `run.complete` with `run.completed` response envelope
- enforce serve-mode active-run validation for `run.complete` and remove completed runs from active state
- emit deterministic completion tool-event stream frame in serve mode (`run.stream.tool_events` with `event=run.completed`)
- advertise `run.complete` in capabilities and document completion semantics in README
- add unit, functional, integration, and regression coverage across parser/dispatcher/serve/CLI paths

Closes #359

## Validation
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
