### PR TITLE
feat(demo): add deterministic one-command local/rpc/events/package wrappers (#675)

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,24 @@ Run the deterministic local demo smoke suite (same manifest used by codex-light 
 
 Smoke logs are written under `ci-artifacts/demo-smoke/`.
 
+Run one-command demo wrappers for key flows:
+
+```bash
+# local onboarding + baseline runtime checks
+./scripts/demo/local.sh
+
+# rpc capabilities + fixture-backed dispatch replay
+./scripts/demo/rpc.sh
+
+# scheduled events inspect/validate/dry-run flow
+./scripts/demo/events.sh
+
+# package validate/install/list/activate lifecycle
+./scripts/demo/package.sh
+```
+
+Each wrapper supports `--skip-build` and `--binary <path>` for deterministic runs with a prebuilt binary.
+
 Queue a webhook-triggered immediate event from a payload file (debounced):
 
 ```bash

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tau_demo_common_print_usage() {
+  local script_name="$1"
+  local summary="$2"
+  cat <<EOF
+Usage: ${script_name} [--repo-root PATH] [--binary PATH] [--skip-build] [--help]
+
+${summary}
+
+Options:
+  --repo-root PATH  Repository root (defaults to caller-derived root)
+  --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
+  --skip-build      Skip cargo build and require --binary to exist
+  --help            Show this usage message
+EOF
+}
+
+tau_demo_common_init() {
+  local demo_name="$1"
+  local summary="$2"
+  shift 2
+
+  local caller_script="${BASH_SOURCE[1]}"
+  local caller_dir
+  caller_dir="$(cd "$(dirname "${caller_script}")" && pwd)"
+
+  TAU_DEMO_NAME="${demo_name}"
+  TAU_DEMO_SUMMARY="${summary}"
+  TAU_DEMO_REPO_ROOT="$(cd "${caller_dir}/../.." && pwd)"
+  TAU_DEMO_BINARY="${TAU_DEMO_REPO_ROOT}/target/debug/tau-coding-agent"
+  TAU_DEMO_SKIP_BUILD="false"
+  TAU_DEMO_STEP_TOTAL=0
+  TAU_DEMO_STEP_PASSED=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo-root)
+        if [[ $# -lt 2 ]]; then
+          echo "missing value for --repo-root" >&2
+          tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}" >&2
+          return 2
+        fi
+        TAU_DEMO_REPO_ROOT="$2"
+        shift 2
+        ;;
+      --binary)
+        if [[ $# -lt 2 ]]; then
+          echo "missing value for --binary" >&2
+          tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}" >&2
+          return 2
+        fi
+        TAU_DEMO_BINARY="$2"
+        shift 2
+        ;;
+      --skip-build)
+        TAU_DEMO_SKIP_BUILD="true"
+        shift
+        ;;
+      --help)
+        tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}"
+        return 64
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  if [[ ! -d "${TAU_DEMO_REPO_ROOT}" ]]; then
+    echo "invalid --repo-root path (directory not found): ${TAU_DEMO_REPO_ROOT}" >&2
+    return 2
+  fi
+  TAU_DEMO_REPO_ROOT="$(cd "${TAU_DEMO_REPO_ROOT}" && pwd)"
+
+  if [[ "${TAU_DEMO_BINARY}" != /* ]]; then
+    TAU_DEMO_BINARY="${TAU_DEMO_REPO_ROOT}/${TAU_DEMO_BINARY}"
+  fi
+}
+
+tau_demo_common_require_command() {
+  local executable="$1"
+  if ! command -v "${executable}" >/dev/null 2>&1; then
+    echo "missing required executable: ${executable}" >&2
+    return 1
+  fi
+}
+
+tau_demo_common_require_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    echo "missing required file: ${path}" >&2
+    return 1
+  fi
+}
+
+tau_demo_common_require_dir() {
+  local path="$1"
+  if [[ ! -d "${path}" ]]; then
+    echo "missing required directory: ${path}" >&2
+    return 1
+  fi
+}
+
+tau_demo_common_prepare_binary() {
+  if [[ "${TAU_DEMO_SKIP_BUILD}" == "true" ]]; then
+    if [[ ! -f "${TAU_DEMO_BINARY}" ]]; then
+      echo "missing tau-coding-agent binary (use --binary or remove --skip-build): ${TAU_DEMO_BINARY}" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  tau_demo_common_require_command cargo
+  echo "[demo:${TAU_DEMO_NAME}] building tau-coding-agent"
+  (
+    cd "${TAU_DEMO_REPO_ROOT}"
+    cargo build -p tau-coding-agent >/dev/null
+  )
+  tau_demo_common_require_file "${TAU_DEMO_BINARY}"
+}
+
+tau_demo_common_run_step() {
+  local label="$1"
+  shift
+
+  TAU_DEMO_STEP_TOTAL=$((TAU_DEMO_STEP_TOTAL + 1))
+  local rendered_command
+  printf -v rendered_command '%q ' "${TAU_DEMO_BINARY}" "$@"
+  rendered_command="${rendered_command% }"
+
+  echo "[demo:${TAU_DEMO_NAME}] [${TAU_DEMO_STEP_TOTAL}] ${label}"
+  echo "[demo:${TAU_DEMO_NAME}] command: ${rendered_command}"
+
+  if [[ -n "${TAU_DEMO_TRACE_LOG:-}" ]]; then
+    printf '%s\t%s\n' "${label}" "${rendered_command}" >>"${TAU_DEMO_TRACE_LOG}"
+  fi
+
+  if (
+    cd "${TAU_DEMO_REPO_ROOT}"
+    "${TAU_DEMO_BINARY}" "$@"
+  ); then
+    TAU_DEMO_STEP_PASSED=$((TAU_DEMO_STEP_PASSED + 1))
+    echo "[demo:${TAU_DEMO_NAME}] PASS ${label}"
+    return 0
+  else
+    local rc=$?
+    echo "[demo:${TAU_DEMO_NAME}] FAIL ${label} exit=${rc}" >&2
+    return "${rc}"
+  fi
+}
+
+tau_demo_common_finish() {
+  local failed=$((TAU_DEMO_STEP_TOTAL - TAU_DEMO_STEP_PASSED))
+  echo "[demo:${TAU_DEMO_NAME}] summary: total=${TAU_DEMO_STEP_TOTAL} passed=${TAU_DEMO_STEP_PASSED} failed=${failed}"
+}

--- a/scripts/demo/events.sh
+++ b/scripts/demo/events.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "events" "Run deterministic scheduled-events demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+tau_demo_common_require_dir "${TAU_DEMO_REPO_ROOT}/examples/events"
+tau_demo_common_require_file "${TAU_DEMO_REPO_ROOT}/examples/events-state.json"
+tau_demo_common_prepare_binary
+
+tau_demo_common_run_step \
+  "events-validate-json" \
+  --events-dir ./examples/events \
+  --events-state-path ./examples/events-state.json \
+  --events-validate \
+  --events-validate-json
+
+tau_demo_common_run_step \
+  "events-inspect-json" \
+  --events-dir ./examples/events \
+  --events-state-path ./examples/events-state.json \
+  --events-inspect \
+  --events-inspect-json
+
+tau_demo_common_run_step \
+  "events-dry-run-strict" \
+  --events-dir ./examples/events \
+  --events-state-path ./examples/events-state.json \
+  --events-dry-run \
+  --events-dry-run-json \
+  --events-dry-run-strict
+tau_demo_common_finish

--- a/scripts/demo/local.sh
+++ b/scripts/demo/local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "local" "Run local bootstrap and offline runtime sanity demo commands." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+tau_demo_common_require_file "${TAU_DEMO_REPO_ROOT}/examples/starter/package.json"
+tau_demo_common_require_dir "${TAU_DEMO_REPO_ROOT}/examples/extensions"
+tau_demo_common_prepare_binary
+
+tau_demo_common_run_step "onboard-non-interactive" --onboard --onboard-non-interactive
+tau_demo_common_run_step "extension-list" --extension-list --extension-list-root ./examples/extensions
+tau_demo_common_run_step "rpc-capabilities" --rpc-capabilities
+tau_demo_common_finish

--- a/scripts/demo/package.sh
+++ b/scripts/demo/package.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "package" "Run deterministic package lifecycle demo commands against starter fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+tau_demo_common_require_file "${TAU_DEMO_REPO_ROOT}/examples/starter/package.json"
+tau_demo_common_require_command mktemp
+tau_demo_common_prepare_binary
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/tau-demo-package.XXXXXX")"
+cleanup() {
+  rm -rf "${scratch_dir}"
+}
+trap cleanup EXIT
+
+install_root="${scratch_dir}/packages"
+activate_destination="${scratch_dir}/packages-active"
+
+tau_demo_common_run_step "package-validate" --package-validate ./examples/starter/package.json
+tau_demo_common_run_step \
+  "package-install" \
+  --package-install ./examples/starter/package.json \
+  --package-install-root "${install_root}"
+
+tau_demo_common_run_step \
+  "package-list" \
+  --package-list \
+  --package-list-root "${install_root}"
+
+tau_demo_common_run_step \
+  "package-activate" \
+  --package-activate \
+  --package-activate-root "${install_root}" \
+  --package-activate-destination "${activate_destination}"
+tau_demo_common_finish

--- a/scripts/demo/rpc.sh
+++ b/scripts/demo/rpc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "rpc" "Run deterministic RPC capabilities and NDJSON dispatch demo commands." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+tau_demo_common_require_command mktemp
+tau_demo_common_prepare_binary
+
+tmp_frames_file="$(mktemp "${TMPDIR:-/tmp}/tau-demo-rpc.XXXXXX")"
+cleanup() {
+  rm -f "${tmp_frames_file}"
+}
+trap cleanup EXIT
+
+cat >"${tmp_frames_file}" <<'EOF'
+{"schema_version":1,"request_id":"req-cap","kind":"capabilities.request","payload":{}}
+{"schema_version":1,"request_id":"req-cancel","kind":"run.cancel","payload":{"run_id":"run-1"}}
+{"schema_version":1,"request_id":"req-status","kind":"run.status","payload":{"run_id":"run-1"}}
+{"schema_version":1,"request_id":"req-fail","kind":"run.fail","payload":{"run_id":"run-1","reason":"failed in dispatch"}}
+{"schema_version":1,"request_id":"req-timeout","kind":"run.timeout","payload":{"run_id":"run-1","reason":"timed out in dispatch"}}
+EOF
+
+tau_demo_common_run_step "rpc-capabilities" --rpc-capabilities
+tau_demo_common_run_step \
+  "rpc-dispatch-ndjson-file" \
+  --rpc-dispatch-ndjson-file "${tmp_frames_file}"
+tau_demo_common_finish


### PR DESCRIPTION
Closes #675

## Summary of behavior changes
- add `scripts/demo/common.sh` with deterministic arg parsing, prerequisite checks, and explicit PASS/FAIL step markers
- add one-command wrappers:
  - `scripts/demo/local.sh`
  - `scripts/demo/rpc.sh`
  - `scripts/demo/events.sh`
  - `scripts/demo/package.sh`
- add script test coverage in `.github/scripts/test_demo_scripts.py` across unit/functional/integration/regression categories
- document wrapper usage in `/Users/n/RustroverProjects/rust_pi/README.md`

## Risks and compatibility notes
- low risk: wrapper scripts only, no runtime behavior changes in Rust crates
- wrappers default to building `tau-coding-agent`; `--skip-build` + `--binary` allows deterministic prebuilt execution
- scripts fail closed when prerequisites are missing (non-zero exit)

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/local.sh --skip-build`
- `./scripts/demo/rpc.sh --skip-build`
- `./scripts/demo/events.sh --skip-build`
- `./scripts/demo/package.sh --skip-build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent --test examples_assets`

## Test matrix
- Unit: script parser rejects unknown args (`test_unit_script_argument_parser_rejects_unknown_argument`)
- Functional: each wrapper executes expected command chain with deterministic summaries
- Integration: wrappers reference checked-in `examples/*` paths and run against repo fixtures
- Regression: wrappers fail closed when binary/prerequisites are missing
