### PR TITLE
Add /pi chat commands for issue sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ In bridge mode:
 - bot replies include run/model/token metadata in the issue comment footer
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
 - set `--github-artifact-retention-days 0` to disable artifact expiration
+- `/pi chat start` initializes an issue chat session; `/pi chat resume` acknowledges an existing session; `/pi chat reset` clears the stored session for the issue
 - `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts show <artifact_id>` shows one artifact record; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:


### PR DESCRIPTION
## Summary\n- Add /pi chat start|resume|reset commands to manage issue chat sessions\n- Initialize/reset session files and update state store on chat commands\n- Extend docs and tests (unit, integration, regression) for chat command behavior\n\n## Risks\n- Reset now deletes session files; concurrent runs are blocked and must be stopped first\n- Chat commands add new control flow in issue command handler\n\n## Validation\n- cargo test -p pi-coding-agent --bin pi-coding-agent\n\nCloses #449