### PR TITLE
feat(events): add strict dry-run preflight gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,16 @@ cargo run -p tau-coding-agent -- \
   --events-dry-run-json
 ```
 
+Fail fast in CI when dry-run detects malformed or invalid event definitions:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-dry-run \
+  --events-dry-run-strict
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1342,6 +1342,19 @@ pub(crate) struct Cli {
     pub(crate) events_dry_run_json: bool,
 
     #[arg(
+        long = "events-dry-run-strict",
+        env = "TAU_EVENTS_DRY_RUN_STRICT",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "events_dry_run",
+        help = "Exit non-zero when --events-dry-run reports malformed or invalid definitions"
+    )]
+    pub(crate) events_dry_run_strict: bool,
+
+    #[arg(
         long = "events-template-write",
         env = "TAU_EVENTS_TEMPLATE_WRITE",
         value_name = "PATH",


### PR DESCRIPTION
## Summary
- add `--events-dry-run-strict` CLI flag (requires `--events-dry-run`)
- enforce non-zero exit when strict dry-run reports one or more `error` decisions
- keep dry-run rendering unchanged for text and JSON outputs
- preserve read-only dry-run behavior with no event/state mutation
- document strict-mode CI usage in README

Closes #573

## Risks and compatibility
- low runtime risk: strict mode is opt-in and scoped to startup preflight path
- compatibility impact: none for existing workflows unless strict mode is explicitly enabled
- operator impact: enables deterministic CI gating for malformed/invalid event definitions

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Test matrix
- Unit: strict-gate function rejects error rows and allows clean reports
- Functional: startup preflight strict dry-run succeeds on clean event definitions
- Integration: startup preflight strict dry-run fails with deterministic non-zero error on invalid definitions
- Regression: non-strict dry-run continues to report invalid entries without failing preflight
