### PR TITLE
feat(transports): add multi-channel runtime and CLI validation (#754)

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1642,6 +1642,68 @@ pub(crate) struct Cli {
     pub(crate) event_webhook_signature_max_skew_seconds: u64,
 
     #[arg(
+        long = "multi-channel-contract-runner",
+        env = "TAU_MULTI_CHANNEL_CONTRACT_RUNNER",
+        default_value_t = false,
+        help = "Run fixture-driven multi-channel runtime for Telegram/Discord/WhatsApp contracts"
+    )]
+    pub(crate) multi_channel_contract_runner: bool,
+
+    #[arg(
+        long = "multi-channel-fixture",
+        env = "TAU_MULTI_CHANNEL_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json",
+        requires = "multi_channel_contract_runner",
+        help = "Path to multi-channel contract fixture JSON"
+    )]
+    pub(crate) multi_channel_fixture: PathBuf,
+
+    #[arg(
+        long = "multi-channel-state-dir",
+        env = "TAU_MULTI_CHANNEL_STATE_DIR",
+        default_value = ".tau/multi-channel",
+        requires = "multi_channel_contract_runner",
+        help = "Directory for multi-channel runtime state and channel-store outputs"
+    )]
+    pub(crate) multi_channel_state_dir: PathBuf,
+
+    #[arg(
+        long = "multi-channel-queue-limit",
+        env = "TAU_MULTI_CHANNEL_QUEUE_LIMIT",
+        default_value_t = 64,
+        requires = "multi_channel_contract_runner",
+        help = "Maximum fixture events processed per runtime cycle"
+    )]
+    pub(crate) multi_channel_queue_limit: usize,
+
+    #[arg(
+        long = "multi-channel-processed-event-cap",
+        env = "TAU_MULTI_CHANNEL_PROCESSED_EVENT_CAP",
+        default_value_t = 10_000,
+        requires = "multi_channel_contract_runner",
+        help = "Maximum processed-event keys retained for duplicate suppression"
+    )]
+    pub(crate) multi_channel_processed_event_cap: usize,
+
+    #[arg(
+        long = "multi-channel-retry-max-attempts",
+        env = "TAU_MULTI_CHANNEL_RETRY_MAX_ATTEMPTS",
+        default_value_t = 4,
+        requires = "multi_channel_contract_runner",
+        help = "Maximum retry attempts for transient multi-channel runtime failures"
+    )]
+    pub(crate) multi_channel_retry_max_attempts: usize,
+
+    #[arg(
+        long = "multi-channel-retry-base-delay-ms",
+        env = "TAU_MULTI_CHANNEL_RETRY_BASE_DELAY_MS",
+        default_value_t = 0,
+        requires = "multi_channel_contract_runner",
+        help = "Base backoff delay in milliseconds for multi-channel runtime retries (0 disables delay)"
+    )]
+    pub(crate) multi_channel_retry_base_delay_ms: u64,
+
+    #[arg(
         long = "github-issues-bridge",
         env = "TAU_GITHUB_ISSUES_BRIDGE",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -24,8 +24,8 @@ mod macro_profile_commands;
 mod mcp_server;
 mod model_catalog;
 mod multi_agent_router;
-#[cfg(test)]
 mod multi_channel_contract;
+mod multi_channel_runtime;
 mod observability_loggers;
 mod onboarding;
 mod orchestrator;
