### PR TITLE
feat: Claude Code oauth/session backend for Anthropic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Implemented now:
 - Tool-call loop (`assistant -> tool -> assistant`) in `tau-agent-core`
 - Multi-provider model routing: `openai/*`, `anthropic/*`, `google/*`
 - OpenAI oauth/session fallback to Codex CLI backend when provider credential-store entry is missing
+- Anthropic oauth/session routing to Claude Code CLI backend (subscription/account login workflows)
 - Google oauth/adc routing to Gemini CLI backend (subscription login and Vertex/ADC workflows)
 - Interactive CLI and one-shot prompt mode
 - Token-by-token CLI output rendering controls
@@ -117,6 +118,32 @@ cargo run -p tau-coding-agent -- \
 ```
 
 `tau-coding-agent` prefers provider credential-store oauth/session entries when present; if the OpenAI entry is missing and Codex backend is enabled, it falls back to `codex exec` for local subscription-backed runs.
+
+Use Anthropic with Claude Code subscription login (without setting `ANTHROPIC_API_KEY`):
+
+```bash
+claude
+# complete account login flow in the CLI
+
+cargo run -p tau-coding-agent -- \
+  --model anthropic/claude-sonnet-4-20250514 \
+  --anthropic-auth-mode oauth-token \
+  --anthropic-claude-backend=true \
+  --anthropic-claude-cli claude \
+  --anthropic-claude-timeout-ms 120000
+```
+
+Use Anthropic session-mode backend routing (same Claude Code login backend):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model anthropic/claude-sonnet-4-20250514 \
+  --anthropic-auth-mode session-token \
+  --anthropic-claude-backend=true \
+  --anthropic-claude-cli claude
+```
+
+`/auth status anthropic` and `/doctor` reflect Anthropic oauth/session backend readiness (`--anthropic-claude-backend`, executable availability) separately from API-key mode.
 
 Use Google Gemini with subscription login (without setting `GEMINI_API_KEY`):
 

