### PR TITLE
feat: live canvas session linkage and transport-safe remote canvas stream

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -257,7 +257,7 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
         usage: CANVAS_USAGE,
         description: "Manage collaborative live-canvas state backed by Yrs CRDT persistence",
         details:
-            "Supports create/update/show/export flows for node and edge state with deterministic markdown/json renderers.",
+            "Supports create/update/show/export/import flows for node and edge state with deterministic markdown/json renderers and replay-safe event envelopes.",
         example: "/canvas update architecture node-upsert api \"API Service\" 120 64",
     },
     CommandSpec {
@@ -672,6 +672,12 @@ pub(crate) fn handle_command_with_session_import_mode(
     }
 
     if command_name == "/canvas" {
+        let session_link = session_runtime
+            .as_ref()
+            .map(|runtime| CanvasSessionLinkContext {
+                session_path: runtime.store.path().to_path_buf(),
+                session_head_id: runtime.active_head,
+            });
         println!(
             "{}",
             execute_canvas_command(
@@ -680,6 +686,8 @@ pub(crate) fn handle_command_with_session_import_mode(
                     canvas_root: PathBuf::from(".tau/canvas"),
                     channel_store_root: PathBuf::from(".tau/channel-store"),
                     principal: resolve_local_principal(),
+                    origin: CanvasEventOrigin::default(),
+                    session_link,
                 }
             )
         );

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -95,7 +95,10 @@ pub(crate) use crate::auth_commands::execute_auth_command;
 pub(crate) use crate::auth_commands::{parse_auth_command, AuthCommand};
 pub(crate) use crate::auth_types::{CredentialStoreEncryptionMode, ProviderAuthMethod};
 pub(crate) use crate::bootstrap_helpers::{command_file_error_mode_label, init_tracing};
-pub(crate) use crate::canvas::{execute_canvas_command, CanvasCommandConfig, CANVAS_USAGE};
+pub(crate) use crate::canvas::{
+    execute_canvas_command, CanvasCommandConfig, CanvasEventOrigin, CanvasSessionLinkContext,
+    CANVAS_USAGE,
+};
 use crate::channel_store::ChannelStore;
 pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -8832,7 +8832,7 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/skills-sync [lockfile_path]"));
     assert!(help.contains("/macro <save|run|list|show|delete> ..."));
     assert!(help.contains("/auth <login|status|logout|matrix> ..."));
-    assert!(help.contains("/canvas <create|update|show|export>"));
+    assert!(help.contains("/canvas <create|update|show|export|import>"));
     assert!(help.contains("/rbac <check|whoami> ..."));
     assert!(help.contains("/approvals <list|approve|reject> [--json] [--status <pending|approved|rejected|expired|consumed>] [request_id] [reason]"));
     assert!(help.contains("/integration-auth <set|status|rotate|revoke> ..."));
@@ -8895,7 +8895,7 @@ fn functional_render_command_help_supports_profile_topic_without_slash() {
 fn functional_render_command_help_supports_canvas_topic_without_slash() {
     let help = render_command_help("canvas").expect("render help");
     assert!(help.contains("command: /canvas"));
-    assert!(help.contains("usage: /canvas <create|update|show|export>"));
+    assert!(help.contains("usage: /canvas <create|update|show|export|import>"));
     assert!(help.contains("example: /canvas update architecture node-upsert"));
 }
 


### PR DESCRIPTION
## Summary
- add replay-safe canvas event envelopes with deterministic `event_id` and remote source metadata
- add canvas/session linkage persistence (`session-links.jsonl`) and local command linkage from active session runtime
- add `/canvas import <canvas_id> <path>` with schema/id validation and deterministic snapshot normalization
- add `/tau canvas ...` command handling for both GitHub Issues and Slack bridges with transport metadata and session head association

Closes #509

## Risks and compatibility
- canvas `events.jsonl` schema now includes additional fields (`schema_version`, `event_id`, `origin`, `session_link`); older records remain readable via serde defaults
- channel-store canvas event keys now include the event id suffix (`canvas:<action>:<event_id>`)
- remote replay guard intentionally skips duplicate and stale out-of-order remote events to maintain deterministic convergence

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent canvas -- --test-threads=1`
- `cargo test --workspace`
