### PR TITLE
docs: remove final residual pi branding reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-tau
 
-Pure Rust implementation of core `upstream pi mono` concepts.
+Pure Rust implementation of core upstream mono concepts.
 
 This workspace mirrors the high-level package boundaries from the upstream mono baseline and provides a functional baseline:
 


### PR DESCRIPTION
## Summary
- remove the final residual `pi` branding text from README intro
- normalize phrasing to Tau-neutral upstream wording
- verify no remaining tracked `pi` branding references in README/docs/code text

## Risks and compatibility notes
- docs-only change; no runtime or API behavior changes

## Validation evidence
- rg -n "\\bpi\\b|pi-mono|\\.pi/|/pi\\b" README.md docs crates .github -g'!target'
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #585
