### PR TITLE
feat(runtime): include transport health in status commands

### DIFF
--- a/crates/tau-coding-agent/src/transport_health.rs
+++ b/crates/tau-coding-agent/src/transport_health.rs
@@ -23,3 +23,67 @@ pub(crate) struct TransportHealthSnapshot {
     #[serde(default)]
     pub(crate) last_cycle_duplicates: usize,
 }
+
+impl TransportHealthSnapshot {
+    pub(crate) fn status_lines(&self) -> Vec<String> {
+        vec![
+            format!("transport_updated_unix_ms: {}", self.updated_unix_ms),
+            format!("transport_cycle_duration_ms: {}", self.cycle_duration_ms),
+            format!("transport_queue_depth: {}", self.queue_depth),
+            format!("transport_active_runs: {}", self.active_runs),
+            format!("transport_failure_streak: {}", self.failure_streak),
+            format!(
+                "transport_last_cycle_discovered: {}",
+                self.last_cycle_discovered
+            ),
+            format!(
+                "transport_last_cycle_processed: {}",
+                self.last_cycle_processed
+            ),
+            format!(
+                "transport_last_cycle_completed: {}",
+                self.last_cycle_completed
+            ),
+            format!("transport_last_cycle_failed: {}", self.last_cycle_failed),
+            format!(
+                "transport_last_cycle_duplicates: {}",
+                self.last_cycle_duplicates
+            ),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransportHealthSnapshot;
+
+    #[test]
+    fn unit_transport_health_status_lines_are_deterministic() {
+        let snapshot = TransportHealthSnapshot {
+            updated_unix_ms: 100,
+            cycle_duration_ms: 25,
+            queue_depth: 3,
+            active_runs: 1,
+            failure_streak: 2,
+            last_cycle_discovered: 10,
+            last_cycle_processed: 8,
+            last_cycle_completed: 7,
+            last_cycle_failed: 1,
+            last_cycle_duplicates: 2,
+        };
+        let lines = snapshot.status_lines();
+        assert_eq!(lines[0], "transport_updated_unix_ms: 100");
+        assert_eq!(lines[3], "transport_active_runs: 1");
+        assert_eq!(lines[4], "transport_failure_streak: 2");
+        assert_eq!(lines[9], "transport_last_cycle_duplicates: 2");
+    }
+
+    #[test]
+    fn regression_transport_health_status_lines_render_default_zero_values() {
+        let snapshot = TransportHealthSnapshot::default();
+        let lines = snapshot.status_lines();
+        assert_eq!(lines[0], "transport_updated_unix_ms: 0");
+        assert_eq!(lines[4], "transport_failure_streak: 0");
+        assert_eq!(lines[9], "transport_last_cycle_duplicates: 0");
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic transport-health status lines on `TransportHealthSnapshot`
- include transport health diagnostics in Slack `/tau status` responses
- include transport health diagnostics in GitHub `/tau status` responses
- extend status rendering tests to cover default and legacy health behavior

Closes #536

## Risks and Compatibility
- status output now includes additional `transport_*` lines; existing fields and command behavior remain unchanged
- legacy state compatibility is preserved through defaulted health snapshots

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
