### PR TITLE
feat(auth): add provider histogram summaries to diagnostics (#432)

### DIFF
--- a/crates/pi-coding-agent/src/auth_commands.rs
+++ b/crates/pi-coding-agent/src/auth_commands.rs
@@ -1136,6 +1136,16 @@ pub(crate) fn auth_mode_counts(
     counts
 }
 
+pub(crate) fn auth_provider_counts(
+    rows: &[AuthStatusRow],
+) -> std::collections::BTreeMap<String, usize> {
+    let mut counts = std::collections::BTreeMap::new();
+    for row in rows {
+        *counts.entry(row.provider.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
 pub(crate) fn auth_source_kind(source: &str) -> &'static str {
     let normalized = source.trim();
     if normalized == "credential_store" {
@@ -1257,6 +1267,7 @@ pub(crate) fn execute_auth_status_command(
     let mode_supported_total = rows.iter().filter(|row| row.mode_supported).count();
     let mode_unsupported_total = total_rows.saturating_sub(mode_supported_total);
     let mode_counts_total = auth_mode_counts(&rows);
+    let provider_counts_total = auth_provider_counts(&rows);
     let state_counts_total = auth_state_counts(&rows);
     let source_kind_counts_total = auth_source_kind_counts(&rows);
     let revoked_counts_total = auth_revoked_counts(&rows);
@@ -1296,6 +1307,7 @@ pub(crate) fn execute_auth_status_command(
     let mode_supported = rows.iter().filter(|row| row.mode_supported).count();
     let mode_unsupported = rows.len().saturating_sub(mode_supported);
     let mode_counts = auth_mode_counts(&rows);
+    let provider_counts = auth_provider_counts(&rows);
     let state_counts = auth_state_counts(&rows);
     let source_kind_counts = auth_source_kind_counts(&rows);
     let revoked_counts = auth_revoked_counts(&rows);
@@ -1319,6 +1331,8 @@ pub(crate) fn execute_auth_status_command(
             "mode_unsupported_total": mode_unsupported_total,
             "mode_counts_total": mode_counts_total,
             "mode_counts": mode_counts,
+            "provider_counts_total": provider_counts_total,
+            "provider_counts": provider_counts,
             "available": available,
             "unavailable": unavailable,
             "state_counts_total": state_counts_total,
@@ -1333,7 +1347,7 @@ pub(crate) fn execute_auth_status_command(
     }
 
     let mut lines = vec![format!(
-        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
+        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         rows.len(),
         mode_supported,
@@ -1352,6 +1366,8 @@ pub(crate) fn execute_auth_status_command(
         mode_unsupported_total,
         format_auth_state_counts(&mode_counts),
         format_auth_state_counts(&mode_counts_total),
+        format_auth_state_counts(&provider_counts),
+        format_auth_state_counts(&provider_counts_total),
         format_auth_state_counts(&state_counts),
         format_auth_state_counts(&state_counts_total),
         format_auth_state_counts(&source_kind_counts),
@@ -1448,6 +1464,7 @@ pub(crate) fn execute_auth_matrix_command(
     let mode_supported_total = rows.iter().filter(|row| row.mode_supported).count();
     let mode_unsupported_total = total_rows.saturating_sub(mode_supported_total);
     let mode_counts_total = auth_mode_counts(&rows);
+    let provider_counts_total = auth_provider_counts(&rows);
     let state_counts_total = auth_state_counts(&rows);
     let source_kind_counts_total = auth_source_kind_counts(&rows);
     let revoked_counts_total = auth_revoked_counts(&rows);
@@ -1487,6 +1504,7 @@ pub(crate) fn execute_auth_matrix_command(
     let mode_supported = rows.iter().filter(|row| row.mode_supported).count();
     let mode_unsupported = rows.len().saturating_sub(mode_supported);
     let mode_counts = auth_mode_counts(&rows);
+    let provider_counts = auth_provider_counts(&rows);
     let state_counts = auth_state_counts(&rows);
     let source_kind_counts = auth_source_kind_counts(&rows);
     let revoked_counts = auth_revoked_counts(&rows);
@@ -1511,6 +1529,8 @@ pub(crate) fn execute_auth_matrix_command(
             "mode_unsupported_total": mode_unsupported_total,
             "mode_counts_total": mode_counts_total,
             "mode_counts": mode_counts,
+            "provider_counts_total": provider_counts_total,
+            "provider_counts": provider_counts,
             "available": available,
             "unavailable": unavailable,
             "state_counts_total": state_counts_total,
@@ -1525,7 +1545,7 @@ pub(crate) fn execute_auth_matrix_command(
     }
 
     let mut lines = vec![format!(
-        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
+        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         selected_modes.len(),
         rows.len(),
@@ -1545,6 +1565,8 @@ pub(crate) fn execute_auth_matrix_command(
         mode_unsupported_total,
         format_auth_state_counts(&mode_counts),
         format_auth_state_counts(&mode_counts_total),
+        format_auth_state_counts(&provider_counts),
+        format_auth_state_counts(&provider_counts_total),
         format_auth_state_counts(&state_counts),
         format_auth_state_counts(&state_counts_total),
         format_auth_state_counts(&source_kind_counts),


### PR DESCRIPTION
## Summary
- add deterministic provider histogram helper (`auth_provider_counts`) for auth diagnostics
- include `provider_counts_total` (baseline/pre-filter) and `provider_counts` (post-filter) in `/auth status` and `/auth matrix` JSON output
- include `provider_counts` and `provider_counts_total` in `/auth status` and `/auth matrix` text summaries
- extend auth diagnostics tests across unit, functional, integration, and regression scenarios (including zero-row behavior)

## Risks and compatibility
- additive output change only: new JSON fields and additional text summary keys
- no changes to existing filtering semantics or credential resolution paths
- consumers parsing text summaries strictly by full-line equality may need to account for added fields

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #432
