### PR TITLE
Add issue comment streaming with chunked edits

### DIFF
--- a/crates/pi-coding-agent/src/github_issues.rs
+++ b/crates/pi-coding-agent/src/github_issues.rs
@@ -2303,12 +2303,11 @@ mod tests {
         collect_issue_events, event_action_from_body, extract_footer_event_keys,
         is_retryable_github_status, normalize_artifact_retention_days, parse_pi_issue_command,
         post_issue_comment_chunks, render_issue_comment_chunks_with_limit,
-        render_issue_comment_response_parts, retry_delay,
-        run_prompt_for_event, sanitize_for_path, session_path_for_issue, EventAction,
-        GithubApiClient, GithubBridgeEvent, GithubBridgeEventKind, GithubIssue, GithubIssueComment,
-        GithubIssuesBridgeRuntime, GithubIssuesBridgeRuntimeConfig, GithubIssuesBridgeStateStore,
-        GithubUser, PiIssueCommand, PromptRunReport, PromptUsageSummary, RepoRef,
-        EVENT_KEY_MARKER_PREFIX,
+        render_issue_comment_response_parts, retry_delay, run_prompt_for_event, sanitize_for_path,
+        session_path_for_issue, EventAction, GithubApiClient, GithubBridgeEvent,
+        GithubBridgeEventKind, GithubIssue, GithubIssueComment, GithubIssuesBridgeRuntime,
+        GithubIssuesBridgeRuntimeConfig, GithubIssuesBridgeStateStore, GithubUser, PiIssueCommand,
+        PromptRunReport, PromptUsageSummary, RepoRef, EVENT_KEY_MARKER_PREFIX,
     };
     use crate::{
         channel_store::{ChannelArtifactRecord, ChannelStore},


### PR DESCRIPTION
## Summary\n- Stream issue replies by editing the in-flight comment when possible, appending follow-ups when needed\n- Chunk long issue comment responses with the event key marker in the first chunk\n- Add tests covering chunking, edit fallback, and append behavior\n\n## Risks\n- Comment chunk ordering relies on GitHub API consistency for sequential calls\n- Edit failures now fall back to create; may increase comment volume if edits are rejected\n\n## Validation\n- cargo test -p pi-coding-agent --bin pi-coding-agent\n\nCloses #448