### PR TITLE
ci: add deferred heavy lane scheduling and governance outputs

### DIFF
--- a/.github/scripts/ci_quality_mode.py
+++ b/.github/scripts/ci_quality_mode.py
@@ -15,47 +15,92 @@ class QualityModeDecision:
     mode: str
     reason: str
     heavy_changed: bool
+    run_coverage: bool
+    run_cross_platform: bool
+    heavy_reason: str
 
 
-def parse_bool(raw: str) -> bool:
+def parse_bool(raw: str | None) -> bool:
+    if raw is None:
+        return False
     return raw.strip().lower() in TRUE_VALUES
 
 
 def resolve_quality_mode(
-    event_name: str, head_ref: str, heavy_changed: bool
+    event_name: str,
+    head_ref: str,
+    heavy_changed: bool,
+    run_coverage_requested: bool,
+    run_cross_platform_requested: bool,
 ) -> QualityModeDecision:
     event = (event_name or "").strip().lower()
     head = (head_ref or "").strip()
     is_codex_branch = head.startswith("codex/")
+    run_coverage = False
+    run_cross_platform = False
+    heavy_reason = "non-deferred-event"
+
+    if event == "schedule":
+        run_coverage = True
+        run_cross_platform = True
+        heavy_reason = "scheduled-deferred-heavy"
+    elif event == "workflow_dispatch":
+        run_coverage = run_coverage_requested
+        run_cross_platform = run_cross_platform_requested
+        if run_coverage or run_cross_platform:
+            heavy_reason = "manual-dispatch-requested"
+        else:
+            heavy_reason = "manual-dispatch-default"
+    elif event == "pull_request":
+        heavy_reason = "pull-request-cost-governed"
 
     if event == "pull_request" and is_codex_branch and not heavy_changed:
         return QualityModeDecision(
             mode="codex-light",
             reason="codex-branch-non-heavy-pr",
             heavy_changed=heavy_changed,
+            run_coverage=run_coverage,
+            run_cross_platform=run_cross_platform,
+            heavy_reason=heavy_reason,
         )
     if event == "pull_request" and is_codex_branch and heavy_changed:
         return QualityModeDecision(
             mode="full",
             reason="codex-branch-heavy-pr",
             heavy_changed=heavy_changed,
+            run_coverage=run_coverage,
+            run_cross_platform=run_cross_platform,
+            heavy_reason=heavy_reason,
         )
     if event == "pull_request":
         return QualityModeDecision(
             mode="full",
             reason="pull-request-default",
             heavy_changed=heavy_changed,
+            run_coverage=run_coverage,
+            run_cross_platform=run_cross_platform,
+            heavy_reason=heavy_reason,
         )
     return QualityModeDecision(
         mode="full",
         reason="non-pr-default",
         heavy_changed=heavy_changed,
+        run_coverage=run_coverage,
+        run_cross_platform=run_cross_platform,
+        heavy_reason=heavy_reason,
     )
 
 
 def render_summary(decision: QualityModeDecision) -> str:
     lane = "light (codex smoke)" if decision.mode == "codex-light" else "full (workspace)"
     heavy = "true" if decision.heavy_changed else "false"
+    run_coverage = "true" if decision.run_coverage else "false"
+    run_cross_platform = "true" if decision.run_cross_platform else "false"
+    heavy_lane = (
+        "enabled"
+        if decision.run_coverage or decision.run_cross_platform
+        else "disabled"
+    )
     return "\n".join(
         [
             "### CI Cost Governance",
@@ -63,6 +108,10 @@ def render_summary(decision: QualityModeDecision) -> str:
             f"- Lane: {lane}",
             f"- Reason: {decision.reason}",
             f"- Heavy paths changed: {heavy}",
+            f"- Heavy lane: {heavy_lane}",
+            f"- Heavy reason: {decision.heavy_reason}",
+            f"- Run coverage: {run_coverage}",
+            f"- Run cross-platform smoke: {run_cross_platform}",
         ]
     )
 
@@ -70,10 +119,15 @@ def render_summary(decision: QualityModeDecision) -> str:
 def append_github_output(output_path: Path, decision: QualityModeDecision) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     heavy = "true" if decision.heavy_changed else "false"
