### PR TITLE
feat: dashboard observability status, docs, and demos (#767)

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -141,7 +141,15 @@ class DemoScriptsTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0)
         self.assertEqual(
             completed.stdout.strip().splitlines(),
-            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
+            [
+                "local.sh",
+                "rpc.sh",
+                "events.sh",
+                "package.sh",
+                "multi-channel.sh",
+                "memory.sh",
+                "dashboard.sh",
+            ],
         )
 
     def test_unit_all_script_only_rejects_unknown_demo_names(self) -> None:
@@ -192,7 +200,15 @@ class DemoScriptsTests(unittest.TestCase):
             trace_path = root / "trace.ndjson"
             write_mock_binary(binary_path)
 
-            for script_name in ("local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"):
+            for script_name in (
+                "local.sh",
+                "rpc.sh",
+                "events.sh",
+                "package.sh",
+                "multi-channel.sh",
+                "memory.sh",
+                "dashboard.sh",
+            ):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
                     completed.returncode,
@@ -203,7 +219,7 @@ class DemoScriptsTests(unittest.TestCase):
                 self.assertIn("failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 18)
+            self.assertGreaterEqual(len(rows), 22)
 
     def test_functional_all_script_builds_once_when_skip_build_is_disabled(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -259,10 +275,10 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=6 passed=6 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=7 passed=7 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 18)
+            self.assertGreaterEqual(len(rows), 22)
 
     def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -311,14 +327,22 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=6 passed=6 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=7 passed=7 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 6, "passed": 6, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 7, "passed": 7, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
-                ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
+                [
+                    "local.sh",
+                    "rpc.sh",
+                    "events.sh",
+                    "package.sh",
+                    "multi-channel.sh",
+                    "memory.sh",
+                    "dashboard.sh",
+                ],
             )
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)
@@ -391,6 +415,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
             self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
             self.assertIn("[demo:all] [6] memory.sh", completed.stdout)
+            self.assertIn("[demo:all] [7] dashboard.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -403,7 +428,15 @@ class DemoScriptsTests(unittest.TestCase):
         payload = json.loads(completed.stdout)
         self.assertEqual(
             payload["demos"],
-            ["local.sh", "rpc.sh", "events.sh", "package.sh", "multi-channel.sh", "memory.sh"],
+            [
+                "local.sh",
+                "rpc.sh",
+                "events.sh",
+                "package.sh",
+                "multi-channel.sh",
+                "memory.sh",
+                "dashboard.sh",
+            ],
         )
 
     def test_integration_all_script_report_file_tracks_selected_subset_order(self) -> None:
@@ -549,8 +582,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 6)
-            self.assertEqual(payload["summary"]["failed"], 6)
+            self.assertEqual(payload["summary"]["total"], 7)
+            self.assertEqual(payload["summary"]["failed"], 7)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -735,6 +735,7 @@ pub(crate) struct Cli {
         env = "TAU_CHANNEL_STORE_INSPECT",
         conflicts_with = "channel_store_repair",
         conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
         value_name = "transport/channel_id",
         help = "Inspect ChannelStore state for one channel and exit"
     )]
@@ -745,6 +746,7 @@ pub(crate) struct Cli {
         env = "TAU_CHANNEL_STORE_REPAIR",
         conflicts_with = "channel_store_inspect",
         conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
         value_name = "transport/channel_id",
         help = "Repair malformed ChannelStore JSONL files for one channel and exit"
     )]
@@ -755,6 +757,7 @@ pub(crate) struct Cli {
         env = "TAU_TRANSPORT_HEALTH_INSPECT",
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
+        conflicts_with = "dashboard_status_inspect",
         value_name = "target",
         help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, memory, dashboard"
     )]
@@ -772,6 +775,29 @@ pub(crate) struct Cli {
         help = "Emit --transport-health-inspect output as pretty JSON"
     )]
     pub(crate) transport_health_json: bool,
