### PR TITLE
feat(orchestrator): enforce fail-closed delegated policy inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cargo run -p pi-coding-agent -- \
   --orchestrator-max-delegated-total-response-chars 160000
 ```
 
-Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `delegated-step` (when enabled), `review`, and `consolidation` phases, including response budget metadata and accept/reject consolidation decisions.
+Plan-first mode emits deterministic orchestration traces for `planner`, `executor`, `delegated-step` (when enabled), `review`, and `consolidation` phases, including response budget metadata and accept/reject consolidation decisions. Delegated mode also enforces fail-closed inherited policy context: runtime now verifies and injects tool-policy context into delegated steps and rejects delegated execution if policy inheritance context cannot be constructed.
 
 Use Anthropic:
 

--- a/crates/pi-coding-agent/src/main.rs
+++ b/crates/pi-coding-agent/src/main.rs
@@ -155,6 +155,7 @@ pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLo
 #[cfg(test)]
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
+pub(crate) use crate::orchestrator::run_plan_first_prompt_with_policy_context;
 pub(crate) use crate::package_manifest::{
     execute_package_activate_command, execute_package_activate_on_startup,
     execute_package_conflicts_command, execute_package_install_command,

--- a/crates/pi-coding-agent/src/startup_local_runtime.rs
+++ b/crates/pi-coding-agent/src/startup_local_runtime.rs
@@ -116,6 +116,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 cli.orchestrator_max_delegated_step_response_chars,
                 cli.orchestrator_max_delegated_total_response_chars,
                 cli.orchestrator_delegate_steps,
+                tool_policy_json,
                 &extension_runtime_hooks,
             )
             .await?;


### PR DESCRIPTION
## Summary
Closes #398.

Adds explicit fail-closed policy inheritance context handling for delegated plan-first orchestration.

## Changes
- Introduced `run_plan_first_prompt_with_policy_context` in orchestrator flow.
- Delegated execution now rejects when policy inheritance context is missing/empty.
- Delegated-step traces now include `policy_inheritance=verified` and context-size metadata.
- Delegated-step prompts now include an explicit inherited policy context section.
- Runtime wiring now constructs inherited policy context deterministically from effective tool-policy JSON + runtime hook state.
- Runtime fails closed with actionable errors when policy context cannot be built.
- Updated README plan-first behavior docs.

## Test Matrix
- Unit:
  - policy-context rendering determinism and fail-closed invalid-payload behavior.
  - delegated prompt contract includes inherited policy section.
- Functional:
  - delegated plan-first happy path remains successful.
- Integration:
  - runtime orchestration path constructs/wires policy context (covered through full runtime suite).
- Regression:
  - delegated plan-first fails closed when policy context is missing.

## Validation
- `cargo fmt --all`
- `cargo test -p pi-coding-agent unit_render_orchestrator_policy_inheritance_context_is_deterministic -- --test-threads=1`
- `cargo test -p pi-coding-agent regression_run_plan_first_prompt_with_policy_context_fails_when_context_missing -- --test-threads=1`
- `cargo test -p pi-coding-agent functional_run_plan_first_prompt_delegate_steps_executes_and_consolidates -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
