### PR TITLE
Add /auth matrix provider-mode diagnostics

### DIFF
--- a/crates/pi-coding-agent/src/commands.rs
+++ b/crates/pi-coding-agent/src/commands.rs
@@ -238,11 +238,11 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "/auth",
-        usage: "/auth <login|status|logout> ...",
+        usage: "/auth <login|status|logout|matrix> ...",
         description: "Manage provider authentication state and credential-store sessions",
         details:
-            "Supports login/status/logout flows with provider capability checks and optional --json output.",
-        example: "/auth status openai --json",
+            "Supports login/status/logout flows plus provider-mode matrix diagnostics with optional --json output.",
+        example: "/auth matrix --json",
     },
     CommandSpec {
         name: "/integration-auth",


### PR DESCRIPTION
## Summary
- add `/auth matrix` to report provider x auth-mode capability/readiness diagnostics
- support text and JSON output with deterministic ordering and summary counts
- expand parser/help surface and add unit/functional/integration/regression tests for matrix behavior and error handling

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent auth -- --test-threads=1`
- `cargo test -p pi-coding-agent functional_render_help_overview_lists_known_commands -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #390
