### PR TITLE
feat(rpc): emit cancel terminal stream event in serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Run long-lived RPC NDJSON server mode over stdin/stdout:
 cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 ```
 
-In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` must reference an active `run_id` or it returns a structured `error` envelope.
+In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` closes active runs with `run.cancelled` plus a terminal `run.stream.tool_events` event (unknown `run_id` still returns a structured `error` envelope).
 Terminal lifecycle envelopes (`run.cancelled`, `run.completed`, `run.failed`, `run.timed_out`) include explicit `terminal` and `terminal_state` payload fields; terminal serve-mode stream tool events mirror the same terminal metadata.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -5,6 +5,7 @@ This fixture corpus locks deterministic RPC behavior across request schema versi
 - `dispatch-mixed-supported.json`: supported schema versions (`0`, `1`) in preflight dispatch mode.
 - `dispatch-unsupported-continues.json`: unsupported schema regression while continuing to later valid frames.
 - `serve-mixed-supported.json`: supported schema versions (`0`, `1`) in stateful serve mode.
+- `serve-cancel-supported.json`: serve-mode cancel lifecycle with deterministic terminal stream event.
 - `serve-unsupported-continues.json`: unsupported schema regression while serve mode continues processing.
 
 Each fixture file includes input lines, expected processing/error counts, and expected response envelopes.

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "name": "serve-cancel-supported",
+  "mode": "serve_ndjson",
+  "input_lines": [
+    "{\"schema_version\":1,\"request_id\":\"req-start\",\"kind\":\"run.start\",\"payload\":{\"prompt\":\"hello\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status-active\",\"kind\":\"run.status\",\"payload\":{\"run_id\":\"run-req-start\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-cancel\",\"kind\":\"run.cancel\",\"payload\":{\"run_id\":\"run-req-start\"}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status-inactive\",\"kind\":\"run.status\",\"payload\":{\"run_id\":\"run-req-start\"}}"
+  ],
+  "expected_processed_lines": 4,
+  "expected_error_count": 0,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.accepted",
+      "payload": {
+        "status": "accepted",
+        "mode": "preflight",
+        "prompt_chars": 5,
+        "run_id": "run-req-start"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.stream.tool_events",
+      "payload": {
+        "run_id": "run-req-start",
+        "event": "run.started",
+        "mode": "preflight",
+        "sequence": 0
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-start",
+      "kind": "run.stream.assistant_text",
+      "payload": {
+        "run_id": "run-req-start",
+        "delta": "preflight run accepted (5 prompt chars)",
+        "final": false,
+        "mode": "preflight",
+        "sequence": 1
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status-active",
+      "kind": "run.status",
+      "payload": {
+        "status": "active",
+        "mode": "preflight",
+        "run_id": "run-req-start",
+        "active": true,
+        "known": true
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-cancel",
+      "kind": "run.cancelled",
+      "payload": {
+        "status": "cancelled",
+        "terminal": true,
+        "terminal_state": "cancelled",
+        "mode": "preflight",
+        "run_id": "run-req-start"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-cancel",
+      "kind": "run.stream.tool_events",
+      "payload": {
+        "run_id": "run-req-start",
+        "event": "run.cancelled",
+        "terminal": true,
+        "terminal_state": "cancelled",
+        "mode": "preflight",
+        "sequence": 2
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status-inactive",
+      "kind": "run.status",
+      "payload": {
+        "status": "inactive",
+        "mode": "preflight",
+        "run_id": "run-req-start",
+        "active": false,
+        "known": false
+      }
+    }
+  ]
+}

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5420,6 +5420,7 @@ fn rpc_serve_ndjson_flag_streams_ordered_response_lines() {
         .stdout(predicate::str::contains("\"active\":true"))
         .stdout(predicate::str::contains("\"request_id\":\"req-cancel\""))
         .stdout(predicate::str::contains("\"kind\":\"run.cancelled\""))
+        .stdout(predicate::str::contains("\"event\":\"run.cancelled\""))
         .stdout(predicate::str::contains("\"terminal_state\":\"cancelled\""))
         .stdout(predicate::str::contains(
             "\"request_id\":\"req-status-inactive\"",
@@ -5494,20 +5495,21 @@ fn rpc_serve_ndjson_flag_supports_run_timeout_lifecycle() {
 
 #[test]
 fn integration_rpc_serve_ndjson_replays_schema_compat_fixture() {
-    let fixture = load_rpc_schema_compat_fixture("serve-mixed-supported.json");
-    assert_eq!(fixture.name, "serve-mixed-supported");
-    assert_eq!(fixture.mode, RpcSchemaCompatMode::ServeNdjson);
-    assert_eq!(fixture.expected_processed_lines, fixture.input_lines.len());
-    assert_eq!(fixture.expected_error_count, 0);
+    for fixture_name in ["serve-mixed-supported.json", "serve-cancel-supported.json"] {
+        let fixture = load_rpc_schema_compat_fixture(fixture_name);
+        assert_eq!(fixture.mode, RpcSchemaCompatMode::ServeNdjson);
+        assert_eq!(fixture.expected_processed_lines, fixture.input_lines.len());
+        assert_eq!(fixture.expected_error_count, 0);
 
-    let mut cmd = binary_command();
-    cmd.arg("--rpc-serve-ndjson")
-        .write_stdin(fixture.input_lines.join("\n"));
+        let mut cmd = binary_command();
+        cmd.arg("--rpc-serve-ndjson")
+            .write_stdin(fixture.input_lines.join("\n"));
 
-    let assert = cmd.assert().success();
-    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
-    let responses = parse_ndjson_values(&stdout);
-    assert_eq!(responses, fixture.expected_responses);
+        let assert = cmd.assert().success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+        let responses = parse_ndjson_values(&stdout);
+        assert_eq!(responses, fixture.expected_responses);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- in serve mode, successful `run.cancel` now emits a terminal `run.stream.tool_events` frame (`event: run.cancelled`) after `run.cancelled`
- keep dispatch mode behavior unchanged while making serve-mode terminal transitions stream-symmetric
- update protocol tests for serve ordering/continuation cases affected by cancel stream emission
- add schema-compat fixture `serve-cancel-supported.json` and include it in fixture replay coverage
- update CLI RPC integration assertions and README lifecycle contract text

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #369
