### PR TITLE
feat: unify auth UX and diagnostics for subscription backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Dependency update automation is configured in `.github/dependabot.yml`.
 
 ## Usage
 
+Auth mode guidance (local subscription login vs CI):
+
+| Provider | Local/dev recommended | CI/automation recommended |
+| --- | --- | --- |
+| OpenAI | `--openai-auth-mode oauth-token` or `session-token` with Codex backend (`--openai-codex-backend=true`) | `--openai-auth-mode api-key` with `OPENAI_API_KEY` |
+| Anthropic | `--anthropic-auth-mode oauth-token` or `session-token` with Claude backend (`--anthropic-claude-backend=true`) | `--anthropic-auth-mode api-key` with `ANTHROPIC_API_KEY` |
+| Google | `--google-auth-mode oauth-token` (Gemini login) or `--google-auth-mode adc` (Vertex/ADC) with Gemini backend (`--google-gemini-backend=true`) | `--google-auth-mode api-key` with `GEMINI_API_KEY` |
+
+`/auth status` and `/auth matrix` include `supported`, `available`, `source`, `expires`, `refreshable`, and `next_action` fields for deterministic diagnostics and machine parsing.
+
 Set an API key for your provider:
 
 ```bash

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -552,6 +552,8 @@ pub(crate) fn handle_command(
         openai_auth_mode: ProviderAuthMethod::ApiKey,
         anthropic_auth_mode: ProviderAuthMethod::ApiKey,
         google_auth_mode: ProviderAuthMethod::ApiKey,
+        openai_codex_backend: true,
+        openai_codex_cli: "codex".to_string(),
         anthropic_claude_backend: true,
         anthropic_claude_cli: "claude".to_string(),
         google_gemini_backend: true,

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -138,6 +138,8 @@ pub(crate) struct AuthCommandConfig {
     pub(crate) openai_auth_mode: ProviderAuthMethod,
     pub(crate) anthropic_auth_mode: ProviderAuthMethod,
     pub(crate) google_auth_mode: ProviderAuthMethod,
+    pub(crate) openai_codex_backend: bool,
+    pub(crate) openai_codex_cli: String,
     pub(crate) anthropic_claude_backend: bool,
     pub(crate) anthropic_claude_cli: String,
     pub(crate) google_gemini_backend: bool,

--- a/crates/tau-coding-agent/src/startup_config.rs
+++ b/crates/tau-coding-agent/src/startup_config.rs
@@ -16,6 +16,8 @@ pub(crate) fn build_auth_command_config(cli: &Cli) -> AuthCommandConfig {
         openai_auth_mode: cli.openai_auth_mode.into(),
         anthropic_auth_mode: cli.anthropic_auth_mode.into(),
         google_auth_mode: cli.google_auth_mode.into(),
+        openai_codex_backend: cli.openai_codex_backend,
+        openai_codex_cli: cli.openai_codex_cli.clone(),
         anthropic_claude_backend: cli.anthropic_claude_backend,
         anthropic_claude_cli: cli.anthropic_claude_cli.clone(),
         google_gemini_backend: cli.google_gemini_backend,

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -526,6 +526,7 @@ fn test_profile_defaults() -> ProfileDefaults {
 fn test_auth_command_config() -> AuthCommandConfig {
     let mut config = build_auth_command_config(&test_cli());
     if let Ok(current_exe) = std::env::current_exe() {
+        config.openai_codex_cli = current_exe.display().to_string();
         config.anthropic_claude_cli = current_exe.display().to_string();
         config.google_gemini_cli = current_exe.display().to_string();
     }


### PR DESCRIPTION
Closes #477

## Summary of behavior changes
- Standardizes auth status/matrix output rows with additional normalized fields:
  - `supported`
  - `available`
  - `source`
  - `expires`
  - `refreshable`
  - `next_action`
- Adds provider-specific `next_action` guidance for missing keys, unsupported modes, backend-disabled states, missing executables, and re-auth flows.
- Extends OpenAI oauth/session status handling to report Codex backend readiness when credential-store entries are absent.
- Extends `/auth login` OpenAI oauth/session flow to report Codex backend readiness when no token env vars are provided.
- Extends `/doctor` backend checks to include OpenAI Codex oauth/session backend readiness, aligning with Anthropic/Google backend checks.
- Updates README with concise local-vs-CI auth routing matrix across OpenAI/Anthropic/Google.

## Risks and compatibility notes
- Existing fields remain present (`mode_supported`, `expires_unix`) for backward compatibility; normalized aliases are additive.
- Auth text output now includes `supported`, `expires`, `refreshable`, and `next_action` fields per provider row.
- OpenAI oauth/session status/login behavior is more explicit about Codex backend paths when store entries are missing.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

All commands passed locally before PR creation.
