### PR TITLE
feat: implement dashboard runtime transport mode

### DIFF
--- a/crates/tau-coding-agent/src/channel_store_admin.rs
+++ b/crates/tau-coding-agent/src/channel_store_admin.rs
@@ -7,6 +7,7 @@ enum TransportHealthInspectTarget {
     GithubRepo { owner: String, repo: String },
     MultiChannel,
     Memory,
+    Dashboard,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -103,7 +104,7 @@ fn parse_transport_health_inspect_target(raw: &str) -> Result<TransportHealthIns
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         bail!(
-            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, or memory",
+            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, memory, or dashboard",
             raw
         );
     }
@@ -120,16 +121,19 @@ fn parse_transport_health_inspect_target(raw: &str) -> Result<TransportHealthIns
     if trimmed.eq_ignore_ascii_case("memory") {
         return Ok(TransportHealthInspectTarget::Memory);
     }
+    if trimmed.eq_ignore_ascii_case("dashboard") {
+        return Ok(TransportHealthInspectTarget::Dashboard);
+    }
 
     let Some((transport, repo_slug)) = trimmed.split_once(':') else {
         bail!(
-            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, or memory",
+            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, memory, or dashboard",
             raw
         );
     };
     if !transport.eq_ignore_ascii_case("github") {
         bail!(
-            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, or memory",
+            "invalid --transport-health-inspect '{}', expected slack, github, github:owner/repo, multi-channel, memory, or dashboard",
             raw
         );
     }
@@ -163,6 +167,9 @@ fn collect_transport_health_rows(
             Ok(vec![collect_multi_channel_transport_health_row(cli)?])
         }
         TransportHealthInspectTarget::Memory => Ok(vec![collect_memory_transport_health_row(cli)?]),
+        TransportHealthInspectTarget::Dashboard => {
+            Ok(vec![collect_dashboard_transport_health_row(cli)?])
+        }
     }
 }
 
@@ -255,6 +262,17 @@ fn collect_memory_transport_health_row(cli: &Cli) -> Result<TransportHealthInspe
     Ok(TransportHealthInspectRow {
         transport: "memory".to_string(),
         target: "semantic-memory".to_string(),
+        state_path: state_path.display().to_string(),
+        health,
+    })
+}
+
+fn collect_dashboard_transport_health_row(cli: &Cli) -> Result<TransportHealthInspectRow> {
+    let state_path = cli.dashboard_state_dir.join("state.json");
+    let health = load_transport_health_snapshot(&state_path)?;
+    Ok(TransportHealthInspectRow {
+        transport: "dashboard".to_string(),
+        target: "operator-control-plane".to_string(),
         state_path: state_path.display().to_string(),
         health,
     })
@@ -360,6 +378,10 @@ mod tests {
             parse_transport_health_inspect_target("memory").expect("memory"),
             TransportHealthInspectTarget::Memory
         );
+        assert_eq!(
+            parse_transport_health_inspect_target("dashboard").expect("dashboard"),
+            TransportHealthInspectTarget::Dashboard
+        );
     }
 
     #[test]
@@ -395,11 +417,13 @@ mod tests {
         let slack_root = temp.path().join("slack");
         let multi_channel_root = temp.path().join("multi-channel");
         let memory_root = temp.path().join("memory");
+        let dashboard_root = temp.path().join("dashboard");
         let github_repo_dir = github_root.join("owner__repo");
         std::fs::create_dir_all(&github_repo_dir).expect("create github repo dir");
         std::fs::create_dir_all(&slack_root).expect("create slack dir");
         std::fs::create_dir_all(&multi_channel_root).expect("create multi-channel dir");
         std::fs::create_dir_all(&memory_root).expect("create memory dir");
+        std::fs::create_dir_all(&dashboard_root).expect("create dashboard dir");
 
         std::fs::write(
             github_repo_dir.join("state.json"),
@@ -492,11 +516,36 @@ mod tests {
         )
         .expect("write memory state");
 
+        std::fs::write(
+            dashboard_root.join("state.json"),
+            r#"{
+  "schema_version": 1,
+  "processed_case_keys": [],
+  "widget_views": [],
+  "control_audit": [],
+  "health": {
+    "updated_unix_ms": 500,
+    "cycle_duration_ms": 40,
+    "queue_depth": 0,
+    "active_runs": 0,
+    "failure_streak": 0,
+    "last_cycle_discovered": 2,
+    "last_cycle_processed": 2,
+    "last_cycle_completed": 2,
+    "last_cycle_failed": 0,
+    "last_cycle_duplicates": 0
+  }
+}
+"#,
+        )
+        .expect("write dashboard state");
+
         let mut cli = Cli::parse_from(["tau-rs"]);
         cli.github_state_dir = github_root;
         cli.slack_state_dir = slack_root;
         cli.multi_channel_state_dir = multi_channel_root;
         cli.memory_state_dir = memory_root;
+        cli.dashboard_state_dir = dashboard_root;
 
         let github_rows =
             collect_transport_health_rows(&cli, &TransportHealthInspectTarget::GithubAll)
@@ -528,16 +577,26 @@ mod tests {
         assert_eq!(memory_rows[0].target, "semantic-memory");
         assert_eq!(memory_rows[0].health.last_cycle_discovered, 5);
 
+        let dashboard_rows =
+            collect_transport_health_rows(&cli, &TransportHealthInspectTarget::Dashboard)
+                .expect("collect dashboard rows");
+        assert_eq!(dashboard_rows.len(), 1);
+        assert_eq!(dashboard_rows[0].transport, "dashboard");
+        assert_eq!(dashboard_rows[0].target, "operator-control-plane");
+        assert_eq!(dashboard_rows[0].health.last_cycle_discovered, 2);
+
         let rendered = render_transport_health_rows(&[
             github_rows[0].clone(),
             slack_rows[0].clone(),
             multi_channel_rows[0].clone(),
             memory_rows[0].clone(),
+            dashboard_rows[0].clone(),
         ]);
         assert!(rendered.contains("transport=github"));
         assert!(rendered.contains("transport=slack"));
         assert!(rendered.contains("transport=multi-channel"));
         assert!(rendered.contains("transport=memory"));
+        assert!(rendered.contains("transport=dashboard"));
     }
 
     #[test]
@@ -593,6 +652,31 @@ mod tests {
 
         let rows = collect_transport_health_rows(&cli, &TransportHealthInspectTarget::Memory)
             .expect("collect memory row");
+        assert_eq!(rows[0].health, TransportHealthSnapshot::default());
+    }
+
+    #[test]
+    fn regression_collect_transport_health_rows_defaults_missing_health_fields_for_dashboard() {
+        let temp = tempdir().expect("tempdir");
+        let dashboard_root = temp.path().join("dashboard");
+        std::fs::create_dir_all(&dashboard_root).expect("create dashboard dir");
+        std::fs::write(
+            dashboard_root.join("state.json"),
+            r#"{
+  "schema_version": 1,
+  "processed_case_keys": [],
+  "widget_views": [],
+  "control_audit": []
+}
+"#,
+        )
+        .expect("write legacy dashboard state");
+
+        let mut cli = Cli::parse_from(["tau-rs"]);
+        cli.dashboard_state_dir = PathBuf::from(&dashboard_root);
+
+        let rows = collect_transport_health_rows(&cli, &TransportHealthInspectTarget::Dashboard)
+            .expect("collect dashboard row");
         assert_eq!(rows[0].health, TransportHealthSnapshot::default());
     }
 }

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -756,7 +756,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, memory"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, memory, dashboard"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -1762,6 +1762,67 @@ pub(crate) struct Cli {
         help = "Base backoff delay in milliseconds for semantic memory runtime retries (0 disables delay)"
     )]
     pub(crate) memory_retry_base_delay_ms: u64,
