### PR TITLE
ci: implement bounded checkout retry strategy in quality workflow (#677)

### DIFF
--- a/.github/scripts/ci_checkout_retry.py
+++ b/.github/scripts/ci_checkout_retry.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ALLOWED_OUTCOMES = {"success", "failure", "skipped", "cancelled", "unknown"}
+
+
+@dataclass(frozen=True)
+class CheckoutRetryPolicy:
+    max_attempts: int
+    base_delay_seconds: int
+    cap_delay_seconds: int
+    max_total_delay_seconds: int
+
+
+@dataclass(frozen=True)
+class CheckoutRetryReport:
+    policy: CheckoutRetryPolicy
+    outcomes: list[str]
+    retry_delays_seconds: list[int]
+    planned_total_delay_seconds: int
+    actual_total_delay_seconds: int
+    success_attempt: int | None
+    status: str
+    mode: str
+
+
+def normalize_outcomes(raw: str, max_attempts: int) -> list[str]:
+    outcomes = [entry.strip().lower() for entry in raw.split(",") if entry.strip()]
+    if len(outcomes) > max_attempts:
+        raise ValueError(
+            f"checkout outcomes length {len(outcomes)} exceeds --max-attempts {max_attempts}"
+        )
+    for outcome in outcomes:
+        if outcome not in ALLOWED_OUTCOMES:
+            raise ValueError(
+                f"unsupported checkout outcome '{outcome}'; expected one of: {sorted(ALLOWED_OUTCOMES)}"
+            )
+    while len(outcomes) < max_attempts:
+        outcomes.append("skipped")
+    return outcomes
+
+
+def compute_retry_delays(policy: CheckoutRetryPolicy) -> list[int]:
+    delays: list[int] = []
+    for retry_index in range(1, policy.max_attempts):
+        delay = policy.base_delay_seconds * (2 ** (retry_index - 1))
+        delays.append(min(delay, policy.cap_delay_seconds))
+    return delays
+
+
+def build_report(policy: CheckoutRetryPolicy, outcomes: list[str]) -> CheckoutRetryReport:
+    retry_delays = compute_retry_delays(policy)
+    planned_total_delay = sum(retry_delays)
+    success_attempt = next(
+        (index + 1 for index, outcome in enumerate(outcomes) if outcome == "success"),
+        None,
+    )
+    if success_attempt is None:
+        actual_delay = planned_total_delay
+        status = "failure"
+        mode = "checkout_retries_exhausted"
+    else:
+        actual_delay = sum(retry_delays[: max(0, success_attempt - 1)])
+        status = "success"
+        mode = (
+            "first_attempt_success"
+            if success_attempt == 1
+            else "resolved_after_retry"
+        )
+
+    return CheckoutRetryReport(
+        policy=policy,
+        outcomes=outcomes,
+        retry_delays_seconds=retry_delays,
+        planned_total_delay_seconds=planned_total_delay,
+        actual_total_delay_seconds=actual_delay,
+        success_attempt=success_attempt,
+        status=status,
+        mode=mode,
+    )
+
+
+def render_summary(report: CheckoutRetryReport) -> str:
+    success_attempt = (
+        str(report.success_attempt) if report.success_attempt is not None else "none"
+    )
+    return "\n".join(
+        [
+            "### Checkout Retry",
+            f"- Status: {report.status}",
+            f"- Mode: {report.mode}",
+            f"- Outcomes: {','.join(report.outcomes)}",
+            f"- Max attempts: {report.policy.max_attempts}",
+            f"- Retry delays (s): {report.retry_delays_seconds}",
+            f"- Planned total delay (s): {report.planned_total_delay_seconds}",
+            f"- Actual total delay (s): {report.actual_total_delay_seconds}",
+            f"- Success attempt: {success_attempt}",
+        ]
+    )
+
+
+def write_summary(path: Path | None, summary: str) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(summary)
+        handle.write("\n")
+
+
+def write_output(path: Path | None, report: CheckoutRetryReport) -> None:
+    if path is None:
+        return
+    success_attempt = (
+        str(report.success_attempt) if report.success_attempt is not None else ""
+    )
+    rows = [
+        f"checkout_retry_status={report.status}",
+        f"checkout_retry_mode={report.mode}",
+        f"checkout_retry_success_attempt={success_attempt}",
+        f"checkout_retry_outcomes={','.join(report.outcomes)}",
+        f"checkout_retry_planned_total_delay_seconds={report.planned_total_delay_seconds}",
+        f"checkout_retry_actual_total_delay_seconds={report.actual_total_delay_seconds}",
+    ]
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(rows))
+        handle.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Deterministic checkout retry diagnostics helper for CI."
+    )
+    parser.add_argument(
+        "--outcomes",
+        default="",
+        help="Comma-separated attempt outcomes (success|failure|skipped|cancelled|unknown)",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=3,
+        help="Maximum checkout attempts",
+    )
+    parser.add_argument(
+        "--base-delay-seconds",
+        type=int,
+        default=3,
+        help="Base backoff delay in seconds",
+    )
+    parser.add_argument(
+        "--cap-delay-seconds",
+        type=int,
+        default=6,
+        help="Maximum backoff delay in seconds",
+    )
+    parser.add_argument(
+        "--max-total-delay-seconds",
+        type=int,
+        default=12,
+        help="Maximum allowed planned retry delay budget",
+    )
+    parser.add_argument(
+        "--summary",
+        default="",
+        help="Optional markdown summary output path",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Optional key=value output path (GitHub output format)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit report as JSON to stdout",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Emit policy report without requiring checkout outcomes",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.max_attempts < 1:
+        raise ValueError("--max-attempts must be >= 1")
+    if args.base_delay_seconds < 0:
+        raise ValueError("--base-delay-seconds must be >= 0")
+    if args.cap_delay_seconds < 0:
+        raise ValueError("--cap-delay-seconds must be >= 0")
+    if args.cap_delay_seconds < args.base_delay_seconds:
+        raise ValueError("--cap-delay-seconds must be >= --base-delay-seconds")
+    if args.max_total_delay_seconds < 0:
+        raise ValueError("--max-total-delay-seconds must be >= 0")
+
+    policy = CheckoutRetryPolicy(
+        max_attempts=args.max_attempts,
+        base_delay_seconds=args.base_delay_seconds,
+        cap_delay_seconds=args.cap_delay_seconds,
+        max_total_delay_seconds=args.max_total_delay_seconds,
+    )
+    outcomes = (
+        ["skipped"] * policy.max_attempts
+        if args.dry_run
+        else normalize_outcomes(args.outcomes, policy.max_attempts)
+    )
+    report = build_report(policy, outcomes)
+
+    if report.planned_total_delay_seconds > policy.max_total_delay_seconds:
+        raise ValueError(
+            "planned total retry delay exceeds budget: "
+            f"{report.planned_total_delay_seconds}s > {policy.max_total_delay_seconds}s"
+        )
+
+    summary_text = render_summary(report)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "status": report.status,
+                    "mode": report.mode,
+                    "outcomes": report.outcomes,
+                    "max_attempts": report.policy.max_attempts,
+                    "retry_delays_seconds": report.retry_delays_seconds,
+                    "planned_total_delay_seconds": report.planned_total_delay_seconds,
+                    "actual_total_delay_seconds": report.actual_total_delay_seconds,
+                    "success_attempt": report.success_attempt,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(summary_text)
+
+    summary_path = Path(args.summary).resolve() if args.summary.strip() else None
+    output_path = Path(args.output).resolve() if args.output.strip() else None
+    write_summary(summary_path, summary_text)
+    write_output(output_path, report)
+
+    if args.dry_run:
+        return 0
+    return 0 if report.status == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_checkout_retry.py
+++ b/.github/scripts/test_ci_checkout_retry.py
@@ -1,0 +1,112 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ci_checkout_retry  # noqa: E402
+
+
+REPO_ROOT = SCRIPT_DIR.parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class CheckoutRetryTests(unittest.TestCase):
+    def test_unit_compute_retry_delays_applies_exponential_backoff_with_cap(self):
+        policy = ci_checkout_retry.CheckoutRetryPolicy(
+            max_attempts=4,
+            base_delay_seconds=3,
+            cap_delay_seconds=6,
+            max_total_delay_seconds=30,
+        )
+        delays = ci_checkout_retry.compute_retry_delays(policy)
+        self.assertEqual(delays, [3, 6, 6])
+
+    def test_functional_cli_dry_run_reports_deterministic_policy_json(self):
+        script_path = SCRIPT_DIR / "ci_checkout_retry.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--dry-run",
+                "--max-attempts",
+                "3",
+                "--base-delay-seconds",
+                "3",
+                "--cap-delay-seconds",
+                "6",
+                "--max-total-delay-seconds",
+                "12",
+                "--json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["retry_delays_seconds"], [3, 6])
+        self.assertEqual(payload["planned_total_delay_seconds"], 9)
+        self.assertEqual(payload["status"], "failure")
+
+    def test_integration_ci_workflow_uses_retry_attempts_and_helper_script(self):
+        raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("id: checkout_attempt_1", raw)
+        self.assertIn("id: checkout_attempt_2", raw)
+        self.assertIn("id: checkout_attempt_3", raw)
+        self.assertIn(".github/scripts/ci_checkout_retry.py", raw)
+        self.assertIn("Fail when checkout retries are exhausted", raw)
+
+    def test_regression_cli_rejects_delay_budget_overrun(self):
+        script_path = SCRIPT_DIR / "ci_checkout_retry.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--dry-run",
+                "--max-attempts",
+                "4",
+                "--base-delay-seconds",
+                "10",
+                "--cap-delay-seconds",
+                "30",
+                "--max-total-delay-seconds",
+                "5",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("planned total retry delay exceeds budget", completed.stderr)
+
+    def test_regression_cli_outputs_failure_exit_code_when_outcomes_exhausted(self):
+        script_path = SCRIPT_DIR / "ci_checkout_retry.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "output.txt"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script_path),
+                    "--outcomes",
+                    "failure,failure,failure",
+                    "--output",
+                    str(output_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 1)
+            output = output_path.read_text(encoding="utf-8")
+            self.assertIn("checkout_retry_status=failure", output)
+            self.assertIn("checkout_retry_mode=checkout_retries_exhausted", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,84 @@ jobs:
       run_cross_platform: ${{ steps.quality_mode.outputs.run_cross_platform }}
       heavy_reason: ${{ steps.quality_mode.outputs.heavy_reason }}
     steps:
-      - name: Checkout
+      - name: Checkout (attempt 1)
+        id: checkout_attempt_1
         uses: actions/checkout@v6
+        continue-on-error: true
+
+      - name: Backoff before checkout retry 2
+        if: steps.checkout_attempt_1.outcome == 'failure'
+        shell: bash
+        run: sleep 3
+
+      - name: Checkout (attempt 2)
+        id: checkout_attempt_2
+        if: steps.checkout_attempt_1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+
+      - name: Backoff before checkout retry 3
+        if: steps.checkout_attempt_1.outcome == 'failure' && steps.checkout_attempt_2.outcome == 'failure'
+        shell: bash
+        run: sleep 6
+
+      - name: Checkout (attempt 3)
+        id: checkout_attempt_3
+        if: steps.checkout_attempt_1.outcome == 'failure' && steps.checkout_attempt_2.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+
+      - name: Evaluate checkout retry outcomes
+        id: checkout_retry_report
+        if: always() && (steps.checkout_attempt_1.outcome == 'success' || steps.checkout_attempt_2.outcome == 'success' || steps.checkout_attempt_3.outcome == 'success')
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempt_1="${{ steps.checkout_attempt_1.outcome }}"
+          attempt_2="${{ steps.checkout_attempt_2.outcome }}"
+          attempt_3="${{ steps.checkout_attempt_3.outcome }}"
+          if [[ -z "${attempt_2}" ]]; then
+            attempt_2="skipped"
+          fi
+          if [[ -z "${attempt_3}" ]]; then
+            attempt_3="skipped"
+          fi
+
+          python3 .github/scripts/ci_checkout_retry.py \
+            --outcomes "${attempt_1},${attempt_2},${attempt_3}" \
+            --max-attempts 3 \
+            --base-delay-seconds 3 \
+            --cap-delay-seconds 6 \
+            --max-total-delay-seconds 12 \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --output "$GITHUB_OUTPUT"
+
+      - name: Fail when checkout retries are exhausted
+        if: steps.checkout_attempt_1.outcome != 'success' && steps.checkout_attempt_2.outcome != 'success' && steps.checkout_attempt_3.outcome != 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempt_1="${{ steps.checkout_attempt_1.outcome }}"
+          attempt_2="${{ steps.checkout_attempt_2.outcome }}"
+          attempt_3="${{ steps.checkout_attempt_3.outcome }}"
+          if [[ -z "${attempt_2}" ]]; then
+            attempt_2="skipped"
+          fi
+          if [[ -z "${attempt_3}" ]]; then
+            attempt_3="skipped"
+          fi
+
+          echo "::error::checkout failed after 3 bounded attempts; mode=checkout_retries_exhausted; outcomes=${attempt_1},${attempt_2},${attempt_3}"
+          {
+            echo "### Checkout Retry"
+            echo "- Status: failure"
+            echo "- Mode: checkout_retries_exhausted"
+            echo "- Outcomes: ${attempt_1},${attempt_2},${attempt_3}"
+            echo "- Max attempts: 3"
+            echo "- Retry delays (s): [3, 6]"
+            echo "- Planned total delay (s): 9"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
       - name: Detect change scope
         id: change_scope


### PR DESCRIPTION
Closes #677

## Summary of behavior changes
- add `/.github/scripts/ci_checkout_retry.py` for deterministic checkout retry policy diagnostics
- add `/.github/scripts/test_ci_checkout_retry.py` with unit/functional/integration/regression coverage
- harden `quality-linux` checkout path in `/.github/workflows/ci.yml` with bounded retries:
  - attempt 1
  - bounded backoff (3s) and attempt 2
  - bounded backoff (6s) and attempt 3
  - deterministic success/failure reporting and fail-closed exhaustion behavior

## Risks and compatibility notes
- quality workflow gates and cost-governance logic remain intact after checkout
- checkout retry budget is bounded (`max attempts=3`, planned delay `9s`) to prevent runtime/cost explosion
- fallback failure output now includes deterministic mode and outcomes for transport diagnostics

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_ci_checkout_retry.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `python3 .github/scripts/ci_checkout_retry.py --dry-run --max-attempts 3 --base-delay-seconds 3 --cap-delay-seconds 6 --max-total-delay-seconds 12 --json`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

## Test matrix
- Unit: retry delay schedule and policy math (`test_unit_compute_retry_delays_applies_exponential_backoff_with_cap`)
- Functional: CLI dry-run deterministic JSON/report behavior (`test_functional_cli_dry_run_reports_deterministic_policy_json`)
- Integration: workflow wiring asserts retry path + helper invocation in `ci.yml` (`test_integration_ci_workflow_uses_retry_attempts_and_helper_script`)
- Regression: delay-budget guard + exhausted-outcome behavior (`test_regression_cli_rejects_delay_budget_overrun`, `test_regression_cli_outputs_failure_exit_code_when_outcomes_exhausted`)