@@ -246,7 +246,8 @@ pub(crate) use crate::rpc_protocol::{
 };
 pub(crate) use crate::runtime_cli_validation::{
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
-    validate_github_issues_bridge_cli, validate_slack_bridge_cli,
+    validate_github_issues_bridge_cli, validate_multi_channel_contract_runner_cli,
+    validate_slack_bridge_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -356,6 +357,7 @@ pub(crate) use crate::trust_roots::{
     parse_trust_rotation_spec, parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
 };
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
+use multi_channel_runtime::{run_multi_channel_contract_runner, MultiChannelRuntimeConfig};
 use slack::{run_slack_bridge, SlackBridgeRuntimeConfig};
 
 #[tokio::main]

--- a/crates/tau-coding-agent/src/multi_channel_runtime.rs
+++ b/crates/tau-coding-agent/src/multi_channel_runtime.rs
@@ -1,0 +1,471 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
+use crate::multi_channel_contract::{
+    event_contract_key, load_multi_channel_contract_fixture, MultiChannelContractFixture,
+    MultiChannelEventKind, MultiChannelInboundEvent,
+};
+use crate::{current_unix_timestamp_ms, write_text_atomic};
+
+const MULTI_CHANNEL_RUNTIME_STATE_SCHEMA_VERSION: u32 = 1;
+
+fn multi_channel_runtime_state_schema_version() -> u32 {
+    MULTI_CHANNEL_RUNTIME_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiChannelRuntimeConfig {
+    pub(crate) fixture_path: PathBuf,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) queue_limit: usize,
+    pub(crate) processed_event_cap: usize,
+    pub(crate) retry_max_attempts: usize,
+    pub(crate) retry_base_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct MultiChannelRuntimeSummary {
+    pub(crate) discovered_events: usize,
+    pub(crate) queued_events: usize,
+    pub(crate) completed_events: usize,
+    pub(crate) duplicate_skips: usize,
+    pub(crate) transient_failures: usize,
+    pub(crate) retry_attempts: usize,
+    pub(crate) failed_events: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MultiChannelRuntimeState {
+    #[serde(default = "multi_channel_runtime_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    processed_event_keys: Vec<String>,
+}
+
+impl Default for MultiChannelRuntimeState {
+    fn default() -> Self {
+        Self {
+            schema_version: MULTI_CHANNEL_RUNTIME_STATE_SCHEMA_VERSION,
+            processed_event_keys: Vec::new(),
+        }
+    }
+}
+
+pub(crate) async fn run_multi_channel_contract_runner(
+    config: MultiChannelRuntimeConfig,
+) -> Result<()> {
+    let fixture = load_multi_channel_contract_fixture(&config.fixture_path)?;
+    let mut runtime = MultiChannelRuntime::new(config)?;
+    let summary = runtime.run_once(&fixture).await?;
+    println!(
+        "multi-channel runner summary: discovered={} queued={} completed={} duplicate_skips={} retries={} transient_failures={} failed={}",
+        summary.discovered_events,
+        summary.queued_events,
+        summary.completed_events,
+        summary.duplicate_skips,
+        summary.retry_attempts,
+        summary.transient_failures,
+        summary.failed_events
+    );
+    Ok(())
+}
+
+struct MultiChannelRuntime {
+    config: MultiChannelRuntimeConfig,
+    state: MultiChannelRuntimeState,
+    processed_event_keys: HashSet<String>,
+}
+
+impl MultiChannelRuntime {
+    fn new(config: MultiChannelRuntimeConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)
+            .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+        let mut state = load_multi_channel_runtime_state(&config.state_dir.join("state.json"))?;
+        state.processed_event_keys =
+            normalize_processed_keys(&state.processed_event_keys, config.processed_event_cap);
+        let processed_event_keys = state.processed_event_keys.iter().cloned().collect();
+        Ok(Self {
+            config,
+            state,
+            processed_event_keys,
+        })
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.config.state_dir.join("state.json")
+    }
+
+    async fn run_once(
+        &mut self,
+        fixture: &MultiChannelContractFixture,
+    ) -> Result<MultiChannelRuntimeSummary> {
+        let mut summary = MultiChannelRuntimeSummary {
+            discovered_events: fixture.events.len(),
+            ..MultiChannelRuntimeSummary::default()
+        };
+
+        let mut queued_events = fixture.events.clone();
+        queued_events.sort_by(|left, right| {
+            left.timestamp_ms
+                .cmp(&right.timestamp_ms)
+                .then_with(|| event_contract_key(left).cmp(&event_contract_key(right)))
+        });
+        queued_events.truncate(self.config.queue_limit);
+        summary.queued_events = queued_events.len();
+
+        for event in queued_events {
+            let event_key = event_contract_key(&event);
+            if self.processed_event_keys.contains(&event_key) {
+                summary.duplicate_skips = summary.duplicate_skips.saturating_add(1);
+                continue;
+            }
+
+            let simulated_transient_failures = simulated_transient_failures(&event);
+            let mut attempt = 1usize;
+            loop {
+                if attempt <= simulated_transient_failures {
+                    summary.transient_failures = summary.transient_failures.saturating_add(1);
+                    if attempt >= self.config.retry_max_attempts {
+                        summary.failed_events = summary.failed_events.saturating_add(1);
+                        break;
+                    }
+                    summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                    apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+
+                match self.persist_event(&event, &event_key) {
+                    Ok(()) => {
+                        self.record_processed_event(&event_key);
+                        summary.completed_events = summary.completed_events.saturating_add(1);
+                        break;
+                    }
+                    Err(error) => {
+                        if attempt >= self.config.retry_max_attempts {
+                            eprintln!(
+                                "multi-channel runner event failed: key={} transport={} error={error}",
+                                event_key,
+                                event.transport.as_str()
+                            );
+                            summary.failed_events = summary.failed_events.saturating_add(1);
+                            break;
+                        }
+                        summary.transient_failures = summary.transient_failures.saturating_add(1);
+                        summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                        apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                        attempt = attempt.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        save_multi_channel_runtime_state(&self.state_path(), &self.state)?;
+        Ok(summary)
+    }
+
+    fn persist_event(&self, event: &MultiChannelInboundEvent, event_key: &str) -> Result<()> {
+        let store = ChannelStore::open(
+            &self.config.state_dir.join("channel-store"),
+            event.transport.as_str(),
+            &event.conversation_id,
+        )?;
+        let timestamp_unix_ms = current_unix_timestamp_ms();
+
+        store.append_log_entry(&ChannelLogEntry {
+            timestamp_unix_ms,
+            direction: "inbound".to_string(),
+            event_key: Some(event_key.to_string()),
+            source: event.transport.as_str().to_string(),
+            payload: serde_json::to_value(event).context("serialize inbound event payload")?,
+        })?;
+
+        if !event.text.trim().is_empty() {
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "user".to_string(),
+                text: event.text.trim().to_string(),
+            })?;
+        }
+
+        let response_text = render_response(event);
+        store.append_log_entry(&ChannelLogEntry {
+            timestamp_unix_ms: current_unix_timestamp_ms(),
+            direction: "outbound".to_string(),
+            event_key: Some(event_key.to_string()),
+            source: "tau-multi-channel-runner".to_string(),
+            payload: json!({
+                "response": response_text,
+                "event_key": event_key,
+                "transport": event.transport.as_str(),
+            }),
+        })?;
+        store.append_context_entry(&ChannelContextEntry {
+            timestamp_unix_ms: current_unix_timestamp_ms(),
+            role: "assistant".to_string(),
+            text: response_text,
+        })?;
+
+        Ok(())
+    }
+
+    fn record_processed_event(&mut self, event_key: &str) {
+        if self.processed_event_keys.contains(event_key) {
+            return;
+        }
+        self.state.processed_event_keys.push(event_key.to_string());
+        self.processed_event_keys.insert(event_key.to_string());
+        if self.state.processed_event_keys.len() > self.config.processed_event_cap {
+            let overflow = self
+                .state
+                .processed_event_keys
+                .len()
+                .saturating_sub(self.config.processed_event_cap);
+            let removed = self.state.processed_event_keys.drain(0..overflow);
+            for key in removed {
+                self.processed_event_keys.remove(&key);
+            }
+        }
+    }
+}
+
+fn render_response(event: &MultiChannelInboundEvent) -> String {
+    let transport = event.transport.as_str();
+    let event_id = event.event_id.trim();
+    if matches!(event.event_kind, MultiChannelEventKind::Command)
+        || event.text.trim().starts_with('/')
+    {
+        return format!(
+            "command acknowledged: transport={} event_id={} conversation={}",
+            transport, event_id, event.conversation_id
+        );
+    }
+    format!(
+        "message processed: transport={} event_id={} text_chars={}",
+        transport,
+        event_id,
+        event.text.chars().count()
+    )
+}
+
+fn normalize_processed_keys(raw: &[String], cap: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for key in raw {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.insert(owned.clone()) {
+            normalized.push(owned);
+        }
+    }
+    if cap == 0 {
+        return Vec::new();
+    }
+    if normalized.len() > cap {
+        normalized.drain(0..normalized.len().saturating_sub(cap));
+    }
+    normalized
+}
+
+fn simulated_transient_failures(event: &MultiChannelInboundEvent) -> usize {
+    event
+        .metadata
+        .get("simulate_transient_failures")
+        .and_then(|value| value.as_u64())
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(0)
+}
+
+fn retry_delay_ms(base_delay_ms: u64, attempt: usize) -> u64 {
+    if base_delay_ms == 0 {
+        return 0;
+    }
+    let exponent = attempt.saturating_sub(1).min(10) as u32;
+    base_delay_ms.saturating_mul(1_u64 << exponent)
+}
+
+async fn apply_retry_delay(base_delay_ms: u64, attempt: usize) {
+    let delay_ms = retry_delay_ms(base_delay_ms, attempt);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    }
+}
+
+fn load_multi_channel_runtime_state(path: &Path) -> Result<MultiChannelRuntimeState> {
+    if !path.exists() {
+        return Ok(MultiChannelRuntimeState::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed = match serde_json::from_str::<MultiChannelRuntimeState>(&raw) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "multi-channel runner: failed to parse state file {} ({error}); starting fresh",
+                path.display()
+            );
+            return Ok(MultiChannelRuntimeState::default());
+        }
+    };
+    if parsed.schema_version != MULTI_CHANNEL_RUNTIME_STATE_SCHEMA_VERSION {
+        eprintln!(
+            "multi-channel runner: unsupported state schema {} in {}; starting fresh",
+            parsed.schema_version,
+            path.display()
+        );
+        return Ok(MultiChannelRuntimeState::default());
+    }
+    Ok(parsed)
+}
+
+fn save_multi_channel_runtime_state(path: &Path, state: &MultiChannelRuntimeState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("serialize multi-channel state")?;
+    write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::{
+        load_multi_channel_runtime_state, retry_delay_ms, MultiChannelRuntime,
+        MultiChannelRuntimeConfig,
+    };
+    use crate::channel_store::ChannelStore;
+    use crate::multi_channel_contract::{
+        load_multi_channel_contract_fixture, parse_multi_channel_contract_fixture,
+    };
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("multi-channel-contract")
+            .join(name)
+    }
+
+    fn build_config(root: &Path) -> MultiChannelRuntimeConfig {
+        MultiChannelRuntimeConfig {
+            fixture_path: fixture_path("baseline-three-channel.json"),
+            state_dir: root.join(".tau/multi-channel"),
+            queue_limit: 64,
+            processed_event_cap: 10_000,
+            retry_max_attempts: 3,
+            retry_base_delay_ms: 0,
+        }
+    }
+
+    #[test]
+    fn unit_retry_delay_ms_scales_with_attempt_number() {
+        assert_eq!(retry_delay_ms(0, 1), 0);
+        assert_eq!(retry_delay_ms(10, 1), 10);
+        assert_eq!(retry_delay_ms(10, 2), 20);
+        assert_eq!(retry_delay_ms(10, 3), 40);
+    }
+
+    #[tokio::test]
+    async fn functional_runner_processes_fixture_and_persists_channel_store_entries() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_multi_channel_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = MultiChannelRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_events, 3);
+        assert_eq!(summary.queued_events, 3);
+        assert_eq!(summary.completed_events, 3);
+        assert_eq!(summary.duplicate_skips, 0);
+        assert_eq!(summary.failed_events, 0);
+
+        for event in &fixture.events {
+            let store = ChannelStore::open(
+                &config.state_dir.join("channel-store"),
+                event.transport.as_str(),
+                &event.conversation_id,
+            )
+            .expect("open store");
+            let logs = store.load_log_entries().expect("load logs");
+            let context = store.load_context_entries().expect("load context");
+            assert_eq!(logs.len(), 2);
+            assert!(context.len() >= 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn integration_runner_retries_transient_failure_then_recovers() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.retry_max_attempts = 4;
+        let fixture_raw = r#"{
+  "schema_version": 1,
+  "name": "transient-retry",
+  "events": [
+    {
+      "schema_version": 1,
+      "transport": "telegram",
+      "event_kind": "message",
+      "event_id": "tg-transient-1",
+      "conversation_id": "telegram-chat-transient",
+      "actor_id": "telegram-user-1",
+      "timestamp_ms": 1760100000000,
+      "text": "hello",
+      "metadata": { "simulate_transient_failures": 1 }
+    }
+  ]
+}"#;
+        let fixture = parse_multi_channel_contract_fixture(fixture_raw).expect("parse fixture");
+        let mut runtime = MultiChannelRuntime::new(config).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.completed_events, 1);
+        assert_eq!(summary.transient_failures, 1);
+        assert_eq!(summary.retry_attempts, 1);
+        assert_eq!(summary.failed_events, 0);
+    }
+
+    #[tokio::test]
+    async fn integration_runner_respects_queue_limit_for_backpressure() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.queue_limit = 2;
+        let fixture =
+            load_multi_channel_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = MultiChannelRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_events, 3);
+        assert_eq!(summary.queued_events, 2);
+        assert_eq!(summary.completed_events, 2);
+        let state = load_multi_channel_runtime_state(&config.state_dir.join("state.json"))
+            .expect("load state");
+        assert_eq!(state.processed_event_keys.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn regression_runner_skips_duplicate_events_from_persisted_state() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_multi_channel_contract_fixture(&config.fixture_path).expect("fixture should load");
+
+        let mut first_runtime = MultiChannelRuntime::new(config.clone()).expect("first runtime");
+        let first_summary = first_runtime.run_once(&fixture).await.expect("first run");
+        assert_eq!(first_summary.completed_events, 3);
+
+        let mut second_runtime = MultiChannelRuntime::new(config).expect("second runtime");
+        let second_summary = second_runtime.run_once(&fixture).await.expect("second run");
+        assert_eq!(second_summary.completed_events, 0);
+        assert_eq!(second_summary.duplicate_skips, 3);
+    }
+}

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -129,6 +129,45 @@ pub(crate) fn validate_events_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_multi_channel_contract_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.multi_channel_contract_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--multi-channel-contract-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--multi-channel-contract-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge || cli.slack_bridge || cli.events_runner {
+        bail!("--multi-channel-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, or --events-runner");
+    }
+    if cli.multi_channel_queue_limit == 0 {
+        bail!("--multi-channel-queue-limit must be greater than 0");
+    }
+    if cli.multi_channel_processed_event_cap == 0 {
+        bail!("--multi-channel-processed-event-cap must be greater than 0");
+    }
+    if cli.multi_channel_retry_max_attempts == 0 {
+        bail!("--multi-channel-retry-max-attempts must be greater than 0");
+    }
+    if !cli.multi_channel_fixture.exists() {
+        bail!(
+            "--multi-channel-fixture '{}' does not exist",
+            cli.multi_channel_fixture.display()
+        );
+    }
+    if !cli.multi_channel_fixture.is_file() {
+        bail!(
+            "--multi-channel-fixture '{}' must point to a file",
+            cli.multi_channel_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.event_webhook_ingest_file.is_none() {
         return Ok(());

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -11,6 +11,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_github_issues_bridge_cli(cli)?;
     validate_slack_bridge_cli(cli)?;
     validate_events_runner_cli(cli)?;
+    validate_multi_channel_contract_runner_cli(cli)?;
 
     if cli.github_issues_bridge {
         let repo_slug = cli.github_repo.clone().ok_or_else(|| {
@@ -131,6 +132,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             poll_interval: Duration::from_millis(cli.events_poll_interval_ms.max(1)),
             queue_limit: cli.events_queue_limit.max(1),
             stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.multi_channel_contract_runner {
+        run_multi_channel_contract_runner(MultiChannelRuntimeConfig {
+            fixture_path: cli.multi_channel_fixture.clone(),
+            state_dir: cli.multi_channel_state_dir.clone(),
+            queue_limit: cli.multi_channel_queue_limit.max(1),
+            processed_event_cap: cli.multi_channel_processed_event_cap.max(1),
+            retry_max_attempts: cli.multi_channel_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.multi_channel_retry_base_delay_ms,
         })
         .await?;
         return Ok(true);

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -57,6 +57,33 @@ cargo run -p tau-coding-agent -- \
   --slack-thread-detail-threshold-chars 1500
 ```
 
+## Multi-channel contract runner (Telegram, Discord, WhatsApp)
+
+Use this fixture-driven runtime mode to validate channel-store writes, retry behavior, and
+deduplication for supported transports.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --multi-channel-contract-runner \
+  --multi-channel-fixture crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json \
+  --multi-channel-state-dir .tau/multi-channel \
+  --multi-channel-queue-limit 64 \
+  --multi-channel-processed-event-cap 10000 \
+  --multi-channel-retry-max-attempts 4 \
+  --multi-channel-retry-base-delay-ms 0
+```
+
+The runner writes channel-store output under:
+
+- `.tau/multi-channel/channel-store/telegram/...`
+- `.tau/multi-channel/channel-store/discord/...`
+- `.tau/multi-channel/channel-store/whatsapp/...`
+
+Runtime state for duplicate suppression is persisted at:
+
+- `.tau/multi-channel/state.json`
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -89,6 +89,8 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `github_issues.rs`: GitHub Issues bridge transport.
 - `slack.rs`: Slack Socket Mode bridge transport.
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
+- `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) fixture/schema contract.
+- `multi_channel_runtime.rs`: multi-channel runtime loop (queueing, retry, dedupe, channel-store writes).
 - `runtime_cli_validation.rs`: validation for integration runtime flags.
 - `startup_transport_modes.rs`: transport mode dispatch entry.
 
@@ -117,6 +119,7 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 - `tests.rs`: large integration/regression suite for `tau-coding-agent`.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) schema and fixture validation contract.
+- `multi_channel_runtime.rs`: fixture-driven runtime tests covering queueing, retries, and replay idempotency.
 - `#[cfg(test)]` exports in `main.rs`: test-only visibility for parser/helpers.
 
 Prefer adding tests next to the module behavior being changed, plus regression coverage in `tests.rs` when behavior spans modules.


### PR DESCRIPTION
Closes #754
Refs #752 #750 #749

## Summary of behavior changes
- adds a new runtime mode `--multi-channel-contract-runner` for fixture-driven Telegram/Discord/WhatsApp processing
- introduces multi-channel runtime configuration flags:
  - `--multi-channel-fixture`
  - `--multi-channel-state-dir`
  - `--multi-channel-queue-limit`
  - `--multi-channel-processed-event-cap`
  - `--multi-channel-retry-max-attempts`
  - `--multi-channel-retry-base-delay-ms`
- adds runtime dispatch wiring in transport startup (`startup_transport_modes.rs`)
- adds runtime validation guardrails (`runtime_cli_validation.rs`) for prompt conflicts, transport conflicts, and invalid limits/fixture paths
- adds `multi_channel_runtime.rs` implementation with deterministic queue ordering, persisted dedupe state, retry/backoff behavior, and ChannelStore writes
- expands tests to cover parser defaults/overrides, validation error paths, and runtime unit/functional/integration/regression flows
- updates transport/operator docs and code map for the new mode

## Risks and compatibility notes
- this introduces a new transport mode but does not change existing GitHub/Slack/events runtime behavior
- state is persisted under the configured multi-channel state dir (`state.json` plus channel-store records); malformed or schema-mismatched state safely falls back to fresh state
- retry backoff defaults to no delay (`0ms`) to keep CI deterministic and fast; operators can opt into delay
- no breaking CLI changes to existing flags

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
