### PR TITLE
Add protocol kind inventories to RPC capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ cargo run -p pi-coding-agent -- \
   --rpc-dispatch-frame-file /tmp/rpc-frame.json
 ```
 
-RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity + declared `status_values`/`terminal_states`), and `contracts.errors.codes` taxonomy metadata (machine-readable RPC error contract list).
+RPC request frame schema versions `0` and `1` are accepted; response frames are emitted with schema version `1`. `capabilities.request` accepts optional `request_schema_version` for explicit negotiation, and `capabilities.response` includes `response_schema_version`, `supported_request_schema_versions`, `negotiated_request_schema_version`, `contracts.run_status` metadata (terminal flag contract + serve closed-status retention capacity + declared `status_values`/`terminal_states`), `contracts.errors.codes` taxonomy metadata (machine-readable RPC error contract list), and `contracts.protocol` kind inventories (`request_kinds`, `response_kinds`, `stream_event_kinds`).
 Schema compatibility fixture replay coverage for dispatch/serve mode lives under `crates/pi-coding-agent/testdata/rpc-schema-compat/`.
 
 For invalid request frames, dispatch still prints a structured JSON error envelope (`kind: "error"` with `payload.code` and `payload.message`) and exits non-zero.

--- a/crates/pi-coding-agent/src/rpc_protocol.rs
+++ b/crates/pi-coding-agent/src/rpc_protocol.rs
@@ -1409,6 +1409,26 @@ mod tests {
         assert_eq!(error_codes[0]["code"].as_str(), Some("invalid_json"));
         assert_eq!(error_codes[0]["category"].as_str(), Some("validation"));
         assert_eq!(error_codes[6]["code"].as_str(), Some("internal_error"));
+        let request_kinds = capabilities_response.payload["contracts"]["protocol"]["request_kinds"]
+            .as_array()
+            .expect("request kinds array");
+        assert_eq!(request_kinds.len(), 7);
+        assert_eq!(request_kinds[0].as_str(), Some("capabilities.request"));
+        let response_kinds = capabilities_response.payload["contracts"]["protocol"]
+            ["response_kinds"]
+            .as_array()
+            .expect("response kinds array");
+        assert_eq!(response_kinds.len(), 10);
+        assert_eq!(response_kinds[0].as_str(), Some("capabilities.response"));
+        let stream_event_kinds = capabilities_response.payload["contracts"]["protocol"]
+            ["stream_event_kinds"]
+            .as_array()
+            .expect("stream event kinds array");
+        assert_eq!(stream_event_kinds.len(), 2);
+        assert_eq!(
+            stream_event_kinds[0].as_str(),
+            Some("run.stream.tool_events")
+        );
 
         let start = parse_rpc_frame(
             r#"{

--- a/crates/pi-coding-agent/tests/cli_integration.rs
+++ b/crates/pi-coding-agent/tests/cli_integration.rs
@@ -5030,6 +5030,9 @@ fn rpc_dispatch_frame_file_flag_outputs_capabilities_response() {
         .stdout(predicate::str::contains(
             "\"terminal_state_field_present_for_terminal_status\": true",
         ))
+        .stdout(predicate::str::contains("\"request_kinds\": ["))
+        .stdout(predicate::str::contains("\"response_kinds\": ["))
+        .stdout(predicate::str::contains("\"stream_event_kinds\": ["))
         .stdout(predicate::str::contains("\"code\": \"invalid_payload\""))
         .stdout(predicate::str::contains("\"code\": \"unsupported_schema\""));
 }


### PR DESCRIPTION
## Summary
- add machine-readable protocol kind inventories to `capabilities.response` under `contracts.protocol`
- declare deterministic `request_kinds`, `response_kinds`, and `stream_event_kinds`
- extend unit/functional/integration assertions and update README contract documentation

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pi-coding-agent rpc_capabilities::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent rpc_protocol::tests -- --test-threads=1`
- `cargo test -p pi-coding-agent --test cli_integration rpc_dispatch_frame_file -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`

Closes #387
