### PR TITLE
feat(coding-agent): add events simulation preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,17 @@ cargo run -p tau-coding-agent -- \
   --events-template-timezone UTC
 ```
 
+Simulate next-due schedule posture without executing events:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-simulate \
+  --events-simulate-horizon-seconds 3600 \
+  --events-simulate-json
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1229,6 +1229,7 @@ pub(crate) struct Cli {
         env = "TAU_EVENTS_INSPECT",
         default_value_t = false,
         conflicts_with = "events_validate",
+        conflicts_with = "events_simulate",
         conflicts_with = "events_template_write",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
@@ -1254,6 +1255,7 @@ pub(crate) struct Cli {
         env = "TAU_EVENTS_VALIDATE",
         default_value_t = false,
         conflicts_with = "events_inspect",
+        conflicts_with = "events_simulate",
         conflicts_with = "events_template_write",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
@@ -1275,11 +1277,47 @@ pub(crate) struct Cli {
     pub(crate) events_validate_json: bool,
 
     #[arg(
+        long = "events-simulate",
+        env = "TAU_EVENTS_SIMULATE",
+        default_value_t = false,
+        conflicts_with = "events_inspect",
+        conflicts_with = "events_validate",
+        conflicts_with = "events_template_write",
+        conflicts_with = "events_runner",
+        conflicts_with = "event_webhook_ingest_file",
+        help = "Simulate next event due timings and horizon posture, then exit"
+    )]
+    pub(crate) events_simulate: bool,
+
+    #[arg(
+        long = "events-simulate-json",
+        env = "TAU_EVENTS_SIMULATE_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "events_simulate",
+        help = "Emit --events-simulate output as pretty JSON"
+    )]
+    pub(crate) events_simulate_json: bool,
+
+    #[arg(
+        long = "events-simulate-horizon-seconds",
+        env = "TAU_EVENTS_SIMULATE_HORIZON_SECONDS",
+        default_value_t = 3_600,
+        requires = "events_simulate",
+        help = "Horizon window used to classify event next-due timing"
+    )]
+    pub(crate) events_simulate_horizon_seconds: u64,
+
+    #[arg(
         long = "events-template-write",
         env = "TAU_EVENTS_TEMPLATE_WRITE",
         value_name = "PATH",
         conflicts_with = "events_inspect",
         conflicts_with = "events_validate",
+        conflicts_with = "events_simulate",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
         help = "Write a schedule-specific event template JSON file and exit"

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -143,9 +143,10 @@ pub(crate) use crate::diagnostics_commands::{
     DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
-    execute_events_inspect_command, execute_events_template_write_command,
-    execute_events_validate_command, ingest_webhook_immediate_event, run_event_scheduler,
-    EventSchedulerConfig, EventWebhookIngestConfig,
+    execute_events_inspect_command, execute_events_simulate_command,
+    execute_events_template_write_command, execute_events_validate_command,
+    ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
+    EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -129,6 +129,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.events_simulate {
+        execute_events_simulate_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.events_template_write.is_some() {
         execute_events_template_write_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add startup preflight command `--events-simulate` with optional JSON output
- add simulation horizon flag `--events-simulate-horizon-seconds`
- compute deterministic schedule simulation rows for immediate/at/periodic events and classify each row as due, within-horizon, or beyond-horizon
- include malformed and invalid definition diagnostics in the simulation report
- document CLI usage in README and wire command into startup preflight routing

Closes #566

## Risks and compatibility
- low runtime risk: new behavior is opt-in preflight path only and does not alter the normal prompt loop
- compatibility risk: none for existing flags; conflicts are explicit with other event preflight commands
- operational consideration: large event directories can produce larger report output; JSON mode is provided for machine parsing

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Test matrix
- Unit: schedule classification and report row semantics for due/horizon/beyond-horizon states
- Functional: text report rendering and CLI-facing report behavior
- Integration: mixed schedule simulation with persisted state replay
- Regression: malformed/invalid definitions and stale schedules continue to report deterministically
