### PR TITLE
feat(tau-coding-agent): gateway contract schema and fixtures

### DIFF
--- a/crates/tau-coding-agent/src/gateway_contract.rs
+++ b/crates/tau-coding-agent/src/gateway_contract.rs
@@ -1,0 +1,602 @@
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+pub(crate) const GATEWAY_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+pub(crate) const GATEWAY_ERROR_INVALID_REQUEST: &str = "gateway_invalid_request";
+pub(crate) const GATEWAY_ERROR_UNSUPPORTED_METHOD: &str = "gateway_unsupported_method";
+pub(crate) const GATEWAY_ERROR_BACKEND_UNAVAILABLE: &str = "gateway_backend_unavailable";
+
+fn gateway_contract_schema_version() -> u32 {
+    GATEWAY_CONTRACT_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GatewayOutcomeKind {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct GatewayCaseExpectation {
+    pub(crate) outcome: GatewayOutcomeKind,
+    pub(crate) status_code: u16,
+    #[serde(default)]
+    pub(crate) error_code: String,
+    #[serde(default)]
+    pub(crate) response_body: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct GatewayContractCase {
+    #[serde(default = "gateway_contract_schema_version")]
+    pub(crate) schema_version: u32,
+    pub(crate) case_id: String,
+    pub(crate) method: String,
+    pub(crate) endpoint: String,
+    pub(crate) actor_id: String,
+    #[serde(default)]
+    pub(crate) body: serde_json::Value,
+    #[serde(default)]
+    pub(crate) simulate_retryable_failure: bool,
+    pub(crate) expected: GatewayCaseExpectation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct GatewayContractFixture {
+    pub(crate) schema_version: u32,
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) description: String,
+    pub(crate) cases: Vec<GatewayContractCase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GatewayContractCapabilities {
+    pub(crate) schema_version: u32,
+    pub(crate) supported_outcomes: BTreeSet<GatewayOutcomeKind>,
+    pub(crate) supported_error_codes: BTreeSet<String>,
+    pub(crate) supported_methods: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GatewayReplayStep {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GatewayReplayResult {
+    pub(crate) step: GatewayReplayStep,
+    pub(crate) status_code: u16,
+    pub(crate) error_code: Option<String>,
+    pub(crate) response_body: serde_json::Value,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct GatewayReplaySummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) success_cases: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+}
+
+#[cfg(test)]
+pub(crate) trait GatewayContractDriver {
+    fn apply_case(&mut self, case: &GatewayContractCase) -> Result<GatewayReplayResult>;
+}
+
+pub(crate) fn parse_gateway_contract_fixture(raw: &str) -> Result<GatewayContractFixture> {
+    let fixture = serde_json::from_str::<GatewayContractFixture>(raw)
+        .context("failed to parse gateway contract fixture")?;
+    validate_gateway_contract_fixture(&fixture)?;
+    Ok(fixture)
+}
+
+pub(crate) fn load_gateway_contract_fixture(path: &Path) -> Result<GatewayContractFixture> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    parse_gateway_contract_fixture(&raw)
+        .with_context(|| format!("invalid fixture {}", path.display()))
+}
+
+pub(crate) fn gateway_contract_capabilities() -> GatewayContractCapabilities {
+    GatewayContractCapabilities {
+        schema_version: GATEWAY_CONTRACT_SCHEMA_VERSION,
+        supported_outcomes: [
+            GatewayOutcomeKind::Success,
+            GatewayOutcomeKind::MalformedInput,
+            GatewayOutcomeKind::RetryableFailure,
+        ]
+        .into_iter()
+        .collect(),
+        supported_error_codes: supported_error_codes()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        supported_methods: supported_methods()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+pub(crate) fn validate_gateway_contract_compatibility(
+    fixture: &GatewayContractFixture,
+) -> Result<()> {
+    let capabilities = gateway_contract_capabilities();
+    if fixture.schema_version != capabilities.schema_version {
+        bail!(
+            "unsupported gateway contract schema version {} (expected {})",
+            fixture.schema_version,
+            capabilities.schema_version
+        );
+    }
+
+    for case in &fixture.cases {
+        if !capabilities
+            .supported_outcomes
+            .contains(&case.expected.outcome)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported outcome {:?}",
+                case.case_id,
+                case.expected.outcome
+            );
+        }
+        let code = case.expected.error_code.trim();
+        if !code.is_empty() && !capabilities.supported_error_codes.contains(code) {
+            bail!(
+                "fixture case '{}' uses unsupported error_code '{}'",
+                case.case_id,
+                code
+            );
+        }
+        let method = normalize_method(&case.method);
+        if case.expected.outcome != GatewayOutcomeKind::MalformedInput
+            && !capabilities.supported_methods.contains(&method)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported method '{}' for non-malformed outcome",
+                case.case_id,
+                case.method
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_gateway_contract_fixture(fixture: &GatewayContractFixture) -> Result<()> {
+    if fixture.schema_version != GATEWAY_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "unsupported gateway contract schema version {} (expected {})",
+            fixture.schema_version,
+            GATEWAY_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if fixture.name.trim().is_empty() {
+        bail!("fixture name cannot be empty");
+    }
+    if fixture.cases.is_empty() {
+        bail!("fixture must include at least one case");
+    }
+
+    let mut case_ids = HashSet::new();
+    for (index, case) in fixture.cases.iter().enumerate() {
+        validate_gateway_case(case, index)?;
+        let case_id = case.case_id.trim().to_string();
+        if !case_ids.insert(case_id.clone()) {
+            bail!("fixture contains duplicate case_id '{}'", case_id);
+        }
+    }
+    validate_gateway_contract_compatibility(fixture)?;
+    Ok(())
+}
+
+pub(crate) fn evaluate_gateway_case(case: &GatewayContractCase) -> GatewayReplayResult {
+    if case.simulate_retryable_failure {
+        return GatewayReplayResult {
+            step: GatewayReplayStep::RetryableFailure,
+            status_code: 503,
+            error_code: Some(GATEWAY_ERROR_BACKEND_UNAVAILABLE.to_string()),
+            response_body: json!({"status":"retryable","reason":"backend_unavailable"}),
+        };
+    }
+
+    let method = normalize_method(&case.method);
+    if !supported_methods().contains(method.as_str()) {
+        return GatewayReplayResult {
+            step: GatewayReplayStep::MalformedInput,
+            status_code: 405,
+            error_code: Some(GATEWAY_ERROR_UNSUPPORTED_METHOD.to_string()),
+            response_body: json!({"status":"rejected","reason":"unsupported_method"}),
+        };
+    }
+
+    let endpoint = case.endpoint.trim();
+    let actor_id = case.actor_id.trim();
+    if endpoint.is_empty() || !endpoint.starts_with('/') || actor_id.is_empty() {
+        return GatewayReplayResult {
+            step: GatewayReplayStep::MalformedInput,
+            status_code: 400,
+            error_code: Some(GATEWAY_ERROR_INVALID_REQUEST.to_string()),
+            response_body: json!({"status":"rejected","reason":"invalid_request"}),
+        };
+    }
+
+    let status_code = match method.as_str() {
+        "POST" => 201,
+        "DELETE" => 202,
+        _ => 200,
+    };
+    GatewayReplayResult {
+        step: GatewayReplayStep::Success,
+        status_code,
+        error_code: None,
+        response_body: json!({
+            "status":"accepted",
+            "method": method,
+            "endpoint": endpoint,
+            "actor_id": actor_id,
+        }),
+    }
+}
+
+pub(crate) fn validate_gateway_case_result_against_contract(
+    case: &GatewayContractCase,
+    result: &GatewayReplayResult,
+) -> Result<()> {
+    let expected_step = match case.expected.outcome {
+        GatewayOutcomeKind::Success => GatewayReplayStep::Success,
+        GatewayOutcomeKind::MalformedInput => GatewayReplayStep::MalformedInput,
+        GatewayOutcomeKind::RetryableFailure => GatewayReplayStep::RetryableFailure,
+    };
+    if result.step != expected_step {
+        bail!(
+            "case '{}' expected step {:?} but observed {:?}",
+            case.case_id,
+            expected_step,
+            result.step
+        );
+    }
+
+    if result.status_code != case.expected.status_code {
+        bail!(
+            "case '{}' expected status_code {} but observed {}",
+            case.case_id,
+            case.expected.status_code,
+            result.status_code
+        );
+    }
+
+    match case.expected.outcome {
+        GatewayOutcomeKind::Success => {
+            if result.error_code.is_some() {
+                bail!(
+                    "case '{}' expected empty error_code for success but observed {:?}",
+                    case.case_id,
+                    result.error_code
+                );
+            }
+        }
+        GatewayOutcomeKind::MalformedInput | GatewayOutcomeKind::RetryableFailure => {
+            let expected_code = case.expected.error_code.trim();
+            if result.error_code.as_deref() != Some(expected_code) {
+                bail!(
+                    "case '{}' expected error_code '{}' but observed {:?}",
+                    case.case_id,
+                    expected_code,
+                    result.error_code
+                );
+            }
+        }
+    }
+
+    if result.response_body != case.expected.response_body {
+        bail!(
+            "case '{}' expected response_body {} but observed {}",
+            case.case_id,
+            case.expected.response_body,
+            result.response_body
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn run_gateway_contract_replay<D: GatewayContractDriver>(
+    fixture: &GatewayContractFixture,
+    driver: &mut D,
+) -> Result<GatewayReplaySummary> {
+    validate_gateway_contract_fixture(fixture)?;
+    let mut summary = GatewayReplaySummary {
+        discovered_cases: fixture.cases.len(),
+        ..GatewayReplaySummary::default()
+    };
+
+    for case in &fixture.cases {
+        let result = driver.apply_case(case)?;
+        validate_gateway_case_result_against_contract(case, &result)?;
+        match case.expected.outcome {
+            GatewayOutcomeKind::Success => {
+                summary.success_cases = summary.success_cases.saturating_add(1);
+            }
+            GatewayOutcomeKind::MalformedInput => {
+                summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+            }
+            GatewayOutcomeKind::RetryableFailure => {
+                summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+            }
+        }
+    }
+    Ok(summary)
+}
+
+fn validate_gateway_case(case: &GatewayContractCase, index: usize) -> Result<()> {
+    if case.schema_version != GATEWAY_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "fixture case index {} has unsupported schema_version {} (expected {})",
+            index,
+            case.schema_version,
+            GATEWAY_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if case.case_id.trim().is_empty() {
+        bail!("fixture case index {} has empty case_id", index);
+    }
+    if case.method.trim().is_empty() {
+        bail!("fixture case '{}' has empty method", case.case_id);
+    }
+    if case.endpoint.trim().is_empty() {
+        bail!("fixture case '{}' has empty endpoint", case.case_id);
+    }
+    if !case.body.is_object() && !case.body.is_null() {
+        bail!(
+            "fixture case '{}' body must be object or null",
+            case.case_id
+        );
+    }
+
+    if case.simulate_retryable_failure
+        && case.expected.outcome != GatewayOutcomeKind::RetryableFailure
+    {
+        bail!(
+            "fixture case '{}' sets simulate_retryable_failure=true but expected outcome is {:?}",
+            case.case_id,
+            case.expected.outcome
+        );
+    }
+    if case.expected.outcome == GatewayOutcomeKind::RetryableFailure
+        && !case.simulate_retryable_failure
+    {
+        bail!(
+            "fixture case '{}' expects retryable_failure but simulate_retryable_failure=false",
+            case.case_id
+        );
+    }
+
+    validate_gateway_expectation(case)?;
+    Ok(())
+}
+
+fn validate_gateway_expectation(case: &GatewayContractCase) -> Result<()> {
+    if !case.expected.response_body.is_object() {
+        bail!(
+            "fixture case '{}' expected.response_body must be an object",
+            case.case_id
+        );
+    }
+
+    match case.expected.outcome {
+        GatewayOutcomeKind::Success => {
+            if !case.expected.error_code.trim().is_empty() {
+                bail!(
+                    "fixture case '{}' success outcome must not include error_code",
+                    case.case_id
+                );
+            }
+            if !(200..=299).contains(&case.expected.status_code) {
+                bail!(
+                    "fixture case '{}' success outcome requires 2xx status_code (found {})",
+                    case.case_id,
+                    case.expected.status_code
+                );
+            }
+        }
+        GatewayOutcomeKind::MalformedInput | GatewayOutcomeKind::RetryableFailure => {
+            let code = case.expected.error_code.trim();
+            if code.is_empty() {
+                bail!(
+                    "fixture case '{}' {:?} outcome requires error_code",
+                    case.case_id,
+                    case.expected.outcome
+                );
+            }
+            if !supported_error_codes().contains(&code) {
+                bail!(
+                    "fixture case '{}' uses unsupported error_code '{}'",
+                    case.case_id,
+                    code
+                );
+            }
+            if case.expected.status_code < 400 {
+                bail!(
+                    "fixture case '{}' non-success outcome requires >=400 status_code (found {})",
+                    case.case_id,
+                    case.expected.status_code
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn normalize_method(raw: &str) -> String {
+    raw.trim().to_ascii_uppercase()
+}
+
+fn supported_methods() -> BTreeSet<&'static str> {
+    ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        .into_iter()
+        .collect()
+}
+
+fn supported_error_codes() -> BTreeSet<&'static str> {
+    [
+        GATEWAY_ERROR_INVALID_REQUEST,
+        GATEWAY_ERROR_UNSUPPORTED_METHOD,
+        GATEWAY_ERROR_BACKEND_UNAVAILABLE,
+    ]
+    .into_iter()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use serde_json::json;
+
+    use super::{
+        evaluate_gateway_case, load_gateway_contract_fixture, parse_gateway_contract_fixture,
+        run_gateway_contract_replay, GatewayContractCase, GatewayContractDriver,
+    };
+    use super::{GatewayReplayResult, GATEWAY_ERROR_UNSUPPORTED_METHOD};
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("gateway-contract")
+            .join(name)
+    }
+
+    #[derive(Default)]
+    struct DeterministicGatewayDriver;
+
+    impl GatewayContractDriver for DeterministicGatewayDriver {
+        fn apply_case(&mut self, case: &GatewayContractCase) -> Result<GatewayReplayResult> {
+            Ok(evaluate_gateway_case(case))
+        }
+    }
+
+    #[test]
+    fn unit_parse_gateway_contract_fixture_rejects_unsupported_schema() {
+        let raw = r#"{
+  "schema_version": 99,
+  "name": "gateway-invalid-schema",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "bad-schema",
+      "method": "POST",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops",
+      "body": {},
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {"status":"accepted","method":"POST","endpoint":"/v1/tasks","actor_id":"ops"}
+      }
+    }
+  ]
+}"#;
+        let error = parse_gateway_contract_fixture(raw).expect_err("schema should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported gateway contract schema version"));
+    }
+
+    #[test]
+    fn unit_validate_gateway_contract_fixture_rejects_duplicate_case_id() {
+        let error = load_gateway_contract_fixture(&fixture_path("invalid-duplicate-case-id.json"))
+            .expect_err("duplicate case_id fixture should fail");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("duplicate case_id"),
+            "unexpected error output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn functional_fixture_loads_success_malformed_and_retryable_cases() {
+        let fixture = load_gateway_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("load mixed outcomes fixture");
+        assert_eq!(fixture.schema_version, 1);
+        assert_eq!(fixture.cases.len(), 3);
+        assert_eq!(fixture.cases[0].case_id, "gateway-success");
+        assert_eq!(
+            fixture.cases[1].case_id,
+            "gateway-malformed-unsupported-method"
+        );
+        assert_eq!(fixture.cases[2].case_id, "gateway-retryable-backend");
+    }
+
+    #[test]
+    fn integration_gateway_contract_replay_is_deterministic_across_reloads() {
+        let fixture_path = fixture_path("mixed-outcomes.json");
+        let fixture_a = load_gateway_contract_fixture(&fixture_path).expect("load fixture a");
+        let fixture_b = load_gateway_contract_fixture(&fixture_path).expect("load fixture b");
+        let mut driver_a = DeterministicGatewayDriver;
+        let mut driver_b = DeterministicGatewayDriver;
+
+        let summary_a =
+            run_gateway_contract_replay(&fixture_a, &mut driver_a).expect("replay fixture a");
+        let summary_b =
+            run_gateway_contract_replay(&fixture_b, &mut driver_b).expect("replay fixture b");
+
+        assert_eq!(summary_a, summary_b);
+        assert_eq!(summary_a.discovered_cases, 3);
+        assert_eq!(summary_a.success_cases, 1);
+        assert_eq!(summary_a.malformed_cases, 1);
+        assert_eq!(summary_a.retryable_failures, 1);
+    }
+
+    #[test]
+    fn regression_fixture_rejects_unsupported_error_code() {
+        let error = load_gateway_contract_fixture(&fixture_path("invalid-error-code.json"))
+            .expect_err("unsupported error code should fail");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("unsupported error_code"),
+            "unexpected error output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn regression_gateway_contract_replay_rejects_mismatched_expected_response_body() {
+        let mut fixture = load_gateway_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("load fixture");
+        fixture.cases[0].expected.response_body = json!({
+            "status":"accepted",
+            "method":"POST",
+            "endpoint":"/v1/tasks",
+            "actor_id":"unexpected"
+        });
+        let mut driver = DeterministicGatewayDriver;
+        let error =
+            run_gateway_contract_replay(&fixture, &mut driver).expect_err("replay should fail");
+        assert!(error.to_string().contains("expected response_body"));
+    }
+
+    #[test]
+    fn regression_gateway_contract_evaluator_marks_unsupported_method_as_malformed() {
+        let fixture = load_gateway_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("load fixture");
+        let result = evaluate_gateway_case(&fixture.cases[1]);
+        assert_eq!(
+            result.error_code.as_deref(),
+            Some(GATEWAY_ERROR_UNSUPPORTED_METHOD)
+        );
+        assert_eq!(result.status_code, 405);
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -18,6 +18,8 @@ mod dashboard_runtime;
 mod diagnostics_commands;
 mod events;
 mod extension_manifest;
+#[allow(dead_code)]
+mod gateway_contract;
 mod gemini_cli_client;
 mod github_issues;
 mod github_issues_helpers;

--- a/crates/tau-coding-agent/testdata/gateway-contract/README.md
+++ b/crates/tau-coding-agent/testdata/gateway-contract/README.md
@@ -1,0 +1,20 @@
+# Gateway Contract Fixtures
+
+This fixture corpus defines deterministic contract coverage for the Tau gateway service and
+external API schema.
+
+## Files
+
+- `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
+- `invalid-error-code.json`: regression fixture for unsupported `error_code`.
+
+## Schema Notes
+
+- Fixture schema version: `1`.
+- Supported methods for successful replay: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`.
+- Outcome coverage: `success`, `malformed_input`, `retryable_failure`.
+- Supported deterministic error codes:
+  - `gateway_invalid_request`
+  - `gateway_unsupported_method`
+  - `gateway_backend_unavailable`

--- a/crates/tau-coding-agent/testdata/gateway-contract/invalid-duplicate-case-id.json
+++ b/crates/tau-coding-agent/testdata/gateway-contract/invalid-duplicate-case-id.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "gateway-invalid-duplicate-case-id",
+  "description": "Regression fixture asserting duplicate case identifiers are rejected deterministically.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "method": "GET",
+      "endpoint": "/v1/health",
+      "actor_id": "ops-bot",
+      "body": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "method": "GET",
+          "endpoint": "/v1/health",
+          "actor_id": "ops-bot"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "method": "POST",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops-bot",
+      "body": {
+        "task": "reindex"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "method": "POST",
+          "endpoint": "/v1/tasks",
+          "actor_id": "ops-bot"
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/gateway-contract/invalid-error-code.json
+++ b/crates/tau-coding-agent/testdata/gateway-contract/invalid-error-code.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "gateway-invalid-error-code",
+  "description": "Regression fixture asserting unsupported gateway error codes are rejected.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "gateway-malformed-unsupported-error-code",
+      "method": "TRACE",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops-bot",
+      "body": {
+        "task": "reindex"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 405,
+        "error_code": "gateway_method_forbidden",
+        "response_body": {
+          "status": "rejected",
+          "reason": "unsupported_method"
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/gateway-contract/mixed-outcomes.json
+++ b/crates/tau-coding-agent/testdata/gateway-contract/mixed-outcomes.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "name": "gateway-mixed-outcomes",
+  "description": "Deterministic gateway contract replay matrix with success, malformed input, and retryable failure outcomes.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "gateway-success",
+      "method": "POST",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops-bot",
+      "body": {
+        "task": "reindex"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "method": "POST",
+          "endpoint": "/v1/tasks",
+          "actor_id": "ops-bot"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "gateway-malformed-unsupported-method",
+      "method": "TRACE",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops-bot",
+      "body": {
+        "task": "reindex"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 405,
+        "error_code": "gateway_unsupported_method",
+        "response_body": {
+          "status": "rejected",
+          "reason": "unsupported_method"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "gateway-retryable-backend",
+      "method": "GET",
+      "endpoint": "/v1/tasks/42",
+      "actor_id": "ops-bot",
+      "body": {},
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "gateway_backend_unavailable",
+        "response_body": {
+          "status": "retryable",
+          "reason": "backend_unavailable"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a new gateway contract module with schema types, parser/validator, compatibility checks, and deterministic replay evaluator
- add gateway fixture corpus for success/malformed/retryable outcomes and regression invalid fixture coverage
- wire the module into crate compilation for contract test execution

Closes #777

## Behavior Changes
- introduces `gateway_contract` deterministic contract parsing/validation and replay result verification
- adds fixture artifacts under `crates/tau-coding-agent/testdata/gateway-contract`
- adds unit/functional/integration/regression tests for gateway contract behavior

## Risks and Compatibility
- low runtime risk: module is currently contract-artifact only and not invoked by runtime execution paths
- no API break: no existing CLI/runtime behavior changed
- compile risk mitigated with strict lint and full workspace tests

## Validation Evidence
- `cargo fmt --all`
- `cargo test -p tau-coding-agent gateway_contract -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
