### PR TITLE
Add capabilities.request schema negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
-RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, and `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity).
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, and `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity).
 Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.


### PR DESCRIPTION
## Summary
- add optional `request_schema_version` negotiation input to `capabilities.request`
- include `negotiated_request_schema_version` in `capabilities.response`
- classify unsupported/invalid requested schema values as `invalid_payload` and cover with CLI/integration/regression tests

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #381
