### PR TITLE
feat: add fail-fast mode for demo orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --list
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
+./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -92,6 +92,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --list
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
+./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -9,6 +9,7 @@ list_only="false"
 json_output="false"
 has_only_filter="false"
 report_file=""
+fail_fast="false"
 
 demo_scripts=(
   "local.sh"
@@ -132,7 +133,7 @@ print_summary_json() {
 
 print_usage() {
   cat <<EOF
-Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--help]
+Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--help]
 
 Run checked-in Tau demo wrappers (local/rpc/events/package) with deterministic summary output.
 
@@ -144,6 +145,7 @@ Options:
   --only DEMOS      Comma-separated subset (names: local,rpc,events,package)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
+  --fail-fast       Stop after first failed wrapper
   --help            Show this usage message
 EOF
 }
@@ -209,6 +211,10 @@ while [[ $# -gt 0 ]]; do
       fi
       report_file="$2"
       shift 2
+      ;;
+    --fail-fast)
+      fail_fast="true"
+      shift
       ;;
     --help)
       print_usage
@@ -307,6 +313,10 @@ for demo_script in "${selected_demo_scripts[@]}"; do
   else
     failed=$((failed + 1))
     log_error "[demo:all] FAIL ${demo_script}"
+    if [[ "${fail_fast}" == "true" ]]; then
+      log_error "[demo:all] fail-fast triggered; stopping after ${demo_script}"
+      break
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary
- add `--fail-fast` to `scripts/demo/all.sh`
- stop demo orchestration immediately after the first failed wrapper when the flag is enabled
- keep default behavior unchanged (continue through all selected wrappers)
- document fail-fast demo usage in README and quickstart
- add unit/functional/integration coverage for fail-fast behavior in `.github/scripts/test_demo_scripts.py`

## Risks and Compatibility
- low risk: default path is unchanged unless `--fail-fast` is explicitly set
- fail-fast mode intentionally changes execution count in summary/report output after first failure
- no runtime API changes beyond the demo shell wrapper interface

## Validation Evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `cargo test --workspace -- --test-threads=1`

Closes #709
