### PR TITLE
feat: add timeout guardrails to demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
+./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -93,6 +93,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
+./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -5,7 +5,7 @@ tau_demo_common_print_usage() {
   local script_name="$1"
   local summary="$2"
   cat <<EOF
-Usage: ${script_name} [--repo-root PATH] [--binary PATH] [--skip-build] [--help]
+Usage: ${script_name} [--repo-root PATH] [--binary PATH] [--skip-build] [--timeout-seconds N] [--help]
 
 ${summary}
 
@@ -13,6 +13,7 @@ Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
+  --timeout-seconds Positive integer timeout for each demo step
   --help            Show this usage message
 EOF
 }
@@ -31,6 +32,7 @@ tau_demo_common_init() {
   TAU_DEMO_REPO_ROOT="$(cd "${caller_dir}/../.." && pwd)"
   TAU_DEMO_BINARY="${TAU_DEMO_REPO_ROOT}/target/debug/tau-coding-agent"
   TAU_DEMO_SKIP_BUILD="false"
+  TAU_DEMO_TIMEOUT_SECONDS=""
   TAU_DEMO_STEP_TOTAL=0
   TAU_DEMO_STEP_PASSED=0
 
@@ -58,6 +60,20 @@ tau_demo_common_init() {
         TAU_DEMO_SKIP_BUILD="true"
         shift
         ;;
+      --timeout-seconds)
+        if [[ $# -lt 2 ]]; then
+          echo "missing value for --timeout-seconds" >&2
+          tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}" >&2
+          return 2
+        fi
+        if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+          echo "invalid value for --timeout-seconds (expected positive integer): $2" >&2
+          tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}" >&2
+          return 2
+        fi
+        TAU_DEMO_TIMEOUT_SECONDS="$2"
+        shift 2
+        ;;
       --help)
         tau_demo_common_print_usage "$(basename "${caller_script}")" "${summary}"
         return 64
@@ -78,6 +94,10 @@ tau_demo_common_init() {
 
   if [[ "${TAU_DEMO_BINARY}" != /* ]]; then
     TAU_DEMO_BINARY="${TAU_DEMO_REPO_ROOT}/${TAU_DEMO_BINARY}"
+  fi
+
+  if [[ -n "${TAU_DEMO_TIMEOUT_SECONDS}" ]]; then
+    tau_demo_common_require_command python3 || return 1
   fi
 }
 
@@ -123,6 +143,36 @@ tau_demo_common_prepare_binary() {
   tau_demo_common_require_file "${TAU_DEMO_BINARY}"
 }
 
+tau_demo_common_exec_binary() {
+  if [[ -z "${TAU_DEMO_TIMEOUT_SECONDS}" ]]; then
+    (
+      cd "${TAU_DEMO_REPO_ROOT}"
+      "${TAU_DEMO_BINARY}" "$@"
+    )
+    return $?
+  fi
+
+  (
+    cd "${TAU_DEMO_REPO_ROOT}"
+    python3 - "${TAU_DEMO_TIMEOUT_SECONDS}" "${TAU_DEMO_BINARY}" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout_seconds = int(sys.argv[1])
+binary = sys.argv[2]
+args = sys.argv[3:]
+
+try:
+    completed = subprocess.run([binary, *args], timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+
+sys.exit(completed.returncode)
+PY
+  )
+  return $?
+}
+
 tau_demo_common_run_step() {
   local label="$1"
   shift
@@ -139,16 +189,17 @@ tau_demo_common_run_step() {
     printf '%s\t%s\n' "${label}" "${rendered_command}" >>"${TAU_DEMO_TRACE_LOG}"
   fi
 
-  if (
-    cd "${TAU_DEMO_REPO_ROOT}"
-    "${TAU_DEMO_BINARY}" "$@"
-  ); then
+  if tau_demo_common_exec_binary "$@"; then
     TAU_DEMO_STEP_PASSED=$((TAU_DEMO_STEP_PASSED + 1))
     echo "[demo:${TAU_DEMO_NAME}] PASS ${label}"
     return 0
   else
     local rc=$?
-    echo "[demo:${TAU_DEMO_NAME}] FAIL ${label} exit=${rc}" >&2
+    if [[ "${rc}" -eq 124 && -n "${TAU_DEMO_TIMEOUT_SECONDS}" ]]; then
+      echo "[demo:${TAU_DEMO_NAME}] TIMEOUT ${label} after ${TAU_DEMO_TIMEOUT_SECONDS}s" >&2
+    else
+      echo "[demo:${TAU_DEMO_NAME}] FAIL ${label} exit=${rc}" >&2
+    fi
     return "${rc}"
   fi
 }


### PR DESCRIPTION
## Summary
- add `--timeout-seconds` support to demo wrappers via `scripts/demo/common.sh`
- enforce per-step timeout in `tau_demo_common_run_step` using `python3` subprocess timeout handling
- add `--timeout-seconds` passthrough to `scripts/demo/all.sh`
- keep default behavior unchanged when timeout flag is not set
- document timeout usage in README and quickstart demo commands
- add timeout-focused unit/functional/integration/regression coverage in `.github/scripts/test_demo_scripts.py`

## Risks and Compatibility
- low risk: timeout logic is opt-in and inactive by default
- timeout mode requires `python3` availability (validated and hard-failed with deterministic error if missing)
- timeout expirations return exit code `124`, which is now represented in summary/report payloads

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #713
