### PR TITLE
feat: cache /doctor --online release lookups with stale fallback

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -575,6 +575,8 @@ pub(crate) fn handle_command(
                 login_backend_available: false,
             }],
             release_channel_path: PathBuf::from(".tau/release-channel.json"),
+            release_lookup_cache_path: PathBuf::from(".tau/release-lookup-cache.json"),
+            release_lookup_cache_ttl_ms: 900_000,
             session_enabled: true,
             session_path: PathBuf::from(".tau/sessions/default.jsonl"),
             skills_dir: PathBuf::from(".tau/skills"),

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -42,6 +42,8 @@ pub(crate) struct DoctorCommandConfig {
     pub(crate) model: String,
     pub(crate) provider_keys: Vec<DoctorProviderKeyStatus>,
     pub(crate) release_channel_path: PathBuf,
+    pub(crate) release_lookup_cache_path: PathBuf,
+    pub(crate) release_lookup_cache_ttl_ms: u64,
     pub(crate) session_enabled: bool,
     pub(crate) session_path: PathBuf,
     pub(crate) skills_dir: PathBuf,

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -591,6 +591,8 @@ fn skills_command_config(
                 login_backend_available: false,
             }],
             release_channel_path: PathBuf::from(".tau/release-channel.json"),
+            release_lookup_cache_path: PathBuf::from(".tau/release-lookup-cache.json"),
+            release_lookup_cache_ttl_ms: 900_000,
             session_enabled: true,
             session_path: PathBuf::from(".tau/sessions/default.jsonl"),
             skills_dir: skills_dir.to_path_buf(),
@@ -7565,6 +7567,10 @@ fn unit_build_doctor_command_config_collects_sorted_unique_provider_states() {
     assert!(config
         .release_channel_path
         .ends_with(Path::new(".tau").join("release-channel.json")));
+    assert!(config
+        .release_lookup_cache_path
+        .ends_with(Path::new(".tau").join("release-lookup-cache.json")));
+    assert_eq!(config.release_lookup_cache_ttl_ms, 900_000);
 
     let provider_rows = config
         .provider_keys
@@ -7753,6 +7759,8 @@ fn functional_execute_doctor_command_supports_text_and_json_modes() {
             },
         ],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: true,
         session_path,
         skills_dir,
@@ -7813,6 +7821,8 @@ fn functional_execute_doctor_cli_command_accepts_online_without_network_when_sto
         model: "openai/gpt-4o-mini".to_string(),
         provider_keys: vec![],
         release_channel_path,
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),
@@ -7845,6 +7855,8 @@ fn integration_run_doctor_checks_identifies_missing_runtime_prerequisites() {
             login_backend_available: false,
         }],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: true,
         session_path: temp.path().join("missing-parent").join("session.jsonl"),
         skills_dir: temp.path().join("missing-skills"),
@@ -7923,6 +7935,8 @@ fn integration_run_doctor_checks_reports_google_backend_status_for_oauth_mode() 
             login_backend_available: false,
         }],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),
@@ -7967,6 +7981,8 @@ fn integration_run_doctor_checks_reports_anthropic_backend_status_for_oauth_mode
             login_backend_available: false,
         }],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),
@@ -8001,6 +8017,8 @@ fn integration_execute_doctor_command_with_online_lookup_reports_update_availabl
         model: "openai/gpt-4o-mini".to_string(),
         provider_keys: vec![],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),
@@ -8115,6 +8133,8 @@ fn regression_run_doctor_checks_reports_type_and_readability_errors() {
             login_backend_available: false,
         }],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: true,
         session_path,
         skills_dir,
@@ -8175,6 +8195,8 @@ fn regression_run_doctor_checks_reports_invalid_release_channel_store() {
             login_backend_available: false,
         }],
         release_channel_path,
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),
@@ -8206,6 +8228,8 @@ fn regression_run_doctor_checks_with_online_lookup_surfaces_lookup_errors() {
         model: "openai/gpt-4o-mini".to_string(),
         provider_keys: vec![],
         release_channel_path: temp.path().join("release-channel.json"),
+        release_lookup_cache_path: temp.path().join("release-lookup-cache.json"),
+        release_lookup_cache_ttl_ms: 900_000,
         session_enabled: false,
         session_path: temp.path().join("session.jsonl"),
         skills_dir: temp.path().join("skills"),


### PR DESCRIPTION
## Summary
- add release lookup cache schema, path defaults, and TTL controls for online release diagnostics
- implement cache-aware release resolution with three modes: fresh cache reuse, live refresh, and stale-cache fallback on lookup failure
- wire `/doctor --online` to cached release resolution while preserving default offline behavior
- extend tests across release-channel cache behavior plus doctor config wiring

## Risks & Compatibility
- no behavior change for default `/doctor` (still offline)
- `/doctor --online` may now return cached release data within TTL (reduced network usage and improved resilience)
- stale cache fallback is used only when live lookup fails and stale cache exists
- cache write failures do not fail release diagnostics; live data still returns when available

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- release_channel doctor`
- `cargo test --workspace -- --test-threads=1`

Closes #622
