### PR TITLE
Normalize run.status payload shape with explicit terminal flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ cat /tmp/rpc-frames.ndjson | cargo run -p pi-coding-agent -- --rpc-serve-ndjson
 
 In `--rpc-serve-ndjson` mode, run lifecycle is stateful: `run.start` returns a `run_id` and emits deterministic `run.stream.tool_events` plus `run.stream.assistant_text` frames, `run.status` reports active/inactive state for that `run_id`, `run.complete` closes active runs with `run.completed`, `run.fail` closes active runs with `run.failed`, `run.timeout` closes active runs with `run.timed_out`, and `run.cancel` closes active runs with `run.cancelled` plus terminal `run.stream.tool_events` and terminal `run.stream.assistant_text` frames (unknown `run_id` still returns a structured `error` envelope).
 Terminal lifecycle envelopes (`run.cancelled`, `run.completed`, `run.failed`, `run.timed_out`) include explicit `terminal` and `terminal_state` payload fields; terminal serve-mode stream tool events and assistant_text frames mirror the same terminal metadata (`final: true` on assistant_text).
-In serve mode, `run.status` also retains closed-run terminal outcomes for known `run_id` values (`known: true`, `active: false`, terminal metadata, and `reason` when applicable). Closed-run retention is bounded to a fixed in-memory window to keep long-lived sessions stable.
+In serve mode, `run.status` also retains closed-run terminal outcomes for known `run_id` values (`known: true`, `active: false`, terminal metadata, and `reason` when applicable). `run.status` payloads always include an explicit `terminal` flag (`false` for active/unknown, `true` for closed terminal states). Closed-run retention is bounded to a fixed in-memory window to keep long-lived sessions stable.
 
 Run the autonomous events scheduler (immediate, one-shot, periodic):
 

--- a/crates/pi-coding-agent/src/rpc_protocol.rs
+++ b/crates/pi-coding-agent/src/rpc_protocol.rs
@@ -329,6 +329,7 @@ pub(crate) fn dispatch_rpc_frame(frame: &RpcFrame) -> Result<RpcResponseFrame> {
                     "run_id": run_id,
                     "active": false,
                     "known": false,
+                    "terminal": false,
                 }),
             ))
         }
@@ -521,6 +522,7 @@ fn dispatch_rpc_frame_for_serve(
                         "run_id": run_id,
                         "active": true,
                         "known": true,
+                        "terminal": false,
                     }),
                 )]);
             }
@@ -553,6 +555,7 @@ fn dispatch_rpc_frame_for_serve(
                     "run_id": run_id,
                     "active": false,
                     "known": false,
+                    "terminal": false,
                 }),
             )])
         }
@@ -1373,6 +1376,7 @@ mod tests {
         assert_eq!(status_response.payload["run_id"].as_str(), Some("run-1"));
         assert_eq!(status_response.payload["active"].as_bool(), Some(false));
         assert_eq!(status_response.payload["known"].as_bool(), Some(false));
+        assert_eq!(status_response.payload["terminal"].as_bool(), Some(false));
     }
 
     #[test]
