### PR TITLE
ci: path-scoped quality lane resolver and diagnostics

### DIFF
--- a/.github/scripts/ci_quality_mode.py
+++ b/.github/scripts/ci_quality_mode.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class QualityModeDecision:
+    mode: str
+    reason: str
+    heavy_changed: bool
+
+
+def parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in TRUE_VALUES
+
+
+def resolve_quality_mode(
+    event_name: str, head_ref: str, heavy_changed: bool
+) -> QualityModeDecision:
+    event = (event_name or "").strip().lower()
+    head = (head_ref or "").strip()
+    is_codex_branch = head.startswith("codex/")
+
+    if event == "pull_request" and is_codex_branch and not heavy_changed:
+        return QualityModeDecision(
+            mode="codex-light",
+            reason="codex-branch-non-heavy-pr",
+            heavy_changed=heavy_changed,
+        )
+    if event == "pull_request" and is_codex_branch and heavy_changed:
+        return QualityModeDecision(
+            mode="full",
+            reason="codex-branch-heavy-pr",
+            heavy_changed=heavy_changed,
+        )
+    if event == "pull_request":
+        return QualityModeDecision(
+            mode="full",
+            reason="pull-request-default",
+            heavy_changed=heavy_changed,
+        )
+    return QualityModeDecision(
+        mode="full",
+        reason="non-pr-default",
+        heavy_changed=heavy_changed,
+    )
+
+
+def render_summary(decision: QualityModeDecision) -> str:
+    lane = "light (codex smoke)" if decision.mode == "codex-light" else "full (workspace)"
+    heavy = "true" if decision.heavy_changed else "false"
+    return "\n".join(
+        [
+            "### CI Cost Governance",
+            f"- Mode: {decision.mode}",
+            f"- Lane: {lane}",
+            f"- Reason: {decision.reason}",
+            f"- Heavy paths changed: {heavy}",
+        ]
+    )
+
+
+def append_github_output(output_path: Path, decision: QualityModeDecision) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    heavy = "true" if decision.heavy_changed else "false"
+    lines = [
+        f"mode={decision.mode}",
+        f"reason={decision.reason}",
+        f"heavy_changed={heavy}",
+    ]
+    with output_path.open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(f"{line}\n")
+
+
+def append_summary(summary_path: Path, summary: str) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    with summary_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{summary}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Resolve CI quality mode and render cost-governance diagnostics."
+    )
+    parser.add_argument("--event-name", default="", help="GitHub event name")
+    parser.add_argument("--head-ref", default="", help="GitHub head ref")
+    parser.add_argument(
+        "--heavy-changed",
+        default="false",
+        help="Whether heavy paths changed (true/false)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to GITHUB_OUTPUT-compatible file",
+    )
+    parser.add_argument(
+        "--summary",
+        required=True,
+        help="Path to GITHUB_STEP_SUMMARY-compatible file",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    heavy_changed = parse_bool(args.heavy_changed)
+    decision = resolve_quality_mode(args.event_name, args.head_ref, heavy_changed)
+    append_github_output(Path(args.output), decision)
+    append_summary(Path(args.summary), render_summary(decision))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_quality_mode.py
+++ b/.github/scripts/test_ci_quality_mode.py
@@ -1,0 +1,85 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ci_quality_mode  # noqa: E402
+
+
+class QualityModeTests(unittest.TestCase):
+    def test_unit_resolve_quality_mode_codex_non_heavy_uses_light_lane(self):
+        decision = ci_quality_mode.resolve_quality_mode(
+            event_name="pull_request",
+            head_ref="codex/issue-123",
+            heavy_changed=False,
+        )
+        self.assertEqual(decision.mode, "codex-light")
+        self.assertEqual(decision.reason, "codex-branch-non-heavy-pr")
+        self.assertFalse(decision.heavy_changed)
+
+    def test_functional_render_summary_includes_cost_governance_fields(self):
+        decision = ci_quality_mode.QualityModeDecision(
+            mode="full",
+            reason="codex-branch-heavy-pr",
+            heavy_changed=True,
+        )
+        summary = ci_quality_mode.render_summary(decision)
+        self.assertIn("### CI Cost Governance", summary)
+        self.assertIn("- Mode: full", summary)
+        self.assertIn("- Reason: codex-branch-heavy-pr", summary)
+        self.assertIn("- Heavy paths changed: true", summary)
+
+    def test_integration_cli_writes_workflow_output_and_summary(self):
+        script_path = SCRIPT_DIR / "ci_quality_mode.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "github_output.txt"
+            summary_path = Path(temp_dir) / "summary.md"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(script_path),
+                    "--event-name",
+                    "pull_request",
+                    "--head-ref",
+                    "codex/issue-456",
+                    "--heavy-changed",
+                    "false",
+                    "--output",
+                    str(output_path),
+                    "--summary",
+                    str(summary_path),
+                ],
+                check=True,
+            )
+            output_raw = output_path.read_text(encoding="utf-8")
+            summary_raw = summary_path.read_text(encoding="utf-8")
+            self.assertIn("mode=codex-light", output_raw)
+            self.assertIn("reason=codex-branch-non-heavy-pr", output_raw)
+            self.assertIn("heavy_changed=false", output_raw)
+            self.assertIn("Lane: light (codex smoke)", summary_raw)
+
+    def test_regression_non_codex_or_heavy_pr_never_downgrades(self):
+        non_codex = ci_quality_mode.resolve_quality_mode(
+            event_name="pull_request",
+            head_ref="feature/new-lane",
+            heavy_changed=False,
+        )
+        self.assertEqual(non_codex.mode, "full")
+        self.assertEqual(non_codex.reason, "pull-request-default")
+
+        heavy_codex = ci_quality_mode.resolve_quality_mode(
+            event_name="pull_request",
+            head_ref="codex/issue-789",
+            heavy_changed=True,
+        )
+        self.assertEqual(heavy_codex.mode, "full")
+        self.assertEqual(heavy_codex.reason, "codex-branch-heavy-pr")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,20 +38,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Detect change scope
+        id: change_scope
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            heavy:
+              - "crates/tau-coding-agent/**"
+              - "crates/tau-agent-core/**"
+              - "crates/tau-ai/**"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - ".github/workflows/**"
+              - ".github/scripts/**"
+
+      - name: Validate CI quality mode helper
+        run: python3 -m unittest discover -s .github/scripts -p "test_ci_quality_mode.py"
+
       - name: Determine quality mode
         id: quality_mode
         shell: bash
         run: |
           set -euo pipefail
