### PR TITLE
feat: add sessions_search built-in retrieval tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This workspace mirrors the high-level package boundaries from the upstream mono 
 - `crates/tau-ai`: provider-agnostic message and tool model + OpenAI/Anthropic/Google adapters
 - `crates/tau-agent-core`: event-driven agent loop with tool execution
 - `crates/tau-tui`: minimal differential terminal rendering primitives
-- `crates/tau-coding-agent`: CLI harness with built-in `read`, `write`, `edit`, and `bash` tools
+- `crates/tau-coding-agent`: CLI harness with built-in `read`, `write`, `edit`, `bash`, and session intelligence tools (`sessions_list`, `sessions_history`, `sessions_search`, `sessions_send`)
 
 ## Current Scope
 


### PR DESCRIPTION
## Summary
- add a new built-in tool: sessions_search
- support path-scoped search on a specific session file
- support cross-session discovery search under allowed roots when path is omitted
- enforce argument validation for query, role filter, and bounded limits
- return deterministic JSON telemetry fields: sessions_scanned, entries_scanned, matches, returned, skipped_invalid
- update README tool inventory to include sessions_search

## Risks and compatibility notes
- tool-surface change: model runtime now exposes one additional built-in tool
- no behavior changes to existing tools; sessions_search is additive
- cross-session mode scans session candidates under allowed roots, bounded by default scan limits

## Validation evidence
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent sessions_search_tool
- cargo test --workspace

Closes #583
