### PR TITLE
feat: add one-command demo orchestration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 Run deterministic local demos:
 
 ```bash
+./scripts/demo/all.sh
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -88,6 +88,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ## Run deterministic local demos
 
 ```bash
+./scripts/demo/all.sh
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+binary="${repo_root}/target/debug/tau-coding-agent"
+skip_build="false"
+
+print_usage() {
+  cat <<EOF
+Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--help]
+
+Run all checked-in Tau demo wrappers (local/rpc/events/package) with aggregate summary output.
+
+Options:
+  --repo-root PATH  Repository root (defaults to caller-derived root)
+  --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
+  --skip-build      Skip cargo build and require --binary to exist
+  --help            Show this usage message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --repo-root" >&2
+        print_usage >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --binary)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --binary" >&2
+        print_usage >&2
+        exit 2
+      fi
+      binary="$2"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build="true"
+      shift
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "${repo_root}" ]]; then
+  echo "invalid --repo-root path (directory not found): ${repo_root}" >&2
+  exit 2
+fi
+repo_root="$(cd "${repo_root}" && pwd)"
+
+if [[ "${binary}" != /* ]]; then
+  binary="${repo_root}/${binary}"
+fi
+
+if [[ "${skip_build}" == "true" && ! -f "${binary}" ]]; then
+  echo "missing tau-coding-agent binary (use --binary or remove --skip-build): ${binary}" >&2
+  exit 1
+fi
+
+demo_scripts=(
+  "local.sh"
+  "rpc.sh"
+  "events.sh"
+  "package.sh"
+)
+
+total=0
+passed=0
+failed=0
+
+for demo_script in "${demo_scripts[@]}"; do
+  total=$((total + 1))
+  echo "[demo:all] [${total}] ${demo_script}"
+  args=("${script_dir}/${demo_script}" "--repo-root" "${repo_root}" "--binary" "${binary}")
+  if [[ "${skip_build}" == "true" ]]; then
+    args+=("--skip-build")
+  fi
+
+  if "${args[@]}"; then
+    passed=$((passed + 1))
+    echo "[demo:all] PASS ${demo_script}"
+  else
+    failed=$((failed + 1))
+    echo "[demo:all] FAIL ${demo_script}" >&2
+  fi
+done
+
+echo "[demo:all] summary: total=${total} passed=${passed} failed=${failed}"
+if [[ ${failed} -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes #696

## Summary of behavior changes
- Add `scripts/demo/all.sh` to run `local.sh`, `rpc.sh`, `events.sh`, and `package.sh` in a deterministic sequence.
- Add deterministic aggregate reporting (`total/passed/failed`) and fail-closed exit behavior when any sub-demo fails.
- Add demo script test coverage for unknown argument handling, success orchestration, execution order visibility, and missing-binary regression behavior.
- Document the new one-command demo path in `README.md` and quickstart.

## Risks and compatibility notes
- No runtime behavior change for existing wrappers; `all.sh` composes existing scripts and preserves pass-through style flags.
- New script depends on the same binary and demo wrappers already required by existing demo workflow.
- Minimal risk surface: shell orchestration and docs/tests only.

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/all.sh --skip-build`
- `cargo test --workspace -- --test-threads=1`
