### PR TITLE
feat(transports): add multi-channel observability and rollout assets (#755)

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -141,7 +141,7 @@ class DemoScriptsTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(
             completed.stdout.strip().splitlines(),
-            ["local.sh", "rpc.sh", "events.sh", "package.sh"],
+            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
         )
 
     def test_unit_all_script_only_rejects_unknown_demo_names(self) -> None:
@@ -192,7 +192,7 @@ class DemoScriptsTests(unittest.TestCase):
             trace_path = root / "trace.ndjson"
             write_mock_binary(binary_path)
 
-            for script_name in ("local.sh", "rpc.sh", "events.sh", "package.sh"):
+            for script_name in ("local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
                     completed.returncode,
@@ -203,7 +203,7 @@ class DemoScriptsTests(unittest.TestCase):
                 self.assertIn("failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 12)
+            self.assertGreaterEqual(len(rows), 15)
 
     def test_functional_all_script_builds_once_when_skip_build_is_disabled(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -259,10 +259,10 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=4 passed=4 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=5 passed=5 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 12)
+            self.assertGreaterEqual(len(rows), 15)
 
     def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -311,14 +311,14 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=4 passed=4 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=5 passed=5 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 4, "passed": 4, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 5, "passed": 5, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
-                ["local.sh", "rpc.sh", "events.sh", "package.sh"],
+                ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
             )
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)
@@ -389,6 +389,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [2] rpc.sh", completed.stdout)
             self.assertIn("[demo:all] [3] events.sh", completed.stdout)
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
+            self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -399,7 +400,10 @@ class DemoScriptsTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 0)
         payload = json.loads(completed.stdout)
-        self.assertEqual(payload["demos"], ["local.sh", "rpc.sh", "events.sh", "package.sh"])
+        self.assertEqual(
+            payload["demos"],
+            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
+        )
 
     def test_integration_all_script_report_file_tracks_selected_subset_order(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -544,8 +548,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 4)
-            self.assertEqual(payload["summary"]["failed"], 4)
+            self.assertEqual(payload["summary"]["total"], 5)
+            self.assertEqual(payload["summary"]["failed"], 5)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -756,7 +756,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -1662,7 +1662,6 @@ pub(crate) struct Cli {
         long = "multi-channel-state-dir",
         env = "TAU_MULTI_CHANNEL_STATE_DIR",
         default_value = ".tau/multi-channel",
-        requires = "multi_channel_contract_runner",
         help = "Directory for multi-channel runtime state and channel-store outputs"
     )]
     pub(crate) multi_channel_state_dir: PathBuf,

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -1308,6 +1308,30 @@ fn regression_cli_multi_channel_fixture_requires_multi_channel_runner_flag() {
 }
 
 #[test]
+fn unit_cli_transport_health_inspect_accepts_multi_channel_target() {
+    let cli = Cli::parse_from(["tau-rs", "--transport-health-inspect", "multi-channel"]);
+    assert_eq!(
+        cli.transport_health_inspect.as_deref(),
+        Some("multi-channel")
+    );
+}
+
+#[test]
+fn functional_cli_transport_health_inspect_accepts_multi_channel_state_dir_override() {
+    let cli = Cli::parse_from([
+        "tau-rs",
+        "--transport-health-inspect",
+        "multi-channel",
+        "--multi-channel-state-dir",
+        ".tau/multi-channel-alt",
+    ]);
+    assert_eq!(
+        cli.multi_channel_state_dir,
+        PathBuf::from(".tau/multi-channel-alt")
+    );
+}
+
+#[test]
 fn unit_cli_qa_loop_flags_default_to_disabled() {
     let cli = Cli::parse_from(["tau-rs"]);
     assert!(!cli.qa_loop);

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -94,11 +94,13 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
+./scripts/demo/all.sh --only multi-channel --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh
 ./scripts/demo/package.sh
+./scripts/demo/multi-channel.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -83,6 +83,18 @@ The runner writes channel-store output under:
 Runtime state for duplicate suppression is persisted at:
 
 - `.tau/multi-channel/state.json`
+- `.tau/multi-channel/runtime-events.jsonl` (per-cycle observability log)
+
+Inspect multi-channel transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-state-dir .tau/multi-channel \
+  --transport-health-inspect multi-channel \
+  --transport-health-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/multi-channel-ops.md`.
 
 ## ChannelStore inspection and repair
 

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -17,6 +17,7 @@ demo_scripts=(
   "rpc.sh"
   "events.sh"
   "package.sh"
+  "multi-channel.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -68,6 +69,10 @@ normalize_demo_name() {
       ;;
     package|package.sh)
       echo "package.sh"
+      return 0
+      ;;
+    multi-channel|multichannel|multi-channel.sh|multichannel.sh)
+      echo "multi-channel.sh"
       return 0
       ;;
     *)
@@ -180,14 +185,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/multi-channel.sh
+++ b/scripts/demo/multi-channel.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "multi-channel" "Run deterministic multi-channel runtime and health-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json"
+demo_state_dir=".tau/demo-multi-channel"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "multi-channel-runner" \
+  --multi-channel-contract-runner \
+  --multi-channel-fixture ./crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json \
+  --multi-channel-state-dir "${demo_state_dir}" \
+  --multi-channel-queue-limit 64 \
+  --multi-channel-processed-event-cap 10000 \
+  --multi-channel-retry-max-attempts 4 \
+  --multi-channel-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-multi-channel" \
+  --multi-channel-state-dir "${demo_state_dir}" \
+  --transport-health-inspect multi-channel \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-telegram" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect telegram/telegram-chat-42
+
+tau_demo_common_finish


### PR DESCRIPTION
Closes #755
Refs #752 #750 #749

## Summary of behavior changes
- adds persisted multi-channel transport health metrics to `.tau/.../state.json`:
  - cycle duration, backlog/queue depth, failure streak, discovered/processed/completed/failed/duplicate counts
- adds per-cycle observability event log at `runtime-events.jsonl` with deterministic reason codes:
  - `healthy_cycle`, `queue_backpressure_applied`, `duplicate_events_skipped`, `retry_attempted`, `transient_failures_observed`, `event_processing_failed`
- extends `--transport-health-inspect` support to include a new `multi-channel` target
- updates transport health parsing/collection logic and tests for multi-channel rows
- allows `--multi-channel-state-dir` override for non-runner health inspection workflows
- adds deterministic demo wrapper `scripts/demo/multi-channel.sh`
- integrates multi-channel wrapper into `scripts/demo/all.sh` inventory and alias parsing
- updates quickstart and transport docs plus new operator runbook:
  - `docs/guides/multi-channel-ops.md`

## Risks and compatibility notes
- existing GitHub/Slack/events transport behavior remains unchanged
- `scripts/demo/all.sh` now runs one additional wrapper (`multi-channel.sh`), increasing all-demo runtime slightly
- multi-channel state schema remains backward-compatible due serde defaults; older state files without health fields are still readable
- `--multi-channel-state-dir` no longer requires `--multi-channel-contract-runner`, enabling health/admin use cases without changing runner semantics

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
