### PR TITLE
feat: add dashboard contract schema fixtures

### DIFF
--- a/crates/tau-coding-agent/src/dashboard_contract.rs
+++ b/crates/tau-coding-agent/src/dashboard_contract.rs
@@ -1,0 +1,846 @@
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+pub(crate) const DASHBOARD_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+pub(crate) const DASHBOARD_ERROR_EMPTY_INPUT: &str = "dashboard_empty_input";
+pub(crate) const DASHBOARD_ERROR_INVALID_SCOPE: &str = "dashboard_invalid_scope";
+pub(crate) const DASHBOARD_ERROR_INVALID_FILTER: &str = "dashboard_invalid_filter";
+pub(crate) const DASHBOARD_ERROR_INVALID_ACTION: &str = "dashboard_invalid_action";
+pub(crate) const DASHBOARD_ERROR_BACKEND_UNAVAILABLE: &str = "dashboard_backend_unavailable";
+
+const DASHBOARD_WIDGET_REFRESH_INTERVAL_MAX_MS: u64 = 86_400_000;
+
+fn dashboard_contract_schema_version() -> u32 {
+    DASHBOARD_CONTRACT_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DashboardFixtureMode {
+    Snapshot,
+    Filter,
+    Control,
+}
+
+impl DashboardFixtureMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Snapshot => "snapshot",
+            Self::Filter => "filter",
+            Self::Control => "control",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DashboardOutcomeKind {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DashboardFilterKind {
+    TimeWindow,
+    Channel,
+    Severity,
+    Search,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DashboardControlAction {
+    Pause,
+    Resume,
+    Refresh,
+}
+
+impl DashboardControlAction {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Pause => "pause",
+            Self::Resume => "resume",
+            Self::Refresh => "refresh",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DashboardWidgetKind {
+    HealthSummary,
+    TransportTable,
+    QueueChart,
+    RunTimeline,
+    SessionList,
+    AlertFeed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardScope {
+    pub(crate) workspace_id: String,
+    #[serde(default)]
+    pub(crate) operator_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardFilter {
+    pub(crate) filter_id: String,
+    pub(crate) kind: DashboardFilterKind,
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardWidgetSpec {
+    pub(crate) widget_id: String,
+    pub(crate) kind: DashboardWidgetKind,
+    pub(crate) title: String,
+    pub(crate) query_key: String,
+    pub(crate) refresh_interval_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardCaseExpectation {
+    pub(crate) outcome: DashboardOutcomeKind,
+    #[serde(default)]
+    pub(crate) error_code: String,
+    #[serde(default)]
+    pub(crate) widgets: Vec<DashboardWidgetSpec>,
+    #[serde(default)]
+    pub(crate) audit_event_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardContractCase {
+    #[serde(default = "dashboard_contract_schema_version")]
+    pub(crate) schema_version: u32,
+    pub(crate) case_id: String,
+    pub(crate) mode: DashboardFixtureMode,
+    pub(crate) scope: DashboardScope,
+    #[serde(default)]
+    pub(crate) filters: Vec<DashboardFilter>,
+    #[serde(default)]
+    pub(crate) requested_widgets: Vec<DashboardWidgetSpec>,
+    #[serde(default)]
+    pub(crate) control_action: Option<DashboardControlAction>,
+    #[serde(default)]
+    pub(crate) simulate_retryable_failure: bool,
+    pub(crate) expected: DashboardCaseExpectation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DashboardContractFixture {
+    pub(crate) schema_version: u32,
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) description: String,
+    pub(crate) cases: Vec<DashboardContractCase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DashboardContractCapabilities {
+    pub(crate) schema_version: u32,
+    pub(crate) supported_modes: BTreeSet<DashboardFixtureMode>,
+    pub(crate) supported_outcomes: BTreeSet<DashboardOutcomeKind>,
+    pub(crate) supported_error_codes: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DashboardReplayStep {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DashboardReplayResult {
+    pub(crate) step: DashboardReplayStep,
+    pub(crate) error_code: Option<String>,
+    pub(crate) widgets: Vec<DashboardWidgetSpec>,
+    pub(crate) audit_event_key: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DashboardReplaySummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) success_cases: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+}
+
+pub(crate) trait DashboardContractDriver {
+    fn apply_case(&mut self, case: &DashboardContractCase) -> Result<DashboardReplayResult>;
+}
+
+pub(crate) fn parse_dashboard_contract_fixture(raw: &str) -> Result<DashboardContractFixture> {
+    let fixture = serde_json::from_str::<DashboardContractFixture>(raw)
+        .context("failed to parse dashboard contract fixture")?;
+    validate_dashboard_contract_fixture(&fixture)?;
+    Ok(fixture)
+}
+
+pub(crate) fn load_dashboard_contract_fixture(path: &Path) -> Result<DashboardContractFixture> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    parse_dashboard_contract_fixture(&raw)
+        .with_context(|| format!("invalid fixture {}", path.display()))
+}
+
+pub(crate) fn dashboard_contract_capabilities() -> DashboardContractCapabilities {
+    DashboardContractCapabilities {
+        schema_version: DASHBOARD_CONTRACT_SCHEMA_VERSION,
+        supported_modes: [
+            DashboardFixtureMode::Snapshot,
+            DashboardFixtureMode::Filter,
+            DashboardFixtureMode::Control,
+        ]
+        .into_iter()
+        .collect(),
+        supported_outcomes: [
+            DashboardOutcomeKind::Success,
+            DashboardOutcomeKind::MalformedInput,
+            DashboardOutcomeKind::RetryableFailure,
+        ]
+        .into_iter()
+        .collect(),
+        supported_error_codes: supported_error_codes()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+pub(crate) fn validate_dashboard_contract_compatibility(
+    fixture: &DashboardContractFixture,
+) -> Result<()> {
+    let capabilities = dashboard_contract_capabilities();
+    if fixture.schema_version != capabilities.schema_version {
+        bail!(
+            "unsupported dashboard contract schema version {} (expected {})",
+            fixture.schema_version,
+            capabilities.schema_version
+        );
+    }
+    for case in &fixture.cases {
+        if !capabilities.supported_modes.contains(&case.mode) {
+            bail!(
+                "fixture case '{}' uses unsupported mode '{}'",
+                case.case_id,
+                case.mode.as_str()
+            );
+        }
+        if !capabilities
+            .supported_outcomes
+            .contains(&case.expected.outcome)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported outcome {:?}",
+                case.case_id,
+                case.expected.outcome
+            );
+        }
+        let error_code = case.expected.error_code.trim();
+        if !error_code.is_empty() && !capabilities.supported_error_codes.contains(error_code) {
+            bail!(
+                "fixture case '{}' uses unsupported error_code '{}'",
+                case.case_id,
+                error_code
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_dashboard_contract_fixture(
+    fixture: &DashboardContractFixture,
+) -> Result<()> {
+    if fixture.schema_version != DASHBOARD_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "unsupported dashboard contract schema version {} (expected {})",
+            fixture.schema_version,
+            DASHBOARD_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if fixture.name.trim().is_empty() {
+        bail!("fixture name cannot be empty");
+    }
+    if fixture.cases.is_empty() {
+        bail!("fixture must include at least one case");
+    }
+
+    let mut case_ids = HashSet::new();
+    for (index, case) in fixture.cases.iter().enumerate() {
+        validate_dashboard_case(case, index)?;
+        let trimmed_case_id = case.case_id.trim().to_string();
+        if !case_ids.insert(trimmed_case_id.clone()) {
+            bail!("fixture contains duplicate case_id '{}'", trimmed_case_id);
+        }
+    }
+
+    validate_dashboard_contract_compatibility(fixture)?;
+    Ok(())
+}
+
+pub(crate) fn run_dashboard_contract_replay<D: DashboardContractDriver>(
+    fixture: &DashboardContractFixture,
+    driver: &mut D,
+) -> Result<DashboardReplaySummary> {
+    validate_dashboard_contract_fixture(fixture)?;
+    let mut summary = DashboardReplaySummary {
+        discovered_cases: fixture.cases.len(),
+        ..DashboardReplaySummary::default()
+    };
+
+    for case in &fixture.cases {
+        let result = driver.apply_case(case)?;
+        assert_dashboard_replay_matches_expectation(case, &result)?;
+        match case.expected.outcome {
+            DashboardOutcomeKind::Success => {
+                summary.success_cases = summary.success_cases.saturating_add(1);
+            }
+            DashboardOutcomeKind::MalformedInput => {
+                summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+            }
+            DashboardOutcomeKind::RetryableFailure => {
+                summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn validate_dashboard_case(case: &DashboardContractCase, index: usize) -> Result<()> {
+    if case.schema_version != DASHBOARD_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "fixture case index {} has unsupported schema_version {} (expected {})",
+            index,
+            case.schema_version,
+            DASHBOARD_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if case.case_id.trim().is_empty() {
+        bail!("fixture case index {} has empty case_id", index);
+    }
+    if case.scope.workspace_id.trim().is_empty()
+        && case.expected.outcome != DashboardOutcomeKind::MalformedInput
+    {
+        bail!(
+            "fixture case '{}' has empty scope.workspace_id without malformed_input expectation",
+            case.case_id
+        );
+    }
+    if case.simulate_retryable_failure
+        && case.expected.outcome != DashboardOutcomeKind::RetryableFailure
+    {
+        bail!(
+            "fixture case '{}' sets simulate_retryable_failure=true but expected outcome is {:?}",
+            case.case_id,
+            case.expected.outcome
+        );
+    }
+    if case.expected.outcome == DashboardOutcomeKind::RetryableFailure
+        && !case.simulate_retryable_failure
+    {
+        bail!(
+            "fixture case '{}' expects retryable_failure but simulate_retryable_failure=false",
+            case.case_id
+        );
+    }
+    if case.mode == DashboardFixtureMode::Control && case.control_action.is_none() {
+        bail!(
+            "fixture case '{}' control mode requires control_action",
+            case.case_id
+        );
+    }
+    if case.mode == DashboardFixtureMode::Filter
+        && case.expected.outcome != DashboardOutcomeKind::MalformedInput
+        && case.filters.is_empty()
+    {
+        bail!(
+            "fixture case '{}' filter mode requires at least one filter unless malformed_input",
+            case.case_id
+        );
+    }
+    if case.expected.outcome == DashboardOutcomeKind::Success && case.requested_widgets.is_empty() {
+        bail!(
+            "fixture case '{}' success outcome requires requested_widgets",
+            case.case_id
+        );
+    }
+
+    validate_filters(case)?;
+    validate_widgets(&case.requested_widgets, &case.case_id, "requested_widgets")?;
+    validate_expectation(case)?;
+    Ok(())
+}
+
+fn validate_filters(case: &DashboardContractCase) -> Result<()> {
+    let mut filter_ids = HashSet::new();
+    for filter in &case.filters {
+        if filter.filter_id.trim().is_empty() {
+            bail!(
+                "fixture case '{}' has filter with empty filter_id",
+                case.case_id
+            );
+        }
+        let normalized_id = filter.filter_id.trim().to_string();
+        if !filter_ids.insert(normalized_id.clone()) {
+            bail!(
+                "fixture case '{}' has duplicate filter_id '{}'",
+                case.case_id,
+                normalized_id
+            );
+        }
+        if case.expected.outcome != DashboardOutcomeKind::MalformedInput
+            && filter.value.trim().is_empty()
+        {
+            bail!(
+                "fixture case '{}' filter '{}' has empty value without malformed_input expectation",
+                case.case_id,
+                normalized_id
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_widgets(
+    widgets: &[DashboardWidgetSpec],
+    case_id: &str,
+    field_name: &str,
+) -> Result<()> {
+    let mut widget_ids = HashSet::new();
+    for widget in widgets {
+        if widget.widget_id.trim().is_empty() {
+            bail!("fixture case '{}' has widget with empty widget_id", case_id);
+        }
+        let normalized_widget_id = widget.widget_id.trim().to_string();
+        if !widget_ids.insert(normalized_widget_id.clone()) {
+            bail!(
+                "fixture case '{}' has duplicate widget_id '{}' in {}",
+                case_id,
+                normalized_widget_id,
+                field_name
+            );
+        }
+        if widget.title.trim().is_empty() {
+            bail!(
+                "fixture case '{}' widget '{}' has empty title",
+                case_id,
+                normalized_widget_id
+            );
+        }
+        if widget.query_key.trim().is_empty() {
+            bail!(
+                "fixture case '{}' widget '{}' has empty query_key",
+                case_id,
+                normalized_widget_id
+            );
+        }
+        if widget.refresh_interval_ms == 0 {
+            bail!(
+                "fixture case '{}' widget '{}' has refresh_interval_ms=0",
+                case_id,
+                normalized_widget_id
+            );
+        }
+        if widget.refresh_interval_ms > DASHBOARD_WIDGET_REFRESH_INTERVAL_MAX_MS {
+            bail!(
+                "fixture case '{}' widget '{}' has refresh_interval_ms {} above max {}",
+                case_id,
+                normalized_widget_id,
+                widget.refresh_interval_ms,
+                DASHBOARD_WIDGET_REFRESH_INTERVAL_MAX_MS
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_expectation(case: &DashboardContractCase) -> Result<()> {
+    let error_code = case.expected.error_code.trim();
+    match case.expected.outcome {
+        DashboardOutcomeKind::Success => {
+            if !error_code.is_empty() {
+                bail!(
+                    "fixture case '{}' success outcome must not include error_code",
+                    case.case_id
+                );
+            }
+            if case.expected.widgets.is_empty() {
+                bail!(
+                    "fixture case '{}' success outcome requires expected.widgets",
+                    case.case_id
+                );
+            }
+            if case.mode == DashboardFixtureMode::Control
+                && case.expected.audit_event_key.is_empty()
+            {
+                bail!(
+                    "fixture case '{}' control success requires expected.audit_event_key",
+                    case.case_id
+                );
+            }
+        }
+        DashboardOutcomeKind::MalformedInput | DashboardOutcomeKind::RetryableFailure => {
+            if error_code.is_empty() {
+                bail!(
+                    "fixture case '{}' {:?} outcome requires error_code",
+                    case.case_id,
+                    case.expected.outcome
+                );
+            }
+            if !supported_error_codes().contains(&error_code) {
+                bail!(
+                    "fixture case '{}' uses unsupported error_code '{}'",
+                    case.case_id,
+                    error_code
+                );
+            }
+            if !case.expected.widgets.is_empty() {
+                bail!(
+                    "fixture case '{}' non-success outcome must not include expected.widgets",
+                    case.case_id
+                );
+            }
+            if !case.expected.audit_event_key.is_empty() {
+                bail!(
+                    "fixture case '{}' non-success outcome must not include expected.audit_event_key",
+                    case.case_id
+                );
+            }
+        }
+    }
+
+    validate_widgets(&case.expected.widgets, &case.case_id, "expected.widgets")?;
+    Ok(())
+}
+
+fn assert_dashboard_replay_matches_expectation(
+    case: &DashboardContractCase,
+    result: &DashboardReplayResult,
+) -> Result<()> {
+    let expected_step = match case.expected.outcome {
+        DashboardOutcomeKind::Success => DashboardReplayStep::Success,
+        DashboardOutcomeKind::MalformedInput => DashboardReplayStep::MalformedInput,
+        DashboardOutcomeKind::RetryableFailure => DashboardReplayStep::RetryableFailure,
+    };
+    if result.step != expected_step {
+        bail!(
+            "case '{}' expected step {:?} but observed {:?}",
+            case.case_id,
+            expected_step,
+            result.step
+        );
+    }
+
+    match case.expected.outcome {
+        DashboardOutcomeKind::Success => {
+            if result.error_code.is_some() {
+                bail!(
+                    "case '{}' expected empty error_code for success but observed {:?}",
+                    case.case_id,
+                    result.error_code
+                );
+            }
+            if result.widgets != case.expected.widgets {
+                bail!(
+                    "case '{}' expected widgets {:?} but observed {:?}",
+                    case.case_id,
+                    case.expected.widgets,
+                    result.widgets
+                );
+            }
+            if result.audit_event_key != case.expected.audit_event_key {
+                bail!(
+                    "case '{}' expected audit_event_key '{}' but observed '{}'",
+                    case.case_id,
+                    case.expected.audit_event_key,
+                    result.audit_event_key
+                );
+            }
+        }
+        DashboardOutcomeKind::MalformedInput | DashboardOutcomeKind::RetryableFailure => {
+            let expected_code = case.expected.error_code.trim();
+            if result.error_code.as_deref() != Some(expected_code) {
+                bail!(
+                    "case '{}' expected error_code '{}' but observed {:?}",
+                    case.case_id,
+                    expected_code,
+                    result.error_code
+                );
+            }
+            if !result.widgets.is_empty() {
+                bail!(
+                    "case '{}' expected no widgets for non-success outcome but observed {} widgets",
+                    case.case_id,
+                    result.widgets.len()
+                );
+            }
+            if !result.audit_event_key.is_empty() {
+                bail!(
+                    "case '{}' expected empty audit_event_key for non-success outcome but observed '{}'",
+                    case.case_id,
+                    result.audit_event_key
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn supported_error_codes() -> [&'static str; 5] {
+    [
+        DASHBOARD_ERROR_EMPTY_INPUT,
+        DASHBOARD_ERROR_INVALID_SCOPE,
+        DASHBOARD_ERROR_INVALID_FILTER,
+        DASHBOARD_ERROR_INVALID_ACTION,
+        DASHBOARD_ERROR_BACKEND_UNAVAILABLE,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{
+        load_dashboard_contract_fixture, parse_dashboard_contract_fixture,
+        run_dashboard_contract_replay, DashboardContractCase, DashboardContractDriver,
+        DashboardContractFixture, DashboardFixtureMode, DashboardReplayResult, DashboardReplayStep,
+        DASHBOARD_ERROR_BACKEND_UNAVAILABLE, DASHBOARD_ERROR_EMPTY_INPUT,
+        DASHBOARD_ERROR_INVALID_ACTION, DASHBOARD_ERROR_INVALID_FILTER,
+        DASHBOARD_ERROR_INVALID_SCOPE,
+    };
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("dashboard-contract")
+            .join(name)
+    }
+
+    #[derive(Default)]
+    struct DeterministicDashboardDriver;
+
+    impl DashboardContractDriver for DeterministicDashboardDriver {
+        fn apply_case(
+            &mut self,
+            case: &DashboardContractCase,
+        ) -> anyhow::Result<DashboardReplayResult> {
+            if case.simulate_retryable_failure {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::RetryableFailure,
+                    error_code: Some(DASHBOARD_ERROR_BACKEND_UNAVAILABLE.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+
+            if case.scope.workspace_id.trim().is_empty() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_INVALID_SCOPE.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+
+            if case.requested_widgets.is_empty() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_EMPTY_INPUT.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+
+            if case.mode == DashboardFixtureMode::Filter && case.filters.is_empty() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_EMPTY_INPUT.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+            if case
+                .filters
+                .iter()
+                .any(|filter| filter.value.trim().is_empty())
+            {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_INVALID_FILTER.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+
+            if case.mode == DashboardFixtureMode::Control && case.control_action.is_none() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_INVALID_ACTION.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+
+            let mut widgets = case.requested_widgets.clone();
+            widgets.sort_by(|left, right| left.widget_id.cmp(&right.widget_id));
+
+            let audit_event_key = match case.mode {
+                DashboardFixtureMode::Control => {
+                    let action = case
+                        .control_action
+                        .expect("control mode should include action")
+                        .as_str();
+                    format!("dashboard-control:{action}:{}", case.case_id.trim())
+                }
+                _ => String::new(),
+            };
+
+            Ok(DashboardReplayResult {
+                step: DashboardReplayStep::Success,
+                error_code: None,
+                widgets,
+                audit_event_key,
+            })
+        }
+    }
+
+    #[test]
+    fn unit_parse_dashboard_contract_fixture_rejects_unsupported_schema() {
+        let raw = r#"{
+  "schema_version": 99,
+  "name": "unsupported",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "snapshot",
+      "mode": "snapshot",
+      "scope": { "workspace_id": "tau-core" },
+      "requested_widgets": [
+        {
+          "widget_id": "health-summary",
+          "kind": "health_summary",
+          "title": "Health",
+          "query_key": "transport.health",
+          "refresh_interval_ms": 5000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "health-summary",
+            "kind": "health_summary",
+            "title": "Health",
+            "query_key": "transport.health",
+            "refresh_interval_ms": 5000
+          }
+        ]
+      }
+    }
+  ]
+}"#;
+        let error = parse_dashboard_contract_fixture(raw).expect_err("schema should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported dashboard contract schema version"));
+    }
+
+    #[test]
+    fn unit_validate_dashboard_contract_fixture_rejects_duplicate_case_id() {
+        let error =
+            load_dashboard_contract_fixture(&fixture_path("invalid-duplicate-case-id.json"))
+                .expect_err("duplicate case id should fail");
+        assert!(format!("{error:#}").contains("duplicate case_id"));
+    }
+
+    #[test]
+    fn functional_fixture_loads_success_malformed_and_retryable_cases() {
+        let fixture = load_dashboard_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture should load");
+        assert_eq!(fixture.cases.len(), 3);
+        assert_eq!(fixture.cases[0].case_id, "snapshot-core-overview");
+        assert_eq!(fixture.cases[1].case_id, "filter-empty-close-window");
+        assert_eq!(fixture.cases[2].case_id, "control-pause-retryable");
+    }
+
+    #[test]
+    fn functional_dashboard_contract_replay_executes_outcome_matrix() {
+        let fixture = load_dashboard_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture should load");
+        let mut driver = DeterministicDashboardDriver;
+        let summary = run_dashboard_contract_replay(&fixture, &mut driver).expect("replay");
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.success_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.retryable_failures, 1);
+    }
+
+    #[test]
+    fn integration_dashboard_contract_replay_is_deterministic_across_reloads() {
+        let path = fixture_path("snapshot-layout.json");
+        let first = load_dashboard_contract_fixture(&path).expect("first load");
+        let second = load_dashboard_contract_fixture(&path).expect("second load");
+        assert_eq!(first, second);
+
+        let mut first_driver = DeterministicDashboardDriver;
+        let first_summary =
+            run_dashboard_contract_replay(&first, &mut first_driver).expect("first replay");
+
+        let mut second_driver = DeterministicDashboardDriver;
+        let second_summary =
+            run_dashboard_contract_replay(&second, &mut second_driver).expect("second replay");
+
+        assert_eq!(first_summary, second_summary);
+    }
+
+    #[test]
+    fn regression_fixture_rejects_unsupported_error_code() {
+        let error = load_dashboard_contract_fixture(&fixture_path("invalid-error-code.json"))
+            .expect_err("unsupported error code should fail");
+        assert!(format!("{error:#}").contains("unsupported error_code"));
+    }
+
+    #[test]
+    fn regression_dashboard_contract_replay_rejects_mismatched_expected_widgets() {
+        let mut fixture = load_dashboard_contract_fixture(&fixture_path("snapshot-layout.json"))
+            .expect("fixture");
+        fixture.cases[0].expected.widgets[0].title = "Incorrect".to_string();
+
+        let mut driver = DeterministicDashboardDriver;
+        let error =
+            run_dashboard_contract_replay(&fixture, &mut driver).expect_err("mismatch should fail");
+        assert!(error.to_string().contains("expected widgets"));
+    }
+
+    #[test]
+    fn regression_dashboard_contract_replay_rejects_mismatched_control_audit_event_key() {
+        let mut fixture = DashboardContractFixture {
+            schema_version: 1,
+            name: "control-mismatch".to_string(),
+            description: String::new(),
+            cases: vec![
+                load_dashboard_contract_fixture(&fixture_path("snapshot-layout.json"))
+                    .expect("fixture")
+                    .cases
+                    .into_iter()
+                    .find(|case| case.mode == DashboardFixtureMode::Control)
+                    .expect("control case"),
+            ],
+        };
+        fixture.cases[0].expected.audit_event_key = "wrong-audit-key".to_string();
+        let mut driver = DeterministicDashboardDriver;
+        let error =
+            run_dashboard_contract_replay(&fixture, &mut driver).expect_err("audit mismatch");
+        assert!(error.to_string().contains("expected audit_event_key"));
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -13,6 +13,8 @@ mod cli_types;
 mod codex_cli_client;
 mod commands;
 mod credentials;
+#[cfg(test)]
+mod dashboard_contract;
 mod diagnostics_commands;
 mod events;
 mod extension_manifest;

--- a/crates/tau-coding-agent/testdata/dashboard-contract/README.md
+++ b/crates/tau-coding-agent/testdata/dashboard-contract/README.md
@@ -1,0 +1,17 @@
+# Dashboard Contract Fixtures
+
+This fixture corpus defines deterministic contract coverage for the web dashboard/operator control
+plane schema.
+
+## Files
+
+- `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `snapshot-layout.json`: deterministic success-only replay fixture.
+- `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
+- `invalid-error-code.json`: regression fixture for unsupported `error_code`.
+
+## Schema Notes
+
+- Fixture schema version: `1`.
+- Mode coverage: `snapshot`, `filter`, `control`.
+- Outcome coverage: `success`, `malformed_input`, `retryable_failure`.

--- a/crates/tau-coding-agent/testdata/dashboard-contract/invalid-duplicate-case-id.json
+++ b/crates/tau-coding-agent/testdata/dashboard-contract/invalid-duplicate-case-id.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "name": "invalid-duplicate-case-id",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "mode": "snapshot",
+      "scope": {
+        "workspace_id": "tau-core"
+      },
+      "requested_widgets": [
+        {
+          "widget_id": "health-summary",
+          "kind": "health_summary",
+          "title": "Health",
+          "query_key": "runtime.health",
+          "refresh_interval_ms": 3000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "health-summary",
+            "kind": "health_summary",
+            "title": "Health",
+            "query_key": "runtime.health",
+            "refresh_interval_ms": 3000
+          }
+        ]
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "mode": "snapshot",
+      "scope": {
+        "workspace_id": "tau-core"
+      },
+      "requested_widgets": [
+        {
+          "widget_id": "transport-table",
+          "kind": "transport_table",
+          "title": "Transports",
+          "query_key": "transport.health",
+          "refresh_interval_ms": 5000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "transport-table",
+            "kind": "transport_table",
+            "title": "Transports",
+            "query_key": "transport.health",
+            "refresh_interval_ms": 5000
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/dashboard-contract/invalid-error-code.json
+++ b/crates/tau-coding-agent/testdata/dashboard-contract/invalid-error-code.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "name": "invalid-error-code",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "filter-invalid-error-code",
+      "mode": "filter",
+      "scope": {
+        "workspace_id": "tau-core"
+      },
+      "filters": [
+        {
+          "filter_id": "severity",
+          "kind": "severity",
+          "value": ""
+        }
+      ],
+      "requested_widgets": [
+        {
+          "widget_id": "alert-feed",
+          "kind": "alert_feed",
+          "title": "Alerts",
+          "query_key": "runtime.alerts",
+          "refresh_interval_ms": 5000
+        }
+      ],
+      "expected": {
+        "outcome": "malformed_input",
+        "error_code": "dashboard_unsupported_error_code",
+        "widgets": []
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/dashboard-contract/mixed-outcomes.json
+++ b/crates/tau-coding-agent/testdata/dashboard-contract/mixed-outcomes.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "name": "mixed-outcomes",
+  "description": "Covers success, malformed_input, and retryable_failure for dashboard contract replay.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "snapshot-core-overview",
+      "mode": "snapshot",
+      "scope": {
+        "workspace_id": "tau-core",
+        "operator_id": "ops-user-1"
+      },
+      "requested_widgets": [
+        {
+          "widget_id": "transport-table",
+          "kind": "transport_table",
+          "title": "Transport Health",
+          "query_key": "transport.health",
+          "refresh_interval_ms": 5000
+        },
+        {
+          "widget_id": "health-summary",
+          "kind": "health_summary",
+          "title": "Runtime Health",
+          "query_key": "runtime.health",
+          "refresh_interval_ms": 3000
+        },
+        {
+          "widget_id": "run-timeline",
+          "kind": "run_timeline",
+          "title": "Run Timeline",
+          "query_key": "runtime.timeline",
+          "refresh_interval_ms": 10000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "health-summary",
+            "kind": "health_summary",
+            "title": "Runtime Health",
+            "query_key": "runtime.health",
+            "refresh_interval_ms": 3000
+          },
+          {
+            "widget_id": "run-timeline",
+            "kind": "run_timeline",
+            "title": "Run Timeline",
+            "query_key": "runtime.timeline",
+            "refresh_interval_ms": 10000
+          },
+          {
+            "widget_id": "transport-table",
+            "kind": "transport_table",
+            "title": "Transport Health",
+            "query_key": "transport.health",
+            "refresh_interval_ms": 5000
+          }
+        ]
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "filter-empty-close-window",
+      "mode": "filter",
+      "scope": {
+        "workspace_id": "tau-core",
+        "operator_id": "ops-user-2"
+      },
+      "filters": [
+        {
+          "filter_id": "close-window",
+          "kind": "time_window",
+          "value": ""
+        }
+      ],
+      "requested_widgets": [
+        {
+          "widget_id": "queue-chart",
+          "kind": "queue_chart",
+          "title": "Queue Depth",
+          "query_key": "runtime.queue_depth",
+          "refresh_interval_ms": 4000
+        }
+      ],
+      "expected": {
+        "outcome": "malformed_input",
+        "error_code": "dashboard_invalid_filter",
+        "widgets": []
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "control-pause-retryable",
+      "mode": "control",
+      "scope": {
+        "workspace_id": "tau-core",
+        "operator_id": "ops-user-3"
+      },
+      "control_action": "pause",
+      "requested_widgets": [
+        {
+          "widget_id": "session-list",
+          "kind": "session_list",
+          "title": "Session Inventory",
+          "query_key": "runtime.sessions",
+          "refresh_interval_ms": 8000
+        }
+      ],
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "error_code": "dashboard_backend_unavailable",
+        "widgets": []
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/dashboard-contract/snapshot-layout.json
+++ b/crates/tau-coding-agent/testdata/dashboard-contract/snapshot-layout.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "name": "snapshot-layout",
+  "description": "Success-only fixture for deterministic dashboard replay and control audit outputs.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "snapshot-release-health",
+      "mode": "snapshot",
+      "scope": {
+        "workspace_id": "tau-release",
+        "operator_id": "ops-release-1"
+      },
+      "requested_widgets": [
+        {
+          "widget_id": "alert-feed",
+          "kind": "alert_feed",
+          "title": "Alert Feed",
+          "query_key": "runtime.alerts",
+          "refresh_interval_ms": 7000
+        },
+        {
+          "widget_id": "health-summary",
+          "kind": "health_summary",
+          "title": "Release Health",
+          "query_key": "release.health",
+          "refresh_interval_ms": 3000
+        },
+        {
+          "widget_id": "transport-table",
+          "kind": "transport_table",
+          "title": "Transport Table",
+          "query_key": "release.transports",
+          "refresh_interval_ms": 6000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "alert-feed",
+            "kind": "alert_feed",
+            "title": "Alert Feed",
+            "query_key": "runtime.alerts",
+            "refresh_interval_ms": 7000
+          },
+          {
+            "widget_id": "health-summary",
+            "kind": "health_summary",
+            "title": "Release Health",
+            "query_key": "release.health",
+            "refresh_interval_ms": 3000
+          },
+          {
+            "widget_id": "transport-table",
+            "kind": "transport_table",
+            "title": "Transport Table",
+            "query_key": "release.transports",
+            "refresh_interval_ms": 6000
+          }
+        ]
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "control-resume-streams",
+      "mode": "control",
+      "scope": {
+        "workspace_id": "tau-release",
+        "operator_id": "ops-release-2"
+      },
+      "control_action": "resume",
+      "requested_widgets": [
+        {
+          "widget_id": "queue-chart",
+          "kind": "queue_chart",
+          "title": "Queue Recovery",
+          "query_key": "runtime.queue_depth",
+          "refresh_interval_ms": 4000
+        }
+      ],
+      "expected": {
+        "outcome": "success",
+        "widgets": [
+          {
+            "widget_id": "queue-chart",
+            "kind": "queue_chart",
+            "title": "Queue Recovery",
+            "query_key": "runtime.queue_depth",
+            "refresh_interval_ms": 4000
+          }
+        ],
+        "audit_event_key": "dashboard-control:resume:control-resume-streams"
+      }
+    }
+  ]
+}

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -89,6 +89,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `github_issues.rs`: GitHub Issues bridge transport.
 - `slack.rs`: Slack Socket Mode bridge transport.
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
+- `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `memory_contract.rs`: semantic-memory fixture/schema contract definitions and validators.
 - `memory_runtime.rs`: semantic-memory runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) fixture/schema contract.
@@ -119,6 +120,7 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 ### Test surfaces
 
 - `tests.rs`: large integration/regression suite for `tau-coding-agent`.
+- `dashboard_contract.rs`: dashboard contract schema/fixture validation and replay contract tests.
 - `memory_contract.rs`: semantic-memory schema/fixture compatibility and replay contract tests.
 - `memory_runtime.rs`: semantic-memory runtime tests for retries, idempotency, and health signals.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.


### PR DESCRIPTION
## Summary
- add dashboard contract module with schema types, parser/validator, compatibility checks, and deterministic contract replay harness
- add dashboard fixture corpus under `crates/tau-coding-agent/testdata/dashboard-contract/` covering:
  - success/malformed/retryable outcome matrix
  - deterministic success replay fixture
  - duplicate-case regression fixture
  - invalid-error-code regression fixture
- add unit/functional/integration/regression tests for dashboard contract behavior and replay mismatches
- document the new dashboard contract surface in `docs/tau-coding-agent/code-map.md`

## Risks and compatibility
- low runtime risk: module is test-scoped (`#[cfg(test)]`) during the contract phase to avoid changing non-dashboard runtime behavior before implementation task `#766`
- fixture schema is new and isolated; no existing transport or command contract is modified

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent dashboard_contract -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`

Closes #765
