### PR TITLE
feat: memory observability docs demo rollout

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -141,7 +141,7 @@ class DemoScriptsTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(
             completed.stdout.strip().splitlines(),
-            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
+            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
         )
 
     def test_unit_all_script_only_rejects_unknown_demo_names(self) -> None:
@@ -192,7 +192,7 @@ class DemoScriptsTests(unittest.TestCase):
             trace_path = root / "trace.ndjson"
             write_mock_binary(binary_path)
 
-            for script_name in ("local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"):
+            for script_name in ("local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
                     completed.returncode,
@@ -203,7 +203,7 @@ class DemoScriptsTests(unittest.TestCase):
                 self.assertIn("failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 15)
+            self.assertGreaterEqual(len(rows), 18)
 
     def test_functional_all_script_builds_once_when_skip_build_is_disabled(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -259,10 +259,10 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=5 passed=5 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=6 passed=6 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 15)
+            self.assertGreaterEqual(len(rows), 18)
 
     def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -311,14 +311,14 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=5 passed=5 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=6 passed=6 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 5, "passed": 5, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 6, "passed": 6, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
-                ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
+                ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
             )
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)
@@ -390,6 +390,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [3] events.sh", completed.stdout)
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
             self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
+            self.assertIn("[demo:all] [6] memory.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -402,7 +403,7 @@ class DemoScriptsTests(unittest.TestCase):
         payload = json.loads(completed.stdout)
         self.assertEqual(
             payload["demos"],
-            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh"],
+            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
         )
 
     def test_integration_all_script_report_file_tracks_selected_subset_order(self) -> None:
@@ -548,8 +549,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 5)
-            self.assertEqual(payload["summary"]["failed"], 5)
+            self.assertEqual(payload["summary"]["total"], 6)
+            self.assertEqual(payload["summary"]["failed"], 6)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -756,7 +756,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, memory"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -1393,6 +1393,24 @@ fn functional_cli_transport_health_inspect_accepts_multi_channel_state_dir_overr
 }
 
 #[test]
+fn unit_cli_transport_health_inspect_accepts_memory_target() {
+    let cli = Cli::parse_from(["tau-rs", "--transport-health-inspect", "memory"]);
+    assert_eq!(cli.transport_health_inspect.as_deref(), Some("memory"));
+}
+
+#[test]
+fn functional_cli_transport_health_inspect_accepts_memory_state_dir_override() {
+    let cli = Cli::parse_from([
+        "tau-rs",
+        "--transport-health-inspect",
+        "memory",
+        "--memory-state-dir",
+        ".tau/memory-alt",
+    ]);
+    assert_eq!(cli.memory_state_dir, PathBuf::from(".tau/memory-alt"));
+}
+
+#[test]
 fn unit_cli_qa_loop_flags_default_to_disabled() {
     let cli = Cli::parse_from(["tau-rs"]);
     assert!(!cli.qa_loop);

--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -1,0 +1,72 @@
+# Memory Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven semantic memory runtime (`--memory-contract-runner`).
+
+## Health and observability signals
+
+Primary status signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --memory-state-dir .tau/memory \
+  --transport-health-inspect memory \
+  --transport-health-json
+```
+
+Primary state files:
+
+- `.tau/memory/state.json`
+- `.tau/memory/runtime-events.jsonl`
+- `.tau/memory/channel-store/memory/<channel_id>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/memory.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent memory_contract -- --test-threads=1`
+2. Validate runtime coverage:
+   `cargo test -p tau-coding-agent memory_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/memory.sh`
+4. Confirm health snapshot is `healthy` before promotion:
+   `--transport-health-inspect memory --transport-health-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`.
+
+## Rollback plan
+
+1. Stop invoking `--memory-contract-runner`.
+2. Preserve `.tau/memory/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and channel-store write permissions.
+- Symptom: health state `degraded` with `retry_attempted`.
+  Action: inspect `simulate_retryable_failure` fixture paths and adjust retry controls only when transient errors are expected.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated runtime failures.
+- Symptom: non-zero `queue_depth`.
+  Action: increase `--memory-queue-limit` or reduce per-cycle fixture volume.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -96,6 +96,40 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/multi-channel-ops.md`.
 
+## Semantic memory contract runner
+
+Use this fixture-driven runtime mode to validate semantic memory extraction/retrieval
+processing, retry handling, and channel-store snapshot writes.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --memory-contract-runner \
+  --memory-fixture crates/tau-coding-agent/testdata/memory-contract/mixed-outcomes.json \
+  --memory-state-dir .tau/memory \
+  --memory-queue-limit 64 \
+  --memory-processed-case-cap 10000 \
+  --memory-retry-max-attempts 4 \
+  --memory-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/memory/state.json`
+- `.tau/memory/runtime-events.jsonl`
+- `.tau/memory/channel-store/memory/<channel_id>/...`
+
+Inspect semantic memory health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --memory-state-dir .tau/memory \
+  --transport-health-inspect memory \
+  --transport-health-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/memory-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -18,6 +18,7 @@ demo_scripts=(
   "events.sh"
   "package.sh"
   "multi-channel.sh"
+  "memory.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -73,6 +74,10 @@ normalize_demo_name() {
       ;;
     multi-channel|multichannel|multi-channel.sh|multichannel.sh)
       echo "multi-channel.sh"
+      return 0
+      ;;
+    memory|memory.sh)
+      echo "memory.sh"
       return 0
       ;;
     *)
@@ -185,14 +190,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/memory) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,memory)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/memory.sh
+++ b/scripts/demo/memory.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "memory" "Run deterministic semantic memory runtime and health-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/memory-contract/retrieve-ranking.json"
+demo_state_dir=".tau/demo-memory"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "memory-runner" \
+  --memory-contract-runner \
+  --memory-fixture ./crates/tau-coding-agent/testdata/memory-contract/retrieve-ranking.json \
+  --memory-state-dir "${demo_state_dir}" \
+  --memory-queue-limit 64 \
+  --memory-processed-case-cap 10000 \
+  --memory-retry-max-attempts 4 \
+  --memory-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-memory" \
+  --memory-state-dir "${demo_state_dir}" \
+  --transport-health-inspect memory \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-memory-telegram" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect memory/telegram:ops
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- add `memory` support to `--transport-health-inspect`, including CLI/docs coverage and transport health row loading from `--memory-state-dir/state.json`
- add memory observability regression coverage in runtime events assertions for degraded cycles and reason-code contracts
- add production runbook for memory rollout/rollback and troubleshooting at `docs/guides/memory-ops.md`
- add deterministic memory demo wrapper `scripts/demo/memory.sh` and wire it into `scripts/demo/all.sh` + demo script test matrix

## Risks and compatibility
- low risk: adds a new supported inspect target without changing existing target behavior (`slack`, `github`, `multi-channel`)
- demo inventory now includes `memory.sh`; downstream tooling parsing the all-demo list now sees one additional entry
- memory demo intentionally uses `retrieve-ranking` fixture to produce a healthy-cycle baseline for rollout verification

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent memory_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent channel_store_admin -- --test-threads=1`
- `cargo test -p tau-coding-agent transport_health_inspect -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/memory.sh --repo-root . --binary ./target/debug/tau-coding-agent --skip-build`

Closes #761
