### PR TITLE
feat(rpc): add explicit terminal lifecycle metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
 In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+Terminal lifecycle envelopes (`run.cancelled`, `run.completed`, `run.failed`, `run.timed_out`) include explicit `terminal` and `terminal_state` payload fields; terminal serve-mode stream tool events mirror the same terminal metadata.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -8,3 +8,4 @@ This fixture corpus locks deterministic RPC behavior across request schema versi
 - `serve-unsupported-continues.json`: unsupported schema regression while serve mode continues processing.
 
 Each fixture file includes input lines, expected processing/error counts, and expected response envelopes.
+Terminal fixture expectations assert explicit `terminal` and `terminal_state` metadata for terminal lifecycle envelopes/events.

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
@@ -16,6 +16,8 @@
       "kind": "run.cancelled",
       "payload": {
         "status": "cancelled",
+        "terminal": true,
+        "terminal_state": "cancelled",
         "mode": "preflight",
         "run_id": "run-legacy"
       }
@@ -38,6 +40,8 @@
       "kind": "run.timed_out",
       "payload": {
         "status": "timed_out",
+        "terminal": true,
+        "terminal_state": "timed_out",
         "mode": "preflight",
         "run_id": "run-legacy",
         "reason": "deadline"

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
@@ -63,6 +63,8 @@
       "kind": "run.completed",
       "payload": {
         "status": "completed",
+        "terminal": true,
+        "terminal_state": "completed",
         "mode": "preflight",
         "run_id": "run-req-start-legacy"
       }
@@ -74,6 +76,8 @@
       "payload": {
         "run_id": "run-req-start-legacy",
         "event": "run.completed",
+        "terminal": true,
+        "terminal_state": "completed",
         "mode": "preflight",
         "sequence": 2
       }

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5103,7 +5103,11 @@ fn rpc_dispatch_frame_file_flag_outputs_run_completed_response() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("\"kind\": \"run.completed\""))
-        .stdout(predicate::str::contains("\"run_id\": \"run-123\""));
+        .stdout(predicate::str::contains("\"run_id\": \"run-123\""))
+        .stdout(predicate::str::contains("\"terminal\": true"))
+        .stdout(predicate::str::contains(
+            "\"terminal_state\": \"completed\"",
+        ));
 }
 
 #[test]
@@ -5131,7 +5135,9 @@ fn rpc_dispatch_frame_file_flag_outputs_run_failed_response() {
         .success()
         .stdout(predicate::str::contains("\"kind\": \"run.failed\""))
         .stdout(predicate::str::contains("\"run_id\": \"run-123\""))
-        .stdout(predicate::str::contains("\"reason\": \"tool timeout\""));
+        .stdout(predicate::str::contains("\"reason\": \"tool timeout\""))
+        .stdout(predicate::str::contains("\"terminal\": true"))
+        .stdout(predicate::str::contains("\"terminal_state\": \"failed\""));
 }
 
 #[test]
@@ -5159,7 +5165,11 @@ fn rpc_dispatch_frame_file_flag_outputs_run_timed_out_response() {
         .success()
         .stdout(predicate::str::contains("\"kind\": \"run.timed_out\""))
         .stdout(predicate::str::contains("\"run_id\": \"run-123\""))
-        .stdout(predicate::str::contains("\"reason\": \"timeout reached\""));
+        .stdout(predicate::str::contains("\"reason\": \"timeout reached\""))
+        .stdout(predicate::str::contains("\"terminal\": true"))
+        .stdout(predicate::str::contains(
+            "\"terminal_state\": \"timed_out\"",
+        ));
 }
 
 #[test]
@@ -5410,6 +5420,7 @@ fn rpc_serve_ndjson_flag_streams_ordered_response_lines() {
         .stdout(predicate::str::contains("\"active\":true"))
         .stdout(predicate::str::contains("\"request_id\":\"req-cancel\""))
         .stdout(predicate::str::contains("\"kind\":\"run.cancelled\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"cancelled\""))
         .stdout(predicate::str::contains(
             "\"request_id\":\"req-status-inactive\"",
         ))
@@ -5430,7 +5441,9 @@ fn rpc_serve_ndjson_flag_supports_run_complete_lifecycle() {
         .success()
         .stdout(predicate::str::contains("\"request_id\":\"req-complete\""))
         .stdout(predicate::str::contains("\"kind\":\"run.completed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"completed\""))
         .stdout(predicate::str::contains("\"event\":\"run.completed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"completed\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
         .stdout(predicate::str::contains("\"active\":false"));
 }
@@ -5449,7 +5462,9 @@ fn rpc_serve_ndjson_flag_supports_run_fail_lifecycle() {
         .success()
         .stdout(predicate::str::contains("\"request_id\":\"req-fail\""))
         .stdout(predicate::str::contains("\"kind\":\"run.failed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"failed\""))
         .stdout(predicate::str::contains("\"event\":\"run.failed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"failed\""))
         .stdout(predicate::str::contains("\"reason\":\"provider timeout\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
         .stdout(predicate::str::contains("\"active\":false"));
@@ -5469,7 +5484,9 @@ fn rpc_serve_ndjson_flag_supports_run_timeout_lifecycle() {
         .success()
         .stdout(predicate::str::contains("\"request_id\":\"req-timeout\""))
         .stdout(predicate::str::contains("\"kind\":\"run.timed_out\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"timed_out\""))
         .stdout(predicate::str::contains("\"event\":\"run.timed_out\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"timed_out\""))
         .stdout(predicate::str::contains("\"reason\":\"deadline exceeded\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
         .stdout(predicate::str::contains("\"active\":false"));


### PR DESCRIPTION
## Summary
- add explicit terminal metadata fields (`terminal`, `terminal_state`) to terminal lifecycle envelopes: `run.cancelled`, `run.completed`, `run.failed`, and `run.timed_out`
- add aligned terminal metadata to terminal serve-mode `run.stream.tool_events` frames (`run.completed`, `run.failed`, `run.timed_out` events)
- extend protocol unit/functional/integration/regression assertions plus CLI RPC integration checks for terminal taxonomy
- update schema-compat fixture expectations and README contract notes

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #367
