### PR TITLE
ci: gate helper test suite by helper change scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
               - "**/Cargo.toml"
               - "Cargo.toml"
               - "Cargo.lock"
+            helpers:
+              - ".github/workflows/**"
+              - ".github/scripts/**"
 
       - name: Determine rust scope
         id: rust_scope
@@ -155,7 +158,23 @@ jobs:
           echo "### Rust Scope" >> "$GITHUB_STEP_SUMMARY"
           echo "- Rust/Cargo changed: ${rust_changed}" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Determine helper test scope
+        id: helper_scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          helper_tests_needed="${{ steps.change_scope.outputs.helpers }}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            helper_tests_needed="true"
+          elif [[ -z "${helper_tests_needed}" ]]; then
+            helper_tests_needed="false"
+          fi
+          echo "helper_tests_needed=${helper_tests_needed}" >> "$GITHUB_OUTPUT"
+          echo "### Helper Tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Helper tests needed: ${helper_tests_needed}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Validate CI helper scripts
+        if: steps.helper_scope.outputs.helper_tests_needed == 'true'
         run: python3 -m unittest discover -s .github/scripts -p "test_*.py"
 
       - name: Determine quality mode


### PR DESCRIPTION
## Summary
- add `helpers` scope filter in CI path detection
- derive `helper_tests_needed` and report it in step summary
- gate `.github/scripts` helper test suite on helper scope for PRs
- preserve helper-test execution for non-PR events (schedule/dispatch)

## Risks and Compatibility
- low risk: helper tests are now skipped only when PRs do not touch helper/workflow files
- helper/workflow PRs retain helper test coverage
- non-PR runs still execute helper tests for baseline coverage

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Closes #733