--- a/crates/tau-coding-agent/src/claude_cli_client.rs
+++ b/crates/tau-coding-agent/src/claude_cli_client.rs
@@ -1,0 +1,503 @@
+use std::process::Stdio;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::process::Command;
+
+use tau_ai::{
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
+    StreamDeltaHandler, TauAiError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClaudeCliConfig {
+    pub(crate) executable: String,
+    pub(crate) extra_args: Vec<String>,
+    pub(crate) timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClaudeCliClient {
+    config: ClaudeCliConfig,
+}
+
+impl ClaudeCliClient {
+    pub(crate) fn new(config: ClaudeCliConfig) -> Result<Self, TauAiError> {
+        if config.executable.trim().is_empty() {
+            return Err(TauAiError::InvalidResponse(
+                "claude cli executable is empty".to_string(),
+            ));
+        }
+        if config.timeout_ms == 0 {
+            return Err(TauAiError::InvalidResponse(
+                "claude cli timeout must be greater than 0ms".to_string(),
+            ));
+        }
+        Ok(Self { config })
+    }
+}
+
+async fn spawn_with_text_file_busy_retry(
+    command: &mut Command,
+    executable: &str,
+) -> Result<tokio::process::Child, TauAiError> {
+    const MAX_TEXT_FILE_BUSY_RETRIES: u32 = 5;
+    const TEXT_FILE_BUSY_ERRNO: i32 = 26;
+    for attempt in 0..=MAX_TEXT_FILE_BUSY_RETRIES {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) => {
+                if error.raw_os_error() == Some(TEXT_FILE_BUSY_ERRNO)
+                    && attempt < MAX_TEXT_FILE_BUSY_RETRIES
+                {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    continue;
+                }
+                return Err(TauAiError::InvalidResponse(format!(
+                    "failed to spawn claude cli '{executable}': {error}"
+                )));
+            }
+        }
+    }
+
+    Err(TauAiError::InvalidResponse(format!(
+        "failed to spawn claude cli '{executable}': unknown error"
+    )))
+}
+
+#[async_trait]
+impl LlmClient for ClaudeCliClient {
+    async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, TauAiError> {
+        let prompt = render_claude_prompt(&request);
+        let mut command = Command::new(&self.config.executable);
+        command.kill_on_drop(true);
+        command.arg("-p");
+        command.arg(prompt);
+        command.arg("--output-format");
+        command.arg("json");
+        command.arg("--model");
+        command.arg(&request.model);
+        command.args(&self.config.extra_args);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        let child = spawn_with_text_file_busy_retry(&mut command, &self.config.executable).await?;
+
+        let output = tokio::time::timeout(
+            Duration::from_millis(self.config.timeout_ms),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| {
+            TauAiError::InvalidResponse(format!(
+                "claude cli timed out after {}ms",
+                self.config.timeout_ms
+            ))
+        })?
+        .map_err(|error| {
+            TauAiError::InvalidResponse(format!("claude cli process failed: {error}"))
+        })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if !output.status.success() {
+            let status = output
+                .status
+                .code()
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "signal".to_string());
+            let summary = summarize_process_failure(&stderr, &stdout);
+            return Err(TauAiError::InvalidResponse(format!(
+                "claude cli failed with status {status}: {summary}"
+            )));
+        }
+
+        let message_text = extract_assistant_text(&stdout)?;
+        if message_text.trim().is_empty() {
+            return Err(TauAiError::InvalidResponse(
+                "claude cli returned empty assistant output".to_string(),
+            ));
+        }
+
+        Ok(ChatResponse {
+            message: Message::assistant_text(message_text),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        })
+    }
+
+    async fn complete_with_stream(
+        &self,
+        request: ChatRequest,
+        on_delta: Option<StreamDeltaHandler>,
+    ) -> Result<ChatResponse, TauAiError> {
+        let response = self.complete(request).await?;
+        if let Some(handler) = on_delta {
+            let text = response.message.text_content();
+            if !text.trim().is_empty() {
+                handler(text);
+            }
+        }
+        Ok(response)
+    }
+}
+
+fn extract_assistant_text(stdout: &str) -> Result<String, TauAiError> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(error_message) = extract_error_message(&value) {
+            return Err(TauAiError::InvalidResponse(format!(
+                "claude cli returned an error payload: {error_message}"
+            )));
+        }
+        if let Some(result) = extract_result_message(&value) {
+            return Ok(result);
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+fn extract_error_message(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if map
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                return map
+                    .get("result")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|message| !message.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        map.get("error")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|message| !message.is_empty())
+                            .map(str::to_string)
+                    })
+                    .or_else(|| {
+                        map.get("message")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|message| !message.is_empty())
+                            .map(str::to_string)
+                    })
+                    .or(Some("claude cli reported an error".to_string()));
+            }
+            None
+        }
+        Value::Array(entries) => entries.iter().find_map(extract_error_message),
+        _ => None,
+    }
+}
+
+fn extract_result_message(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => map
+            .get("result")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|result| !result.is_empty())
+            .map(str::to_string),
+        Value::Array(entries) => entries.iter().rev().find_map(extract_result_message),
+        _ => None,
+    }
+}
+
+fn summarize_process_failure(stderr: &str, stdout: &str) -> String {
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        return truncate_for_log(stderr);
+    }
+
+    let stdout = stdout.trim();
+    if !stdout.is_empty() {
+        return truncate_for_log(stdout);
+    }
+
+    "no error output".to_string()
+}
+
+fn truncate_for_log(text: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    if text.chars().count() <= MAX_CHARS {
+        return text.to_string();
+    }
+    text.chars().take(MAX_CHARS).collect::<String>() + "..."
+}
+
+fn render_claude_prompt(request: &ChatRequest) -> String {
+    let mut lines = vec![
+        "You are the Anthropic Claude Code-compatible Tau backend.".to_string(),
+        "Respond with the assistant's next message for the conversation below.".to_string(),
+        "Return plain assistant text only.".to_string(),
+        "Conversation:".to_string(),
+    ];
+
+    for message in &request.messages {
+        lines.push(format!("[{}]", role_label(message.role)));
+        if let Some(tool_name) = &message.tool_name {
+            lines.push(format!("tool_name={tool_name}"));
+        }
+        if let Some(tool_call_id) = &message.tool_call_id {
+            lines.push(format!("tool_call_id={tool_call_id}"));
+        }
+        if message.is_error {
+            lines.push("tool_error=true".to_string());
+        }
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } => lines.push(text.clone()),
+                ContentBlock::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                } => lines.push(format!(
+                    "{{\"tool_call\":{{\"id\":\"{id}\",\"name\":\"{name}\",\"arguments\":{arguments}}}}}"
+                )),
+            }
+        }
+    }
+
+    if !request.tools.is_empty() {
+        lines.push("Tau tools available in caller runtime (context only):".to_string());
+        for tool in &request.tools {
+            lines.push(format!("- {}: {}", tool.name, tool.description));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn role_label(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+
+    use tau_ai::ToolDefinition;
+    use tempfile::tempdir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn test_request() -> ChatRequest {
+        ChatRequest {
+            model: "claude-sonnet-4-20250514".to_string(),
+            messages: vec![
+                Message::system("system message"),
+                Message::user("hello"),
+                Message::assistant_text("intermediate"),
+            ],
+            tools: vec![ToolDefinition {
+                name: "read".to_string(),
+                description: "Read a file".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"}
+                    },
+                    "required": ["path"]
+                }),
+            }],
+            max_tokens: None,
+            temperature: None,
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_script(dir: &Path, body: &str) -> PathBuf {
+        let script = dir.join("mock-claude.sh");
+        let content = format!("#!/bin/sh\nset -eu\n{body}\n");
+        std::fs::write(&script, content).expect("write script");
+        let mut perms = std::fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).expect("chmod script");
+        script
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn integration_claude_cli_client_reads_json_result_field() {
+        let dir = tempdir().expect("tempdir");
+        let script = write_script(
+            dir.path(),
+            r#"
+if [ "$1" != "-p" ]; then
+  echo "expected -p argument" >&2
+  exit 11
+fi
+shift 2
+fmt=""
+model=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-format) shift; fmt="$1";;
+    --model) shift; model="$1";;
+  esac
+  shift
+done
+if [ "$fmt" != "json" ]; then
+  echo "expected json output format" >&2
+  exit 12
+fi
+if [ "$model" != "claude-sonnet-4-20250514" ]; then
+  echo "expected model argument" >&2
+  exit 13
+fi
+printf '{"type":"result","subtype":"success","is_error":false,"result":"claude mock reply"}'
+"#,
+        );
+        let client = ClaudeCliClient::new(ClaudeCliConfig {
+            executable: script.display().to_string(),
+            extra_args: vec![],
+            timeout_ms: 6_000,
+        })
+        .expect("build client");
+
+        let response = client.complete(test_request()).await.expect("completion");
+        assert_eq!(response.message.text_content(), "claude mock reply");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn functional_claude_cli_client_falls_back_to_plain_stdout() {
+        let dir = tempdir().expect("tempdir");
+        let script = write_script(dir.path(), r#"printf "plain claude stdout""#);
+        let client = ClaudeCliClient::new(ClaudeCliConfig {
+            executable: script.display().to_string(),
+            extra_args: vec![],
+            timeout_ms: 30_000,
+        })
+        .expect("build client");
+
+        let response = client.complete(test_request()).await.expect("completion");
+        assert_eq!(response.message.text_content(), "plain claude stdout");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn regression_claude_cli_client_reports_non_zero_exit() {
+        let dir = tempdir().expect("tempdir");
+        let script = write_script(
+            dir.path(),
+            r#"
+echo "claude auth failed" >&2
+exit 42
+"#,
+        );
+        let client = ClaudeCliClient::new(ClaudeCliConfig {
+            executable: script.display().to_string(),
+            extra_args: vec![],
+            timeout_ms: 30_000,
+        })
+        .expect("build client");
+
+        let error = client
+            .complete(test_request())
+            .await
+            .expect_err("expected failure");
+        assert!(error.to_string().contains("status 42"));
+        assert!(error.to_string().contains("claude auth failed"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn integration_claude_cli_client_stream_callback_receives_text() {
+        let dir = tempdir().expect("tempdir");
+        let script = write_script(
+            dir.path(),
+            r#"printf '{"type":"result","subtype":"success","is_error":false,"result":"stream payload"}'"#,
+        );
+        let client = ClaudeCliClient::new(ClaudeCliConfig {
+            executable: script.display().to_string(),
+            extra_args: vec![],
+            timeout_ms: 30_000,
+        })
+        .expect("build client");
+
+        let chunks = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&chunks);
+        let stream_sink: StreamDeltaHandler = Arc::new(move |delta: String| {
+            sink.lock().expect("delta lock").push(delta);
+        });
+        let response = client
+            .complete_with_stream(test_request(), Some(stream_sink))
+            .await
+            .expect("stream completion");
+        assert_eq!(response.message.text_content(), "stream payload");
+
+        let captured = chunks.lock().expect("chunks lock");
+        assert_eq!(captured.as_slice(), ["stream payload"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn regression_claude_cli_client_reports_timeout() {
+        let dir = tempdir().expect("tempdir");
+        let script = write_script(
+            dir.path(),
+            r#"
+sleep 1
+printf '{"type":"result","subtype":"success","is_error":false,"result":"late"}'
+"#,
+        );
+        let client = ClaudeCliClient::new(ClaudeCliConfig {
+            executable: script.display().to_string(),
+            extra_args: vec![],
+            timeout_ms: 50,
+        })
+        .expect("build client");
+
+        let error = client
+            .complete(test_request())
+            .await
+            .expect_err("timeout should fail");
+        assert!(error.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn unit_render_claude_prompt_includes_roles_and_tools() {
+        let prompt = render_claude_prompt(&test_request());
+        assert!(prompt.contains("Anthropic Claude Code-compatible Tau backend"));
+        assert!(prompt.contains("[system]"));
+        assert!(prompt.contains("[user]"));
+        assert!(prompt.contains("[assistant]"));
+        assert!(prompt.contains("Tau tools available in caller runtime"));
+        assert!(prompt.contains("- read: Read a file"));
+    }
+
+    #[test]
+    fn unit_extract_assistant_text_prefers_result_field() {
+        let text =
+            extract_assistant_text("{\"type\":\"result\",\"is_error\":false,\"result\":\"hello\"}")
+                .expect("extract");
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn regression_extract_assistant_text_reports_error_payload() {
+        let error =
+            extract_assistant_text("{\"type\":\"result\",\"is_error\":true,\"result\":\"denied\"}")
+                .expect_err("error payload should fail");
+        assert!(error.to_string().contains("denied"));
+    }
+}

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -195,6 +195,42 @@ pub(crate) struct Cli {
     pub(crate) anthropic_auth_mode: CliProviderAuthMode,
 
     #[arg(
+        long = "anthropic-claude-backend",
+        env = "TAU_ANTHROPIC_CLAUDE_BACKEND",
+        default_value_t = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Enable Claude Code CLI backend for Anthropic oauth/session auth modes"
+    )]
+    pub(crate) anthropic_claude_backend: bool,
+
+    #[arg(
+        long = "anthropic-claude-cli",
+        env = "TAU_ANTHROPIC_CLAUDE_CLI",
+        default_value = "claude",
+        help = "Claude Code CLI executable path used by Anthropic oauth/session backend"
+    )]
+    pub(crate) anthropic_claude_cli: String,
+
+    #[arg(
+        long = "anthropic-claude-args",
+        env = "TAU_ANTHROPIC_CLAUDE_ARGS",
+        value_delimiter = ',',
+        help = "Additional argument(s) forwarded to claude for Anthropic oauth/session backend"
+    )]
+    pub(crate) anthropic_claude_args: Vec<String>,
+
+    #[arg(
+        long = "anthropic-claude-timeout-ms",
+        env = "TAU_ANTHROPIC_CLAUDE_TIMEOUT_MS",
+        default_value_t = 120_000,
+        help = "Timeout in milliseconds for each Claude Code CLI request"
+    )]
+    pub(crate) anthropic_claude_timeout_ms: u64,
+
+    #[arg(
         long = "google-auth-mode",
         env = "TAU_GOOGLE_AUTH_MODE",
         value_enum,

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -552,6 +552,8 @@ pub(crate) fn handle_command(
         openai_auth_mode: ProviderAuthMethod::ApiKey,
         anthropic_auth_mode: ProviderAuthMethod::ApiKey,
         google_auth_mode: ProviderAuthMethod::ApiKey,
+        anthropic_claude_backend: true,
+        anthropic_claude_cli: "claude".to_string(),
         google_gemini_backend: true,
         google_gemini_cli: "gemini".to_string(),
     };

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -4,6 +4,7 @@ mod auth_types;
 mod bootstrap_helpers;
 mod channel_store;
 mod channel_store_admin;
+mod claude_cli_client;
 mod cli_args;
 mod cli_executable;
 mod cli_types;

--- a/crates/tau-coding-agent/src/provider_auth.rs
+++ b/crates/tau-coding-agent/src/provider_auth.rs
@@ -38,8 +38,8 @@ const ANTHROPIC_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
     },
     ProviderAuthCapability {
         method: ProviderAuthMethod::OauthToken,
-        supported: false,
-        reason: "not_implemented",
+        supported: true,
+        reason: "supported",
     },
     ProviderAuthCapability {
         method: ProviderAuthMethod::Adc,
@@ -48,8 +48,8 @@ const ANTHROPIC_AUTH_CAPABILITIES: &[ProviderAuthCapability] = &[
     },
     ProviderAuthCapability {
         method: ProviderAuthMethod::SessionToken,
-        supported: false,
-        reason: "unsupported",
+        supported: true,
+        reason: "supported",
     },
 ];
 

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -138,6 +138,8 @@ pub(crate) struct AuthCommandConfig {
     pub(crate) openai_auth_mode: ProviderAuthMethod,
     pub(crate) anthropic_auth_mode: ProviderAuthMethod,
     pub(crate) google_auth_mode: ProviderAuthMethod,
+    pub(crate) anthropic_claude_backend: bool,
+    pub(crate) anthropic_claude_cli: String,
     pub(crate) google_gemini_backend: bool,
     pub(crate) google_gemini_cli: String,
 }

--- a/crates/tau-coding-agent/src/startup_config.rs
+++ b/crates/tau-coding-agent/src/startup_config.rs
@@ -16,6 +16,8 @@ pub(crate) fn build_auth_command_config(cli: &Cli) -> AuthCommandConfig {
         openai_auth_mode: cli.openai_auth_mode.into(),
         anthropic_auth_mode: cli.anthropic_auth_mode.into(),
         google_auth_mode: cli.google_auth_mode.into(),
+        anthropic_claude_backend: cli.anthropic_claude_backend,
+        anthropic_claude_cli: cli.anthropic_claude_cli.clone(),
         google_gemini_backend: cli.google_gemini_backend,
         google_gemini_cli: cli.google_gemini_cli.clone(),
     }

--- a/docs/provider-auth/provider-auth-capability-matrix.md
+++ b/docs/provider-auth/provider-auth-capability-matrix.md
@@ -28,6 +28,7 @@ Diagnostics (`/auth status` and `/auth matrix`) read from this abstraction and n
 | OpenAI API Platform | API key / service account key | No | Supported now | OpenAI API docs require API keys via `Authorization: Bearer` headers for API requests. |
 | OpenAI consumer subscription products | Web/app account session | No (official API path not documented) | Not supported | No official API docs path for using consumer subscription web sessions as API credentials. This project must not use cookie/session scraping. |
 | Anthropic direct API | `x-api-key` header | No | Supported now | Anthropic API docs require `x-api-key` headers on API requests, along with version headers. |
+| Claude Code CLI | Account login session via `claude` CLI | Yes (local backend path) | Supported with prerequisites | Supported through the official Claude Code CLI runtime (`-p` + JSON output). Requires local `claude` executable and active CLI login; this is separate from direct HTTP API auth. |
 | Anthropic on AWS Bedrock | AWS IAM credentials | N/A (cloud IAM path) | Supported with prerequisites | Auth is handled by AWS IAM in Bedrock channel, not Anthropic consumer subscription login. |
 | Anthropic on Google Vertex AI | Google IAM/ADC | N/A (cloud IAM path) | Supported with prerequisites | Auth is handled by Google Cloud identity/ADC for Vertex channel. |
 | Gemini API (Google AI Studio) | API key | No | Supported now | Gemini API docs require `x-goog-api-key` for API calls. |
@@ -37,6 +38,7 @@ Diagnostics (`/auth status` and `/auth matrix`) read from this abstraction and n
 ## Source References
 - OpenAI API authentication reference: <https://platform.openai.com/docs/api-reference/authentication?api-mode=responses>
 - Anthropic API getting started: <https://docs.anthropic.com/en/api/getting-started>
+- Claude Code CLI reference and non-interactive usage: <https://docs.anthropic.com/en/docs/claude-code/cli-reference>
 - Gemini API reference (API key auth): <https://ai.google.dev/api>
 - Gemini OAuth quickstart: <https://ai.google.dev/gemini-api/docs/oauth>
 - Google ADC docs: <https://cloud.google.com/docs/authentication/provide-credentials-adc>
@@ -46,8 +48,9 @@ Diagnostics (`/auth status` and `/auth matrix`) read from this abstraction and n
 - Keep OpenAI API auth limited to documented API credentials (API key/service account key) until official docs publish a supported user-login API auth mechanism.
 
 2. Anthropic channel gate (`#104`, `#116`)
-- Treat direct Anthropic API and cloud-channel IAM as separate capabilities.
-- Do not model consumer subscription login as a direct API auth path.
+- Treat direct Anthropic API, Claude Code CLI login backend, and cloud-channel IAM as separate capabilities.
+- Do not model browser session reuse/cookie scraping as an auth path.
+- Keep CI/server deterministic path on API key while allowing local Claude Code backend for oauth/session modes.
 
 3. Gemini login gate (`#105`, `#117`)
 - Allow design/implementation for OAuth and ADC paths with strict preflight validation.


### PR DESCRIPTION
Closes #475

## Summary of behavior changes
- Adds a Claude Code CLI-backed Anthropic runtime client (`claude -p ... --output-format json`) for subscription/account login modes.
- Enables Anthropic auth capabilities for `oauth_token` and `session_token`.
- Routes Anthropic provider auth modes:
  - `api_key` -> existing Anthropic HTTP client
  - `oauth_token`/`session_token` -> new Claude Code CLI backend
- Adds Anthropic backend control flags:
  - `--anthropic-claude-backend`
  - `--anthropic-claude-cli`
  - `--anthropic-claude-args`
  - `--anthropic-claude-timeout-ms`
- Updates `/auth login anthropic`, `/auth status anthropic`, and `/doctor` to report backend readiness and actionable fail states.
- Updates provider auth docs and README subscription login usage.

## Risks and compatibility notes
- Anthropic API-key mode remains unchanged and deterministic for CI/server workflows.
- Anthropic oauth/session backend now depends on local `claude` executable availability and active CLI login state.
- Non-zero exit codes, timeout, and structured error payloads from the Claude CLI are surfaced as deterministic provider errors.
- Source-kind accounting in auth matrix/status now includes backend sources (`claude_cli`) under non-store/non-flag bucket.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

All commands passed locally on this branch before PR creation.
