### PR TITLE
Add multi-channel contract schema and fixture corpus

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -24,6 +24,8 @@ mod macro_profile_commands;
 mod mcp_server;
 mod model_catalog;
 mod multi_agent_router;
+#[cfg(test)]
+mod multi_channel_contract;
 mod observability_loggers;
 mod onboarding;
 mod orchestrator;

--- a/crates/tau-coding-agent/src/multi_channel_contract.rs
+++ b/crates/tau-coding-agent/src/multi_channel_contract.rs
@@ -1,0 +1,333 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub(crate) const MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+fn multi_channel_contract_schema_version() -> u32 {
+    MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MultiChannelTransport {
+    Telegram,
+    Discord,
+    Whatsapp,
+}
+
+impl MultiChannelTransport {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Telegram => "telegram",
+            Self::Discord => "discord",
+            Self::Whatsapp => "whatsapp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MultiChannelEventKind {
+    Message,
+    Edit,
+    Command,
+    System,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct MultiChannelAttachment {
+    pub(crate) attachment_id: String,
+    pub(crate) url: String,
+    #[serde(default)]
+    pub(crate) content_type: String,
+    #[serde(default)]
+    pub(crate) file_name: String,
+    #[serde(default)]
+    pub(crate) size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct MultiChannelInboundEvent {
+    #[serde(default = "multi_channel_contract_schema_version")]
+    pub(crate) schema_version: u32,
+    pub(crate) transport: MultiChannelTransport,
+    pub(crate) event_kind: MultiChannelEventKind,
+    pub(crate) event_id: String,
+    pub(crate) conversation_id: String,
+    #[serde(default)]
+    pub(crate) thread_id: String,
+    pub(crate) actor_id: String,
+    #[serde(default)]
+    pub(crate) actor_display: String,
+    pub(crate) timestamp_ms: u64,
+    #[serde(default)]
+    pub(crate) text: String,
+    #[serde(default)]
+    pub(crate) attachments: Vec<MultiChannelAttachment>,
+    #[serde(default)]
+    pub(crate) metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct MultiChannelContractFixture {
+    pub(crate) schema_version: u32,
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) description: String,
+    pub(crate) events: Vec<MultiChannelInboundEvent>,
+}
+
+pub(crate) fn parse_multi_channel_contract_fixture(
+    raw: &str,
+) -> Result<MultiChannelContractFixture> {
+    let fixture = serde_json::from_str::<MultiChannelContractFixture>(raw)
+        .context("failed to parse multi-channel contract fixture")?;
+    validate_multi_channel_contract_fixture(&fixture)?;
+    Ok(fixture)
+}
+
+pub(crate) fn load_multi_channel_contract_fixture(
+    path: &Path,
+) -> Result<MultiChannelContractFixture> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    parse_multi_channel_contract_fixture(&raw)
+        .with_context(|| format!("invalid fixture {}", path.display()))
+}
+
+pub(crate) fn validate_multi_channel_contract_fixture(
+    fixture: &MultiChannelContractFixture,
+) -> Result<()> {
+    if fixture.schema_version != MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "unsupported multi-channel contract schema version {} (expected {})",
+            fixture.schema_version,
+            MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if fixture.name.trim().is_empty() {
+        bail!("fixture name cannot be empty");
+    }
+    if fixture.events.is_empty() {
+        bail!("fixture must include at least one event");
+    }
+
+    let mut event_keys = HashSet::new();
+    for (index, event) in fixture.events.iter().enumerate() {
+        validate_multi_channel_event(event, index)?;
+        let key = event_contract_key(event);
+        if !event_keys.insert(key.clone()) {
+            bail!("fixture contains duplicate transport event key '{key}'");
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_multi_channel_event(event: &MultiChannelInboundEvent, index: usize) -> Result<()> {
+    if event.schema_version != MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "fixture event index {} has unsupported schema_version {} (expected {})",
+            index,
+            event.schema_version,
+            MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if event.event_id.trim().is_empty() {
+        bail!("fixture event index {} has empty event_id", index);
+    }
+    if event.conversation_id.trim().is_empty() {
+        bail!("fixture event index {} has empty conversation_id", index);
+    }
+    if event.actor_id.trim().is_empty() {
+        bail!("fixture event index {} has empty actor_id", index);
+    }
+    if event.timestamp_ms == 0 {
+        bail!("fixture event index {} has zero timestamp_ms", index);
+    }
+    if event.text.trim().is_empty() && event.attachments.is_empty() {
+        bail!(
+            "fixture event index {} must include non-empty text or at least one attachment",
+            index
+        );
+    }
+    if event.metadata.keys().any(|key| key.trim().is_empty()) {
+        bail!("fixture event index {} includes empty metadata key", index);
+    }
+
+    let mut attachment_ids = HashSet::new();
+    for attachment in &event.attachments {
+        validate_attachment(attachment, index)?;
+        let trimmed_id = attachment.attachment_id.trim().to_string();
+        if !attachment_ids.insert(trimmed_id.clone()) {
+            bail!(
+                "fixture event index {} includes duplicate attachment_id '{}'",
+                index,
+                trimmed_id
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_attachment(attachment: &MultiChannelAttachment, event_index: usize) -> Result<()> {
+    if attachment.attachment_id.trim().is_empty() {
+        bail!(
+            "fixture event index {} has attachment with empty attachment_id",
+            event_index
+        );
+    }
+    let url = attachment.url.trim();
+    if !(url.starts_with("https://") || url.starts_with("http://localhost")) {
+        bail!(
+            "fixture event index {} has invalid attachment url '{}'",
+            event_index,
+            attachment.url
+        );
+    }
+    if !attachment.content_type.trim().is_empty() && !attachment.content_type.contains('/') {
+        bail!(
+            "fixture event index {} has invalid content_type '{}'",
+            event_index,
+            attachment.content_type
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn event_contract_key(event: &MultiChannelInboundEvent) -> String {
+    format!("{}:{}", event.transport.as_str(), event.event_id.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    use super::{
+        event_contract_key, load_multi_channel_contract_fixture,
+        parse_multi_channel_contract_fixture, MultiChannelTransport,
+    };
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("multi-channel-contract")
+            .join(name)
+    }
+
+    #[test]
+    fn unit_parse_multi_channel_fixture_rejects_unsupported_schema() {
+        let raw = r#"{
+  "schema_version": 99,
+  "name": "unsupported",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "telegram",
+      "event_kind": "message",
+      "event_id": "evt-1",
+      "conversation_id": "chat-1",
+      "actor_id": "user-1",
+      "timestamp_ms": 1,
+      "text": "hello"
+    }
+  ]
+}"#;
+        let error = parse_multi_channel_contract_fixture(raw).expect_err("schema should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported multi-channel contract schema version"));
+    }
+
+    #[test]
+    fn unit_validate_multi_channel_event_rejects_empty_identifier() {
+        let raw = r#"{
+  "schema_version": 1,
+  "name": "bad-event-id",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "discord",
+      "event_kind": "message",
+      "event_id": " ",
+      "conversation_id": "channel-1",
+      "actor_id": "user-1",
+      "timestamp_ms": 1,
+      "text": "hello"
+    }
+  ]
+}"#;
+        let error =
+            parse_multi_channel_contract_fixture(raw).expect_err("empty event id should fail");
+        assert!(error
+            .to_string()
+            .contains("fixture event index 0 has empty event_id"));
+    }
+
+    #[test]
+    fn functional_fixture_baseline_supports_telegram_discord_whatsapp() {
+        let fixture =
+            load_multi_channel_contract_fixture(&fixture_path("baseline-three-channel.json"))
+                .expect("fixture should load");
+        let transports = fixture
+            .events
+            .iter()
+            .map(|event| event.transport)
+            .collect::<HashSet<MultiChannelTransport>>();
+        assert_eq!(fixture.events.len(), 3);
+        assert!(transports.contains(&MultiChannelTransport::Telegram));
+        assert!(transports.contains(&MultiChannelTransport::Discord));
+        assert!(transports.contains(&MultiChannelTransport::Whatsapp));
+    }
+
+    #[test]
+    fn integration_fixture_loader_is_deterministic_across_reloads() {
+        let path = fixture_path("baseline-three-channel.json");
+        let first = load_multi_channel_contract_fixture(&path).expect("first load");
+        let second = load_multi_channel_contract_fixture(&path).expect("second load");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn integration_fixture_roundtrip_preserves_event_contract_keys() {
+        let fixture =
+            load_multi_channel_contract_fixture(&fixture_path("baseline-three-channel.json"))
+                .expect("fixture should load");
+        let first_keys = fixture
+            .events
+            .iter()
+            .map(event_contract_key)
+            .collect::<Vec<String>>();
+        let serialized = serde_json::to_string(&fixture).expect("serialize");
+        let roundtrip = parse_multi_channel_contract_fixture(&serialized).expect("roundtrip parse");
+        let second_keys = roundtrip
+            .events
+            .iter()
+            .map(event_contract_key)
+            .collect::<Vec<String>>();
+        assert_eq!(first_keys, second_keys);
+    }
+
+    #[test]
+    fn regression_fixture_rejects_duplicate_transport_event_key() {
+        let error = load_multi_channel_contract_fixture(&fixture_path("duplicate-event-key.json"))
+            .expect_err("duplicate key fixture should fail");
+        let message = format!("{error:#}");
+        assert!(message.contains("duplicate transport event key"));
+    }
+
+    #[test]
+    fn regression_fixture_rejects_attachment_without_https_url() {
+        let error =
+            load_multi_channel_contract_fixture(&fixture_path("invalid-attachment-url.json"))
+                .expect_err("invalid attachment fixture should fail");
+        let message = format!("{error:#}");
+        assert!(message.contains("invalid attachment url"));
+    }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-contract/README.md
+++ b/crates/tau-coding-agent/testdata/multi-channel-contract/README.md
@@ -1,0 +1,14 @@
+# Multi-Channel Contract Fixtures
+
+This directory contains deterministic fixtures for the normalized inbound event contract used by
+the Telegram, Discord, and WhatsApp transport roadmap work.
+
+- `baseline-three-channel.json`: valid fixture with one event per supported channel.
+- `duplicate-event-key.json`: invalid fixture that intentionally duplicates a transport/event key.
+- `invalid-attachment-url.json`: invalid fixture that intentionally uses a disallowed URL scheme.
+
+Schema:
+
+- Top-level `schema_version` must match `MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION`.
+- Each event includes `transport`, `event_kind`, identity fields, timestamp, and message content.
+- Attachments must use `https://` URLs (or `http://localhost` for local test hooks).

--- a/crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "name": "baseline-three-channel",
+  "description": "One valid event for Telegram, Discord, and WhatsApp.",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "telegram",
+      "event_kind": "message",
+      "event_id": "tg-1001",
+      "conversation_id": "telegram-chat-42",
+      "thread_id": "",
+      "actor_id": "telegram-user-7",
+      "actor_display": "ops-bot-telegram",
+      "timestamp_ms": 1760000001000,
+      "text": "Deploy status for prod-eu?",
+      "attachments": [],
+      "metadata": {
+        "chat_type": "group",
+        "message_source": "polling"
+      }
+    },
+    {
+      "schema_version": 1,
+      "transport": "discord",
+      "event_kind": "command",
+      "event_id": "dc-2001",
+      "conversation_id": "discord-channel-ops",
+      "thread_id": "discord-thread-77",
+      "actor_id": "discord-user-3",
+      "actor_display": "infra-lead",
+      "timestamp_ms": 1760000002000,
+      "text": "/health transport",
+      "attachments": [],
+      "metadata": {
+        "guild_id": "guild-1",
+        "command_origin": "slash"
+      }
+    },
+    {
+      "schema_version": 1,
+      "transport": "whatsapp",
+      "event_kind": "message",
+      "event_id": "wa-3001",
+      "conversation_id": "whatsapp-room-incident",
+      "thread_id": "",
+      "actor_id": "whatsapp-user-19",
+      "actor_display": "oncall-manager",
+      "timestamp_ms": 1760000003000,
+      "text": "See attached screenshot for alert spike.",
+      "attachments": [
+        {
+          "attachment_id": "wa-att-1",
+          "url": "https://example.com/incident/alert-spike.png",
+          "content_type": "image/png",
+          "file_name": "alert-spike.png",
+          "size_bytes": 2048
+        }
+      ],
+      "metadata": {
+        "device": "mobile",
+        "message_source": "webhook"
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-contract/duplicate-event-key.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-contract/duplicate-event-key.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "duplicate-event-key",
+  "description": "Invalid fixture with repeated transport/event_id pair.",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "telegram",
+      "event_kind": "message",
+      "event_id": "dup-1",
+      "conversation_id": "telegram-chat-1",
+      "actor_id": "telegram-user-1",
+      "timestamp_ms": 1760000100000,
+      "text": "first payload"
+    },
+    {
+      "schema_version": 1,
+      "transport": "telegram",
+      "event_kind": "edit",
+      "event_id": "dup-1",
+      "conversation_id": "telegram-chat-2",
+      "actor_id": "telegram-user-2",
+      "timestamp_ms": 1760000101000,
+      "text": "second payload"
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-contract/invalid-attachment-url.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-contract/invalid-attachment-url.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "name": "invalid-attachment-url",
+  "description": "Invalid fixture with disallowed attachment URL scheme.",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "whatsapp",
+      "event_kind": "message",
+      "event_id": "wa-invalid-1",
+      "conversation_id": "whatsapp-chat-1",
+      "actor_id": "whatsapp-user-1",
+      "timestamp_ms": 1760000200000,
+      "text": "payload with invalid attachment url",
+      "attachments": [
+        {
+          "attachment_id": "wa-invalid-att-1",
+          "url": "ftp://example.com/file.bin",
+          "content_type": "application/octet-stream",
+          "file_name": "file.bin",
+          "size_bytes": 64
+        }
+      ]
+    }
+  ]
+}

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -116,6 +116,7 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 
 - `tests.rs`: large integration/regression suite for `tau-coding-agent`.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.
+- `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) schema and fixture validation contract.
 - `#[cfg(test)]` exports in `main.rs`: test-only visibility for parser/helpers.
 
 Prefer adding tests next to the module behavior being changed, plus regression coverage in `tests.rs` when behavior spans modules.


### PR DESCRIPTION
## Summary
- add a dedicated multi-channel contract module for normalized inbound Telegram/Discord/WhatsApp events
- add schema parsing/loading/validation helpers for deterministic fixture-driven transport development
- add fixture corpus (baseline, duplicate key regression, invalid attachment URL regression)
- add unit/functional/integration/regression coverage for schema rules and deterministic roundtrip behavior
- update code-map docs with the new contract surface

## Risks and compatibility
- Low runtime risk: changes are test-contract focused and introduced under cfg(test) module wiring
- Future transport implementations must adhere to these schema validation rules (duplicate key and attachment URL constraints)

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- python3 -m unittest discover -s .github/scripts -p "test_*.py"

Closes #753
Refs #751 #750 #749