+    run_coverage = "true" if decision.run_coverage else "false"
+    run_cross_platform = "true" if decision.run_cross_platform else "false"
     lines = [
         f"mode={decision.mode}",
         f"reason={decision.reason}",
         f"heavy_changed={heavy}",
+        f"run_coverage={run_coverage}",
+        f"run_cross_platform={run_cross_platform}",
+        f"heavy_reason={decision.heavy_reason}",
     ]
     with output_path.open("a", encoding="utf-8") as handle:
         for line in lines:
@@ -98,6 +152,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Whether heavy paths changed (true/false)",
     )
     parser.add_argument(
+        "--run-coverage",
+        default="false",
+        help="Whether coverage is requested by workflow dispatch input",
+    )
+    parser.add_argument(
+        "--run-cross-platform",
+        default="false",
+        help="Whether cross-platform smoke is requested by workflow dispatch input",
+    )
+    parser.add_argument(
         "--output",
         required=True,
         help="Path to GITHUB_OUTPUT-compatible file",
@@ -114,7 +178,15 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
     heavy_changed = parse_bool(args.heavy_changed)
-    decision = resolve_quality_mode(args.event_name, args.head_ref, heavy_changed)
+    run_coverage_requested = parse_bool(args.run_coverage)
+    run_cross_platform_requested = parse_bool(args.run_cross_platform)
+    decision = resolve_quality_mode(
+        args.event_name,
+        args.head_ref,
+        heavy_changed,
+        run_coverage_requested,
+        run_cross_platform_requested,
+    )
     append_github_output(Path(args.output), decision)
     append_summary(Path(args.summary), render_summary(decision))
     return 0

--- a/.github/scripts/test_ci_quality_mode.py
+++ b/.github/scripts/test_ci_quality_mode.py
@@ -17,22 +17,34 @@ class QualityModeTests(unittest.TestCase):
             event_name="pull_request",
             head_ref="codex/issue-123",
             heavy_changed=False,
+            run_coverage_requested=False,
+            run_cross_platform_requested=False,
         )
         self.assertEqual(decision.mode, "codex-light")
         self.assertEqual(decision.reason, "codex-branch-non-heavy-pr")
         self.assertFalse(decision.heavy_changed)
+        self.assertFalse(decision.run_coverage)
+        self.assertFalse(decision.run_cross_platform)
+        self.assertEqual(decision.heavy_reason, "pull-request-cost-governed")
 
     def test_functional_render_summary_includes_cost_governance_fields(self):
         decision = ci_quality_mode.QualityModeDecision(
             mode="full",
             reason="codex-branch-heavy-pr",
             heavy_changed=True,
+            run_coverage=True,
+            run_cross_platform=False,
+            heavy_reason="manual-dispatch-requested",
         )
         summary = ci_quality_mode.render_summary(decision)
         self.assertIn("### CI Cost Governance", summary)
         self.assertIn("- Mode: full", summary)
         self.assertIn("- Reason: codex-branch-heavy-pr", summary)
         self.assertIn("- Heavy paths changed: true", summary)
+        self.assertIn("- Heavy lane: enabled", summary)
+        self.assertIn("- Heavy reason: manual-dispatch-requested", summary)
+        self.assertIn("- Run coverage: true", summary)
+        self.assertIn("- Run cross-platform smoke: false", summary)
 
     def test_integration_cli_writes_workflow_output_and_summary(self):
         script_path = SCRIPT_DIR / "ci_quality_mode.py"
@@ -44,10 +56,14 @@ class QualityModeTests(unittest.TestCase):
                     sys.executable,
                     str(script_path),
                     "--event-name",
-                    "pull_request",
+                    "schedule",
                     "--head-ref",
                     "codex/issue-456",
                     "--heavy-changed",
+                    "false",
+                    "--run-coverage",
+                    "false",
+                    "--run-cross-platform",
                     "false",
                     "--output",
                     str(output_path),
@@ -58,27 +74,40 @@ class QualityModeTests(unittest.TestCase):
             )
             output_raw = output_path.read_text(encoding="utf-8")
             summary_raw = summary_path.read_text(encoding="utf-8")
-            self.assertIn("mode=codex-light", output_raw)
-            self.assertIn("reason=codex-branch-non-heavy-pr", output_raw)
+            self.assertIn("mode=full", output_raw)
+            self.assertIn("reason=non-pr-default", output_raw)
             self.assertIn("heavy_changed=false", output_raw)
