### PR TITLE
feat(release-channel): add cache show/clear commands

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -88,7 +88,7 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
         usage: RELEASE_CHANNEL_USAGE,
         description: "Show or persist release track selection",
         details:
-            "Supports stable/beta/dev release tracks and persists selections in project-local .tau metadata.",
+            "Supports stable/beta/dev release tracks, online checks, and cache show/clear operations in project-local .tau metadata.",
         example: "/release-channel set beta",
     },
     CommandSpec {

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -9667,7 +9667,7 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/session-stats"));
     assert!(help.contains("/session-diff [<left-id> <right-id>]"));
     assert!(help.contains("/doctor"));
-    assert!(help.contains("/release-channel [show|set <stable|beta|dev>|check]"));
+    assert!(help.contains("/release-channel [show|set <stable|beta|dev>|check|cache <show|clear>]"));
     assert!(help.contains("/session-graph-export <path>"));
     assert!(help.contains("/session-export <path>"));
     assert!(help.contains("/session-import <path>"));
@@ -9804,7 +9804,8 @@ fn functional_render_command_help_supports_doctor_topic_without_slash() {
 fn functional_render_command_help_supports_release_channel_topic_without_slash() {
     let help = render_command_help("release-channel").expect("render help");
     assert!(help.contains("command: /release-channel"));
-    assert!(help.contains("usage: /release-channel [show|set <stable|beta|dev>|check]"));
+    assert!(help
+        .contains("usage: /release-channel [show|set <stable|beta|dev>|check|cache <show|clear>]"));
     assert!(help.contains("example: /release-channel set beta"));
 }
 


### PR DESCRIPTION
## Summary
- extend `/release-channel` with `cache show` and `cache clear` subcommands
- add deterministic cache path resolution next to `release-channel.json`
- add cache status output for missing/present cache metadata (entries, age, source URL)
- add idempotent cache clear behavior (`removed` or `already_missing`)
- update release-channel help/usage coverage in command help tests

Closes #631

## Risks and compatibility
- low risk additive command surface; existing `/release-channel show|set|check` behavior remains unchanged
- output format intentionally deterministic and script-friendly
- cache path resolution depends on release-channel store parent directory; invalid store path shape returns explicit error

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- release_channel_command_cache`
- `cargo test -p tau-coding-agent -- unit_parse_release_channel_command_supports_show_set_and_check`
- `cargo test -p tau-coding-agent -- functional_render_command_help_supports_release_channel_topic_without_slash`
- `cargo test -p tau-coding-agent -- functional_render_help_overview_lists_known_commands`
- `cargo test --workspace -- --test-threads=1`
