### PR TITLE
test(rpc): add schema compatibility fixture replay suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ cargo run -p pi-coding-agent -- \
 ```
 
 RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.response` includes both `response_schema_version` and `supported_request_schema_versions`.
+Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.
 

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -1,0 +1,10 @@
+# RPC Schema Compatibility Fixtures
+
+This fixture corpus locks deterministic RPC behavior across request schema versions and serve/dispatch modes.
+
+- `dispatch-mixed-supported.json`: supported schema versions (`0`, `1`) in preflight dispatch mode.
+- `dispatch-unsupported-continues.json`: unsupported schema regression while continuing to later valid frames.
+- `serve-mixed-supported.json`: supported schema versions (`0`, `1`) in stateful serve mode.
+- `serve-unsupported-continues.json`: unsupported schema regression while serve mode continues processing.
+
+Each fixture file includes input lines, expected processing/error counts, and expected response envelopes.

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "dispatch-mixed-supported",
+  "mode": "dispatch_ndjson",
+  "input_lines": [
+    "{\"schema_version\":0,\"request_id\":\"req-cancel-legacy\",\"kind\":\"run.cancel\",\"payload\":{\"run_id\":\"run-legacy\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status-current\",\"kind\":\"run.status\",\"payload\":{\"run_id\":\"run-legacy\"}}",
+    "{\"schema_version\":0,\"request_id\":\"req-timeout-legacy\",\"kind\":\"run.timeout\",\"payload\":{\"run_id\":\"run-legacy\",\"reason\":\"deadline\"}}"
+  ],
+  "expected_processed_lines": 3,
+  "expected_error_count": 0,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-cancel-legacy",
+      "kind": "run.cancelled",
+      "payload": {
+        "status": "cancelled",
+        "mode": "preflight",
+        "run_id": "run-legacy"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status-current",
+      "kind": "run.status",
+      "payload": {
+        "status": "inactive",
+        "mode": "preflight",
+        "run_id": "run-legacy",
+        "active": false,
+        "known": false
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-timeout-legacy",
+      "kind": "run.timed_out",
+      "payload": {
+        "status": "timed_out",
+        "mode": "preflight",
+        "run_id": "run-legacy",
+        "reason": "deadline"
+      }
+    }
+  ]
+}

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-unsupported-continues.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-unsupported-continues.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "name": "dispatch-unsupported-continues",
+  "mode": "dispatch_ndjson",
+  "input_lines": [
+    "{\"schema_version\":99,\"request_id\":\"req-bad-schema\",\"kind\":\"run.cancel\",\"payload\":{\"run_id\":\"run-legacy\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-good-start\",\"kind\":\"run.start\",\"payload\":{\"prompt\":\"hello\"}}"
+  ],
+  "expected_processed_lines": 2,
+  "expected_error_count": 1,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-bad-schema",
+      "kind": "error",
+      "payload": {
+        "code": "unsupported_schema",
+        "message": "unsupported rpc frame schema: supported request schema versions are [0, 1], found 99"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-good-start",
+      "kind": "run.accepted",
+      "payload": {
+        "status": "accepted",
+        "mode": "preflight",
+        "prompt_chars": 5,
+        "run_id": "run-req-good-start"
+      }
+    }
+  ]
+}

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "name": "serve-mixed-supported",
+  "mode": "serve_ndjson",
+  "input_lines": [
+    "{\"schema_version\":0,\"request_id\":\"req-start-legacy\",\"kind\":\"run.start\",\"payload\":{\"prompt\":\"hello\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status-active\",\"kind\":\"run.status\",\"payload\":{\"run_id\":\"run-req-start-legacy\"}}",
+    "{\"schema_version\":0,\"request_id\":\"req-complete-legacy\",\"kind\":\"run.complete\",\"payload\":{\"run_id\":\"run-req-start-legacy\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status-inactive\",\"kind\":\"run.status\",\"payload\":{\"run_id\":\"run-req-start-legacy\"}}"
+  ],
+  "expected_processed_lines": 4,
+  "expected_error_count": 0,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-start-legacy",
+      "kind": "run.accepted",
+      "payload": {
+        "status": "accepted",
+        "mode": "preflight",
+        "prompt_chars": 5,
+        "run_id": "run-req-start-legacy"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start-legacy",
+      "kind": "run.stream.tool_events",
+      "payload": {
+        "run_id": "run-req-start-legacy",
+        "event": "run.started",
+        "mode": "preflight",
+        "sequence": 0
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start-legacy",
+      "kind": "run.stream.assistant_text",
+      "payload": {
+        "run_id": "run-req-start-legacy",
+        "delta": "preflight run accepted (5 prompt chars)",
+        "final": false,
+        "mode": "preflight",
+        "sequence": 1
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status-active",
+      "kind": "run.status",
+      "payload": {
+        "status": "active",
+        "mode": "preflight",
+        "run_id": "run-req-start-legacy",
+        "active": true,
+        "known": true
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-complete-legacy",
+      "kind": "run.completed",
+      "payload": {
+        "status": "completed",
+        "mode": "preflight",
+        "run_id": "run-req-start-legacy"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-complete-legacy",
+      "kind": "run.stream.tool_events",
+      "payload": {
+        "run_id": "run-req-start-legacy",
+        "event": "run.completed",
+        "mode": "preflight",
+        "sequence": 2
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status-inactive",
+      "kind": "run.status",
+      "payload": {
+        "status": "inactive",
+        "mode": "preflight",
+        "run_id": "run-req-start-legacy",
+        "active": false,
+        "known": false
+      }
+    }
+  ]
+}

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-unsupported-continues.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-unsupported-continues.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "name": "serve-unsupported-continues",
+  "mode": "serve_ndjson",
+  "input_lines": [
+    "{\"schema_version\":99,\"request_id\":\"req-bad-schema\",\"kind\":\"run.cancel\",\"payload\":{\"run_id\":\"run-missing\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-start\",\"kind\":\"run.start\",\"payload\":{\"prompt\":\"x\"}}"
+  ],
+  "expected_processed_lines": 2,
+  "expected_error_count": 1,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-bad-schema",
+      "kind": "error",
+      "payload": {
+        "code": "unsupported_schema",
+        "message": "unsupported rpc frame schema: supported request schema versions are [0, 1], found 99"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.accepted",
+      "payload": {
+        "status": "accepted",
+        "mode": "preflight",
+        "prompt_chars": 1,
+        "run_id": "run-req-start"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.stream.tool_events",
+      "payload": {
+        "run_id": "run-req-start",
+        "event": "run.started",
+        "mode": "preflight",
+        "sequence": 0
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.stream.assistant_text",
+      "payload": {
+        "run_id": "run-req-start",
+        "delta": "preflight run accepted (1 prompt chars)",
+        "final": false,
+        "mode": "preflight",
+        "sequence": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated RPC schema-compatibility fixture corpus under `crates/pi-coding-agent/testdata/rpc-schema-compat/`
- add fixture parser/replayer helpers and unit/functional/integration/regression replay tests in `rpc_protocol`
- add CLI integration and regression fixture replay tests for both `--rpc-dispatch-ndjson-file` and `--rpc-serve-ndjson`
- document fixture location in README RPC section

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #365
