### PR TITLE
feat: add GitHub bridge one-shot poll mode

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1710,6 +1710,19 @@ pub(crate) struct Cli {
     pub(crate) github_poll_interval_seconds: u64,
 
     #[arg(
+        long = "github-poll-once",
+        env = "TAU_GITHUB_POLL_ONCE",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "github_issues_bridge",
+        help = "Run one GitHub bridge poll cycle, drain spawned runs, and exit"
+    )]
+    pub(crate) github_poll_once: bool,
+
+    #[arg(
         long = "github-artifact-retention-days",
         env = "TAU_GITHUB_ARTIFACT_RETENTION_DAYS",
         default_value_t = 30,

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -44,6 +44,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             token,
             bot_login: cli.github_bot_login.clone(),
             poll_interval: Duration::from_secs(cli.github_poll_interval_seconds.max(1)),
+            poll_once: cli.github_poll_once,
             include_issue_body: cli.github_include_issue_body,
             include_edited_comments: cli.github_include_edited_comments,
             processed_event_cap: cli.github_processed_event_cap.max(1),

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -461,6 +461,7 @@ fn test_cli() -> Cli {
         github_api_base: "https://api.github.com".to_string(),
         github_state_dir: PathBuf::from(".tau/github-issues"),
         github_poll_interval_seconds: 30,
+        github_poll_once: false,
         github_artifact_retention_days: 30,
         github_include_issue_body: false,
         github_include_edited_comments: true,
@@ -1139,6 +1140,7 @@ fn functional_cli_integration_secret_id_flags_accept_explicit_values() {
 #[test]
 fn unit_cli_artifact_retention_flags_default_to_30_days() {
     let cli = Cli::parse_from(["tau-rs"]);
+    assert!(!cli.github_poll_once);
     assert_eq!(cli.github_artifact_retention_days, 30);
     assert_eq!(cli.slack_artifact_retention_days, 30);
 }
@@ -1149,13 +1151,25 @@ fn functional_cli_artifact_retention_flags_accept_explicit_values() {
         "tau-rs",
         "--github-issues-bridge",
         "--slack-bridge",
+        "--github-poll-once",
         "--github-artifact-retention-days",
         "14",
         "--slack-artifact-retention-days",
         "0",
     ]);
+    assert!(cli.github_poll_once);
     assert_eq!(cli.github_artifact_retention_days, 14);
     assert_eq!(cli.slack_artifact_retention_days, 0);
+}
+
+#[test]
+fn regression_cli_github_poll_once_accepts_explicit_false() {
+    let cli = Cli::parse_from([
+        "tau-rs",
+        "--github-issues-bridge",
+        "--github-poll-once=false",
+    ]);
+    assert!(!cli.github_poll_once);
 }
 
 #[test]

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -17,6 +17,17 @@ cargo run -p tau-coding-agent -- \
   --github-artifact-retention-days 30
 ```
 
+Run exactly one poll cycle (useful for CI smoke jobs and cron workflows):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --github-issues-bridge \
+  --github-repo owner/repo \
+  --github-poll-once \
+  --github-state-dir .tau/github-issues
+```
+
 Bridge control commands in issue comments:
 
 - `/tau help`


### PR DESCRIPTION
Closes #737
Refs #736
Refs #735

## Summary of behavior changes
- Added new CLI option `--github-poll-once` (`TAU_GITHUB_POLL_ONCE`) for GitHub Issues bridge mode.
- Wired one-shot behavior into transport startup config and bridge runtime config.
- Updated bridge runtime loop so one-shot mode:
  - runs exactly one poll cycle,
  - drains spawned issue runs before exit,
  - exits successfully after completion,
  - returns non-zero on poll failure (while persisting health snapshot state).
- Extended tests:
  - CLI parsing defaults/overrides for `github_poll_once`.
  - Functional runtime one-shot success path.
  - Regression runtime one-shot error propagation path.
- Updated transport guide with one-shot usage example.

## Risks and compatibility notes
- Default behavior is unchanged: continuous polling remains the default when `--github-poll-once` is not set.
- One-shot mode now waits for active runs from the single cycle to finish before exiting; this is intentional for deterministic script/CI behavior.

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
