### PR TITLE
feat(events): add dry-run preflight execution preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,17 @@ cargo run -p tau-coding-agent -- \
   --events-simulate-json
 ```
 
+Preview event execution selection without mutating files or state:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-queue-limit 64 \
+  --events-dry-run \
+  --events-dry-run-json
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1230,6 +1230,7 @@ pub(crate) struct Cli {
         default_value_t = false,
         conflicts_with = "events_validate",
         conflicts_with = "events_simulate",
+        conflicts_with = "events_dry_run",
         conflicts_with = "events_template_write",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
@@ -1256,6 +1257,7 @@ pub(crate) struct Cli {
         default_value_t = false,
         conflicts_with = "events_inspect",
         conflicts_with = "events_simulate",
+        conflicts_with = "events_dry_run",
         conflicts_with = "events_template_write",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
@@ -1282,6 +1284,7 @@ pub(crate) struct Cli {
         default_value_t = false,
         conflicts_with = "events_inspect",
         conflicts_with = "events_validate",
+        conflicts_with = "events_dry_run",
         conflicts_with = "events_template_write",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
@@ -1312,12 +1315,40 @@ pub(crate) struct Cli {
     pub(crate) events_simulate_horizon_seconds: u64,
 
     #[arg(
+        long = "events-dry-run",
+        env = "TAU_EVENTS_DRY_RUN",
+        default_value_t = false,
+        conflicts_with = "events_inspect",
+        conflicts_with = "events_validate",
+        conflicts_with = "events_simulate",
+        conflicts_with = "events_template_write",
+        conflicts_with = "events_runner",
+        conflicts_with = "event_webhook_ingest_file",
+        help = "Preview which events would execute now without mutating state or files"
+    )]
+    pub(crate) events_dry_run: bool,
+
+    #[arg(
+        long = "events-dry-run-json",
+        env = "TAU_EVENTS_DRY_RUN_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "events_dry_run",
+        help = "Emit --events-dry-run output as pretty JSON"
+    )]
+    pub(crate) events_dry_run_json: bool,
+
+    #[arg(
         long = "events-template-write",
         env = "TAU_EVENTS_TEMPLATE_WRITE",
         value_name = "PATH",
         conflicts_with = "events_inspect",
         conflicts_with = "events_validate",
         conflicts_with = "events_simulate",
+        conflicts_with = "events_dry_run",
         conflicts_with = "events_runner",
         conflicts_with = "event_webhook_ingest_file",
         help = "Write a schedule-specific event template JSON file and exit"

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -143,10 +143,10 @@ pub(crate) use crate::diagnostics_commands::{
     DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
-    execute_events_inspect_command, execute_events_simulate_command,
-    execute_events_template_write_command, execute_events_validate_command,
-    ingest_webhook_immediate_event, run_event_scheduler, EventSchedulerConfig,
-    EventWebhookIngestConfig,
+    execute_events_dry_run_command, execute_events_inspect_command,
+    execute_events_simulate_command, execute_events_template_write_command,
+    execute_events_validate_command, ingest_webhook_immediate_event, run_event_scheduler,
+    EventSchedulerConfig, EventWebhookIngestConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -134,6 +134,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.events_dry_run {
+        execute_events_dry_run_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.events_template_write.is_some() {
         execute_events_template_write_command(cli)?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- add startup preflight command `--events-dry-run` with optional JSON output (`--events-dry-run-json`)
- implement deterministic, read-only event execution preview that reports per-event `execute` / `skip` / `error` decisions
- surface explicit reason codes (`due_now`, `not_due`, `stale_immediate`, `queue_limit_reached`, `channel_ref_invalid`, `schedule_invalid`, `read_error`, `json_parse`)
- preserve runtime safety by ensuring dry-run does not mutate event files or state files
- document dry-run usage in README

Closes #569

## Risks and compatibility
- low runtime risk: this is an opt-in startup preflight command path
- compatibility impact: none for existing commands; conflict guards were extended to include dry-run preflight mode
- operational note: dry-run decision ordering is deterministic and queue-limit aware to match operator expectations during rollout checks

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Test matrix
- Unit: dry-run decision classification and queue-limit behavior
- Functional: dry-run report rendering stability
- Integration: dry-run path verified read-only for event/state files
- Regression: malformed/invalid definitions are surfaced deterministically as error decisions
