### PR TITLE
Add required GitHub issue number filter

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1732,6 +1732,16 @@ pub(crate) struct Cli {
     pub(crate) github_required_label: Vec<String>,
 
     #[arg(
+        long = "github-issue-number",
+        env = "TAU_GITHUB_ISSUE_NUMBER",
+        value_delimiter = ',',
+        value_parser = parse_positive_u64,
+        requires = "github_issues_bridge",
+        help = "Only process these GitHub issue numbers (repeatable)"
+    )]
+    pub(crate) github_issue_number: Vec<u64>,
+
+    #[arg(
         long = "github-artifact-retention-days",
         env = "TAU_GITHUB_ARTIFACT_RETENTION_DAYS",
         default_value_t = 30,

--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -66,6 +66,7 @@ pub(crate) struct GithubIssuesBridgeRuntimeConfig {
     pub poll_interval: Duration,
     pub poll_once: bool,
     pub required_labels: Vec<String>,
+    pub required_issue_numbers: Vec<u64>,
     pub include_issue_body: bool,
     pub include_edited_comments: bool,
     pub processed_event_cap: usize,
@@ -894,6 +895,7 @@ struct GithubIssuesBridgeRuntime {
     repo: RepoRef,
     github_client: GithubApiClient,
     required_issue_labels: HashSet<String>,
+    required_issue_numbers: HashSet<u64>,
     state_store: GithubIssuesBridgeStateStore,
     inbound_log: JsonlEventLog,
     outbound_log: JsonlEventLog,
@@ -936,11 +938,18 @@ impl GithubIssuesBridgeRuntime {
             .map(|label| normalize_issue_label(label))
             .filter(|label| !label.is_empty())
             .collect::<HashSet<_>>();
+        let required_issue_numbers = config
+            .required_issue_numbers
+            .iter()
+            .copied()
+            .filter(|issue_number| *issue_number > 0)
+            .collect::<HashSet<_>>();
         Ok(Self {
             config,
             repo,
             github_client,
             required_issue_labels,
+            required_issue_numbers,
             state_store,
             inbound_log,
             outbound_log,
@@ -1029,6 +1038,9 @@ impl GithubIssuesBridgeRuntime {
                 Some(existing) if existing >= issue.updated_at => Some(existing),
                 _ => Some(issue.updated_at.clone()),
             };
+            if !issue_matches_required_numbers(issue.number, &self.required_issue_numbers) {
+                continue;
+            }
             if !issue_matches_required_labels(&issue, &self.required_issue_labels) {
                 continue;
             }
@@ -3436,6 +3448,10 @@ fn normalize_issue_label(raw: &str) -> String {
     raw.trim().to_ascii_lowercase()
 }
 
+fn issue_matches_required_numbers(issue_number: u64, required: &HashSet<u64>) -> bool {
+    required.is_empty() || required.contains(&issue_number)
+}
+
 fn issue_matches_required_labels(issue: &GithubIssue, required: &HashSet<String>) -> bool {
     if required.is_empty() {
         return true;
@@ -3941,16 +3957,16 @@ mod tests {
         collect_issue_events, evaluate_attachment_content_type_policy,
         evaluate_attachment_url_policy, event_action_from_body, extract_attachment_urls,
         extract_footer_event_keys, is_retryable_github_status, issue_matches_required_labels,
-        issue_session_id, normalize_artifact_retention_days, normalize_relative_channel_path,
-        parse_rfc3339_to_unix_ms, parse_tau_issue_command, post_issue_comment_chunks,
-        render_event_prompt, render_issue_command_comment, render_issue_comment_chunks_with_limit,
-        render_issue_comment_response_parts, retry_delay, run_prompt_for_event, sanitize_for_path,
-        session_path_for_issue, DownloadedGithubAttachment, EventAction, GithubApiClient,
-        GithubBridgeEvent, GithubBridgeEventKind, GithubIssue, GithubIssueComment,
-        GithubIssueLabel, GithubIssuesBridgeRuntime, GithubIssuesBridgeRuntimeConfig,
-        GithubIssuesBridgeStateStore, GithubUser, PromptRunReport, PromptUsageSummary, RepoRef,
-        RunPromptForEventRequest, SessionStore, TauIssueCommand, CHAT_SHOW_DEFAULT_LIMIT,
-        EVENT_KEY_MARKER_PREFIX,
+        issue_matches_required_numbers, issue_session_id, normalize_artifact_retention_days,
+        normalize_relative_channel_path, parse_rfc3339_to_unix_ms, parse_tau_issue_command,
+        post_issue_comment_chunks, render_event_prompt, render_issue_command_comment,
+        render_issue_comment_chunks_with_limit, render_issue_comment_response_parts, retry_delay,
+        run_prompt_for_event, sanitize_for_path, session_path_for_issue,
+        DownloadedGithubAttachment, EventAction, GithubApiClient, GithubBridgeEvent,
+        GithubBridgeEventKind, GithubIssue, GithubIssueComment, GithubIssueLabel,
+        GithubIssuesBridgeRuntime, GithubIssuesBridgeRuntimeConfig, GithubIssuesBridgeStateStore,
+        GithubUser, PromptRunReport, PromptUsageSummary, RepoRef, RunPromptForEventRequest,
+        SessionStore, TauIssueCommand, CHAT_SHOW_DEFAULT_LIMIT, EVENT_KEY_MARKER_PREFIX,
     };
     use crate::{
         channel_store::{ChannelArtifactRecord, ChannelStore},
@@ -4024,6 +4040,7 @@ mod tests {
             poll_interval: Duration::from_millis(1),
             poll_once: false,
             required_labels: Vec::new(),
+            required_issue_numbers: Vec::new(),
             include_issue_body: false,
             include_edited_comments: true,
             processed_event_cap: 32,
@@ -4111,6 +4128,15 @@ mod tests {
         assert!(issue_matches_required_labels(&issue, &required));
         let required = HashSet::from([String::from("other")]);
         assert!(!issue_matches_required_labels(&issue, &required));
+    }
+
+    #[test]
+    fn unit_issue_matches_required_numbers_respects_filter_set() {
+        let required = HashSet::from([7_u64, 11_u64]);
+        assert!(issue_matches_required_numbers(7, &required));
+        assert!(!issue_matches_required_numbers(9, &required));
+        let required = HashSet::new();
+        assert!(issue_matches_required_numbers(42, &required));
     }
 
     #[test]
@@ -5196,6 +5222,85 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let mut config = test_bridge_config(&server.base_url(), temp.path());
         config.required_labels = vec!["tau-ready".to_string()];
+        let mut runtime = GithubIssuesBridgeRuntime::new(config)
+            .await
+            .expect("runtime");
+        let first = runtime.poll_once().await.expect("first poll");
+        let second = runtime.poll_once().await.expect("second poll");
+
+        assert_eq!(first.discovered_events, 1);
+        assert_eq!(first.processed_events, 1);
+        assert_eq!(second.processed_events, 0);
+        issues.assert_calls(2);
+        comments_7.assert_calls(2);
+        comments_8.assert_calls(0);
+        working_post.assert_calls(1);
+        update.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn integration_bridge_poll_filters_issues_by_required_number() {
+        let server = MockServer::start();
+        let issues = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/issues");
+            then.status(200).json_body(json!([
+                {
+                    "id": 10,
+                    "number": 7,
+                    "title": "Bridge me",
+                    "body": "",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:05Z",
+                    "user": {"login":"alice"}
+                },
+                {
+                    "id": 11,
+                    "number": 8,
+                    "title": "Skip me",
+                    "body": "",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:06Z",
+                    "user": {"login":"alice"}
+                }
+            ]));
+        });
+        let comments_7 = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/issues/7/comments");
+            then.status(200).json_body(json!([{
+                "id": 200,
+                "body": "hello from issue stream",
+                "created_at": "2026-01-01T00:00:01Z",
+                "updated_at": "2026-01-01T00:00:01Z",
+                "user": {"login":"alice"}
+            }]));
+        });
+        let comments_8 = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/issues/8/comments");
+            then.status(200).json_body(json!([]));
+        });
+        let working_post = server.mock(|when, then| {
+            when.method(POST)
+                .path("/repos/owner/repo/issues/7/comments")
+                .body_includes("Tau is working on run");
+            then.status(201).json_body(json!({
+                "id": 901,
+                "html_url": "https://example.test/comment/901"
+            }));
+        });
+        let update = server.mock(|when, then| {
+            when.method(PATCH)
+                .path("/repos/owner/repo/issues/comments/901")
+                .body_includes("bridge reply")
+                .body_includes("tau-event-key:issue-comment-created:200");
+            then.status(200).json_body(json!({
+                "id": 901,
+                "html_url": "https://example.test/comment/901"
+            }));
+        });
+
+        let temp = tempdir().expect("tempdir");
+        let mut config = test_bridge_config(&server.base_url(), temp.path());
+        config.required_issue_numbers = vec![7];
         let mut runtime = GithubIssuesBridgeRuntime::new(config)
             .await
             .expect("runtime");

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -39,6 +39,9 @@ pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
     {
         bail!("--github-required-label cannot be empty");
     }
+    if cli.github_issue_number.contains(&0) {
+        bail!("--github-issue-number must be greater than 0");
+    }
     if cli
         .github_repo
         .as_deref()

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -50,6 +50,7 @@ pub(crate) async fn run_transport_mode_if_requested(
                 .iter()
                 .map(|label| label.trim().to_string())
                 .collect(),
+            required_issue_numbers: cli.github_issue_number.clone(),
             include_issue_body: cli.github_include_issue_body,
             include_edited_comments: cli.github_include_edited_comments,
             processed_event_cap: cli.github_processed_event_cap.max(1),

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -13,12 +13,14 @@ cargo run -p tau-coding-agent -- \
   --github-repo owner/repo \
   --github-bot-login your-bot-login \
   --github-required-label tau-ready \
+  --github-issue-number 7 \
   --github-state-dir .tau/github-issues \
   --github-poll-interval-seconds 30 \
   --github-artifact-retention-days 30
 ```
 
 `--github-required-label` can be repeated; only issues with at least one matching label are processed.
+`--github-issue-number` can be repeated; only matching issue numbers are processed.
 
 Run exactly one poll cycle (useful for CI smoke jobs and cron workflows):
 


### PR DESCRIPTION
## Summary\n- add --github-issue-number to limit GitHub issues bridge to specific numbers\n- validate CLI input and wire filter into bridge runtime\n- add unit/functional/integration/regression coverage and docs update\n\n## Risks and compatibility\n- Low risk; new flag is optional and defaults to no filtering\n- Filtering may skip issues if misconfigured; existing label-based filtering remains unchanged\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace -- --test-threads=1\n- python3 -m unittest discover -s .github/scripts -p "test_*.py"\n\nCloses #745\nRefs #744 #743