+
+    #[arg(
+        long = "dashboard-status-inspect",
+        env = "TAU_DASHBOARD_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        help = "Inspect dashboard runtime status/guardrail report and exit"
+    )]
+    pub(crate) dashboard_status_inspect: bool,
+
+    #[arg(
+        long = "dashboard-status-json",
+        env = "TAU_DASHBOARD_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "dashboard_status_inspect",
+        help = "Emit --dashboard-status-inspect output as pretty JSON"
+    )]
+    pub(crate) dashboard_status_json: bool,
 
     #[arg(
         long = "extension-exec-manifest",

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -14,6 +14,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
     if cli.channel_store_inspect.is_some()
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
+        || cli.dashboard_status_inspect
     {
         execute_channel_store_admin_command(cli)?;
         return Ok(true);

--- a/docs/guides/dashboard-ops.md
+++ b/docs/guides/dashboard-ops.md
@@ -1,0 +1,91 @@
+# Dashboard Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven dashboard runtime (`--dashboard-contract-runner`).
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --dashboard-state-dir .tau/dashboard \
+  --transport-health-inspect dashboard \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --dashboard-state-dir .tau/dashboard \
+  --dashboard-status-inspect \
+  --dashboard-status-json
+```
+
+Primary state files:
+
+- `.tau/dashboard/state.json`
+- `.tau/dashboard/runtime-events.jsonl`
+- `.tau/dashboard/channel-store/dashboard/<channel_id>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+- `widget_views_updated`
+- `control_actions_applied`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/dashboard.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent dashboard_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent dashboard_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/dashboard.sh`
+4. Verify transport health and status gate:
+   `--transport-health-inspect dashboard --transport-health-json`
+   `--dashboard-status-inspect --dashboard-status-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`.
+
+## Rollback plan
+
+1. Stop invoking `--dashboard-contract-runner`.
+2. Preserve `.tau/dashboard/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and output paths.
+- Symptom: health state `degraded` with `retry_attempted`.
+  Action: inspect fixture cases with simulated transient failures and retry controls.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated failures.
+- Symptom: `rollout_gate=hold` with zero recent events.
+  Action: run demo or targeted fixture to refresh runtime state and confirm status signal freshness.
+- Symptom: non-zero `queue_depth`.
+  Action: increase `--dashboard-queue-limit` or reduce fixture batch size to avoid backlog drops.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -130,6 +130,49 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/memory-ops.md`.
 
+## Dashboard contract runner
+
+Use this fixture-driven runtime mode to validate dashboard state transitions, control actions,
+retry handling, and channel-store snapshot writes.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --dashboard-contract-runner \
+  --dashboard-fixture crates/tau-coding-agent/testdata/dashboard-contract/mixed-outcomes.json \
+  --dashboard-state-dir .tau/dashboard \
+  --dashboard-queue-limit 64 \
+  --dashboard-processed-case-cap 10000 \
+  --dashboard-retry-max-attempts 4 \
+  --dashboard-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/dashboard/state.json`
+- `.tau/dashboard/runtime-events.jsonl`
+- `.tau/dashboard/channel-store/dashboard/<channel_id>/...`
+
+Inspect dashboard transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --dashboard-state-dir .tau/dashboard \
+  --transport-health-inspect dashboard \
+  --transport-health-json
+```
+
+Inspect dashboard rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --dashboard-state-dir .tau/dashboard \
+  --dashboard-status-inspect \
+  --dashboard-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/dashboard-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -19,6 +19,7 @@ demo_scripts=(
   "package.sh"
   "multi-channel.sh"
   "memory.sh"
+  "dashboard.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -78,6 +79,10 @@ normalize_demo_name() {
       ;;
     memory|memory.sh)
       echo "memory.sh"
+      return 0
+      ;;
+    dashboard|dashboard.sh)
+      echo "dashboard.sh"
       return 0
       ;;
     *)
@@ -190,14 +195,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/memory) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/memory/dashboard) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,memory)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,memory,dashboard)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/dashboard.sh
+++ b/scripts/demo/dashboard.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "dashboard" "Run deterministic dashboard runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/dashboard-contract/snapshot-layout.json"
+demo_state_dir=".tau/demo-dashboard"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "dashboard-runner" \
+  --dashboard-contract-runner \
+  --dashboard-fixture ./crates/tau-coding-agent/testdata/dashboard-contract/snapshot-layout.json \
+  --dashboard-state-dir "${demo_state_dir}" \
+  --dashboard-queue-limit 64 \
+  --dashboard-processed-case-cap 10000 \
+  --dashboard-retry-max-attempts 4 \
+  --dashboard-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-dashboard" \
+  --dashboard-state-dir "${demo_state_dir}" \
+  --transport-health-inspect dashboard \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "dashboard-status-inspect" \
+  --dashboard-state-dir "${demo_state_dir}" \
+  --dashboard-status-inspect \
+  --dashboard-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-dashboard-operator" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect dashboard/operator:ops-release-1
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- add a dedicated dashboard operator status surface via `--dashboard-status-inspect` and `--dashboard-status-json`
- aggregate dashboard state + runtime-events cycle signals into a rollout guardrail report (`rollout_gate=pass|hold`)
- add deterministic dashboard demo wrapper and include it in `scripts/demo/all.sh`
- add dashboard operations runbook and transport-guide updates for health/status inspection and rollout/rollback
- extend unit/functional/integration/regression coverage for the new admin surface and demo inventory

Closes #767

## Behavior Changes
- new startup preflight/admin mode for dashboard status inspection
- new JSON/text status report for dashboard runtime state and cycle-reason classification
- demo inventory now includes `dashboard.sh` in canonical order and reporting

## Risks and Compatibility
- low runtime risk: new behavior is additive and gated behind explicit CLI flags
- compatibility: existing channel-store and transport-health commands remain unchanged
- observability dependency: status inspect requires dashboard `state.json`; command fails fast if absent

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/dashboard.sh --skip-build --binary ./target/debug/tau-coding-agent`
