### PR TITLE
Add Slack /pi artifacts commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ In Slack bridge mode:
 - inbound/outbound event payloads are persisted as JSONL logs for replay/debugging
 - duplicate deliveries are deduplicated via persisted event keys
 - stale events are skipped based on `--slack-max-event-age-seconds`
-- `/pi help`, `/pi status`, and `/pi stop` are handled as Slack control commands (no run started)
+- `/pi help`, `/pi status`, `/pi stop`, and `/pi artifacts` are handled as Slack control commands (no run started)
 - attached files are downloaded into channel-local attachment folders and surfaced in prompt context
 - each completed run emits a markdown artifact + metadata under `channel-store/channels/slack/<channel>/artifacts/`
 - set `--slack-artifact-retention-days 0` to disable artifact expiration


### PR DESCRIPTION
## Summary\n- Add /pi artifacts list, purge, and show handling in Slack bridge\n- Render channel artifact reports and wire into Slack control command flow\n- Update README with Slack /pi artifacts usage\n\n## Risks\n- Artifact list output can be long; output capped to 10 rows\n\n## Validation\n- cargo test -p pi-coding-agent --bin pi-coding-agent\n\nCloses #459