### PR TITLE
feat: add /release-channel check command

### DIFF
--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -9472,7 +9472,7 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/session-stats"));
     assert!(help.contains("/session-diff [<left-id> <right-id>]"));
     assert!(help.contains("/doctor"));
-    assert!(help.contains("/release-channel [show|set <stable|beta|dev>]"));
+    assert!(help.contains("/release-channel [show|set <stable|beta|dev>|check]"));
     assert!(help.contains("/session-graph-export <path>"));
     assert!(help.contains("/session-export <path>"));
     assert!(help.contains("/session-import <path>"));
@@ -9609,7 +9609,7 @@ fn functional_render_command_help_supports_doctor_topic_without_slash() {
 fn functional_render_command_help_supports_release_channel_topic_without_slash() {
     let help = render_command_help("release-channel").expect("render help");
     assert!(help.contains("command: /release-channel"));
-    assert!(help.contains("usage: /release-channel [show|set <stable|beta|dev>]"));
+    assert!(help.contains("usage: /release-channel [show|set <stable|beta|dev>|check]"));
     assert!(help.contains("example: /release-channel set beta"));
 }
 


### PR DESCRIPTION
## Summary of behavior changes
- adds `/release-channel check` command to query the latest release tag from GitHub
- uses persisted release-channel state (`stable|beta|dev`) to select the proper release stream
- compares current Tau version vs latest channel version and returns deterministic status (`update_available|up_to_date|unknown`)
- extends release-channel unit/functional/integration/regression tests, including mocked HTTP lookup coverage
- updates help text assertions to include `check`

Closes #610
Refs #609
Refs #608

## Risks and compatibility notes
- command now performs an outbound GitHub API request when `check` is invoked
- any GitHub lookup/network failure is fail-soft and rendered as `status=unknown` with explicit `error=` detail
- no behavior changes to existing `show`/`set` command semantics

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (one known flaky unrelated test observed once in parallel run)
- `cargo test -p tau-coding-agent --bin tau-coding-agent extension_manifest::tests::functional_apply_extension_message_transforms_rewrites_prompt -- --exact --nocapture`
- `cargo test --workspace -- --test-threads=1`
- runtime smoke: `printf '/quit\\n' | cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini`
