### PR TITLE
feat: onboarding wizard bootstrap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ Dependency update automation is configured in `.github/dependabot.yml`.
 
 ## Usage
 
+Run first-time onboarding (creates required `.tau` directories, initializes profile store, and writes a machine-readable report):
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive
+```
+
+Interactive onboarding mode:
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-profile default
+```
+
 Auth mode guidance (local subscription login vs CI):
 
 | Provider | Local/dev recommended | CI/automation recommended |

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -653,6 +653,32 @@ pub(crate) struct Cli {
     pub(crate) command_file_error_mode: CliCommandFileErrorMode,
 
     #[arg(
+        long,
+        env = "TAU_ONBOARD",
+        default_value_t = false,
+        help = "Run onboarding wizard and bootstrap Tau workspace assets, then exit"
+    )]
+    pub(crate) onboard: bool,
+
+    #[arg(
+        long = "onboard-non-interactive",
+        env = "TAU_ONBOARD_NON_INTERACTIVE",
+        default_value_t = false,
+        requires = "onboard",
+        help = "Disable interactive onboarding prompts and apply deterministic defaults"
+    )]
+    pub(crate) onboard_non_interactive: bool,
+
+    #[arg(
+        long = "onboard-profile",
+        env = "TAU_ONBOARD_PROFILE",
+        default_value = "default",
+        requires = "onboard",
+        help = "Profile name created/updated by onboarding"
+    )]
+    pub(crate) onboard_profile: String,
+
+    #[arg(
         long = "channel-store-root",
         env = "TAU_CHANNEL_STORE_ROOT",
         default_value = ".tau/channel-store",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -19,6 +19,7 @@ mod github_issues;
 mod macro_profile_commands;
 mod model_catalog;
 mod observability_loggers;
+mod onboarding;
 mod orchestrator;
 mod package_manifest;
 mod provider_auth;
@@ -156,6 +157,7 @@ pub(crate) use crate::model_catalog::{
 #[cfg(test)]
 pub(crate) use crate::observability_loggers::tool_audit_event_json;
 pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLogger};
+pub(crate) use crate::onboarding::execute_onboarding_command;
 #[cfg(test)]
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;

