### PR TITLE
Add machine-readable RPC error taxonomy contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
-RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, and `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity).
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity), and `contracts.errors.codes` taxonomy metadata (machine-readable RPC error contract list).
 Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5023,7 +5023,10 @@ fn rpc_dispatch_frame_file_flag_outputs_capabilities_response() {
         .stdout(predicate::str::contains("\"protocol_version\": \"0.1.0\""))
         .stdout(predicate::str::contains(
             "\"negotiated_request_schema_version\": 1",
-        ));
+        ))
+        .stdout(predicate::str::contains("\"contracts\": {"))
+        .stdout(predicate::str::contains("\"code\": \"invalid_payload\""))
+        .stdout(predicate::str::contains("\"code\": \"unsupported_schema\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expose a machine-readable RPC error taxonomy in `capabilities.response` under `contracts.errors.codes`
- centralize RPC error-code contract metadata with deterministic order and category/description fields
- keep existing dispatch/serve error behavior unchanged while adding unit/functional/integration coverage for the taxonomy contract

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent --test cli_integration rpc_dispatch_frame_file -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`

Closes #383
