### PR TITLE
feat(auth): add reauth workflow and fallback diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Auth mode guidance (local subscription login vs CI):
 | Anthropic | `--anthropic-auth-mode oauth-token` or `session-token` with Claude backend (`--anthropic-claude-backend=true`) | `--anthropic-auth-mode api-key` with `ANTHROPIC_API_KEY` |
 | Google | `--google-auth-mode oauth-token` (Gemini login) or `--google-auth-mode adc` (Vertex/ADC) with Gemini backend (`--google-gemini-backend=true`) | `--google-auth-mode api-key` with `GEMINI_API_KEY` |
 
-`/auth status` and `/auth matrix` include `supported`, `available`, `source`, `expires`, `refreshable`, and `next_action` fields for deterministic diagnostics and machine parsing.
-`/auth login` supports an opt-in `--launch` mode for provider CLI login bootstrap (`codex --login`, `claude`, `gemini`, `gcloud auth application-default login`).
+`/auth status` and `/auth matrix` include deterministic machine-readable auth diagnostics: `supported`, `available`, `source`, `expires`, `refreshable`, `fallback_order`, `fallback_mode`, `fallback_available`, `reauth_prerequisites`, and `next_action`.
+`/auth login` and `/auth reauth` support an opt-in `--launch` mode for provider CLI login bootstrap (`codex --login`, `claude`, `gemini`, `gcloud auth application-default login`).
 
 Set an API key for your provider:
 
@@ -141,6 +141,16 @@ cargo run -p tau-coding-agent -- \
 ```
 
 `tau-coding-agent` prefers provider credential-store oauth/session entries when present; if the OpenAI entry is missing and Codex backend is enabled, it falls back to `codex exec` for local subscription-backed runs.
+
+Use explicit reauth diagnostics and recovery planning:
+
+```bash
+# emits recovery/fallback hints without launching provider CLI
+/auth reauth openai --mode oauth-token --json
+
+# launches provider login flow when supported
+/auth reauth openai --mode oauth-token --launch --json
+```
 
 Use Anthropic with Claude Code subscription login (without setting `ANTHROPIC_API_KEY`):
 

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -246,11 +246,11 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "/auth",
-        usage: "/auth <login|status|logout|matrix> ...",
+        usage: "/auth <login|reauth|status|logout|matrix> ...",
         description: "Manage provider authentication state and credential-store sessions",
         details:
-            "Supports login/status/logout flows plus provider-mode matrix diagnostics with optional --json output.",
-        example: "/auth matrix openai --mode oauth-token --json",
+            "Supports login/reauth/status/logout flows plus provider-mode matrix diagnostics with optional --json output.",
+        example: "/auth reauth openai --mode oauth-token --launch --json",
     },
     CommandSpec {
         name: "/canvas",

--- a/docs/provider-auth/provider-auth-capability-matrix.md
+++ b/docs/provider-auth/provider-auth-capability-matrix.md
@@ -22,6 +22,20 @@ Core fields:
 
 Diagnostics (`/auth status` and `/auth matrix`) read from this abstraction and never emit secrets.
 
+## CLI Reauth and Fallback Semantics
+- `/auth reauth <provider> [--mode <mode>] [--launch] [--json]` provides explicit recovery guidance per provider/mode.
+- Diagnostics now emit fallback planning fields:
+- `fallback_order`: provider-specific auth-mode recovery chain.
+- `fallback_mode`: first supported fallback mode for the current provider/mode.
+- `fallback_available`: whether the fallback mode is currently healthy.
+- `fallback_hint`: concrete switch/recovery action.
+- `reauth_prerequisites`: provider/mode prerequisites (CLI login/bootstrap requirements).
+
+Current recovery order policy:
+- OpenAI: `oauth_token > session_token > api_key`
+- Anthropic: `oauth_token > session_token > api_key`
+- Google: `oauth_token > adc > api_key`
+
 ## Capability Matrix
 | Provider/Channel | Auth Method | Subscription Login Usable for API Calls | Status | Notes |
 |---|---|---|---|---|


### PR DESCRIPTION
## Summary
- add explicit `/auth reauth` command surface with provider/mode targeting and optional `--launch`
- enrich `/auth status` and `/auth matrix` rows with fallback/recovery diagnostics:
  - `fallback_order`, `fallback_mode`, `fallback_available`, `fallback_reason_code`, `fallback_hint`
  - `reauth_prerequisites`
- switch reauth guidance from login-only hints to explicit `/auth reauth` flows
- update command help/usage and auth documentation with provider-specific reauth prerequisites and fallback order policy
- extend tests across unit, functional, integration, and regression auth paths

## Risks and Compatibility
- auth text row output now includes additional key/value fields; consumers parsing fixed token positions should tolerate additive fields
- new `/auth reauth` subcommand is additive and does not remove existing `/auth login` behavior
- fallback diagnostics use provider-mode planning heuristics and backend/store snapshots at render time

## Validation Evidence
- `cargo fmt --all`
- `cargo test -p tau-coding-agent execute_auth -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #522
