### PR TITLE
feat: add chat show

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ In bridge mode:
 - each completed run emits a markdown artifact plus metadata index entry under `channel-store/.../artifacts/`
 - set `--github-artifact-retention-days 0` to disable artifact expiration
 - `/pi help` prints the supported GitHub issue commands
-- `/pi chat start` initializes an issue chat session; `/pi chat resume` acknowledges an existing session; `/pi chat reset` clears the stored session for the issue; `/pi chat export` writes a JSONL session export artifact; `/pi chat status` reports the current session metadata
+- `/pi chat start` initializes an issue chat session; `/pi chat resume` acknowledges an existing session; `/pi chat reset` clears the stored session for the issue; `/pi chat export` writes a JSONL session export artifact; `/pi chat status` reports the current session metadata; `/pi chat show [limit]` posts recent message previews
 - `/pi artifacts` posts the current issue artifact inventory; `/pi artifacts run <run_id>` filters inventory for one run; `/pi artifacts show <artifact_id>` shows one artifact record; `/pi artifacts purge` removes expired entries and reports lifecycle counts
 
 Run as a Slack Socket Mode conversational transport:


### PR DESCRIPTION
## Summary
- add chat show command for GitHub issue sessions to display recent message previews
- enforce limit parsing and update usage + README
- add unit/regression/integration coverage

## Risks
- Low. New command path and formatting only.

## Validation
- cargo fmt --all
- cargo test -p pi-coding-agent --bin pi-coding-agent

Closes #465