### PR TITLE
Advertise run.status contracts in capabilities response

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
-RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.response` includes both `response_schema_version` and `supported_request_schema_versions`.
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, and `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity).
 Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.

--- a/crates/pi-coding-agent/src/rpc_capabilities.rs
+++ b/crates/pi-coding-agent/src/rpc_capabilities.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 
+use crate::rpc_protocol::RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY;
 use crate::Cli;
 
 pub(crate) const RPC_CAPABILITIES_SCHEMA_VERSION: u32 = 1;
@@ -23,6 +24,12 @@ pub(crate) fn rpc_capabilities_payload() -> Value {
         "schema_version": RPC_CAPABILITIES_SCHEMA_VERSION,
         "protocol_version": RPC_PROTOCOL_VERSION,
         "capabilities": RPC_CAPABILITIES,
+        "contracts": {
+            "run_status": {
+                "terminal_flag_always_present": true,
+                "serve_closed_status_retention_capacity": RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY,
+            }
+        }
     })
 }
 
@@ -41,6 +48,8 @@ pub(crate) fn execute_rpc_capabilities_command(cli: &Cli) -> Result<()> {
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::rpc_protocol::RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY;
+
     use super::{rpc_capabilities_payload, RPC_CAPABILITIES_SCHEMA_VERSION, RPC_PROTOCOL_VERSION};
 
     #[test]
@@ -53,6 +62,14 @@ mod tests {
         assert_eq!(
             payload["protocol_version"].as_str(),
             Some(RPC_PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            payload["contracts"]["run_status"]["terminal_flag_always_present"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            payload["contracts"]["run_status"]["serve_closed_status_retention_capacity"].as_u64(),
+            Some(RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY as u64)
         );
     }
 


### PR DESCRIPTION
## Summary
- extend capabilities.response with contracts.run_status metadata
- advertise run.status terminal-flag guarantee and serve closed-status retention capacity for client negotiation
- source retention capacity from the same RPC serve constant to avoid contract drift
- update dispatch capabilities response wiring, protocol assertions, and docs

## Testing
- cargo fmt --all
- cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1
- cargo test -p pi-coding-agent --test cli_integration rpc_ -- --test-threads=1
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

Closes #379
