### PR TITLE
feat(rpc): persist closed run status for serve lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 
 In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` closes active runs with `run.cancelled` plus a terminal `run.stream.tool_events` event (unknown `run_id` still returns a structured `error` envelope).
 Terminal lifecycle envelopes (`run.cancelled`, `run.completed`, `run.failed`, `run.timed_out`) include explicit `terminal` and `terminal_state` payload fields; terminal serve-mode stream tool events mirror the same terminal metadata.
+In serve mode, `run.status` also retains closed-run terminal outcomes for known `run_id` values (`known: true`, `active: false`, terminal metadata, and `reason` when applicable).
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -10,3 +10,4 @@ This fixture corpus locks deterministic RPC behavior across request schema versi
 
 Each fixture file includes input lines, expected processing/error counts, and expected response envelopes.
 Terminal fixture expectations assert explicit `terminal` and `terminal_state` metadata for terminal lifecycle envelopes/events.
+Serve-mode fixtures also lock `run.status` semantics for closed known runs (`known: true` with terminal metadata).

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
@@ -87,11 +87,13 @@
       "request_id": "req-status-inactive",
       "kind": "run.status",
       "payload": {
-        "status": "inactive",
+        "status": "cancelled",
         "mode": "preflight",
         "run_id": "run-req-start",
         "active": false,
-        "known": false
+        "known": true,
+        "terminal": true,
+        "terminal_state": "cancelled"
       }
     }
   ]

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
@@ -87,11 +87,13 @@
       "request_id": "req-status-inactive",
       "kind": "run.status",
       "payload": {
-        "status": "inactive",
+        "status": "completed",
         "mode": "preflight",
         "run_id": "run-req-start-legacy",
         "active": false,
-        "known": false
+        "known": true,
+        "terminal": true,
+        "terminal_state": "completed"
       }
     }
   ]

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5425,7 +5425,10 @@ fn rpc_serve_ndjson_flag_streams_ordered_response_lines() {
         .stdout(predicate::str::contains(
             "\"request_id\":\"req-status-inactive\"",
         ))
-        .stdout(predicate::str::contains("\"active\":false"));
+        .stdout(predicate::str::contains("\"active\":false"))
+        .stdout(predicate::str::contains("\"known\":true"))
+        .stdout(predicate::str::contains("\"status\":\"cancelled\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"cancelled\""));
 }
 
 #[test]
@@ -5446,7 +5449,10 @@ fn rpc_serve_ndjson_flag_supports_run_complete_lifecycle() {
         .stdout(predicate::str::contains("\"event\":\"run.completed\""))
         .stdout(predicate::str::contains("\"terminal_state\":\"completed\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
-        .stdout(predicate::str::contains("\"active\":false"));
+        .stdout(predicate::str::contains("\"active\":false"))
+        .stdout(predicate::str::contains("\"known\":true"))
+        .stdout(predicate::str::contains("\"status\":\"completed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"completed\""));
 }
 
 #[test]
@@ -5468,7 +5474,11 @@ fn rpc_serve_ndjson_flag_supports_run_fail_lifecycle() {
         .stdout(predicate::str::contains("\"terminal_state\":\"failed\""))
         .stdout(predicate::str::contains("\"reason\":\"provider timeout\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
-        .stdout(predicate::str::contains("\"active\":false"));
+        .stdout(predicate::str::contains("\"active\":false"))
+        .stdout(predicate::str::contains("\"known\":true"))
+        .stdout(predicate::str::contains("\"status\":\"failed\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"failed\""))
+        .stdout(predicate::str::contains("\"reason\":\"provider timeout\""));
 }
 
 #[test]
@@ -5490,7 +5500,11 @@ fn rpc_serve_ndjson_flag_supports_run_timeout_lifecycle() {
         .stdout(predicate::str::contains("\"terminal_state\":\"timed_out\""))
         .stdout(predicate::str::contains("\"reason\":\"deadline exceeded\""))
         .stdout(predicate::str::contains("\"request_id\":\"req-status\""))
-        .stdout(predicate::str::contains("\"active\":false"));
+        .stdout(predicate::str::contains("\"active\":false"))
+        .stdout(predicate::str::contains("\"known\":true"))
+        .stdout(predicate::str::contains("\"status\":\"timed_out\""))
+        .stdout(predicate::str::contains("\"terminal_state\":\"timed_out\""))
+        .stdout(predicate::str::contains("\"reason\":\"deadline exceeded\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- persist closed run terminal state in serve-mode session state for `run.status` lookups
- `run.status` now resolves deterministically across three cases in serve mode:
  - active run: `active=true`, `known=true`, `status=active`
  - closed known run: `active=false`, `known=true`, terminal metadata (plus `reason` when present)
  - unknown run: unchanged (`active=false`, `known=false`)
- clear closed-run status memory when a run_id is reused for a new `run.start`
- update fixture corpus, protocol tests, CLI integration assertions, and README contract docs

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #371
