### PR TITLE
feat: add selective and JSON-capable demo orchestration

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -31,19 +31,27 @@ print("mock-ok " + " ".join(sys.argv[1:]))
     path.chmod(0o755)
 
 
-def run_demo_script(script_name: str, binary_path: Path, trace_path: Path) -> subprocess.CompletedProcess[str]:
+def run_demo_script(
+    script_name: str,
+    binary_path: Path,
+    trace_path: Path,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     script_path = SCRIPTS_DIR / script_name
     env = dict(os.environ)
     env["TAU_DEMO_MOCK_TRACE"] = str(trace_path)
+    command = [
+        str(script_path),
+        "--skip-build",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--binary",
+        str(binary_path),
+    ]
+    if extra_args:
+        command.extend(extra_args)
     return subprocess.run(
-        [
-            str(script_path),
-            "--skip-build",
-            "--repo-root",
-            str(REPO_ROOT),
-            "--binary",
-            str(binary_path),
-        ],
+        command,
         env=env,
         text=True,
         capture_output=True,
@@ -71,6 +79,30 @@ class DemoScriptsTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 2)
         self.assertIn("unknown argument: --definitely-unknown", completed.stderr)
+
+    def test_unit_all_script_list_prints_deterministic_inventory(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPTS_DIR / "all.sh"), "--list"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(
+            completed.stdout.strip().splitlines(),
+            ["local.sh", "rpc.sh", "events.sh", "package.sh"],
+        )
+
+    def test_unit_all_script_only_rejects_unknown_demo_names(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPTS_DIR / "all.sh"), "--only", "rpc,unknown-demo"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("unknown demo names in --only", completed.stderr)
+        self.assertIn("unknown-demo", completed.stderr)
 
     def test_functional_demo_scripts_run_expected_command_chains(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -110,6 +142,38 @@ class DemoScriptsTests(unittest.TestCase):
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 12)
 
+    def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            binary_path = root / "bin" / "tau-coding-agent"
+            trace_path = root / "trace.ndjson"
+            write_mock_binary(binary_path)
+
+            completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--only", "rpc,events"])
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+            self.assertIn("[demo:all] [1] rpc.sh", completed.stdout)
+            self.assertIn("[demo:all] [2] events.sh", completed.stdout)
+            self.assertIn("[demo:all] summary: total=2 passed=2 failed=0", completed.stdout)
+            self.assertNotIn("local.sh", completed.stdout)
+            self.assertNotIn("package.sh", completed.stdout)
+
+            rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+            self.assertGreaterEqual(len(rows), 5)
+
+    def test_functional_all_script_json_summary_reports_selected_demo_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            binary_path = root / "bin" / "tau-coding-agent"
+            trace_path = root / "trace.ndjson"
+            write_mock_binary(binary_path)
+
+            completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--only", "local", "--json"])
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+            payload = json.loads(completed.stdout)
+            self.assertEqual(payload["summary"], {"total": 1, "passed": 1, "failed": 0})
+            self.assertEqual(payload["demos"], [{"name": "local.sh", "status": "passed", "exit_code": 0}])
+            self.assertIn("[demo:all] [1] local.sh", completed.stderr)
+
     def test_integration_demo_scripts_use_checked_in_example_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -140,6 +204,17 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [2] rpc.sh", completed.stdout)
             self.assertIn("[demo:all] [3] events.sh", completed.stdout)
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
+
+    def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPTS_DIR / "all.sh"), "--list", "--json"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["demos"], ["local.sh", "rpc.sh", "events.sh", "package.sh"])
 
     def test_regression_scripts_fail_closed_when_binary_missing_in_skip_build_mode(self) -> None:
         completed = subprocess.run(
@@ -174,6 +249,18 @@ class DemoScriptsTests(unittest.TestCase):
         )
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("missing tau-coding-agent binary", completed.stderr)
+
+    def test_regression_all_script_unknown_only_filter_fails_before_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            binary_path = root / "bin" / "tau-coding-agent"
+            trace_path = root / "trace.ndjson"
+            write_mock_binary(binary_path)
+
+            completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--only", "unknown"])
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("unknown demo names in --only", completed.stderr)
+            self.assertFalse(trace_path.exists())
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Run deterministic local demos:
 
 ```bash
 ./scripts/demo/all.sh
+./scripts/demo/all.sh --list
+./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -89,6 +89,8 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 
 ```bash
 ./scripts/demo/all.sh
+./scripts/demo/all.sh --list
+./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh


### PR DESCRIPTION
Closes #701

## Summary of behavior changes
- Extended `scripts/demo/all.sh` with operator-focused controls:
  - `--list` prints deterministic demo inventory.
  - `--only <name[,name...]>` executes a selected subset in canonical order.
  - `--json` emits deterministic machine-readable output for both list and run summary modes.
- Preserved existing default human-readable behavior for `./scripts/demo/all.sh` without new flags.
- Added validation and fail-closed handling for unknown `--only` names.
- Expanded `.github/scripts/test_demo_scripts.py` for unit/functional/integration/regression coverage of the new orchestration modes.
- Updated quickstart references with concrete `--list` and `--only ... --json` examples.

## Risks and compatibility notes
- Backward compatible for existing demo commands and wrapper scripts.
- `--json` intentionally routes wrapper logs to stderr so stdout remains parseable JSON.
- New `--only` accepts both short and `.sh` demo names, and rejects unknown names with exit code `2`.

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/all.sh --list`
- `./scripts/demo/all.sh --skip-build --only rpc,events --json`
- `cargo test --workspace -- --test-threads=1`
