### PR TITLE
Add run.status value contracts to RPC capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
-RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity), and `contracts.errors.codes` taxonomy metadata (machine-readable RPC error contract list).
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity + declared `status_values`/`terminal_states`), and `contracts.errors.codes` taxonomy metadata (machine-readable RPC error contract list).
 Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.

--- a/crates/pi-coding-agent/src/rpc_protocol.rs
+++ b/crates/pi-coding-agent/src/rpc_protocol.rs
@@ -1383,6 +1383,25 @@ mod tests {
                 .as_u64(),
             Some(RPC_SERVE_CLOSED_RUN_STATUS_CAPACITY as u64)
         );
+        let status_values = capabilities_response.payload["contracts"]["run_status"]
+            ["status_values"]
+            .as_array()
+            .expect("run status values array");
+        assert_eq!(status_values.len(), 6);
+        assert_eq!(status_values[0].as_str(), Some("active"));
+        assert_eq!(status_values[1].as_str(), Some("inactive"));
+        let terminal_states = capabilities_response.payload["contracts"]["run_status"]
+            ["terminal_states"]
+            .as_array()
+            .expect("run terminal states array");
+        assert_eq!(terminal_states.len(), 4);
+        assert_eq!(terminal_states[0].as_str(), Some("cancelled"));
+        assert_eq!(
+            capabilities_response.payload["contracts"]["run_status"]
+                ["terminal_state_field_present_for_terminal_status"]
+                .as_bool(),
+            Some(true)
+        );
         let error_codes = capabilities_response.payload["contracts"]["errors"]["codes"]
             .as_array()
             .expect("error code contracts array");

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5025,6 +5025,11 @@ fn rpc_dispatch_frame_file_flag_outputs_capabilities_response() {
             "\"negotiated_request_schema_version\": 1",
         ))
         .stdout(predicate::str::contains("\"contracts\": {"))
+        .stdout(predicate::str::contains("\"status_values\": ["))
+        .stdout(predicate::str::contains("\"terminal_states\": ["))
+        .stdout(predicate::str::contains(
+            "\"terminal_state_field_present_for_terminal_status\": true",
+        ))
         .stdout(predicate::str::contains("\"code\": \"invalid_payload\""))
         .stdout(predicate::str::contains("\"code\": \"unsupported_schema\""));
 }


### PR DESCRIPTION
## Summary
- add explicit run-status value-set contracts to `capabilities.response` under `contracts.run_status`
- declare deterministic `status_values`, `terminal_states`, and `terminal_state_field_present_for_terminal_status`
- extend unit/functional/integration coverage for capabilities payload contract fields

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent --test cli_integration rpc_dispatch_frame_file -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`

Closes #385
