### PR TITLE
perf: optimize demo orchestrator to build once

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 Run deterministic local demos:
 
 ```bash
+# all.sh prepares the binary once, then reuses it across selected wrappers.
 ./scripts/demo/all.sh
 ./scripts/demo/all.sh --list
 ./scripts/demo/all.sh --only rpc,events --json

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -88,6 +88,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ## Run deterministic local demos
 
 ```bash
+# all.sh prepares the binary once, then reuses it across selected wrappers.
 ./scripts/demo/all.sh
 ./scripts/demo/all.sh --list
 ./scripts/demo/all.sh --only rpc,events --json


### PR DESCRIPTION
## Summary
- optimize `scripts/demo/all.sh` to prepare the `tau-coding-agent` binary once per orchestration run
- forward `--skip-build` to all wrapper scripts from `all.sh` to avoid repeated build work
- keep fail-fast, timeout, list, JSON, and report-file semantics unchanged
- add functional coverage proving exactly one build invocation via mocked `cargo`
- document one-time build behavior in README and quickstart demo sections

## Risks and Compatibility
- low risk: behavior change is internal orchestration efficiency; output contracts are preserved
- default non-`--skip-build` mode now performs one build pre-step rather than wrapper-local build attempts
- custom binary paths still fail deterministically if binary is missing after preparation

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #717
