### PR TITLE
feat(events): add event template writer preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,18 @@ cargo run -p tau-coding-agent -- \
   --events-validate-json
 ```
 
+Generate a schedule-specific event template file for bootstrap authoring:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-template-write .tau/events/daily-status.json \
+  --events-template-schedule periodic \
+  --events-template-channel github/owner/repo#42 \
+  --events-template-id daily-status \
+  --events-template-cron "0 0/15 * * * * *" \
+  --events-template-timezone UTC
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -66,6 +66,13 @@ pub(crate) enum CliWebhookSignatureAlgorithm {
     SlackV0,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliEventTemplateSchedule {
+    Immediate,
+    At,
+    Periodic,
+}
+
 impl From<CliWebhookSignatureAlgorithm> for WebhookSignatureAlgorithm {
     fn from(value: CliWebhookSignatureAlgorithm) -> Self {
         match value {

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -104,9 +104,9 @@ use crate::channel_store::ChannelStore;
 pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
-    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliOrchestratorMode,
-    CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset,
-    CliWebhookSignatureAlgorithm,
+    CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
+    CliEventTemplateSchedule, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
+    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
@@ -143,9 +143,9 @@ pub(crate) use crate::diagnostics_commands::{
     DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
-    execute_events_inspect_command, execute_events_validate_command,
-    ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
-    EventWebhookIngestConfig,
+    execute_events_inspect_command, execute_events_template_write_command,
+    execute_events_validate_command, ingest_webhook_immediate_event, run_event_scheduler,
+    EventSchedulerConfig, EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -129,6 +129,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.events_template_write.is_some() {
+        execute_events_template_write_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.event_webhook_ingest_file.is_some() {
         validate_event_webhook_ingest_cli(cli)?;
         let payload_file = cli


### PR DESCRIPTION
## Summary
- add preflight template scaffolding command: `--events-template-write`
- support schedule variants via `--events-template-schedule` (`immediate`, `at`, `periodic`)
- add safe overwrite guard with explicit opt-in `--events-template-overwrite`
- support authoring overrides for id/channel/prompt/at/cron/timezone
- validate channel ref and periodic schedule inputs before writing
- wire startup preflight dispatch and document template generation usage

Closes #563

## Risks and compatibility notes
- low runtime risk: behavior is preflight-only and does not alter scheduler runtime execution
- CLI surface expanded with events template authoring flags
- existing file paths are now protected by default; overwrite requires explicit flag

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
