### PR TITLE
feat: add /release-channel cache refresh command

### DIFF
--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -9667,7 +9667,9 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/session-stats"));
     assert!(help.contains("/session-diff [<left-id> <right-id>]"));
     assert!(help.contains("/doctor"));
-    assert!(help.contains("/release-channel [show|set <stable|beta|dev>|check|cache <show|clear>]"));
+    assert!(help.contains(
+        "/release-channel [show|set <stable|beta|dev>|check|cache <show|clear|refresh>]"
+    ));
     assert!(help.contains("/session-graph-export <path>"));
     assert!(help.contains("/session-export <path>"));
     assert!(help.contains("/session-import <path>"));
@@ -9804,8 +9806,9 @@ fn functional_render_command_help_supports_doctor_topic_without_slash() {
 fn functional_render_command_help_supports_release_channel_topic_without_slash() {
     let help = render_command_help("release-channel").expect("render help");
     assert!(help.contains("command: /release-channel"));
-    assert!(help
-        .contains("usage: /release-channel [show|set <stable|beta|dev>|check|cache <show|clear>]"));
+    assert!(help.contains(
+        "usage: /release-channel [show|set <stable|beta|dev>|check|cache <show|clear|refresh>]"
+    ));
     assert!(help.contains("example: /release-channel set beta"));
 }
 


### PR DESCRIPTION
Closes #643

## Summary of behavior changes
- Extends `/release-channel` cache subcommands with `refresh`.
- Adds deterministic refresh output:
  - `release cache refresh: path=... status=refreshed entries=... fetched_at_unix_ms=... source_url=...`
- Refactors command execution into option-aware helper path for deterministic integration tests.
- Updates help text assertions to include `cache <show|clear|refresh>`.
- Adds new tests across matrix categories for parser, refresh round-trip, cache persistence, and refresh failure handling.

## Risks and compatibility notes
- CLI usage/help output now includes the additional `refresh` cache subcommand.
- Existing `cache show`/`cache clear` behavior and schema remain unchanged.
- Output-parsing consumers should handle the new `release cache refresh` line when this command is used.

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- release_channel`
- `cargo test --workspace -- --test-threads=1`