--- a/crates/tau-coding-agent/src/onboarding.rs
+++ b/crates/tau-coding-agent/src/onboarding.rs
@@ -1,0 +1,461 @@
+use super::*;
+
+use std::collections::BTreeSet;
+use std::io::{self, Write};
+
+use crate::cli_executable::is_executable_available;
+use crate::macro_profile_commands::{
+    load_profile_store, save_profile_store, validate_profile_name,
+};
+
+const ONBOARDING_REPORT_SCHEMA_VERSION: u32 = 1;
+const ONBOARDING_DEFAULT_PROFILE: &str = "default";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct OnboardingExecutableCheck {
+    pub(crate) integration: String,
+    pub(crate) executable: String,
+    pub(crate) available: bool,
+    pub(crate) required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct OnboardingReport {
+    pub(crate) schema_version: u32,
+    pub(crate) generated_at_ms: u64,
+    pub(crate) mode: String,
+    pub(crate) tau_root: String,
+    pub(crate) profile_name: String,
+    pub(crate) profile_store_path: String,
+    pub(crate) profile_store_action: String,
+    pub(crate) directories_created: Vec<String>,
+    pub(crate) directories_existing: Vec<String>,
+    pub(crate) files_created: Vec<String>,
+    pub(crate) files_existing: Vec<String>,
+    pub(crate) executable_checks: Vec<OnboardingExecutableCheck>,
+    pub(crate) next_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnboardingMode {
+    Interactive,
+    NonInteractive,
+}
+
+pub(crate) fn execute_onboarding_command(cli: &Cli) -> Result<()> {
+    let mode = if cli.onboard_non_interactive {
+        OnboardingMode::NonInteractive
+    } else {
+        OnboardingMode::Interactive
+    };
+    let profile_name = resolve_onboarding_profile_name(&cli.onboard_profile)?;
+    if mode == OnboardingMode::Interactive {
+        let prompt = format!(
+            "onboarding wizard: profile={} continue? [Y/n]: ",
+            profile_name
+        );
+        if !prompt_yes_no(&prompt, true)? {
+            println!("onboarding canceled: no changes applied");
+            return Ok(());
+        }
+    }
+
+    let report = build_onboarding_report(cli, &profile_name, mode)?;
+    let report_path = write_onboarding_report(&report, resolve_onboarding_report_path(cli)?)
+        .context("failed to persist onboarding report")?;
+    println!("{}", render_onboarding_summary(&report, &report_path));
+    Ok(())
+}
+
+fn resolve_onboarding_profile_name(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    let profile_name = if trimmed.is_empty() {
+        ONBOARDING_DEFAULT_PROFILE.to_string()
+    } else {
+        trimmed.to_string()
+    };
+    validate_profile_name(&profile_name)?;
+    Ok(profile_name)
+}
+
+fn build_onboarding_report(
+    cli: &Cli,
+    profile_name: &str,
+    mode: OnboardingMode,
+) -> Result<OnboardingReport> {
+    let tau_root = resolve_tau_root(cli);
+    let directories = collect_bootstrap_directories(cli, &tau_root);
+    let mut directories_created = Vec::new();
+    let mut directories_existing = Vec::new();
+    for directory in directories {
+        ensure_directory(
+            &directory,
+            &mut directories_created,
+            &mut directories_existing,
+        )?;
+    }
+
+    let profile_store_path = tau_root.join("profiles.json");
+    let profile_store_action = ensure_profile_store_entry(cli, &profile_store_path, profile_name)?;
+    let mut files_created = Vec::new();
+    let mut files_existing = Vec::new();
+    if profile_store_action == "created" {
+        files_created.push(profile_store_path.display().to_string());
+    } else {
+        files_existing.push(profile_store_path.display().to_string());
+    }
+
+    let executable_checks = collect_executable_checks(cli);
+    let next_steps = build_onboarding_next_steps(cli, &executable_checks);
+
+    Ok(OnboardingReport {
+        schema_version: ONBOARDING_REPORT_SCHEMA_VERSION,
+        generated_at_ms: current_unix_timestamp_ms(),
+        mode: onboarding_mode_label(mode).to_string(),
+        tau_root: tau_root.display().to_string(),
+        profile_name: profile_name.to_string(),
+        profile_store_path: profile_store_path.display().to_string(),
+        profile_store_action: profile_store_action.to_string(),
+        directories_created,
+        directories_existing,
+        files_created,
+        files_existing,
+        executable_checks,
+        next_steps,
+    })
+}
+
+fn onboarding_mode_label(mode: OnboardingMode) -> &'static str {
+    match mode {
+        OnboardingMode::Interactive => "interactive",
+        OnboardingMode::NonInteractive => "non-interactive",
+    }
+}
+
+fn resolve_tau_root(cli: &Cli) -> PathBuf {
+    if let Some(session_parent) = cli
+        .session
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        if session_parent
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == "sessions")
+        {
+            if let Some(root) = session_parent
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+            {
+                return root.to_path_buf();
+            }
+        }
+    }
+
+    cli.credential_store
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(".tau"))
+}
+
+fn collect_bootstrap_directories(cli: &Cli, tau_root: &Path) -> Vec<PathBuf> {
+    let mut directories = BTreeSet::new();
+    maybe_insert_directory(&mut directories, Some(tau_root));
+    maybe_insert_directory(&mut directories, Some(&tau_root.join("reports")));
+    maybe_insert_directory(&mut directories, cli.session.parent());
+    maybe_insert_directory(&mut directories, cli.credential_store.parent());
+    maybe_insert_directory(&mut directories, Some(&cli.skills_dir));
+    maybe_insert_directory(&mut directories, cli.model_catalog_cache.parent());
+    maybe_insert_directory(&mut directories, Some(&cli.channel_store_root));
+    maybe_insert_directory(&mut directories, Some(&cli.events_dir));
+    maybe_insert_directory(&mut directories, cli.events_state_path.parent());
+    maybe_insert_directory(&mut directories, Some(&cli.github_state_dir));
+    maybe_insert_directory(&mut directories, Some(&cli.slack_state_dir));
+    maybe_insert_directory(&mut directories, Some(&cli.package_install_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_update_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_list_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_remove_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_rollback_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_conflicts_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_activate_root));
+    maybe_insert_directory(&mut directories, Some(&cli.package_activate_destination));
+    maybe_insert_directory(&mut directories, Some(&cli.extension_list_root));
+    maybe_insert_directory(&mut directories, Some(&cli.extension_runtime_root));
+    directories.into_iter().collect()
+}
+
+fn maybe_insert_directory(directories: &mut BTreeSet<PathBuf>, path: Option<&Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    directories.insert(path.to_path_buf());
+}
+
+fn ensure_directory(
+    path: &Path,
+    directories_created: &mut Vec<String>,
+    directories_existing: &mut Vec<String>,
+) -> Result<()> {
+    if path.exists() {
+        if !path.is_dir() {
+            bail!(
+                "onboarding path '{}' exists but is not a directory",
+                path.display()
+            );
+        }
+        directories_existing.push(path.display().to_string());
+    } else {
+        std::fs::create_dir_all(path)
+            .with_context(|| format!("failed to create directory {}", path.display()))?;
+        directories_created.push(path.display().to_string());
+    }
+    Ok(())
+}
+
+fn ensure_profile_store_entry(
+    cli: &Cli,
+    profile_store_path: &Path,
+    profile_name: &str,
+) -> Result<&'static str> {
+    let mut profiles = load_profile_store(profile_store_path)?;
+    if profiles.contains_key(profile_name) {
+        return Ok("unchanged");
+    }
+
+    let file_existed = profile_store_path.exists();
+    profiles.insert(profile_name.to_string(), build_profile_defaults(cli));
+    save_profile_store(profile_store_path, &profiles)?;
+    if file_existed {
+        Ok("updated")
+    } else {
+        Ok("created")
+    }
+}
+
+fn collect_executable_checks(cli: &Cli) -> Vec<OnboardingExecutableCheck> {
+    let openai_required = cli.openai_codex_backend
+        && matches!(
+            cli.openai_auth_mode,
+            CliProviderAuthMode::OauthToken | CliProviderAuthMode::SessionToken
+        );
+    let anthropic_required = cli.anthropic_claude_backend
+        && matches!(
+            cli.anthropic_auth_mode,
+            CliProviderAuthMode::OauthToken | CliProviderAuthMode::SessionToken
+        );
+    let google_required = cli.google_gemini_backend
+        && matches!(
+            cli.google_auth_mode,
+            CliProviderAuthMode::OauthToken | CliProviderAuthMode::Adc
+        );
+    let gcloud_required = matches!(cli.google_auth_mode, CliProviderAuthMode::Adc);
+
+    vec![
+        onboarding_executable_check("openai-codex", &cli.openai_codex_cli, openai_required),
+        onboarding_executable_check(
+            "anthropic-claude",
+            &cli.anthropic_claude_cli,
+            anthropic_required,
+        ),
+        onboarding_executable_check("google-gemini", &cli.google_gemini_cli, google_required),
+        onboarding_executable_check("google-gcloud", &cli.google_gcloud_cli, gcloud_required),
+    ]
+}
+
+fn onboarding_executable_check(
+    integration: &str,
+    executable: &str,
+    required: bool,
+) -> OnboardingExecutableCheck {
+    OnboardingExecutableCheck {
+        integration: integration.to_string(),
+        executable: executable.to_string(),
+        available: is_executable_available(executable),
+        required,
+    }
+}
+
+fn build_onboarding_next_steps(
+    cli: &Cli,
+    executable_checks: &[OnboardingExecutableCheck],
+) -> Vec<String> {
+    let mut next_steps = Vec::new();
+    for check in executable_checks {
+        if check.required && !check.available {
+            next_steps.push(format!(
+                "Install or configure '{}' for {} auth workflows.",
+                check.executable, check.integration
+            ));
+        }
+    }
+    next_steps.push("/auth status".to_string());
+    next_steps.push(format!(
+        "cargo run -p tau-coding-agent -- --model {}",
+        cli.model
+    ));
+    next_steps
+}
+
+fn resolve_onboarding_report_path(cli: &Cli) -> Result<PathBuf> {
+    let tau_root = resolve_tau_root(cli);
+    let reports_dir = tau_root.join("reports");
+    let report_name = format!("onboarding-{}.json", current_unix_timestamp_ms());
+    Ok(reports_dir.join(report_name))
+}
+
+fn write_onboarding_report(report: &OnboardingReport, report_path: PathBuf) -> Result<PathBuf> {
+    let mut payload = serde_json::to_string_pretty(report).context("failed to encode report")?;
+    payload.push('\n');
+    write_text_atomic(&report_path, &payload).with_context(|| {
+        format!(
+            "failed to write onboarding report {}",
+            report_path.display()
+        )
+    })?;
+    Ok(report_path)
+}
+
+fn render_onboarding_summary(report: &OnboardingReport, report_path: &Path) -> String {
+    let mut lines = vec![
+        format!(
+            "onboarding complete: mode={} profile={} report={}",
+            report.mode,
+            report.profile_name,
+            report_path.display()
+        ),
+        format!(
+            "directories: created={} existing={}",
+            report.directories_created.len(),
+            report.directories_existing.len()
+        ),
+        format!(
+            "files: created={} existing={} profile_store_action={}",
+            report.files_created.len(),
+            report.files_existing.len(),
+            report.profile_store_action
+        ),
+    ];
+    for next_step in &report.next_steps {
+        lines.push(format!("next: {next_step}"));
+    }
+    lines.join("\n")
+}
+
+fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool> {
+    print!("{prompt}");
+    io::stdout()
+        .flush()
+        .context("failed to flush onboarding prompt")?;
+    let mut buffer = String::new();
+    io::stdin()
+        .read_line(&mut buffer)
+        .context("failed to read onboarding prompt response")?;
+    Ok(parse_yes_no_response(&buffer, default_yes))
+}
+
+fn parse_yes_no_response(raw: &str, default_yes: bool) -> bool {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" => default_yes,
+        "y" | "yes" => true,
+        "n" | "no" => false,
+        _ => default_yes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_onboarding_report, parse_yes_no_response, resolve_tau_root, OnboardingMode,
+        ONBOARDING_REPORT_SCHEMA_VERSION,
+    };
+    use crate::Cli;
+    use clap::Parser;
+    use std::path::{Path, PathBuf};
+    use tempfile::tempdir;
+
+    fn test_cli() -> Cli {
+        Cli::parse_from(["tau-rs", "--onboard", "--onboard-non-interactive"])
+    }
+
+    fn apply_workspace_paths(cli: &mut Cli, workspace: &Path) {
+        let tau_root = workspace.join(".tau");
+        cli.session = tau_root.join("sessions/default.jsonl");
+        cli.credential_store = tau_root.join("credentials.json");
+        cli.skills_dir = tau_root.join("skills");
+        cli.model_catalog_cache = tau_root.join("models/catalog.json");
+        cli.channel_store_root = tau_root.join("channel-store");
+        cli.events_dir = tau_root.join("events");
+        cli.events_state_path = tau_root.join("events/state.json");
+        cli.github_state_dir = tau_root.join("github-issues");
+        cli.slack_state_dir = tau_root.join("slack");
+        cli.package_install_root = tau_root.join("packages");
+        cli.package_update_root = tau_root.join("packages");
+        cli.package_list_root = tau_root.join("packages");
+        cli.package_remove_root = tau_root.join("packages");
+        cli.package_rollback_root = tau_root.join("packages");
+        cli.package_conflicts_root = tau_root.join("packages");
+        cli.package_activate_root = tau_root.join("packages");
+        cli.package_activate_destination = tau_root.join("packages-active");
+        cli.extension_list_root = tau_root.join("extensions");
+        cli.extension_runtime_root = tau_root.join("extensions");
+    }
+
+    #[test]
+    fn unit_parse_yes_no_response_accepts_supported_values() {
+        assert!(parse_yes_no_response("yes", false));
+        assert!(parse_yes_no_response("Y", false));
+        assert!(!parse_yes_no_response("n", true));
+        assert!(!parse_yes_no_response("no", true));
+        assert!(parse_yes_no_response("", true));
+        assert!(!parse_yes_no_response("", false));
+    }
+
+    #[test]
+    fn functional_resolve_tau_root_prefers_sessions_parent() {
+        let mut cli = test_cli();
+        let temp = tempdir().expect("tempdir");
+        apply_workspace_paths(&mut cli, temp.path());
+        let tau_root = resolve_tau_root(&cli);
+        assert_eq!(tau_root, temp.path().join(".tau"));
+    }
+
+    #[test]
+    fn integration_build_onboarding_report_bootstraps_workspace_and_profile_store() {
+        let temp = tempdir().expect("tempdir");
+        let mut cli = test_cli();
+        apply_workspace_paths(&mut cli, temp.path());
+        cli.onboard_profile = "team-default".to_string();
+
+        let report = build_onboarding_report(&cli, "team-default", OnboardingMode::NonInteractive)
+            .expect("build report");
+
+        assert_eq!(report.schema_version, ONBOARDING_REPORT_SCHEMA_VERSION);
+        assert_eq!(report.profile_name, "team-default");
+        assert!(!report.directories_created.is_empty());
+        assert_eq!(report.profile_store_action, "created");
+        assert!(
+            PathBuf::from(&report.profile_store_path).exists(),
+            "profile store should exist after onboarding"
+        );
+    }
+
+    #[test]
+    fn regression_build_onboarding_report_does_not_overwrite_existing_profile_entry() {
+        let temp = tempdir().expect("tempdir");
+        let mut cli = test_cli();
+        apply_workspace_paths(&mut cli, temp.path());
+        cli.onboard_profile = "default".to_string();
+
+        let first = build_onboarding_report(&cli, "default", OnboardingMode::NonInteractive)
+            .expect("first report");
+        assert_eq!(first.profile_store_action, "created");
+
+        let second = build_onboarding_report(&cli, "default", OnboardingMode::NonInteractive)
+            .expect("second report");
+        assert_eq!(second.profile_store_action, "unchanged");
+    }
+}

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
+    if cli.onboard {
+        execute_onboarding_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.session_validate {
         validate_session_file(cli)?;
         return Ok(true);

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -26,6 +26,7 @@ If a preflight or transport mode completes, runtime startup exits early.
 
 - `cli_args.rs`: all CLI flags and clap definitions.
 - `cli_types.rs`: clap-facing enums and value types.
+- `onboarding.rs`: first-run onboarding wizard and bootstrap report flow.
 - `runtime_types.rs`: shared runtime/config structs used across modules.
 
 Use this area when adding or changing flags, defaults, and typed CLI input behavior.


### PR DESCRIPTION
## Summary
Implements `#493` by adding a first-run onboarding flow that bootstraps Tau workspace state and emits a machine-readable report.

Behavior changes:
- Adds `--onboard`, `--onboard-non-interactive`, and `--onboard-profile` CLI flags.
- Adds startup preflight onboarding command execution (`--onboard` runs and exits).
- Adds onboarding report generation (`.tau/reports/onboarding-<timestamp>.json`) with executable readiness and next-step guidance.
- Creates required workspace directories and profile store entries idempotently.
- Hardens session loading by pre-creating session parent directories.
- Documents onboarding flow in README and code map.

## Risks And Compatibility
- Existing startup flow is unchanged unless `--onboard` is explicitly passed.
- Session loader now creates missing parent directories at load time; this is additive and backward compatible but changes side-effect timing from first append to load.
- New onboarding flags are additive and do not alter default CLI behavior.

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`

Closes #493