-            self.assertIn("Lane: light (codex smoke)", summary_raw)
+            self.assertIn("run_coverage=true", output_raw)
+            self.assertIn("run_cross_platform=true", output_raw)
+            self.assertIn("heavy_reason=scheduled-deferred-heavy", output_raw)
+            self.assertIn("Heavy lane: enabled", summary_raw)
 
-    def test_regression_non_codex_or_heavy_pr_never_downgrades(self):
+    def test_regression_pull_request_never_enables_heavy_lane_from_manual_inputs(self):
         non_codex = ci_quality_mode.resolve_quality_mode(
             event_name="pull_request",
             head_ref="feature/new-lane",
             heavy_changed=False,
+            run_coverage_requested=True,
+            run_cross_platform_requested=True,
         )
         self.assertEqual(non_codex.mode, "full")
         self.assertEqual(non_codex.reason, "pull-request-default")
+        self.assertFalse(non_codex.run_coverage)
+        self.assertFalse(non_codex.run_cross_platform)
+        self.assertEqual(non_codex.heavy_reason, "pull-request-cost-governed")
 
         heavy_codex = ci_quality_mode.resolve_quality_mode(
             event_name="pull_request",
             head_ref="codex/issue-789",
             heavy_changed=True,
+            run_coverage_requested=True,
+            run_cross_platform_requested=True,
         )
         self.assertEqual(heavy_codex.mode, "full")
         self.assertEqual(heavy_codex.reason, "codex-branch-heavy-pr")
+        self.assertFalse(heavy_codex.run_coverage)
+        self.assertFalse(heavy_codex.run_cross_platform)
+        self.assertEqual(heavy_codex.heavy_reason, "pull-request-cost-governed")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - "**/*.md"
       - "docs/**"
+  schedule:
+    - cron: "0 8 * * 1"
   workflow_dispatch:
     inputs:
       run_coverage:
@@ -34,6 +36,10 @@ jobs:
     name: Quality (fmt + clippy + tests)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      run_coverage: ${{ steps.quality_mode.outputs.run_coverage }}
+      run_cross_platform: ${{ steps.quality_mode.outputs.run_cross_platform }}
+      heavy_reason: ${{ steps.quality_mode.outputs.heavy_reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,10 +71,20 @@ jobs:
           if [[ -z "${heavy_changed}" ]]; then
             heavy_changed="false"
           fi
+          coverage_requested="${{ inputs.run_coverage }}"
+          if [[ -z "${coverage_requested}" ]]; then
+            coverage_requested="false"
+          fi
+          cross_platform_requested="${{ inputs.run_cross_platform }}"
+          if [[ -z "${cross_platform_requested}" ]]; then
+            cross_platform_requested="false"
+          fi
           python3 .github/scripts/ci_quality_mode.py \
             --event-name "${{ github.event_name }}" \
             --head-ref "${{ github.head_ref }}" \
             --heavy-changed "${heavy_changed}" \
+            --run-coverage "${coverage_requested}" \
+            --run-cross-platform "${cross_platform_requested}" \
             --output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
@@ -96,7 +112,8 @@ jobs:
 
   cross-platform-smoke:
     name: Cross-platform compile smoke (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch' && inputs.run_cross_platform
+    needs: [quality-linux]
+    if: needs.quality-linux.outputs.run_cross_platform == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,7 +137,7 @@ jobs:
   coverage:
     name: Coverage (llvm-cov)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.run_coverage
+    if: needs.quality-linux.outputs.run_coverage == 'true'
     outputs:
       line_coverage: ${{ steps.coverage.outputs.line_coverage }}
     needs: [quality-linux]


### PR DESCRIPTION
Closes #540

## Summary
- extend CI lane resolver to compute deferred heavy-job eligibility by trigger and dispatch inputs
- add resolver outputs for heavy governance: run_coverage, run_cross_platform, heavy_reason
- add weekly scheduled CI trigger for deferred heavy validation
- route coverage and cross-platform jobs from resolver outputs so PRs stay cost-governed while schedule/manual can run heavy lanes
- expand CI governance summary with heavy-lane diagnostics

## Risks and compatibility notes
- schedule trigger increases periodic CI activity; cadence is bounded to weekly and heavy jobs remain disabled for standard PRs
- workflow_dispatch behavior remains operator-controlled through existing run_coverage and run_cross_platform inputs
- required PR quality lane behavior remains unchanged

## Validation evidence
- python3 -m unittest discover -s .github/scripts -p test_ci_quality_mode.py
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
