### PR TITLE
feat(agent): add sessions_stats built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This workspace mirrors the high-level package boundaries from the upstream mono 
 - `crates/tau-ai`: provider-agnostic message and tool model + OpenAI/Anthropic/Google adapters
 - `crates/tau-agent-core`: event-driven agent loop with tool execution
 - `crates/tau-tui`: minimal differential terminal rendering primitives
-- `crates/tau-coding-agent`: CLI harness with built-in `read`, `write`, `edit`, `bash`, and session intelligence tools (`sessions_list`, `sessions_history`, `sessions_search`, `sessions_send`)
+- `crates/tau-coding-agent`: CLI harness with built-in `read`, `write`, `edit`, `bash`, and session intelligence tools (`sessions_list`, `sessions_history`, `sessions_search`, `sessions_stats`, `sessions_send`)
 
 ## Current Scope
 


### PR DESCRIPTION
## Summary
- add built-in `sessions_stats` tool to `tau-coding-agent` and register it with other session tools
- implement deterministic single-session and aggregate telemetry (`entries`, `branch_tips`, `roots`, `max_depth`, `latest_head`, `latest_depth`, `role_counts`)
- enforce policy-aware path validation and bounded aggregate scan limits
- update README built-in tool inventory to include `sessions_stats`

## Behavior changes
- model turns can now call `sessions_stats` directly without slash command routing
- `sessions_stats` supports:
  - `path` (optional): compute metrics for one validated session file
  - `limit` (optional): bound aggregate scanning across discovered sessions
- aggregate mode tolerates malformed discoverable sessions and reports `skipped_invalid`

## Risks and compatibility
- low risk: feature is additive and does not change existing tool names or argument contracts
- path handling remains fail-closed on out-of-root access and non-regular-file violations
- aggregate mode has explicit scan bounds to avoid unbounded traversal cost

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Issue linkage
Closes #590
Refs #589
