### PR TITLE
feat: multi-agent route-table execution with fallback tracing (closes #495)

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -607,6 +607,14 @@ pub(crate) struct Cli {
     pub(crate) orchestrator_delegate_steps: bool,
 
     #[arg(
+        long = "orchestrator-route-table",
+        env = "TAU_ORCHESTRATOR_ROUTE_TABLE",
+        value_name = "path",
+        help = "Optional JSON route-table path for multi-agent planner/delegated/review role routing"
+    )]
+    pub(crate) orchestrator_route_table: Option<PathBuf>,
+
+    #[arg(
         long,
         env = "TAU_PROMPT_FILE",
         conflicts_with = "prompt",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -18,6 +18,7 @@ mod gemini_cli_client;
 mod github_issues;
 mod macro_profile_commands;
 mod model_catalog;
+mod multi_agent_router;
 mod observability_loggers;
 mod onboarding;
 mod orchestrator;
@@ -155,6 +156,10 @@ pub(crate) use crate::model_catalog::{
     render_model_show, render_models_list, ModelCatalog, ModelCatalogLoadOptions,
     MODELS_LIST_USAGE, MODEL_SHOW_USAGE,
 };
+pub(crate) use crate::multi_agent_router::{
+    build_multi_agent_role_prompt, load_multi_agent_route_table, resolve_multi_agent_role_profile,
+    select_multi_agent_route, MultiAgentRoutePhase, MultiAgentRouteTable,
+};
 #[cfg(test)]
 pub(crate) use crate::observability_loggers::tool_audit_event_json;
 pub(crate) use crate::observability_loggers::{PromptTelemetryLogger, ToolAuditLogger};
@@ -163,6 +168,7 @@ pub(crate) use crate::onboarding::execute_onboarding_command;
 pub(crate) use crate::orchestrator::parse_numbered_plan_steps;
 pub(crate) use crate::orchestrator::run_plan_first_prompt;
 pub(crate) use crate::orchestrator::run_plan_first_prompt_with_policy_context;
