### PR TITLE
Add provider/mode filters for /auth matrix

### DIFF
--- a/crates/pi-coding-agent/src/commands.rs
+++ b/crates/pi-coding-agent/src/commands.rs
@@ -242,7 +242,7 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
         description: "Manage provider authentication state and credential-store sessions",
         details:
             "Supports login/status/logout flows plus provider-mode matrix diagnostics with optional --json output.",
-        example: "/auth matrix --json",
+        example: "/auth matrix openai --mode oauth-token --json",
     },
     CommandSpec {
         name: "/integration-auth",


### PR DESCRIPTION
## Summary
- extend `/auth matrix` with optional provider and auth-mode filters
- support syntax: `/auth matrix [provider] [--mode <mode>] [--json]`
- preserve deterministic ordering/summaries and add parser + filtered-output regression coverage

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent auth -- --test-threads=1`
- `cargo test -p pi-coding-agent functional_render_help_overview_lists_known_commands -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #392
