### PR TITLE
Cap serve-mode closed run status retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 
 In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` closes active runs with `run.cancelled` plus a terminal `run.stream.tool_events` event (unknown `run_id` still returns a structured `error` envelope).
 Terminal lifecycle envelopes (`run.cancelled`, `run.completed`, `run.failed`, `run.timed_out`) include explicit `terminal` and `terminal_state` payload fields; terminal serve-mode stream tool events mirror the same terminal metadata.
-In serve mode, `run.status` also retains closed-run terminal outcomes for known `run_id` values (`known: true`, `active: false`, terminal metadata, and `reason` when applicable).
+In serve mode, `run.status` also retains closed-run terminal outcomes for known `run_id` values (`known: true`, `active: false`, terminal metadata, and `reason` when applicable). Closed-run retention is bounded to a fixed in-memory window to keep long-lived sessions stable.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -11,3 +11,4 @@ This fixture corpus locks deterministic RPC behavior across request schema versi
 Each fixture file includes input lines, expected processing/error counts, and expected response envelopes.
 Terminal fixture expectations assert explicit `terminal` and `terminal_state` metadata for terminal lifecycle envelopes/events.
 Serve-mode fixtures also lock `run.status` semantics for closed known runs (`known: true` with terminal metadata).
+Closed-run status retention is intentionally bounded in serve mode; these fixtures cover behavior within that deterministic retention window.


### PR DESCRIPTION
## Summary
- cap serve-mode closed run status retention to a fixed in-memory window (1024 run_ids)
- evict oldest terminal run outcomes when the closed-run window exceeds capacity
- preserve deterministic run.status semantics for retained run_ids and unknown responses for evicted ids
- document bounded retention behavior in the RPC docs and fixture notes

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #373