### PR TITLE
feat: bootstrap release-channel during onboarding

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -697,6 +697,14 @@ pub(crate) struct Cli {
     pub(crate) onboard_profile: String,
 
     #[arg(
+        long = "onboard-release-channel",
+        env = "TAU_ONBOARD_RELEASE_CHANNEL",
+        requires = "onboard",
+        help = "Optional release channel initialized by onboarding (stable|beta|dev)"
+    )]
+    pub(crate) onboard_release_channel: Option<String>,
+
+    #[arg(
         long = "channel-store-root",
         env = "TAU_CHANNEL_STORE_ROOT",
         default_value = ".tau/channel-store",


### PR DESCRIPTION
## Summary
- add `--onboard-release-channel` CLI option (requires `--onboard`)
- initialize `.tau/release-channel.json` during onboarding when missing (default `stable`)
- support explicit onboarding override for `stable|beta|dev`
- extend onboarding report/summary with release-channel path/value/source/action fields
- add tests for default bootstrap, preserve-on-rerun, override update, and invalid override rejection

## Behavior Changes
- onboarding now creates release-channel state as part of workspace bootstrap
- rerunning onboarding without override preserves existing channel
- invalid onboarding override values fail early with actionable parse errors

## Risks and Compatibility
- low risk and additive: onboarding-only behavior plus report metadata expansion
- compatibility: onboarding report JSON now includes new release-channel fields
- error behavior: malformed `--onboard-release-channel` values now fail onboarding preflight

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Issue Links
Closes #606
Refs #604
Refs #605
