### PR TITLE
feat: add dry-run threshold gates for startup preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,17 @@ cargo run -p tau-coding-agent -- \
   --events-dry-run-strict
 ```
 
+Apply threshold governance (for example, fail when more than 10 events would execute now):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --events-dir .tau/events \
+  --events-state-path .tau/events/state.json \
+  --events-dry-run \
+  --events-dry-run-max-execute-rows 10 \
+  --events-dry-run-max-error-rows 0
+```
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1355,6 +1355,24 @@ pub(crate) struct Cli {
     pub(crate) events_dry_run_strict: bool,
 
     #[arg(
+        long = "events-dry-run-max-error-rows",
+        env = "TAU_EVENTS_DRY_RUN_MAX_ERROR_ROWS",
+        requires = "events_dry_run",
+        value_name = "count",
+        help = "Fail dry-run when error row count exceeds this threshold"
+    )]
+    pub(crate) events_dry_run_max_error_rows: Option<u64>,
+
+    #[arg(
+        long = "events-dry-run-max-execute-rows",
+        env = "TAU_EVENTS_DRY_RUN_MAX_EXECUTE_ROWS",
+        requires = "events_dry_run",
+        value_name = "count",
+        help = "Fail dry-run when execute row count exceeds this threshold"
+    )]
+    pub(crate) events_dry_run_max_execute_rows: Option<u64>,
+
+    #[arg(
         long = "events-template-write",
         env = "TAU_EVENTS_TEMPLATE_WRITE",
         value_name = "PATH",


### PR DESCRIPTION
## Summary
- add dry-run threshold CLI flags for startup preflight governance:
  - --events-dry-run-max-error-rows
  - --events-dry-run-max-execute-rows
- implement deterministic gate evaluation/reporting with stable reason codes
- preserve strict mode behavior by mapping --events-dry-run-strict to max_error_rows=0
- extend README with threshold governance usage example
- add and update unit, functional, integration, and regression coverage around gate behavior

## Risks and compatibility notes
- behavior change: dry-run mode can now fail startup when thresholds are exceeded
- strict mode remains backward-compatible in effect, but now emits unified gate summary text
- threshold flags are optional and no-op when unset

## Validation evidence
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #579