+
+    #[arg(
+        long = "dashboard-contract-runner",
+        env = "TAU_DASHBOARD_CONTRACT_RUNNER",
+        default_value_t = false,
+        help = "Run fixture-driven dashboard runtime contract scenarios"
+    )]
+    pub(crate) dashboard_contract_runner: bool,
+
+    #[arg(
+        long = "dashboard-fixture",
+        env = "TAU_DASHBOARD_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/dashboard-contract/mixed-outcomes.json",
+        requires = "dashboard_contract_runner",
+        help = "Path to dashboard runtime contract fixture JSON"
+    )]
+    pub(crate) dashboard_fixture: PathBuf,
+
+    #[arg(
+        long = "dashboard-state-dir",
+        env = "TAU_DASHBOARD_STATE_DIR",
+        default_value = ".tau/dashboard",
+        help = "Directory for dashboard runtime state and channel-store outputs"
+    )]
+    pub(crate) dashboard_state_dir: PathBuf,
+
+    #[arg(
+        long = "dashboard-queue-limit",
+        env = "TAU_DASHBOARD_QUEUE_LIMIT",
+        default_value_t = 64,
+        requires = "dashboard_contract_runner",
+        help = "Maximum dashboard fixture cases processed per runtime cycle"
+    )]
+    pub(crate) dashboard_queue_limit: usize,
+
+    #[arg(
+        long = "dashboard-processed-case-cap",
+        env = "TAU_DASHBOARD_PROCESSED_CASE_CAP",
+        default_value_t = 10_000,
+        requires = "dashboard_contract_runner",
+        help = "Maximum processed-case keys retained for dashboard duplicate suppression"
+    )]
+    pub(crate) dashboard_processed_case_cap: usize,
+
+    #[arg(
+        long = "dashboard-retry-max-attempts",
+        env = "TAU_DASHBOARD_RETRY_MAX_ATTEMPTS",
+        default_value_t = 4,
+        requires = "dashboard_contract_runner",
+        help = "Maximum retry attempts for transient dashboard runtime failures"
+    )]
+    pub(crate) dashboard_retry_max_attempts: usize,
+
+    #[arg(
+        long = "dashboard-retry-base-delay-ms",
+        env = "TAU_DASHBOARD_RETRY_BASE_DELAY_MS",
+        default_value_t = 0,
+        requires = "dashboard_contract_runner",
+        help = "Base backoff delay in milliseconds for dashboard runtime retries (0 disables delay)"
+    )]
+    pub(crate) dashboard_retry_base_delay_ms: u64,
 
     #[arg(
         long = "github-issues-bridge",

