### PR TITLE
feat: add duration_ms telemetry to demo summary payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Run deterministic local demos:
 ./scripts/demo/package.sh
 ```
 
+`all.sh --json` and `--report-file` entries include `duration_ms` per wrapper.
+
 Clean generated local artifacts/noise:
 
 ```bash

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -101,6 +101,8 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/package.sh
 ```
 
+`all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.
+
 All wrappers support `--skip-build` and `--binary <path>` for prebuilt binaries.
 
 ## Cleanup local generated artifacts


### PR DESCRIPTION
## Summary
- add per-wrapper `duration_ms` telemetry to `scripts/demo/all.sh` JSON/report payload entries
- preserve existing wrapper status fields (`name`, `status`, `exit_code`) and summary counters
- keep text mode behavior unchanged while enriching machine-readable outputs
- update demo script tests to validate `duration_ms` presence/type/range
- document new payload field in README and quickstart

## Risks and Compatibility
- low risk: payload extension is additive; existing fields remain unchanged
- `duration_ms` values are runtime-dependent and non-deterministic by value, but deterministic in shape
- fallback timestamp path is provided when `python3` is unavailable

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #725
