### PR TITLE
feat(auth): add revoked histogram summaries to diagnostics

### DIFF
--- a/crates/pi-coding-agent/src/auth_commands.rs
+++ b/crates/pi-coding-agent/src/auth_commands.rs
@@ -1162,6 +1162,21 @@ pub(crate) fn auth_source_kind_counts(
     counts
 }
 
+pub(crate) fn auth_revoked_counts(
+    rows: &[AuthStatusRow],
+) -> std::collections::BTreeMap<String, usize> {
+    let mut counts = std::collections::BTreeMap::new();
+    for row in rows {
+        let key = if row.revoked {
+            "revoked"
+        } else {
+            "not_revoked"
+        };
+        *counts.entry(key.to_string()).or_insert(0) += 1;
+    }
+    counts
+}
+
 pub(crate) fn format_auth_state_counts(
     state_counts: &std::collections::BTreeMap<String, usize>,
 ) -> String {
@@ -1233,6 +1248,7 @@ pub(crate) fn execute_auth_status_command(
     let mode_unsupported_total = total_rows.saturating_sub(mode_supported_total);
     let state_counts_total = auth_state_counts(&rows);
     let source_kind_counts_total = auth_source_kind_counts(&rows);
+    let revoked_counts_total = auth_revoked_counts(&rows);
     rows = match mode_support {
         AuthMatrixModeSupportFilter::All => rows,
         AuthMatrixModeSupportFilter::Supported => {
@@ -1270,6 +1286,7 @@ pub(crate) fn execute_auth_status_command(
     let mode_unsupported = rows.len().saturating_sub(mode_supported);
     let state_counts = auth_state_counts(&rows);
     let source_kind_counts = auth_source_kind_counts(&rows);
+    let revoked_counts = auth_revoked_counts(&rows);
 
     if json_output {
         return serde_json::json!({
@@ -1294,13 +1311,15 @@ pub(crate) fn execute_auth_status_command(
             "state_counts": state_counts,
             "source_kind_counts_total": source_kind_counts_total,
             "source_kind_counts": source_kind_counts,
+            "revoked_counts_total": revoked_counts_total,
+            "revoked_counts": revoked_counts,
             "entries": rows,
         })
         .to_string();
     }
 
     let mut lines = vec![format!(
-        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={}",
+        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         rows.len(),
         mode_supported,
@@ -1320,7 +1339,9 @@ pub(crate) fn execute_auth_status_command(
         format_auth_state_counts(&state_counts),
         format_auth_state_counts(&state_counts_total),
         format_auth_state_counts(&source_kind_counts),
-        format_auth_state_counts(&source_kind_counts_total)
+        format_auth_state_counts(&source_kind_counts_total),
+        format_auth_state_counts(&revoked_counts),
+        format_auth_state_counts(&revoked_counts_total)
     )];
     for row in rows {
         lines.push(format!(
@@ -1412,6 +1433,7 @@ pub(crate) fn execute_auth_matrix_command(
     let mode_unsupported_total = total_rows.saturating_sub(mode_supported_total);
     let state_counts_total = auth_state_counts(&rows);
     let source_kind_counts_total = auth_source_kind_counts(&rows);
+    let revoked_counts_total = auth_revoked_counts(&rows);
     rows = match mode_support {
         AuthMatrixModeSupportFilter::All => rows,
         AuthMatrixModeSupportFilter::Supported => {
@@ -1449,6 +1471,7 @@ pub(crate) fn execute_auth_matrix_command(
     let mode_unsupported = rows.len().saturating_sub(mode_supported);
     let state_counts = auth_state_counts(&rows);
     let source_kind_counts = auth_source_kind_counts(&rows);
+    let revoked_counts = auth_revoked_counts(&rows);
 
     if json_output {
         return serde_json::json!({
@@ -1474,13 +1497,15 @@ pub(crate) fn execute_auth_matrix_command(
             "state_counts": state_counts,
             "source_kind_counts_total": source_kind_counts_total,
             "source_kind_counts": source_kind_counts,
+            "revoked_counts_total": revoked_counts_total,
+            "revoked_counts": revoked_counts,
             "entries": rows,
         })
         .to_string();
     }
 
     let mut lines = vec![format!(
-        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={}",
+        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         selected_modes.len(),
         rows.len(),
@@ -1501,7 +1526,9 @@ pub(crate) fn execute_auth_matrix_command(
         format_auth_state_counts(&state_counts),
         format_auth_state_counts(&state_counts_total),
         format_auth_state_counts(&source_kind_counts),
-        format_auth_state_counts(&source_kind_counts_total)
+        format_auth_state_counts(&source_kind_counts_total),
+        format_auth_state_counts(&revoked_counts),
+        format_auth_state_counts(&revoked_counts_total)
     )];
     for row in rows {
         lines.push(format!(


### PR DESCRIPTION
## Summary
- add deterministic revoked histograms to auth diagnostics:
  - `revoked_counts_total` (pre-filter baseline)
  - `revoked_counts` (post-filter result set)
- include revoked histograms in both `/auth status` and `/auth matrix` JSON outputs
- include revoked histograms in text summaries for both commands
- preserve existing filter behavior and metadata contracts

## Risks and Compatibility
- low risk: additive diagnostics fields only
- existing command flags and behavior remain backward compatible
- zero-row behavior is preserved with explicit empty histogram marker semantics

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #428