--- a/crates/tau-coding-agent/src/dashboard_contract.rs
+++ b/crates/tau-coding-agent/src/dashboard_contract.rs
@@ -166,6 +166,7 @@ pub(crate) struct DashboardReplayResult {
     pub(crate) audit_event_key: String,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct DashboardReplaySummary {
     pub(crate) discovered_cases: usize,
@@ -174,6 +175,7 @@ pub(crate) struct DashboardReplaySummary {
     pub(crate) retryable_failures: usize,
 }
 
+#[cfg(test)]
 pub(crate) trait DashboardContractDriver {
     fn apply_case(&mut self, case: &DashboardContractCase) -> Result<DashboardReplayResult>;
 }
@@ -287,6 +289,7 @@ pub(crate) fn validate_dashboard_contract_fixture(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn run_dashboard_contract_replay<D: DashboardContractDriver>(
     fixture: &DashboardContractFixture,
     driver: &mut D,
@@ -523,6 +526,7 @@ fn validate_expectation(case: &DashboardContractCase) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn assert_dashboard_replay_matches_expectation(
     case: &DashboardContractCase,
     result: &DashboardReplayResult,

--- a/crates/tau-coding-agent/src/dashboard_runtime.rs
+++ b/crates/tau-coding-agent/src/dashboard_runtime.rs
@@ -1,0 +1,1046 @@
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
+use crate::dashboard_contract::{
+    load_dashboard_contract_fixture, DashboardContractCase, DashboardContractFixture,
+    DashboardControlAction, DashboardFixtureMode, DashboardOutcomeKind, DashboardReplayResult,
+    DashboardReplayStep, DashboardScope, DASHBOARD_ERROR_BACKEND_UNAVAILABLE,
+    DASHBOARD_ERROR_EMPTY_INPUT, DASHBOARD_ERROR_INVALID_ACTION, DASHBOARD_ERROR_INVALID_FILTER,
+    DASHBOARD_ERROR_INVALID_SCOPE,
+};
+use crate::{current_unix_timestamp_ms, write_text_atomic, TransportHealthSnapshot};
+
+const DASHBOARD_RUNTIME_STATE_SCHEMA_VERSION: u32 = 1;
+const DASHBOARD_RUNTIME_EVENTS_LOG_FILE: &str = "runtime-events.jsonl";
+const DASHBOARD_CONTROL_AUDIT_CAP: usize = 512;
+
+fn dashboard_runtime_state_schema_version() -> u32 {
+    DASHBOARD_RUNTIME_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardRuntimeConfig {
+    pub(crate) fixture_path: PathBuf,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) queue_limit: usize,
+    pub(crate) processed_case_cap: usize,
+    pub(crate) retry_max_attempts: usize,
+    pub(crate) retry_base_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DashboardRuntimeSummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) queued_cases: usize,
+    pub(crate) applied_cases: usize,
+    pub(crate) duplicate_skips: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+    pub(crate) retry_attempts: usize,
+    pub(crate) failed_cases: usize,
+    pub(crate) upserted_widgets: usize,
+    pub(crate) control_actions_applied: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DashboardRuntimeCycleReport {
+    timestamp_unix_ms: u64,
+    health_state: String,
+    health_reason: String,
+    reason_codes: Vec<String>,
+    discovered_cases: usize,
+    queued_cases: usize,
+    applied_cases: usize,
+    duplicate_skips: usize,
+    malformed_cases: usize,
+    retryable_failures: usize,
+    retry_attempts: usize,
+    failed_cases: usize,
+    upserted_widgets: usize,
+    control_actions_applied: usize,
+    backlog_cases: usize,
+    failure_streak: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DashboardWidgetView {
+    widget_id: String,
+    kind: String,
+    title: String,
+    query_key: String,
+    refresh_interval_ms: u64,
+    last_case_key: String,
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DashboardControlAuditRecord {
+    event_key: String,
+    case_id: String,
+    action: String,
+    status: String,
+    timestamp_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DashboardRuntimeState {
+    #[serde(default = "dashboard_runtime_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    processed_case_keys: Vec<String>,
+    #[serde(default)]
+    widget_views: Vec<DashboardWidgetView>,
+    #[serde(default)]
+    control_audit: Vec<DashboardControlAuditRecord>,
+    #[serde(default)]
+    health: TransportHealthSnapshot,
+}
+
+impl Default for DashboardRuntimeState {
+    fn default() -> Self {
+        Self {
+            schema_version: DASHBOARD_RUNTIME_STATE_SCHEMA_VERSION,
+            processed_case_keys: Vec::new(),
+            widget_views: Vec::new(),
+            control_audit: Vec::new(),
+            health: TransportHealthSnapshot::default(),
+        }
+    }
+}
+
+pub(crate) async fn run_dashboard_contract_runner(config: DashboardRuntimeConfig) -> Result<()> {
+    let fixture = load_dashboard_contract_fixture(&config.fixture_path)?;
+    let mut runtime = DashboardRuntime::new(config)?;
+    let summary = runtime.run_once(&fixture).await?;
+    let health = runtime.transport_health().clone();
+    let classification = health.classify();
+
+    println!(
+        "dashboard runner summary: discovered={} queued={} applied={} duplicate_skips={} malformed={} retryable_failures={} retries={} failed={} upserted_widgets={} control_actions={}",
+        summary.discovered_cases,
+        summary.queued_cases,
+        summary.applied_cases,
+        summary.duplicate_skips,
+        summary.malformed_cases,
+        summary.retryable_failures,
+        summary.retry_attempts,
+        summary.failed_cases,
+        summary.upserted_widgets,
+        summary.control_actions_applied
+    );
+    println!(
+        "dashboard runner health: state={} failure_streak={} queue_depth={} reason={}",
+        classification.state.as_str(),
+        health.failure_streak,
+        health.queue_depth,
+        classification.reason
+    );
+
+    Ok(())
+}
+
+struct DashboardRuntime {
+    config: DashboardRuntimeConfig,
+    state: DashboardRuntimeState,
+    processed_case_keys: HashSet<String>,
+}
+
+impl DashboardRuntime {
+    fn new(config: DashboardRuntimeConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)
+            .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+        let mut state = load_dashboard_runtime_state(&config.state_dir.join("state.json"))?;
+        state.processed_case_keys =
+            normalize_processed_case_keys(&state.processed_case_keys, config.processed_case_cap);
+        state
+            .widget_views
+            .sort_by(|left, right| left.widget_id.cmp(&right.widget_id));
+
+        let processed_case_keys = state.processed_case_keys.iter().cloned().collect();
+        Ok(Self {
+            config,
+            state,
+            processed_case_keys,
+        })
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.config.state_dir.join("state.json")
+    }
+
+    fn transport_health(&self) -> &TransportHealthSnapshot {
+        &self.state.health
+    }
+
+    async fn run_once(
+        &mut self,
+        fixture: &DashboardContractFixture,
+    ) -> Result<DashboardRuntimeSummary> {
+        let cycle_started = Instant::now();
+        let mut summary = DashboardRuntimeSummary {
+            discovered_cases: fixture.cases.len(),
+            ..DashboardRuntimeSummary::default()
+        };
+
+        let mut queued_cases = fixture.cases.clone();
+        queued_cases.sort_by(|left, right| {
+            left.case_id
+                .cmp(&right.case_id)
+                .then_with(|| left.mode.as_str().cmp(right.mode.as_str()))
+        });
+        queued_cases.truncate(self.config.queue_limit);
+        summary.queued_cases = queued_cases.len();
+
+        for case in queued_cases {
+            let case_key = case_runtime_key(&case);
+            if self.processed_case_keys.contains(&case_key) {
+                summary.duplicate_skips = summary.duplicate_skips.saturating_add(1);
+                continue;
+            }
+
+            let mut attempt = 1_usize;
+            loop {
+                let result = evaluate_dashboard_case(&case)?;
+                validate_case_result_against_contract(&case, &result)?;
+                match result.step {
+                    DashboardReplayStep::Success => {
+                        let (upserted_widgets, control_actions) =
+                            self.persist_success_result(&case, &case_key, &result)?;
+                        summary.applied_cases = summary.applied_cases.saturating_add(1);
+                        summary.upserted_widgets =
+                            summary.upserted_widgets.saturating_add(upserted_widgets);
+                        summary.control_actions_applied = summary
+                            .control_actions_applied
+                            .saturating_add(control_actions);
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    DashboardReplayStep::MalformedInput => {
+                        summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+                        let control_actions =
+                            self.persist_non_success_result(&case, &case_key, &result)?;
+                        summary.control_actions_applied = summary
+                            .control_actions_applied
+                            .saturating_add(control_actions);
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    DashboardReplayStep::RetryableFailure => {
+                        summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+                        if attempt >= self.config.retry_max_attempts {
+                            summary.failed_cases = summary.failed_cases.saturating_add(1);
+                            let control_actions =
+                                self.persist_non_success_result(&case, &case_key, &result)?;
+                            summary.control_actions_applied = summary
+                                .control_actions_applied
+                                .saturating_add(control_actions);
+                            break;
+                        }
+                        summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                        apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                        attempt = attempt.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        let cycle_duration_ms =
+            u64::try_from(cycle_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let health = build_transport_health_snapshot(
+            &summary,
+            cycle_duration_ms,
+            self.state.health.failure_streak,
+        );
+        let classification = health.classify();
+        let reason_codes = cycle_reason_codes(&summary);
+        self.state.health = health.clone();
+
+        save_dashboard_runtime_state(&self.state_path(), &self.state)?;
+        append_dashboard_cycle_report(
+            &self
+                .config
+                .state_dir
+                .join(DASHBOARD_RUNTIME_EVENTS_LOG_FILE),
+            &summary,
+            &health,
+            &classification.reason,
+            &reason_codes,
+        )?;
+
+        Ok(summary)
+    }
+
+    fn persist_success_result(
+        &mut self,
+        case: &DashboardContractCase,
+        case_key: &str,
+        result: &DashboardReplayResult,
+    ) -> Result<(usize, usize)> {
+        let mut upserted = 0_usize;
+        for widget in &result.widgets {
+            let view = DashboardWidgetView {
+                widget_id: widget.widget_id.clone(),
+                kind: format!("{:?}", widget.kind).to_ascii_lowercase(),
+                title: widget.title.clone(),
+                query_key: widget.query_key.clone(),
+                refresh_interval_ms: widget.refresh_interval_ms,
+                last_case_key: case_key.to_string(),
+                updated_unix_ms: current_unix_timestamp_ms(),
+            };
+            if let Some(existing) = self
+                .state
+                .widget_views
+                .iter_mut()
+                .find(|existing| existing.widget_id == widget.widget_id)
+            {
+                *existing = view;
+            } else {
+                self.state.widget_views.push(view);
+            }
+            upserted = upserted.saturating_add(1);
+        }
+        self.state
+            .widget_views
+            .sort_by(|left, right| left.widget_id.cmp(&right.widget_id));
+
+        let mut control_actions = 0_usize;
+        if let Some(action) = case.control_action {
+            self.record_control_audit(case, case_key, action, "success");
+            control_actions = control_actions.saturating_add(1);
+        }
+
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-dashboard-runner".to_string(),
+                payload: json!({
+                    "outcome": "success",
+                    "mode": case.mode.as_str(),
+                    "case_id": case.case_id,
+                    "upserted_widgets": upserted,
+                    "control_action": case.control_action.map(DashboardControlAction::as_str),
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "dashboard case {} applied with {} widget updates",
+                    case.case_id, upserted
+                ),
+            })?;
+            let rendered = render_dashboard_snapshot(&self.state.widget_views, &case.scope);
+            store.write_memory(&rendered)?;
+        }
+
+        Ok((upserted, control_actions))
+    }
+
+    fn persist_non_success_result(
+        &mut self,
+        case: &DashboardContractCase,
+        case_key: &str,
+        result: &DashboardReplayResult,
+    ) -> Result<usize> {
+        let outcome = match result.step {
+            DashboardReplayStep::Success => "success",
+            DashboardReplayStep::MalformedInput => "malformed_input",
+            DashboardReplayStep::RetryableFailure => "retryable_failure",
+        };
+        let mut control_actions = 0_usize;
+        if let Some(action) = case.control_action {
+            self.record_control_audit(case, case_key, action, outcome);
+            control_actions = control_actions.saturating_add(1);
+        }
+
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-dashboard-runner".to_string(),
+                payload: json!({
+                    "outcome": outcome,
+                    "mode": case.mode.as_str(),
+                    "case_id": case.case_id,
+                    "error_code": result.error_code.clone().unwrap_or_default(),
+                    "control_action": case.control_action.map(DashboardControlAction::as_str),
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "dashboard case {} outcome={} error_code={}",
+                    case.case_id,
+                    outcome,
+                    result.error_code.clone().unwrap_or_default()
+                ),
+            })?;
+        }
+
+        Ok(control_actions)
+    }
+
+    fn record_control_audit(
+        &mut self,
+        case: &DashboardContractCase,
+        case_key: &str,
+        action: DashboardControlAction,
+        status: &str,
+    ) {
+        self.state.control_audit.push(DashboardControlAuditRecord {
+            event_key: case_key.to_string(),
+            case_id: case.case_id.trim().to_string(),
+            action: action.as_str().to_string(),
+            status: status.to_string(),
+            timestamp_unix_ms: current_unix_timestamp_ms(),
+        });
+        if self.state.control_audit.len() > DASHBOARD_CONTROL_AUDIT_CAP {
+            let overflow = self
+                .state
+                .control_audit
+                .len()
+                .saturating_sub(DASHBOARD_CONTROL_AUDIT_CAP);
+            self.state.control_audit.drain(0..overflow);
+        }
+    }
+
+    fn scope_channel_store(&self, case: &DashboardContractCase) -> Result<Option<ChannelStore>> {
+        let workspace_id = case.scope.workspace_id.trim();
+        if workspace_id.is_empty() {
+            return Ok(None);
+        }
+        let channel_id = if case.scope.operator_id.trim().is_empty() {
+            format!("workspace:{workspace_id}")
+        } else {
+            format!("operator:{}", case.scope.operator_id.trim())
+        };
+        let store = ChannelStore::open(
+            &self.config.state_dir.join("channel-store"),
+            "dashboard",
+            &channel_id,
+        )?;
+        Ok(Some(store))
+    }
+
+    fn record_processed_case(&mut self, case_key: &str) {
+        if self.processed_case_keys.contains(case_key) {
+            return;
+        }
+        self.state.processed_case_keys.push(case_key.to_string());
+        self.processed_case_keys.insert(case_key.to_string());
+        if self.state.processed_case_keys.len() > self.config.processed_case_cap {
+            let overflow = self
+                .state
+                .processed_case_keys
+                .len()
+                .saturating_sub(self.config.processed_case_cap);
+            let removed = self.state.processed_case_keys.drain(0..overflow);
+            for key in removed {
+                self.processed_case_keys.remove(&key);
+            }
+        }
+    }
+}
+
+fn case_runtime_key(case: &DashboardContractCase) -> String {
+    format!("{}:{}", case.mode.as_str(), case.case_id.trim())
+}
+
+fn build_transport_health_snapshot(
+    summary: &DashboardRuntimeSummary,
+    cycle_duration_ms: u64,
+    previous_failure_streak: usize,
+) -> TransportHealthSnapshot {
+    let backlog_cases = summary
+        .discovered_cases
+        .saturating_sub(summary.queued_cases);
+    let failure_streak = if summary.failed_cases > 0 {
+        previous_failure_streak.saturating_add(1)
+    } else {
+        0
+    };
+    TransportHealthSnapshot {
+        updated_unix_ms: current_unix_timestamp_ms(),
+        cycle_duration_ms,
+        queue_depth: backlog_cases,
+        active_runs: 0,
+        failure_streak,
+        last_cycle_discovered: summary.discovered_cases,
+        last_cycle_processed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases)
+            .saturating_add(summary.failed_cases)
+            .saturating_add(summary.duplicate_skips),
+        last_cycle_completed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases),
+        last_cycle_failed: summary.failed_cases,
+        last_cycle_duplicates: summary.duplicate_skips,
+    }
+}
+
+fn cycle_reason_codes(summary: &DashboardRuntimeSummary) -> Vec<String> {
+    let mut codes = Vec::new();
+    if summary.discovered_cases > summary.queued_cases {
+        codes.push("queue_backpressure_applied".to_string());
+    }
+    if summary.duplicate_skips > 0 {
+        codes.push("duplicate_cases_skipped".to_string());
+    }
+    if summary.malformed_cases > 0 {
+        codes.push("malformed_inputs_observed".to_string());
+    }
+    if summary.retry_attempts > 0 {
+        codes.push("retry_attempted".to_string());
+    }
+    if summary.retryable_failures > 0 {
+        codes.push("retryable_failures_observed".to_string());
+    }
+    if summary.failed_cases > 0 {
+        codes.push("case_processing_failed".to_string());
+    }
+    if summary.upserted_widgets > 0 {
+        codes.push("widget_views_updated".to_string());
+    }
+    if summary.control_actions_applied > 0 {
+        codes.push("control_actions_applied".to_string());
+    }
+    if codes.is_empty() {
+        codes.push("healthy_cycle".to_string());
+    }
+    codes
+}
+
+fn append_dashboard_cycle_report(
+    path: &Path,
+    summary: &DashboardRuntimeSummary,
+    health: &TransportHealthSnapshot,
+    health_reason: &str,
+    reason_codes: &[String],
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+
+    let payload = DashboardRuntimeCycleReport {
+        timestamp_unix_ms: current_unix_timestamp_ms(),
+        health_state: health.classify().state.as_str().to_string(),
+        health_reason: health_reason.to_string(),
+        reason_codes: reason_codes.to_vec(),
+        discovered_cases: summary.discovered_cases,
+        queued_cases: summary.queued_cases,
+        applied_cases: summary.applied_cases,
+        duplicate_skips: summary.duplicate_skips,
+        malformed_cases: summary.malformed_cases,
+        retryable_failures: summary.retryable_failures,
+        retry_attempts: summary.retry_attempts,
+        failed_cases: summary.failed_cases,
+        upserted_widgets: summary.upserted_widgets,
+        control_actions_applied: summary.control_actions_applied,
+        backlog_cases: summary
+            .discovered_cases
+            .saturating_sub(summary.queued_cases),
+        failure_streak: health.failure_streak,
+    };
+    let line = serde_json::to_string(&payload).context("serialize dashboard runtime report")?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+fn evaluate_dashboard_case(case: &DashboardContractCase) -> Result<DashboardReplayResult> {
+    if case.scope.workspace_id.trim().is_empty() {
+        return Ok(DashboardReplayResult {
+            step: DashboardReplayStep::MalformedInput,
+            error_code: Some(DASHBOARD_ERROR_INVALID_SCOPE.to_string()),
+            widgets: Vec::new(),
+            audit_event_key: String::new(),
+        });
+    }
+    if case.requested_widgets.is_empty() {
+        return Ok(DashboardReplayResult {
+            step: DashboardReplayStep::MalformedInput,
+            error_code: Some(DASHBOARD_ERROR_EMPTY_INPUT.to_string()),
+            widgets: Vec::new(),
+            audit_event_key: String::new(),
+        });
+    }
+
+    if case.simulate_retryable_failure {
+        return Ok(DashboardReplayResult {
+            step: DashboardReplayStep::RetryableFailure,
+            error_code: Some(DASHBOARD_ERROR_BACKEND_UNAVAILABLE.to_string()),
+            widgets: Vec::new(),
+            audit_event_key: String::new(),
+        });
+    }
+
+    match case.mode {
+        DashboardFixtureMode::Snapshot => {}
+        DashboardFixtureMode::Filter => {
+            if case.filters.is_empty() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_EMPTY_INPUT.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+            if case
+                .filters
+                .iter()
+                .any(|filter| filter.value.trim().is_empty())
+            {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_INVALID_FILTER.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+        }
+        DashboardFixtureMode::Control => {
+            if case.control_action.is_none() {
+                return Ok(DashboardReplayResult {
+                    step: DashboardReplayStep::MalformedInput,
+                    error_code: Some(DASHBOARD_ERROR_INVALID_ACTION.to_string()),
+                    widgets: Vec::new(),
+                    audit_event_key: String::new(),
+                });
+            }
+        }
+    }
+
+    let mut widgets = case.requested_widgets.clone();
+    widgets.sort_by(|left, right| left.widget_id.cmp(&right.widget_id));
+    let audit_event_key = if case.mode == DashboardFixtureMode::Control {
+        let action = case
+            .control_action
+            .ok_or_else(|| anyhow::anyhow!("control mode requires control_action"))?
+            .as_str();
+        format!("dashboard-control:{action}:{}", case.case_id.trim())
+    } else {
+        String::new()
+    };
+    Ok(DashboardReplayResult {
+        step: DashboardReplayStep::Success,
+        error_code: None,
+        widgets,
+        audit_event_key,
+    })
+}
+
+fn validate_case_result_against_contract(
+    case: &DashboardContractCase,
+    result: &DashboardReplayResult,
+) -> Result<()> {
+    let expected_step = match case.expected.outcome {
+        DashboardOutcomeKind::Success => DashboardReplayStep::Success,
+        DashboardOutcomeKind::MalformedInput => DashboardReplayStep::MalformedInput,
+        DashboardOutcomeKind::RetryableFailure => DashboardReplayStep::RetryableFailure,
+    };
+    if result.step != expected_step {
+        bail!(
+            "case '{}' expected step {:?} but observed {:?}",
+            case.case_id,
+            expected_step,
+            result.step
+        );
+    }
+
+    match case.expected.outcome {
+        DashboardOutcomeKind::Success => {
+            if result.error_code.is_some() {
+                bail!(
+                    "case '{}' expected empty error_code for success but observed {:?}",
+                    case.case_id,
+                    result.error_code
+                );
+            }
+            if result.widgets != case.expected.widgets {
+                bail!(
+                    "case '{}' expected widgets {:?} but observed {:?}",
+                    case.case_id,
+                    case.expected.widgets,
+                    result.widgets
+                );
+            }
+            if result.audit_event_key != case.expected.audit_event_key {
+                bail!(
+                    "case '{}' expected audit_event_key '{}' but observed '{}'",
+                    case.case_id,
+                    case.expected.audit_event_key,
+                    result.audit_event_key
+                );
+            }
+        }
+        DashboardOutcomeKind::MalformedInput | DashboardOutcomeKind::RetryableFailure => {
+            let expected_code = case.expected.error_code.trim();
+            if result.error_code.as_deref() != Some(expected_code) {
+                bail!(
+                    "case '{}' expected error_code '{}' but observed {:?}",
+                    case.case_id,
+                    expected_code,
+                    result.error_code
+                );
+            }
+            if !result.widgets.is_empty() {
+                bail!(
+                    "case '{}' expected no widgets for non-success outcome but observed {} widgets",
+                    case.case_id,
+                    result.widgets.len()
+                );
+            }
+            if !result.audit_event_key.is_empty() {
+                bail!(
+                    "case '{}' expected empty audit_event_key for non-success outcome but observed '{}'",
+                    case.case_id,
+                    result.audit_event_key
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_dashboard_snapshot(widgets: &[DashboardWidgetView], scope: &DashboardScope) -> String {
+    if widgets.is_empty() {
+        return format!(
+            "# Tau Dashboard Snapshot ({})\n\n- No materialized widgets",
+            scope.workspace_id.trim()
+        );
+    }
+    let mut lines = vec![
+        format!("# Tau Dashboard Snapshot ({})", scope.workspace_id.trim()),
+        String::new(),
+    ];
+    for widget in widgets {
+        lines.push(format!(
+            "- {}: {} ({})",
+            widget.widget_id, widget.title, widget.query_key
+        ));
+    }
+    lines.join("\n")
+}
+
+fn normalize_processed_case_keys(raw: &[String], cap: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for key in raw {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.insert(owned.clone()) {
+            normalized.push(owned);
+        }
+    }
+    if cap == 0 {
+        return Vec::new();
+    }
+    if normalized.len() > cap {
+        normalized.drain(0..normalized.len().saturating_sub(cap));
+    }
+    normalized
+}
+
+fn retry_delay_ms(base_delay_ms: u64, attempt: usize) -> u64 {
+    if base_delay_ms == 0 {
+        return 0;
+    }
+    let exponent = attempt.saturating_sub(1).min(10) as u32;
+    base_delay_ms.saturating_mul(1_u64 << exponent)
+}
+
+async fn apply_retry_delay(base_delay_ms: u64, attempt: usize) {
+    let delay_ms = retry_delay_ms(base_delay_ms, attempt);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    }
+}
+
+fn load_dashboard_runtime_state(path: &Path) -> Result<DashboardRuntimeState> {
+    if !path.exists() {
+        return Ok(DashboardRuntimeState::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed = match serde_json::from_str::<DashboardRuntimeState>(&raw) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "dashboard runner: failed to parse state file {} ({error}); starting fresh",
+                path.display()
+            );
+            return Ok(DashboardRuntimeState::default());
+        }
+    };
+    if parsed.schema_version != DASHBOARD_RUNTIME_STATE_SCHEMA_VERSION {
+        eprintln!(
+            "dashboard runner: unsupported state schema {} in {}; starting fresh",
+            parsed.schema_version,
+            path.display()
+        );
+        return Ok(DashboardRuntimeState::default());
+    }
+    Ok(parsed)
+}
+
+fn save_dashboard_runtime_state(path: &Path, state: &DashboardRuntimeState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("serialize dashboard state")?;
+    write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::{
+        load_dashboard_runtime_state, retry_delay_ms, DashboardRuntime, DashboardRuntimeConfig,
+        DASHBOARD_RUNTIME_EVENTS_LOG_FILE,
+    };
+    use crate::channel_store::ChannelStore;
+    use crate::dashboard_contract::load_dashboard_contract_fixture;
+    use crate::transport_health::TransportHealthState;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("dashboard-contract")
+            .join(name)
+    }
+
+    fn build_config(root: &Path) -> DashboardRuntimeConfig {
+        DashboardRuntimeConfig {
+            fixture_path: fixture_path("mixed-outcomes.json"),
+            state_dir: root.join(".tau/dashboard"),
+            queue_limit: 64,
+            processed_case_cap: 10_000,
+            retry_max_attempts: 2,
+            retry_base_delay_ms: 0,
+        }
+    }
+
+    #[test]
+    fn unit_retry_delay_ms_scales_with_attempt_number() {
+        assert_eq!(retry_delay_ms(0, 1), 0);
+        assert_eq!(retry_delay_ms(10, 1), 10);
+        assert_eq!(retry_delay_ms(10, 2), 20);
+        assert_eq!(retry_delay_ms(10, 3), 40);
+    }
+
+    #[tokio::test]
+    async fn functional_runner_processes_fixture_and_persists_dashboard_state() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_dashboard_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = DashboardRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 3);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.retryable_failures, 2);
+        assert_eq!(summary.retry_attempts, 1);
+        assert_eq!(summary.failed_cases, 1);
+        assert_eq!(summary.upserted_widgets, 3);
+        assert_eq!(summary.control_actions_applied, 1);
+        assert_eq!(summary.duplicate_skips, 0);
+
+        let state =
+            load_dashboard_runtime_state(&config.state_dir.join("state.json")).expect("load state");
+        assert_eq!(state.widget_views.len(), 3);
+        assert_eq!(state.control_audit.len(), 1);
+        assert_eq!(state.processed_case_keys.len(), 2);
+        assert_eq!(state.health.last_cycle_discovered, 3);
+        assert_eq!(state.health.last_cycle_failed, 1);
+        assert_eq!(state.health.failure_streak, 1);
+        assert_eq!(
+            state.health.classify().state,
+            TransportHealthState::Degraded
+        );
+
+        let events_log =
+            std::fs::read_to_string(config.state_dir.join(DASHBOARD_RUNTIME_EVENTS_LOG_FILE))
+                .expect("read runtime events");
+        assert!(events_log.contains("retryable_failures_observed"));
+        assert!(events_log.contains("control_actions_applied"));
+
+        let store = ChannelStore::open(
+            &config.state_dir.join("channel-store"),
+            "dashboard",
+            "operator:ops-user-1",
+        )
+        .expect("open channel store");
+        let memory = store
+            .load_memory()
+            .expect("load memory")
+            .expect("memory should exist");
+        assert!(memory.contains("Tau Dashboard Snapshot (tau-core)"));
+        assert!(memory.contains("health-summary"));
+    }
+
+    #[tokio::test]
+    async fn integration_runner_respects_queue_limit_for_backpressure() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.queue_limit = 2;
+        let fixture =
+            load_dashboard_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = DashboardRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 2);
+        assert_eq!(summary.applied_cases, 0);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.failed_cases, 1);
+        let state =
+            load_dashboard_runtime_state(&config.state_dir.join("state.json")).expect("load state");
+        assert_eq!(state.widget_views.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn integration_runner_skips_processed_cases_but_retries_unresolved_failures() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_dashboard_contract_fixture(&config.fixture_path).expect("fixture should load");
+
+        let mut first_runtime = DashboardRuntime::new(config.clone()).expect("first runtime");
+        let first = first_runtime.run_once(&fixture).await.expect("first run");
+        assert_eq!(first.applied_cases, 1);
+        assert_eq!(first.malformed_cases, 1);
+
+        let mut second_runtime = DashboardRuntime::new(config).expect("second runtime");
+        let second = second_runtime.run_once(&fixture).await.expect("second run");
+        assert_eq!(second.duplicate_skips, 2);
+        assert_eq!(second.applied_cases, 0);
+        assert_eq!(second.malformed_cases, 0);
+        assert_eq!(second.failed_cases, 1);
+    }
+
+    #[tokio::test]
+    async fn regression_runner_rejects_contract_drift_between_expected_and_runtime_result() {
+        let temp = tempdir().expect("tempdir");
+        let mut fixture = load_dashboard_contract_fixture(&fixture_path("snapshot-layout.json"))
+            .expect("fixture");
+        fixture.cases[0].expected.widgets[0].title = "invalid-title".to_string();
+        let fixture_path = temp.path().join("drift-fixture.json");
+        std::fs::write(
+            &fixture_path,
+            serde_json::to_string_pretty(&fixture).expect("serialize"),
+        )
+        .expect("write fixture");
+
+        let mut config = build_config(temp.path());
+        config.fixture_path = fixture_path;
+        let mut runtime = DashboardRuntime::new(config.clone()).expect("runtime");
+        let drift_fixture =
+            load_dashboard_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let error = runtime
+            .run_once(&drift_fixture)
+            .await
+            .expect_err("drift should fail");
+        assert!(error.to_string().contains("expected widgets"));
+    }
+
+    #[tokio::test]
+    async fn regression_runner_failure_streak_resets_after_successful_cycle() {
+        let temp = tempdir().expect("tempdir");
+        let mut failing_config = build_config(temp.path());
+        failing_config.retry_max_attempts = 1;
+        let failing_fixture =
+            load_dashboard_contract_fixture(&failing_config.fixture_path).expect("fixture");
+        let mut failing_runtime = DashboardRuntime::new(failing_config.clone()).expect("runtime");
+        let failed = failing_runtime
+            .run_once(&failing_fixture)
+            .await
+            .expect("failed cycle");
+        assert_eq!(failed.failed_cases, 1);
+        let state_after_fail =
+            load_dashboard_runtime_state(&failing_config.state_dir.join("state.json"))
+                .expect("load state after fail");
+        assert_eq!(state_after_fail.health.failure_streak, 1);
+
+        let mut success_config = failing_config.clone();
+        success_config.fixture_path = fixture_path("snapshot-layout.json");
+        let success_fixture =
+            load_dashboard_contract_fixture(&success_config.fixture_path).expect("fixture");
+        let mut success_runtime = DashboardRuntime::new(success_config.clone()).expect("runtime");
+        let success = success_runtime
+            .run_once(&success_fixture)
+            .await
+            .expect("success cycle");
+        assert_eq!(success.failed_cases, 0);
+        assert_eq!(success.applied_cases, 2);
+        let state_after_success =
+            load_dashboard_runtime_state(&success_config.state_dir.join("state.json"))
+                .expect("load state after success");
+        assert_eq!(state_after_success.health.failure_streak, 0);
+        assert_eq!(
+            state_after_success.health.classify().state,
+            TransportHealthState::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn regression_runner_events_log_contains_widget_and_control_reason_codes() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.fixture_path = fixture_path("snapshot-layout.json");
+        let fixture =
+            load_dashboard_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = DashboardRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+        assert_eq!(summary.failed_cases, 0);
+        assert_eq!(summary.control_actions_applied, 1);
+
+        let events_log =
+            std::fs::read_to_string(config.state_dir.join(DASHBOARD_RUNTIME_EVENTS_LOG_FILE))
+                .expect("read runtime events");
+        let parsed = events_log
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("valid json line"))
+            .collect::<Vec<_>>();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["health_state"].as_str(), Some("healthy"));
+        let reason_codes = parsed[0]["reason_codes"]
+            .as_array()
+            .expect("reason codes array");
+        assert!(reason_codes
+            .iter()
+            .any(|value| value.as_str() == Some("widget_views_updated")));
+        assert!(reason_codes
+            .iter()
+            .any(|value| value.as_str() == Some("control_actions_applied")));
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -13,8 +13,8 @@ mod cli_types;
 mod codex_cli_client;
 mod commands;
 mod credentials;
-#[cfg(test)]
 mod dashboard_contract;
+mod dashboard_runtime;
 mod diagnostics_commands;
 mod events;
 mod extension_manifest;
@@ -249,9 +249,10 @@ pub(crate) use crate::rpc_protocol::{
     execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
 };
 pub(crate) use crate::runtime_cli_validation::{
-    validate_event_webhook_ingest_cli, validate_events_runner_cli,
-    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
-    validate_multi_channel_contract_runner_cli, validate_slack_bridge_cli,
+    validate_dashboard_contract_runner_cli, validate_event_webhook_ingest_cli,
+    validate_events_runner_cli, validate_github_issues_bridge_cli,
+    validate_memory_contract_runner_cli, validate_multi_channel_contract_runner_cli,
+    validate_slack_bridge_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -360,6 +361,7 @@ pub(crate) use crate::trust_roots::{
     apply_trust_root_mutation_specs, apply_trust_root_mutations, load_trust_root_records,
     parse_trust_rotation_spec, parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
 };
+use dashboard_runtime::{run_dashboard_contract_runner, DashboardRuntimeConfig};
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use memory_runtime::{run_memory_contract_runner, MemoryRuntimeConfig};
 use multi_channel_runtime::{run_multi_channel_contract_runner, MultiChannelRuntimeConfig};

--- a/crates/tau-coding-agent/src/onboarding.rs
+++ b/crates/tau-coding-agent/src/onboarding.rs
@@ -483,6 +483,7 @@ mod tests {
         cli.channel_store_root = tau_root.join("channel-store");
         cli.events_dir = tau_root.join("events");
         cli.events_state_path = tau_root.join("events/state.json");
+        cli.dashboard_state_dir = tau_root.join("dashboard");
         cli.github_state_dir = tau_root.join("github-issues");
         cli.slack_state_dir = tau_root.join("slack");
         cli.package_install_root = tau_root.join("packages");

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -217,6 +217,50 @@ pub(crate) fn validate_memory_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_dashboard_contract_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.dashboard_contract_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--dashboard-contract-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--dashboard-contract-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.multi_channel_contract_runner
+        || cli.memory_contract_runner
+    {
+        bail!("--dashboard-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, or --memory-contract-runner");
+    }
+    if cli.dashboard_queue_limit == 0 {
+        bail!("--dashboard-queue-limit must be greater than 0");
+    }
+    if cli.dashboard_processed_case_cap == 0 {
+        bail!("--dashboard-processed-case-cap must be greater than 0");
+    }
+    if cli.dashboard_retry_max_attempts == 0 {
+        bail!("--dashboard-retry-max-attempts must be greater than 0");
+    }
+    if !cli.dashboard_fixture.exists() {
+        bail!(
+            "--dashboard-fixture '{}' does not exist",
+            cli.dashboard_fixture.display()
+        );
+    }
+    if !cli.dashboard_fixture.is_file() {
+        bail!(
+            "--dashboard-fixture '{}' must point to a file",
+            cli.dashboard_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.event_webhook_ingest_file.is_none() {
         return Ok(());

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -13,6 +13,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_events_runner_cli(cli)?;
     validate_multi_channel_contract_runner_cli(cli)?;
     validate_memory_contract_runner_cli(cli)?;
+    validate_dashboard_contract_runner_cli(cli)?;
 
     if cli.github_issues_bridge {
         let repo_slug = cli.github_repo.clone().ok_or_else(|| {
@@ -159,6 +160,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_case_cap: cli.memory_processed_case_cap.max(1),
             retry_max_attempts: cli.memory_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.memory_retry_base_delay_ms,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.dashboard_contract_runner {
+        run_dashboard_contract_runner(DashboardRuntimeConfig {
+            fixture_path: cli.dashboard_fixture.clone(),
+            state_dir: cli.dashboard_state_dir.clone(),
+            queue_limit: cli.dashboard_queue_limit.max(1),
+            processed_case_cap: cli.dashboard_processed_case_cap.max(1),
+            retry_max_attempts: cli.dashboard_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.dashboard_retry_base_delay_ms,
         })
         .await?;
         return Ok(true);

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -90,6 +90,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `slack.rs`: Slack Socket Mode bridge transport.
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
+- `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `memory_contract.rs`: semantic-memory fixture/schema contract definitions and validators.
 - `memory_runtime.rs`: semantic-memory runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) fixture/schema contract.
@@ -121,6 +122,7 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 
 - `tests.rs`: large integration/regression suite for `tau-coding-agent`.
 - `dashboard_contract.rs`: dashboard contract schema/fixture validation and replay contract tests.
+- `dashboard_runtime.rs`: dashboard runtime tests for queueing, retries, idempotency, and health signals.
 - `memory_contract.rs`: semantic-memory schema/fixture compatibility and replay contract tests.
 - `memory_runtime.rs`: semantic-memory runtime tests for retries, idempotency, and health signals.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.


### PR DESCRIPTION
## Summary
- implement a fixture-driven dashboard runtime (`dashboard_runtime.rs`) with deterministic queueing, retry/backoff, idempotent processed-case tracking, health snapshots, runtime event logs, and channel-store persistence
- integrate `--dashboard-contract-runner` end-to-end via CLI args, startup transport dispatch, and runtime CLI validation
- extend transport health inspection to include `dashboard` targets and state-dir overrides
- add unit/functional/integration/regression coverage for dashboard runtime behavior, CLI parsing, and dashboard runtime validation; update code map docs

Closes #766

## Risks and Compatibility
- introduces new CLI flags and a new transport-health target; existing flags and behavior remain unchanged
- dashboard runner writes state under `.tau/dashboard` by default; no migration required for existing modes
- contract replay-only helpers in `dashboard_contract.rs` are now `#[cfg(test)]` to avoid non-test dead code warnings

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent dashboard_runtime -- --test-threads=1
- cargo test -p tau-coding-agent dashboard_contract -- --test-threads=1
- cargo test -p tau-coding-agent transport_health_inspect -- --test-threads=1
- cargo test --workspace -- --test-threads=1
- python3 -m unittest discover -s .github/scripts -p "test_*.py"