-          mode="full"
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.head_ref }}" == codex/* ]]; then
-            mode="codex-light"
+          heavy_changed="${{ steps.change_scope.outputs.heavy }}"
+          if [[ -z "${heavy_changed}" ]]; then
+            heavy_changed="false"
           fi
-          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Quality Mode"
-            echo "- Mode: ${mode}"
-          } >> "$GITHUB_STEP_SUMMARY"
+          python3 .github/scripts/ci_quality_mode.py \
+            --event-name "${{ github.event_name }}" \
+            --head-ref "${{ github.head_ref }}" \
+            --heavy-changed "${heavy_changed}" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Closes #538

## Summary
- add a deterministic CI lane resolver helper that computes quality mode from event type, head branch, and heavy-path scope
- wire PR path-scope detection (heavy_changed) into CI using dorny/paths-filter
- surface explicit cost-governance diagnostics in step summary (mode, lane, reason, heavy_changed)
- add dedicated helper tests mapped to unit/functional/integration/regression categories

## Risks and compatibility notes
- introduces a Python helper dependency in CI lane selection; hosted GitHub runners provide Python 3
- keeps full-lane behavior for non-codex PRs and non-PR events to avoid unintended quality downgrades

## Validation evidence
- python3 -m unittest discover -s .github/scripts -p test_ci_quality_mode.py
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
