### PR TITLE
feat(rpc): add run.timeout lifecycle primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
-In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/src/rpc_capabilities.rs
+++ b/crates/pi-coding-agent/src/rpc_capabilities.rs
@@ -13,6 +13,7 @@ const RPC_CAPABILITIES: &[&str] = &[
     "run.fail",
     "run.start",
     "run.status",
+    "run.timeout",
     "run.stream.assistant_text",
     "run.stream.tool_events",
 ];
@@ -73,6 +74,7 @@ mod tests {
                 "run.fail",
                 "run.start",
                 "run.status",
+                "run.timeout",
                 "run.stream.assistant_text",
                 "run.stream.tool_events",
             ]


### PR DESCRIPTION
## Summary
- add `run.timeout` as a supported RPC frame kind and capability
- return deterministic `run.timed_out` envelopes with optional validated `reason`
- extend `--rpc-serve-ndjson` stateful lifecycle to close active runs on timeout and emit `run.stream.tool_events`
- cover parse/dispatch/serve/CLI integration and README lifecycle contract updates

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #363