### PR TITLE
feat: add multi-agent observability status and deterministic demo rollout (#773)

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -147,6 +147,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "events.sh",
                 "package.sh",
                 "multi-channel.sh",
+                "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
             ],
@@ -206,6 +207,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "events.sh",
                 "package.sh",
                 "multi-channel.sh",
+                "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
             ):
@@ -219,7 +221,7 @@ class DemoScriptsTests(unittest.TestCase):
                 self.assertIn("failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 22)
+            self.assertGreaterEqual(len(rows), 26)
 
     def test_functional_all_script_builds_once_when_skip_build_is_disabled(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -275,10 +277,10 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=7 passed=7 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=8 passed=8 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 22)
+            self.assertGreaterEqual(len(rows), 26)
 
     def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -327,11 +329,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=7 passed=7 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=8 passed=8 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 7, "passed": 7, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 8, "passed": 8, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -340,6 +342,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "events.sh",
                     "package.sh",
                     "multi-channel.sh",
+                    "multi-agent.sh",
                     "memory.sh",
                     "dashboard.sh",
                 ],
@@ -414,8 +417,9 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [3] events.sh", completed.stdout)
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
             self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
-            self.assertIn("[demo:all] [6] memory.sh", completed.stdout)
-            self.assertIn("[demo:all] [7] dashboard.sh", completed.stdout)
+            self.assertIn("[demo:all] [6] multi-agent.sh", completed.stdout)
+            self.assertIn("[demo:all] [7] memory.sh", completed.stdout)
+            self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -434,6 +438,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "events.sh",
                 "package.sh",
                 "multi-channel.sh",
+                "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
             ],
@@ -582,8 +587,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 7)
-            self.assertEqual(payload["summary"]["failed"], 7)
+            self.assertEqual(payload["summary"]["total"], 8)
+            self.assertEqual(payload["summary"]["failed"], 8)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -70,11 +70,16 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --only rpc,events --json
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
+./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh
 ./scripts/demo/package.sh
+./scripts/demo/multi-channel.sh
+./scripts/demo/multi-agent.sh
+./scripts/demo/memory.sh
+./scripts/demo/dashboard.sh
 ```
 
 `all.sh --json` and `--report-file` entries include `duration_ms` per wrapper.

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -736,6 +736,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_repair",
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
         value_name = "transport/channel_id",
         help = "Inspect ChannelStore state for one channel and exit"
     )]
@@ -747,6 +748,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
         value_name = "transport/channel_id",
         help = "Repair malformed ChannelStore JSONL files for one channel and exit"
     )]
@@ -758,8 +760,9 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
         conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, memory, dashboard"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -782,6 +785,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_inspect",
         conflicts_with = "channel_store_repair",
         conflicts_with = "transport_health_inspect",
+        conflicts_with = "multi_agent_status_inspect",
         help = "Inspect dashboard runtime status/guardrail report and exit"
     )]
     pub(crate) dashboard_status_inspect: bool,
@@ -798,6 +802,30 @@ pub(crate) struct Cli {
         help = "Emit --dashboard-status-inspect output as pretty JSON"
     )]
     pub(crate) dashboard_status_json: bool,
+
+    #[arg(
+        long = "multi-agent-status-inspect",
+        env = "TAU_MULTI_AGENT_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        help = "Inspect multi-agent runtime status/guardrail report and exit"
+    )]
+    pub(crate) multi_agent_status_inspect: bool,
+
+    #[arg(
+        long = "multi-agent-status-json",
+        env = "TAU_MULTI_AGENT_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "multi_agent_status_inspect",
+        help = "Emit --multi-agent-status-inspect output as pretty JSON"
+    )]
+    pub(crate) multi_agent_status_json: bool,
 
     #[arg(
         long = "extension-exec-manifest",

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -15,6 +15,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.dashboard_status_inspect
+        || cli.multi_agent_status_inspect
     {
         execute_channel_store_admin_command(cli)?;
         return Ok(true);

--- a/crates/tau-coding-agent/testdata/multi-agent-contract/README.md
+++ b/crates/tau-coding-agent/testdata/multi-agent-contract/README.md
@@ -7,6 +7,8 @@ These fixtures validate the schema and replay compatibility contract for Tau mul
 - `mixed-outcomes.json`
   - Covers success, malformed input, and retryable failure outcomes.
   - Serves as deterministic replay baseline for contract conformance tests.
+- `rollout-pass.json`
+  - Success-only fixture for deterministic demo/rollout status checks (`rollout_gate=pass`).
 - `invalid-error-code.json`
   - Regression fixture ensuring unsupported `expected.error_code` values are rejected.
 - `invalid-duplicate-case-id.json`

--- a/crates/tau-coding-agent/testdata/multi-agent-contract/rollout-pass.json
+++ b/crates/tau-coding-agent/testdata/multi-agent-contract/rollout-pass.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "name": "multi-agent-routing-rollout-pass",
+  "description": "Deterministic success-only fixture for rollout demos and status gate checks.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "planner-success",
+      "phase": "planner",
+      "route_table": {
+        "schema_version": 1,
+        "roles": {
+          "planner": {},
+          "planner-fallback": {},
+          "executor": {},
+          "reviewer": {}
+        },
+        "planner": {
+          "role": "planner",
+          "fallback_roles": [
+            "planner-fallback"
+          ]
+        },
+        "delegated": {
+          "role": "executor"
+        },
+        "review": {
+          "role": "reviewer"
+        }
+      },
+      "expected": {
+        "outcome": "success",
+        "selected_role": "planner",
+        "attempted_roles": [
+          "planner",
+          "planner-fallback"
+        ]
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "review-success",
+      "phase": "review",
+      "route_table": {
+        "schema_version": 1,
+        "roles": {
+          "planner": {},
+          "planner-fallback": {},
+          "executor": {},
+          "reviewer": {}
+        },
+        "planner": {
+          "role": "planner",
+          "fallback_roles": [
+            "planner-fallback"
+          ]
+        },
+        "delegated": {
+          "role": "executor"
+        },
+        "review": {
+          "role": "reviewer"
+        }
+      },
+      "expected": {
+        "outcome": "success",
+        "selected_role": "reviewer",
+        "attempted_roles": [
+          "reviewer"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/guides/multi-agent-ops.md
+++ b/docs/guides/multi-agent-ops.md
@@ -1,0 +1,90 @@
+# Multi-Agent Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven multi-agent runtime (`--multi-agent-contract-runner`).
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-agent-state-dir .tau/multi-agent \
+  --transport-health-inspect multi-agent \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-agent-state-dir .tau/multi-agent \
+  --multi-agent-status-inspect \
+  --multi-agent-status-json
+```
+
+Primary state files:
+
+- `.tau/multi-agent/state.json`
+- `.tau/multi-agent/runtime-events.jsonl`
+- `.tau/multi-agent/channel-store/multi-agent/orchestrator-router/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+- `routed_cases_updated`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/multi-agent.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent multi_agent_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent multi_agent_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/multi-agent.sh`
+4. Verify transport health and status gate:
+   `--transport-health-inspect multi-agent --transport-health-json`
+   `--multi-agent-status-inspect --multi-agent-status-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`.
+
+## Rollback plan
+
+1. Stop invoking `--multi-agent-contract-runner`.
+2. Preserve `.tau/multi-agent/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and route-table integrity.
+- Symptom: health state `degraded` with `retry_attempted` or `retryable_failures_observed`.
+  Action: inspect fixture retry scenarios and adjust retry controls only for transient failures.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated failures.
+- Symptom: `rollout_gate=hold` with low event volume.
+  Action: run deterministic demo to refresh runtime state and confirm signal freshness.
+- Symptom: non-zero `queue_depth`.
+  Action: increase `--multi-agent-queue-limit` or reduce fixture batch size to avoid backlog drops.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -95,12 +95,16 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/all.sh --only multi-channel --fail-fast
+./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
 ./scripts/demo/events.sh
 ./scripts/demo/package.sh
 ./scripts/demo/multi-channel.sh
+./scripts/demo/multi-agent.sh
+./scripts/demo/memory.sh
+./scripts/demo/dashboard.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -96,6 +96,49 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/multi-channel-ops.md`.
 
+## Multi-agent contract runner
+
+Use this fixture-driven runtime mode to validate planner/delegated/review route selection,
+retry handling, deduplication, and routed-case snapshot persistence.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --multi-agent-contract-runner \
+  --multi-agent-fixture crates/tau-coding-agent/testdata/multi-agent-contract/rollout-pass.json \
+  --multi-agent-state-dir .tau/multi-agent \
+  --multi-agent-queue-limit 64 \
+  --multi-agent-processed-case-cap 10000 \
+  --multi-agent-retry-max-attempts 4 \
+  --multi-agent-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/multi-agent/state.json`
+- `.tau/multi-agent/runtime-events.jsonl`
+- `.tau/multi-agent/channel-store/multi-agent/orchestrator-router/...`
+
+Inspect multi-agent transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-agent-state-dir .tau/multi-agent \
+  --transport-health-inspect multi-agent \
+  --transport-health-json
+```
+
+Inspect multi-agent rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-agent-state-dir .tau/multi-agent \
+  --multi-agent-status-inspect \
+  --multi-agent-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/multi-agent-ops.md`.
+
 ## Semantic memory contract runner
 
 Use this fixture-driven runtime mode to validate semantic memory extraction/retrieval

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -18,6 +18,7 @@ demo_scripts=(
   "events.sh"
   "package.sh"
   "multi-channel.sh"
+  "multi-agent.sh"
   "memory.sh"
   "dashboard.sh"
 )
@@ -75,6 +76,10 @@ normalize_demo_name() {
       ;;
     multi-channel|multichannel|multi-channel.sh|multichannel.sh)
       echo "multi-channel.sh"
+      return 0
+      ;;
+    multi-agent|multiagent|multi-agent.sh|multiagent.sh)
+      echo "multi-agent.sh"
       return 0
       ;;
     memory|memory.sh)
@@ -195,14 +200,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/memory/dashboard) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,memory,dashboard)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/multi-agent.sh
+++ b/scripts/demo/multi-agent.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "multi-agent" "Run deterministic multi-agent runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/multi-agent-contract/rollout-pass.json"
+demo_state_dir=".tau/demo-multi-agent"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "multi-agent-runner" \
+  --multi-agent-contract-runner \
+  --multi-agent-fixture ./crates/tau-coding-agent/testdata/multi-agent-contract/rollout-pass.json \
+  --multi-agent-state-dir "${demo_state_dir}" \
+  --multi-agent-queue-limit 64 \
+  --multi-agent-processed-case-cap 10000 \
+  --multi-agent-retry-max-attempts 4 \
+  --multi-agent-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-multi-agent" \
+  --multi-agent-state-dir "${demo_state_dir}" \
+  --transport-health-inspect multi-agent \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "multi-agent-status-inspect" \
+  --multi-agent-state-dir "${demo_state_dir}" \
+  --multi-agent-status-inspect \
+  --multi-agent-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-multi-agent-router" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect multi-agent/orchestrator-router
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- add multi-agent observability preflight surfaces:
  - --transport-health-inspect multi-agent
  - --multi-agent-status-inspect
  - --multi-agent-status-json
- add multi-agent status aggregation/reporting from state + runtime-events with rollout gate classification
- add deterministic multi-agent demo wrapper (scripts/demo/multi-agent.sh) and include it in scripts/demo/all.sh list/only/order paths
- add a success-only multi-agent rollout fixture for deterministic operator demos
- add multi-agent operations runbook and update transport/quickstart/README docs
- extend Rust and Python demo-script test coverage for new observability and demo paths

Closes #773

## Behavior Changes
- operators can inspect multi-agent transport health via channel-store admin target multi-agent
- operators can inspect multi-agent rollout status via a dedicated status report (phase/role/category distributions + reason-code histogram + gate)
- demo wrapper inventory now includes multi-agent.sh and can be selected via all.sh --only multi-agent

## Risks and Compatibility
- additive CLI changes only; existing command paths remain unchanged unless new flags are used
- transport health target parser now accepts multi-agent/multiagent aliases
- all.sh wrapper inventory order changes (adds one wrapper) and summary totals increase accordingly

## Validation Evidence
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent multi_agent_status -- --test-threads=1
- cargo test -p tau-coding-agent transport_health_inspect_accepts_multi_agent -- --test-threads=1
- cargo test -p tau-coding-agent collect_transport_health_rows_defaults_missing_health_fields_for_multi_agent -- --test-threads=1
- cargo test -p tau-coding-agent functional_collect_transport_health_rows_reads_github_and_slack_states -- --test-threads=1
- cargo test --workspace -- --test-threads=1
- python3 -m unittest discover -s .github/scripts -p test_*.py
- ./scripts/demo/multi-agent.sh --skip-build
- ./scripts/demo/all.sh --skip-build --only multi-agent --fail-fast
