### PR TITLE
feat(events): add preflight definition validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,16 @@ cargo run -p tau-coding-agent -- \
   --events-inspect-json
 ```
 
+Validate scheduled event definitions and fail fast on invalid files:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-validate \
+  --events-validate-json
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1228,6 +1228,7 @@ pub(crate) struct Cli {
         long = "events-inspect",
         env = "TAU_EVENTS_INSPECT",
         default_value_t = false,
+        conflicts_with = "events_validate",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
         help = "Inspect scheduled events state and due/queue diagnostics, then exit"
@@ -1246,6 +1247,30 @@ pub(crate) struct Cli {
         help = "Emit --events-inspect output as pretty JSON"
     )]
     pub(crate) events_inspect_json: bool,
+
+    #[arg(
+        long = "events-validate",
+        env = "TAU_EVENTS_VALIDATE",
+        default_value_t = false,
+        conflicts_with = "events_inspect",
+        conflicts_with = "events_runner",
+        conflicts_with = "event_webhook_ingest_file",
+        help = "Validate scheduled event definition files and exit non-zero on invalid entries"
+    )]
+    pub(crate) events_validate: bool,
+
+    #[arg(
+        long = "events-validate-json",
+        env = "TAU_EVENTS_VALIDATE_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "events_validate",
+        help = "Emit --events-validate output as pretty JSON"
+    )]
+    pub(crate) events_validate_json: bool,
 
     #[arg(
         long = "events-runner",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -143,8 +143,9 @@ pub(crate) use crate::diagnostics_commands::{
     DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
-    execute_events_inspect_command, ingest_webhook_immediate_event, run_event_scheduler,
-    EventSchedulerConfig, EventWebhookIngestConfig,
+    execute_events_inspect_command, execute_events_validate_command,
+    ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
+    EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -124,6 +124,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.events_validate {
+        execute_events_validate_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli


### PR DESCRIPTION
## Summary
- add new events validation preflight controls: `--events-validate` and `--events-validate-json`
- implement deterministic events definition validator with per-file diagnostics and reason codes
- validate JSON/schema decode, channel reference shape, and periodic schedule evaluability
- fail fast with non-zero exit when invalid or malformed files are present
- add startup preflight dispatch for validation mode and document usage in README

Closes #560

## Risks and compatibility notes
- low runtime risk: all behavior is preflight-only and does not change scheduler execution flow
- CLI surface expanded with two new flags under events tooling
- validation intentionally fails command when invalid files are detected; this is a behavior change only for users invoking `--events-validate`

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
