### PR TITLE
feat: add required-label filtering to GitHub bridge

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1723,6 +1723,15 @@ pub(crate) struct Cli {
     pub(crate) github_poll_once: bool,
 
     #[arg(
+        long = "github-required-label",
+        env = "TAU_GITHUB_REQUIRED_LABEL",
+        value_delimiter = ',',
+        requires = "github_issues_bridge",
+        help = "Only process issues containing one of these labels (repeatable)"
+    )]
+    pub(crate) github_required_label: Vec<String>,
+
+    #[arg(
         long = "github-artifact-retention-days",
         env = "TAU_GITHUB_ARTIFACT_RETENTION_DAYS",
         default_value_t = 30,

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -33,6 +33,13 @@ pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
         bail!("--github-retry-base-delay-ms must be greater than 0");
     }
     if cli
+        .github_required_label
+        .iter()
+        .any(|label| label.trim().is_empty())
+    {
+        bail!("--github-required-label cannot be empty");
+    }
+    if cli
         .github_repo
         .as_deref()
         .map(str::trim)

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -45,6 +45,11 @@ pub(crate) async fn run_transport_mode_if_requested(
             bot_login: cli.github_bot_login.clone(),
             poll_interval: Duration::from_secs(cli.github_poll_interval_seconds.max(1)),
             poll_once: cli.github_poll_once,
+            required_labels: cli
+                .github_required_label
+                .iter()
+                .map(|label| label.trim().to_string())
+                .collect(),
             include_issue_body: cli.github_include_issue_body,
             include_edited_comments: cli.github_include_edited_comments,
             processed_event_cap: cli.github_processed_event_cap.max(1),

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -12,10 +12,13 @@ cargo run -p tau-coding-agent -- \
   --github-issues-bridge \
   --github-repo owner/repo \
   --github-bot-login your-bot-login \
+  --github-required-label tau-ready \
   --github-state-dir .tau/github-issues \
   --github-poll-interval-seconds 30 \
   --github-artifact-retention-days 30
 ```
+
+`--github-required-label` can be repeated; only issues with at least one matching label are processed.
 
 Run exactly one poll cycle (useful for CI smoke jobs and cron workflows):
 


### PR DESCRIPTION
Closes #741
Refs #740
Refs #739

## Summary of behavior changes
- Added repeatable GitHub bridge label filter CLI option: `--github-required-label` (`TAU_GITHUB_REQUIRED_LABEL`, comma-delimited supported).
- Added runtime validation to reject empty required label values.
- Threaded required labels through startup transport config into GitHub bridge runtime config.
- Extended GitHub issue model parsing to include issue labels from the GitHub API.
- Added label-gating logic so bridge processing only runs for issues matching configured labels.
- Updated transport docs with required-label usage guidance.

## Risks and compatibility notes
- Default behavior remains unchanged when no required labels are configured.
- Label matching is case-insensitive and trims whitespace.
- In filtered mode, non-matching issues are intentionally skipped before comment/event processing to reduce unnecessary API work.

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
