### PR TITLE
feat(events): add startup events inspect diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,16 @@ cargo run -p tau-coding-agent -- \
   --events-queue-limit 64
 ```
 
+Inspect scheduled event due/queue health without executing events:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-inspect \
+  --events-inspect-json
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1225,6 +1225,29 @@ pub(crate) struct Cli {
     pub(crate) rpc_serve_ndjson: bool,
 
     #[arg(
+        long = "events-inspect",
+        env = "TAU_EVENTS_INSPECT",
+        default_value_t = false,
+        conflicts_with = "events_runner",
+        conflicts_with = "event_webhook_ingest_file",
+        help = "Inspect scheduled events state and due/queue diagnostics, then exit"
+    )]
+    pub(crate) events_inspect: bool,
+
+    #[arg(
+        long = "events-inspect-json",
+        env = "TAU_EVENTS_INSPECT_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "events_inspect",
+        help = "Emit --events-inspect output as pretty JSON"
+    )]
+    pub(crate) events_inspect_json: bool,
+
+    #[arg(
         long = "events-runner",
         env = "TAU_EVENTS_RUNNER",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -143,8 +143,8 @@ pub(crate) use crate::diagnostics_commands::{
     DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
-    ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
-    EventWebhookIngestConfig,
+    execute_events_inspect_command, ingest_webhook_immediate_event, run_event_scheduler,
+    EventSchedulerConfig, EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -119,6 +119,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.events_inspect {
+        execute_events_inspect_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli


### PR DESCRIPTION
## Summary
- add a new preflight command path for events diagnostics via `--events-inspect`
- add optional structured output via `--events-inspect-json`
- implement deterministic events inspection report math (due, queued, malformed, stale, schedule breakdown, periodic state coverage)
- keep inspect mode strictly read-only and integrate it into startup preflight
- document inspect usage in README

Closes #556

## Risks and compatibility notes
- low runtime risk: feature is preflight-only and does not alter scheduler execution behavior
- CLI surface expanded with two new flags (`--events-inspect`, `--events-inspect-json`)
- `--events-inspect` conflicts with `--events-runner` and `--event-webhook-ingest-file` to avoid ambiguous execution modes

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