+pub(crate) use crate::orchestrator::run_plan_first_prompt_with_policy_context_and_routing;
 pub(crate) use crate::package_manifest::{
     execute_package_activate_command, execute_package_activate_on_startup,
     execute_package_conflicts_command, execute_package_install_command,

--- a/crates/tau-coding-agent/src/multi_agent_router.rs
+++ b/crates/tau-coding-agent/src/multi_agent_router.rs
@@ -1,0 +1,442 @@
+use super::*;
+
+use std::collections::{BTreeMap, HashSet};
+
+const ROUTE_TABLE_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_ROLE_NAME: &str = "default";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) struct MultiAgentRoleProfile {
+    #[serde(default)]
+    pub(crate) model: Option<String>,
+    #[serde(default)]
+    pub(crate) prompt_suffix: Option<String>,
+    #[serde(default)]
+    pub(crate) tool_policy_preset: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MultiAgentRouteTarget {
+    pub(crate) role: String,
+    #[serde(default)]
+    pub(crate) fallback_roles: Vec<String>,
+}
+
+impl Default for MultiAgentRouteTarget {
+    fn default() -> Self {
+        Self {
+            role: DEFAULT_ROLE_NAME.to_string(),
+            fallback_roles: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MultiAgentRouteTable {
+    schema_version: u32,
+    #[serde(default = "default_role_profiles")]
+    pub(crate) roles: BTreeMap<String, MultiAgentRoleProfile>,
+    #[serde(default)]
+    pub(crate) planner: MultiAgentRouteTarget,
+    #[serde(default)]
+    pub(crate) delegated: MultiAgentRouteTarget,
+    #[serde(default)]
+    pub(crate) delegated_categories: BTreeMap<String, MultiAgentRouteTarget>,
+    #[serde(default)]
+    pub(crate) review: MultiAgentRouteTarget,
+}
+
+impl Default for MultiAgentRouteTable {
+    fn default() -> Self {
+        Self {
+            schema_version: ROUTE_TABLE_SCHEMA_VERSION,
+            roles: default_role_profiles(),
+            planner: MultiAgentRouteTarget::default(),
+            delegated: MultiAgentRouteTarget::default(),
+            delegated_categories: BTreeMap::new(),
+            review: MultiAgentRouteTarget::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MultiAgentRoutePhase {
+    Planner,
+    DelegatedStep,
+    Review,
+}
+
+impl MultiAgentRoutePhase {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Planner => "planner",
+            Self::DelegatedStep => "delegated-step",
+            Self::Review => "review",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MultiAgentRouteSelection {
+    pub(crate) phase: MultiAgentRoutePhase,
+    pub(crate) category: Option<String>,
+    pub(crate) primary_role: String,
+    pub(crate) fallback_roles: Vec<String>,
+    pub(crate) attempt_roles: Vec<String>,
+}
+
+fn default_role_profiles() -> BTreeMap<String, MultiAgentRoleProfile> {
+    let mut roles = BTreeMap::new();
+    roles.insert(
+        DEFAULT_ROLE_NAME.to_string(),
+        MultiAgentRoleProfile::default(),
+    );
+    roles
+}
+
+pub(crate) fn load_multi_agent_route_table(path: &Path) -> Result<MultiAgentRouteTable> {
+    if !path.exists() {
+        return Ok(MultiAgentRouteTable::default());
+    }
+
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read orchestrator route table {}", path.display()))?;
+    let mut parsed = serde_json::from_str::<MultiAgentRouteTable>(&raw).with_context(|| {
+        format!(
+            "failed to parse orchestrator route table {}",
+            path.display()
+        )
+    })?;
+    normalize_and_validate_route_table(path, &mut parsed)?;
+    Ok(parsed)
+}
+
+fn normalize_and_validate_route_table(path: &Path, table: &mut MultiAgentRouteTable) -> Result<()> {
+    if table.schema_version != ROUTE_TABLE_SCHEMA_VERSION {
+        bail!(
+            "unsupported orchestrator route table schema_version {} in {} (expected {})",
+            table.schema_version,
+            path.display(),
+            ROUTE_TABLE_SCHEMA_VERSION
+        );
+    }
+
+    let mut normalized_roles = BTreeMap::new();
+    for (raw_role, profile) in std::mem::take(&mut table.roles) {
+        let role = normalize_role_name(raw_role.as_str())
+            .with_context(|| format!("invalid role name '{}'", raw_role))?;
+        if normalized_roles.insert(role.clone(), profile).is_some() {
+            bail!("duplicate role '{}' in {}", role, path.display());
+        }
+    }
+    if normalized_roles.is_empty() {
+        normalized_roles = default_role_profiles();
+    }
+    table.roles = normalized_roles;
+
+    normalize_route_target(path, &table.roles, &mut table.planner, "planner")?;
+    normalize_route_target(path, &table.roles, &mut table.delegated, "delegated")?;
+    normalize_route_target(path, &table.roles, &mut table.review, "review")?;
+
+    for (raw_category, target) in &mut table.delegated_categories {
+        let category = raw_category.trim();
+        if category.is_empty() {
+            bail!(
+                "delegated route category cannot be empty in {}",
+                path.display()
+            );
+        }
+        normalize_route_target(
+            path,
+            &table.roles,
+            target,
+            &format!("delegated_categories['{}']", category),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn normalize_route_target(
+    path: &Path,
+    roles: &BTreeMap<String, MultiAgentRoleProfile>,
+    target: &mut MultiAgentRouteTarget,
+    field_name: &str,
+) -> Result<()> {
+    let primary = normalize_role_name(target.role.as_str()).with_context(|| {
+        format!(
+            "invalid role '{}' for route target '{}' in {}",
+            target.role,
+            field_name,
+            path.display()
+        )
+    })?;
+    if !roles.contains_key(primary.as_str()) {
+        bail!(
+            "route target '{}' references unknown role '{}' in {}",
+            field_name,
+            primary,
+            path.display()
+        );
+    }
+
+    let mut normalized_fallbacks = Vec::new();
+    let mut seen = HashSet::new();
+    for raw_role in std::mem::take(&mut target.fallback_roles) {
+        let role = normalize_role_name(raw_role.as_str()).with_context(|| {
+            format!(
+                "invalid fallback role '{}' for route target '{}' in {}",
+                raw_role,
+                field_name,
+                path.display()
+            )
+        })?;
+        if role == primary {
+            continue;
+        }
+        if !roles.contains_key(role.as_str()) {
+            bail!(
+                "route target '{}' references unknown fallback role '{}' in {}",
+                field_name,
+                role,
+                path.display()
+            );
+        }
+        if seen.insert(role.clone()) {
+            normalized_fallbacks.push(role);
+        }
+    }
+
+    target.role = primary;
+    target.fallback_roles = normalized_fallbacks;
+    Ok(())
+}
+
+fn normalize_role_name(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("role name cannot be empty");
+    }
+    Ok(trimmed.to_string())
+}
+
+pub(crate) fn select_multi_agent_route(
+    table: &MultiAgentRouteTable,
+    phase: MultiAgentRoutePhase,
+    step_text: Option<&str>,
+) -> MultiAgentRouteSelection {
+    let (target, category) = match phase {
+        MultiAgentRoutePhase::Planner => (&table.planner, None),
+        MultiAgentRoutePhase::Review => (&table.review, None),
+        MultiAgentRoutePhase::DelegatedStep => {
+            if let Some(step) = step_text {
+                if let Some((category, category_target)) =
+                    select_delegated_category_target(&table.delegated_categories, step)
+                {
+                    (category_target, Some(category.to_string()))
+                } else {
+                    (&table.delegated, None)
+                }
+            } else {
+                (&table.delegated, None)
+            }
+        }
+    };
+
+    let mut attempt_roles = Vec::with_capacity(target.fallback_roles.len() + 1);
+    attempt_roles.push(target.role.clone());
+    attempt_roles.extend(target.fallback_roles.clone());
+
+    MultiAgentRouteSelection {
+        phase,
+        category,
+        primary_role: target.role.clone(),
+        fallback_roles: target.fallback_roles.clone(),
+        attempt_roles,
+    }
+}
+
+fn select_delegated_category_target<'a>(
+    categories: &'a BTreeMap<String, MultiAgentRouteTarget>,
+    step_text: &str,
+) -> Option<(&'a str, &'a MultiAgentRouteTarget)> {
+    let normalized = step_text.to_ascii_lowercase();
+    categories.iter().find_map(|(category, target)| {
+        let category_match = category.trim().to_ascii_lowercase();
+        (!category_match.is_empty() && normalized.contains(&category_match))
+            .then_some((category.as_str(), target))
+    })
+}
+
+pub(crate) fn resolve_multi_agent_role_profile(
+    table: &MultiAgentRouteTable,
+    role: &str,
+) -> MultiAgentRoleProfile {
+    table.roles.get(role).cloned().unwrap_or_default()
+}
+
+pub(crate) fn build_multi_agent_role_prompt(
+    base_prompt: &str,
+    phase: MultiAgentRoutePhase,
+    role: &str,
+    profile: &MultiAgentRoleProfile,
+) -> String {
+    let suffix = profile
+        .prompt_suffix
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default();
+    let has_explicit_profile = role != DEFAULT_ROLE_NAME
+        || profile.model.is_some()
+        || profile.tool_policy_preset.is_some()
+        || !suffix.is_empty();
+
+    if !has_explicit_profile {
+        return base_prompt.to_string();
+    }
+
+    let model_hint = profile.model.as_deref().unwrap_or("inherit");
+    let tool_policy_hint = profile.tool_policy_preset.as_deref().unwrap_or("inherit");
+    if suffix.is_empty() {
+        return format!(
+            "{base_prompt}\n\nORCHESTRATOR_ROLE_CONTEXT\nphase={}\nrole={}\nmodel_hint={}\ntool_policy_preset={}",
+            phase.as_str(),
+            role,
+            model_hint,
+            tool_policy_hint,
+        );
+    }
+
+    format!(
+        "{base_prompt}\n\nORCHESTRATOR_ROLE_CONTEXT\nphase={}\nrole={}\nmodel_hint={}\ntool_policy_preset={}\n\nRole prompt suffix:\n{}",
+        phase.as_str(),
+        role,
+        model_hint,
+        tool_policy_hint,
+        suffix,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_multi_agent_role_prompt, load_multi_agent_route_table, select_multi_agent_route,
+        MultiAgentRoleProfile, MultiAgentRoutePhase,
+    };
+    use tempfile::tempdir;
+
+    #[test]
+    fn unit_route_selection_prefers_deterministic_category_match() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("route-table.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "schema_version": 1,
+  "roles": {
+    "planner": {},
+    "executor": {},
+    "reviewer": {}
+  },
+  "planner": { "role": "planner" },
+  "delegated": { "role": "executor" },
+  "delegated_categories": {
+    "analysis": { "role": "reviewer" },
+    "build": { "role": "executor" }
+  },
+  "review": { "role": "reviewer" }
+}
+"#,
+        )
+        .expect("write route table");
+
+        let table = load_multi_agent_route_table(&path).expect("load route table");
+        let route = select_multi_agent_route(
+            &table,
+            MultiAgentRoutePhase::DelegatedStep,
+            Some("do analysis first"),
+        );
+        assert_eq!(route.primary_role, "reviewer");
+        assert_eq!(route.category.as_deref(), Some("analysis"));
+    }
+
+    #[test]
+    fn unit_route_selection_dedupes_fallback_order() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("route-table.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "schema_version": 1,
+  "roles": {
+    "planner": {},
+    "executor": {},
+    "reviewer": {}
+  },
+  "planner": { "role": "planner", "fallback_roles": ["executor", "executor", "planner", "reviewer"] },
+  "delegated": { "role": "executor" },
+  "review": { "role": "reviewer" }
+}
+"#,
+        )
+        .expect("write route table");
+
+        let table = load_multi_agent_route_table(&path).expect("load route table");
+        let route = select_multi_agent_route(&table, MultiAgentRoutePhase::Planner, None);
+        assert_eq!(route.attempt_roles, vec!["planner", "executor", "reviewer"]);
+    }
+
+    #[test]
+    fn regression_route_table_validation_rejects_unknown_role_references() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("route-table.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "schema_version": 1,
+  "roles": {
+    "planner": {}
+  },
+  "planner": { "role": "missing" },
+  "delegated": { "role": "planner" },
+  "review": { "role": "planner" }
+}
+"#,
+        )
+        .expect("write route table");
+
+        let error = load_multi_agent_route_table(&path).expect_err("unknown role should fail");
+        assert!(error.to_string().contains("references unknown role"));
+    }
+
+    #[test]
+    fn regression_role_prompt_builder_keeps_legacy_prompt_for_default_profile() {
+        let base = "base prompt";
+        let rendered = build_multi_agent_role_prompt(
+            base,
+            MultiAgentRoutePhase::Planner,
+            "default",
+            &MultiAgentRoleProfile::default(),
+        );
+        assert_eq!(rendered, base);
+    }
+
+    #[test]
+    fn functional_role_prompt_builder_includes_profile_context_and_suffix() {
+        let base = "base prompt";
+        let rendered = build_multi_agent_role_prompt(
+            base,
+            MultiAgentRoutePhase::Review,
+            "reviewer",
+            &MultiAgentRoleProfile {
+                model: Some("openai/gpt-4o-mini".to_string()),
+                prompt_suffix: Some("Check edge cases.".to_string()),
+                tool_policy_preset: Some("balanced".to_string()),
+            },
+        );
+        assert!(rendered.contains("ORCHESTRATOR_ROLE_CONTEXT"));
+        assert!(rendered.contains("role=reviewer"));
+        assert!(rendered.contains("model_hint=openai/gpt-4o-mini"));
+        assert!(rendered.contains("Check edge cases."));
+    }
+}

--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -78,6 +78,12 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         enabled: cli.extension_runtime_hooks,
         root: cli.extension_runtime_root.clone(),
     };
+    let orchestrator_route_table = if let Some(path) = cli.orchestrator_route_table.as_deref() {
+        load_multi_agent_route_table(path)?
+    } else {
+        MultiAgentRouteTable::default()
+    };
+    let orchestrator_route_trace_log = cli.telemetry_log.as_deref();
     let extension_runtime_registrations = if extension_runtime_hooks.enabled {
         discover_extension_runtime_registrations(&extension_runtime_hooks.root)
     } else {
@@ -116,6 +122,8 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 cli.orchestrator_max_delegated_step_response_chars,
                 cli.orchestrator_max_delegated_total_response_chars,
                 cli.orchestrator_delegate_steps,
+                &orchestrator_route_table,
+                orchestrator_route_trace_log,
                 tool_policy_json,
                 &extension_runtime_hooks,
             )
@@ -170,6 +178,8 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         orchestrator_max_delegated_total_response_chars: cli
             .orchestrator_max_delegated_total_response_chars,
         orchestrator_delegate_steps: cli.orchestrator_delegate_steps,
+        orchestrator_route_table: &orchestrator_route_table,
+        orchestrator_route_trace_log,
         command_context,
     };
     if let Some(command_file_path) = cli.command_file.as_deref() {

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -47,21 +47,21 @@ use super::{
     execute_skills_trust_rotate_command, execute_skills_verify_command, execute_startup_preflight,
     format_id_list, format_remap_ids, handle_command, handle_command_with_session_import_mode,
     initialize_session, is_retryable_provider_error, load_branch_aliases, load_credential_store,
-    load_macro_file, load_profile_store, load_session_bookmarks, load_trust_root_records,
-    parse_auth_command, parse_branch_alias_command, parse_command, parse_command_file,
-    parse_doctor_command_args, parse_integration_auth_command, parse_macro_command,
-    parse_numbered_plan_steps, parse_profile_command, parse_sandbox_command_tokens,
-    parse_session_bookmark_command, parse_session_diff_args, parse_session_search_args,
-    parse_session_stats_args, parse_skills_lock_diff_args, parse_skills_prune_args,
-    parse_skills_search_args, parse_skills_trust_list_args, parse_skills_trust_mutation_args,
-    parse_skills_verify_args, parse_trust_rotation_spec, parse_trusted_root_spec,
-    percentile_duration_ms, provider_auth_capability, refresh_provider_access_token,
-    register_runtime_extension_tool_hook_subscriber, render_audit_summary, render_command_help,
-    render_doctor_report, render_doctor_report_json, render_help_overview, render_macro_list,
-    render_macro_show, render_profile_diffs, render_profile_list, render_profile_show,
-    render_session_diff, render_session_graph_dot, render_session_graph_mermaid,
-    render_session_stats, render_session_stats_json, render_skills_list,
-    render_skills_lock_diff_drift, render_skills_lock_diff_in_sync,
+    load_macro_file, load_multi_agent_route_table, load_profile_store, load_session_bookmarks,
+    load_trust_root_records, parse_auth_command, parse_branch_alias_command, parse_command,
+    parse_command_file, parse_doctor_command_args, parse_integration_auth_command,
+    parse_macro_command, parse_numbered_plan_steps, parse_profile_command,
+    parse_sandbox_command_tokens, parse_session_bookmark_command, parse_session_diff_args,
+    parse_session_search_args, parse_session_stats_args, parse_skills_lock_diff_args,
+    parse_skills_prune_args, parse_skills_search_args, parse_skills_trust_list_args,
+    parse_skills_trust_mutation_args, parse_skills_verify_args, parse_trust_rotation_spec,
+    parse_trusted_root_spec, percentile_duration_ms, provider_auth_capability,
+    refresh_provider_access_token, register_runtime_extension_tool_hook_subscriber,
+    render_audit_summary, render_command_help, render_doctor_report, render_doctor_report_json,
+    render_help_overview, render_macro_list, render_macro_show, render_profile_diffs,
+    render_profile_list, render_profile_show, render_session_diff, render_session_graph_dot,
+    render_session_graph_mermaid, render_session_stats, render_session_stats_json,
+    render_skills_list, render_skills_lock_diff_drift, render_skills_lock_diff_in_sync,
     render_skills_lock_write_success, render_skills_search, render_skills_show,
     render_skills_sync_drift_details, render_skills_trust_list, render_skills_verify_report,
     resolve_credential_store_encryption_mode, resolve_fallback_models, resolve_prompt_input,
@@ -69,12 +69,12 @@ use super::{
     resolve_session_graph_format, resolve_skill_trust_roots, resolve_skills_lock_path,
     resolve_store_backed_provider_credential, resolve_system_prompt, rpc_capabilities_payload,
     run_doctor_checks, run_plan_first_prompt, run_plan_first_prompt_with_policy_context,
-    run_prompt_with_cancellation, save_branch_aliases, save_credential_store, save_macro_file,
-    save_profile_store, save_session_bookmarks, search_session_entries,
-    session_bookmark_path_for_session, session_message_preview, shared_lineage_prefix_depth,
-    stream_text_chunks, summarize_audit_file, tool_audit_event_json, tool_policy_to_json,
-    trust_record_status, unknown_command_message, validate_branch_alias_name,
-    validate_event_webhook_ingest_cli, validate_events_runner_cli,
+    run_plan_first_prompt_with_policy_context_and_routing, run_prompt_with_cancellation,
+    save_branch_aliases, save_credential_store, save_macro_file, save_profile_store,
+    save_session_bookmarks, search_session_entries, session_bookmark_path_for_session,
+    session_message_preview, shared_lineage_prefix_depth, stream_text_chunks, summarize_audit_file,
+    tool_audit_event_json, tool_policy_to_json, trust_record_status, unknown_command_message,
+    validate_branch_alias_name, validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_github_issues_bridge_cli, validate_macro_command_entry, validate_macro_name,
     validate_profile_name, validate_rpc_frame_file, validate_session_file,
     validate_skills_prune_file_name, validate_slack_bridge_cli, AuthCommand, AuthCommandConfig,
@@ -85,16 +85,17 @@ use super::{
     CredentialStoreData, CredentialStoreEncryptionMode, DoctorCheckResult, DoctorCommandConfig,
     DoctorCommandOutputFormat, DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient,
     IntegrationAuthCommand, IntegrationCredentialStoreRecord, MacroCommand, MacroFile,
-    ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
-    ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions, RuntimeExtensionHooksConfig,
-    SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry, SessionDiffReport,
-    SessionGraphFormat, SessionRuntime, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
-    SkillsPruneMode, SkillsSyncCommandConfig, SkillsVerifyEntry, SkillsVerifyReport,
-    SkillsVerifyStatus, SkillsVerifySummary, SkillsVerifyTrustSummary, ToolAuditLogger,
-    TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION,
-    MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
-    SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
-    SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
+    MultiAgentRouteTable, ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus,
+    PromptTelemetryLogger, ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions,
+    RuntimeExtensionHooksConfig, SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry,
+    SessionDiffReport, SessionGraphFormat, SessionRuntime, SessionSearchArgs, SessionStats,
+    SessionStatsOutputFormat, SkillsPruneMode, SkillsSyncCommandConfig, SkillsVerifyEntry,
+    SkillsVerifyReport, SkillsVerifyStatus, SkillsVerifySummary, SkillsVerifyTrustSummary,
+    ToolAuditLogger, TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE,
+    MACRO_SCHEMA_VERSION, MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE,
+    SESSION_BOOKMARK_SCHEMA_VERSION, SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS,
+    SESSION_SEARCH_PREVIEW_CHARS, SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE,
+    SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
 };
 use crate::auth_commands::{
     auth_availability_counts, auth_mode_counts, auth_provider_counts, auth_revoked_counts,
@@ -350,6 +351,7 @@ fn test_cli() -> Cli {
         orchestrator_max_delegated_step_response_chars: 20_000,
         orchestrator_max_delegated_total_response_chars: 160_000,
         orchestrator_delegate_steps: false,
+        orchestrator_route_table: None,
         prompt_file: None,
         prompt_template_file: None,
         prompt_template_var: vec![],
@@ -825,6 +827,7 @@ fn unit_cli_orchestrator_flags_default_values_are_stable() {
     assert_eq!(cli.orchestrator_max_delegated_step_response_chars, 20_000);
     assert_eq!(cli.orchestrator_max_delegated_total_response_chars, 160_000);
     assert!(!cli.orchestrator_delegate_steps);
+    assert!(cli.orchestrator_route_table.is_none());
 }
 
 #[test]
@@ -843,6 +846,8 @@ fn functional_cli_orchestrator_flags_accept_overrides() {
         "80",
         "--orchestrator-max-delegated-total-response-chars",
         "240",
+        "--orchestrator-route-table",
+        ".tau/orchestrator/route-table.json",
         "--orchestrator-delegate-steps",
     ]);
     assert_eq!(cli.orchestrator_mode, CliOrchestratorMode::PlanFirst);
@@ -851,6 +856,10 @@ fn functional_cli_orchestrator_flags_accept_overrides() {
     assert_eq!(cli.orchestrator_max_executor_response_chars, 160);
     assert_eq!(cli.orchestrator_max_delegated_step_response_chars, 80);
     assert_eq!(cli.orchestrator_max_delegated_total_response_chars, 240);
+    assert_eq!(
+        cli.orchestrator_route_table.as_deref(),
+        Some(Path::new(".tau/orchestrator/route-table.json"))
+    );
     assert!(cli.orchestrator_delegate_steps);
 }
 
@@ -13030,6 +13039,268 @@ fn unit_parse_numbered_plan_steps_accepts_deterministic_step_format() {
             "Implement fix".to_string(),
             "Verify".to_string(),
         ]
+    );
+}
+
+fn write_route_table_fixture(path: &Path, body: &str) {
+    std::fs::write(path, body).expect("write route table fixture");
+}
+
+#[tokio::test]
+async fn integration_run_plan_first_prompt_with_routing_uses_distinct_delegated_roles() {
+    let temp = tempdir().expect("tempdir");
+    let route_table_path = temp.path().join("route-table.json");
+    write_route_table_fixture(
+        &route_table_path,
+        r#"{
+  "schema_version": 1,
+  "roles": {
+    "planner": { "prompt_suffix": "Plan with strict ordering." },
+    "executor": { "prompt_suffix": "Execute only implementation steps." },
+    "reviewer": { "prompt_suffix": "Focus on verification evidence." }
+  },
+  "planner": { "role": "planner" },
+  "delegated": { "role": "executor" },
+  "delegated_categories": {
+    "verify": { "role": "reviewer" }
+  },
+  "review": { "role": "reviewer" }
+}"#,
+    );
+    let route_table = load_multi_agent_route_table(&route_table_path).expect("load route table");
+
+    let mut agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(VecDeque::from([
+                Ok(ChatResponse {
+                    message: Message::assistant_text("1. Apply patch\n2. Verify behavior"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+                Ok(ChatResponse {
+                    message: Message::assistant_text("patch applied"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+                Ok(ChatResponse {
+                    message: Message::assistant_text("verification complete"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+                Ok(ChatResponse {
+                    message: Message::assistant_text("final delegated response"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+            ])),
+        }),
+        AgentConfig::default(),
+    );
+    let mut runtime = None;
+
+    run_plan_first_prompt_with_policy_context_and_routing(
+        &mut agent,
+        &mut runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        4,
+        4,
+        512,
+        512,
+        1_024,
+        true,
+        Some("preset=balanced;max_command_length=4096"),
+        &route_table,
+        None,
+    )
+    .await
+    .expect("delegated routed execution should succeed");
+
+    let user_prompts = agent
+        .messages()
+        .iter()
+        .filter(|message| message.role == MessageRole::User)
+        .map(|message| message.text_content())
+        .collect::<Vec<_>>();
+    assert!(user_prompts
+        .iter()
+        .any(|prompt| prompt.contains("phase=planner") && prompt.contains("role=planner")));
+    assert!(user_prompts.iter().any(|prompt| {
+        prompt.contains("phase=delegated-step") && prompt.contains("role=executor")
+    }));
+    assert!(user_prompts.iter().any(|prompt| {
+        prompt.contains("phase=delegated-step") && prompt.contains("role=reviewer")
+    }));
+    assert!(user_prompts
+        .iter()
+        .any(|prompt| prompt.contains("phase=review") && prompt.contains("role=reviewer")));
+    assert_eq!(
+        agent
+            .messages()
+            .last()
+            .expect("assistant response")
+            .text_content(),
+        "final delegated response"
+    );
+}
+
+#[tokio::test]
+async fn functional_run_plan_first_prompt_with_routing_emits_fallback_trace_records() {
+    let temp = tempdir().expect("tempdir");
+    let route_table_path = temp.path().join("route-table.json");
+    let telemetry_log = temp.path().join("telemetry.ndjson");
+    write_route_table_fixture(
+        &route_table_path,
+        r#"{
+  "schema_version": 1,
+  "roles": {
+    "planner-primary": {},
+    "planner-fallback": {},
+    "reviewer": {}
+  },
+  "planner": { "role": "planner-primary", "fallback_roles": ["planner-fallback"] },
+  "delegated": { "role": "planner-fallback" },
+  "review": { "role": "reviewer" }
+}"#,
+    );
+    let route_table = load_multi_agent_route_table(&route_table_path).expect("load route table");
+
+    let mut agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(VecDeque::from([
+                Err(TauAiError::InvalidResponse(
+                    "planner primary failed".to_string(),
+                )),
+                Ok(ChatResponse {
+                    message: Message::assistant_text("1. Inspect constraints\n2. Apply fix"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+                Ok(ChatResponse {
+                    message: Message::assistant_text("final execution"),
+                    finish_reason: Some("stop".to_string()),
+                    usage: ChatUsage::default(),
+                }),
+            ])),
+        }),
+        AgentConfig::default(),
+    );
+    let mut runtime = None;
+
+    run_plan_first_prompt_with_policy_context_and_routing(
+        &mut agent,
+        &mut runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        4,
+        4,
+        512,
+        512,
+        1_024,
+        false,
+        None,
+        &route_table,
+        Some(telemetry_log.as_path()),
+    )
+    .await
+    .expect("fallback planner route should recover");
+
+    let telemetry = std::fs::read_to_string(&telemetry_log).expect("read telemetry log");
+    assert!(telemetry.contains("\"record_type\":\"orchestrator_route_trace_v1\""));
+    assert!(telemetry.contains("\"event\":\"fallback\""));
+    assert!(telemetry.contains("\"decision\":\"retry\""));
+    assert!(telemetry.contains("\"reason\":\"prompt_execution_error\""));
+    assert!(telemetry.contains("\"phase\":\"planner\""));
+}
+
+#[tokio::test]
+async fn regression_routed_orchestrator_default_profile_matches_legacy_behavior() {
+    let legacy_responses = VecDeque::from([
+        Ok(ChatResponse {
+            message: Message::assistant_text("1. Inspect constraints\n2. Apply change"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        }),
+        Ok(ChatResponse {
+            message: Message::assistant_text("legacy final"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        }),
+    ]);
+    let routed_responses = VecDeque::from([
+        Ok(ChatResponse {
+            message: Message::assistant_text("1. Inspect constraints\n2. Apply change"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        }),
+        Ok(ChatResponse {
+            message: Message::assistant_text("legacy final"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        }),
+    ]);
+    let mut legacy_agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(legacy_responses),
+        }),
+        AgentConfig::default(),
+    );
+    let mut routed_agent = Agent::new(
+        Arc::new(SequenceClient {
+            outcomes: AsyncMutex::new(routed_responses),
+        }),
+        AgentConfig::default(),
+    );
+    let mut legacy_runtime = None;
+    let mut routed_runtime = None;
+
+    run_plan_first_prompt(
+        &mut legacy_agent,
+        &mut legacy_runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        4,
+        4,
+        512,
+        512,
+        1_024,
+        false,
+    )
+    .await
+    .expect("legacy run should succeed");
+    run_plan_first_prompt_with_policy_context_and_routing(
+        &mut routed_agent,
+        &mut routed_runtime,
+        "ship feature",
+        0,
+        test_render_options(),
+        4,
+        4,
+        512,
+        512,
+        1_024,
+        false,
+        None,
+        &MultiAgentRouteTable::default(),
+        None,
+    )
+    .await
+    .expect("routed default run should succeed");
+
+    assert_eq!(
+        legacy_agent
+            .messages()
+            .last()
+            .expect("legacy final")
+            .text_content(),
+        routed_agent
+            .messages()
+            .last()
+            .expect("routed final")
+            .text_content()
     );
 }
 


### PR DESCRIPTION
Closes #495

## Summary of behavior changes
- Adds orchestrator route-table schema and loader for planner/delegated/review role routing.
- Adds role profiles (model hint, prompt suffix, tool-policy preset hint) and deterministic route selection with category routing for delegated steps.
- Integrates routing into plan-first orchestrator phases with fallback attempts on execution errors.
- Emits route decisions and fallback outcomes to stdout trace lines and structured telemetry NDJSON when telemetry logging is enabled.
- Adds CLI route-table configuration via --orchestrator-route-table / TAU_ORCHESTRATOR_ROUTE_TABLE.

## Risks and compatibility notes
- Default behavior remains unchanged when no route-table is provided.
- New telemetry records append to existing telemetry logs using record_type=orchestrator_route_trace_v1.
- Fallback currently triggers on prompt execution errors; empty-output and budget violations remain fail-closed.

## Validation evidence
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent plan_first_prompt -- --test-threads=1
- cargo test -p tau-coding-agent multi_agent_router -- --test-threads=1
- cargo test -p tau-coding-agent orchestrator_flags -- --test-threads=1
- cargo test -p tau-coding-agent -- --test-threads=1 (fails in this sandbox: httpmock socket bind restricted)
- cargo test --workspace -- --test-threads=1 (fails in this sandbox: httpmock socket bind restricted)