@@ -1744,6 +1748,10 @@ mod tests {
         assert_eq!(report.responses[2].request_id, "req-status");
         assert_eq!(report.responses[2].kind, "run.status");
         assert_eq!(report.responses[2].payload["active"].as_bool(), Some(false));
+        assert_eq!(
+            report.responses[2].payload["terminal"].as_bool(),
+            Some(false)
+        );
         assert_eq!(report.responses[3].request_id, "req-complete");
         assert_eq!(report.responses[3].kind, "run.completed");
         assert_eq!(
@@ -1889,6 +1897,7 @@ not-json
         assert_eq!(rows[4]["request_id"], "req-status-active");
         assert_eq!(rows[4]["kind"], "run.status");
         assert_eq!(rows[4]["payload"]["active"], true);
+        assert_eq!(rows[4]["payload"]["terminal"], false);
         assert_eq!(rows[5]["request_id"], "req-cancel");
         assert_eq!(rows[5]["kind"], "run.cancelled");
         assert_eq!(rows[5]["payload"]["terminal"], true);
@@ -1944,6 +1953,7 @@ not-json
         assert_eq!(rows[3]["request_id"], "req-status-active");
         assert_eq!(rows[3]["kind"], "run.status");
         assert_eq!(rows[3]["payload"]["active"], true);
+        assert_eq!(rows[3]["payload"]["terminal"], false);
         assert_eq!(rows[4]["request_id"], "req-complete");
         assert_eq!(rows[4]["kind"], "run.completed");
         assert_eq!(rows[4]["payload"]["terminal"], true);
@@ -1999,6 +2009,7 @@ not-json
         assert_eq!(rows[3]["request_id"], "req-status-active");
         assert_eq!(rows[3]["kind"], "run.status");
         assert_eq!(rows[3]["payload"]["active"], true);
+        assert_eq!(rows[3]["payload"]["terminal"], false);
         assert_eq!(rows[4]["request_id"], "req-fail");
         assert_eq!(rows[4]["kind"], "run.failed");
         assert_eq!(rows[4]["payload"]["reason"], "provider timeout");
@@ -2058,6 +2069,7 @@ not-json
         assert_eq!(rows[3]["request_id"], "req-status-active");
         assert_eq!(rows[3]["kind"], "run.status");
         assert_eq!(rows[3]["payload"]["active"], true);
+        assert_eq!(rows[3]["payload"]["terminal"], false);
         assert_eq!(rows[4]["request_id"], "req-timeout");
         assert_eq!(rows[4]["kind"], "run.timed_out");
         assert_eq!(rows[4]["payload"]["reason"], "client timeout");
@@ -2135,7 +2147,7 @@ not-json
         assert_eq!(rows[10]["payload"]["known"], true);
         assert_eq!(rows[10]["payload"]["status"], "active");
         assert_eq!(rows[10]["payload"].get("terminal_state"), None);
-        assert_eq!(rows[10]["payload"].get("terminal"), None);
+        assert_eq!(rows[10]["payload"]["terminal"], false);
     }
 
     #[test]
@@ -2184,6 +2196,7 @@ not-json
         assert_eq!(oldest.len(), 1);
         assert_eq!(oldest[0].kind, "run.status");
         assert_eq!(oldest[0].payload["known"], false);
+        assert_eq!(oldest[0].payload["terminal"], false);
 
         let newest_id = format!("run-{}", RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY);
         let newest_status = parse_rpc_frame(&format!(

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/README.md
@@ -12,4 +12,5 @@ Each fixture file includes input lines, expected processing/error counts, and ex
 Terminal fixture expectations assert explicit `terminal` and `terminal_state` metadata for terminal lifecycle envelopes/events.
 Terminal assistant stream expectations assert `final: true` plus deterministic summary deltas on closure transitions.
 Serve-mode fixtures also lock `run.status` semantics for closed known runs (`known: true` with terminal metadata).
+Status fixtures lock explicit `terminal` flag behavior across active, inactive/unknown, and closed states.
 Closed-run status retention is intentionally bounded in serve mode; these fixtures cover behavior within that deterministic retention window.

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/dispatch-mixed-supported.json
@@ -31,7 +31,8 @@
         "mode": "preflight",
         "run_id": "run-legacy",
         "active": false,
-        "known": false
+        "known": false,
+        "terminal": false
       }
     },
     {

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-cancel-supported.json
@@ -54,7 +54,8 @@
         "mode": "preflight",
         "run_id": "run-req-start",
         "active": true,
-        "known": true
+        "known": true,
+        "terminal": false
       }
     },
     {

--- a/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
+++ b/crates/pi-coding-agent/testdata/rpc-schema-compat/serve-mixed-supported.json
@@ -54,7 +54,8 @@
         "mode": "preflight",
         "run_id": "run-req-start-legacy",
         "active": true,
-        "known": true
+        "known": true,
+        "terminal": false
       }
     },
     {


### PR DESCRIPTION
## Summary
- normalize run.status response payloads to always include an explicit terminal flag
- set terminal=false for active and unknown/inactive status responses in both dispatch and serve modes
- keep closed known status behavior unchanged with terminal=true and terminal_state metadata
- update schema-compat fixtures and docs to lock the normalized status-shape contract
- expand RPC protocol assertions to cover explicit non-terminal status flags

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #377
