### PR TITLE
feat: gateway observability surfaces, demo, and ops runbook

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -150,6 +150,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
+                "gateway.sh",
             ],
         )
 
@@ -210,6 +211,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
+                "gateway.sh",
             ):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
@@ -221,7 +223,7 @@ class DemoScriptsTests(unittest.TestCase):
                 self.assertIn("failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 26)
+            self.assertGreaterEqual(len(rows), 30)
 
     def test_functional_all_script_builds_once_when_skip_build_is_disabled(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -277,7 +279,7 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=8 passed=8 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=9 passed=9 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 26)
@@ -329,11 +331,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=8 passed=8 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=9 passed=9 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 8, "passed": 8, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 9, "passed": 9, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -345,6 +347,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "multi-agent.sh",
                     "memory.sh",
                     "dashboard.sh",
+                    "gateway.sh",
                 ],
             )
             for entry in payload["demos"]:
@@ -420,6 +423,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [6] multi-agent.sh", completed.stdout)
             self.assertIn("[demo:all] [7] memory.sh", completed.stdout)
             self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
+            self.assertIn("[demo:all] [9] gateway.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -441,6 +445,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-agent.sh",
                 "memory.sh",
                 "dashboard.sh",
+                "gateway.sh",
             ],
         )
 
@@ -587,8 +592,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 8)
-            self.assertEqual(payload["summary"]["failed"], 8)
+            self.assertEqual(payload["summary"]["total"], 9)
+            self.assertEqual(payload["summary"]["failed"], 9)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --report-file .tau/reports/demo-summary.json
 ./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
+./scripts/demo/all.sh --only gateway --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -80,6 +81,7 @@ Run deterministic local demos:
 ./scripts/demo/multi-agent.sh
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
+./scripts/demo/gateway.sh
 ```
 
 `all.sh --json` and `--report-file` entries include `duration_ms` per wrapper.

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -737,6 +737,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
         value_name = "transport/channel_id",
         help = "Inspect ChannelStore state for one channel and exit"
     )]
@@ -749,6 +750,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
         value_name = "transport/channel_id",
         help = "Repair malformed ChannelStore JSONL files for one channel and exit"
     )]
@@ -761,8 +763,9 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_repair",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -786,6 +789,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_repair",
         conflicts_with = "transport_health_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
         help = "Inspect dashboard runtime status/guardrail report and exit"
     )]
     pub(crate) dashboard_status_inspect: bool,
@@ -810,6 +814,7 @@ pub(crate) struct Cli {
         conflicts_with = "channel_store_repair",
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "gateway_status_inspect",
         help = "Inspect multi-agent runtime status/guardrail report and exit"
     )]
     pub(crate) multi_agent_status_inspect: bool,
@@ -826,6 +831,31 @@ pub(crate) struct Cli {
         help = "Emit --multi-agent-status-inspect output as pretty JSON"
     )]
     pub(crate) multi_agent_status_json: bool,
+
+    #[arg(
+        long = "gateway-status-inspect",
+        env = "TAU_GATEWAY_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        help = "Inspect gateway runtime status/guardrail report and exit"
+    )]
+    pub(crate) gateway_status_inspect: bool,
+
+    #[arg(
+        long = "gateway-status-json",
+        env = "TAU_GATEWAY_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "gateway_status_inspect",
+        help = "Emit --gateway-status-inspect output as pretty JSON"
+    )]
+    pub(crate) gateway_status_json: bool,
 
     #[arg(
         long = "extension-exec-manifest",

--- a/crates/tau-coding-agent/src/events.rs
+++ b/crates/tau-coding-agent/src/events.rs
@@ -2001,8 +2001,18 @@ mod tests {
         std::fs::write(path, payload).expect("write event file");
     }
 
+    fn parse_cli_with_stack() -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::parse_from(["tau-rs"]))
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
     fn template_cli(path: &Path) -> Cli {
-        let mut cli = Cli::parse_from(["tau-rs"]);
+        let mut cli = parse_cli_with_stack();
         cli.events_template_write = Some(path.to_path_buf());
         cli.events_template_schedule = CliEventTemplateSchedule::Immediate;
         cli.events_template_overwrite = false;

--- a/crates/tau-coding-agent/src/onboarding.rs
+++ b/crates/tau-coding-agent/src/onboarding.rs
@@ -470,8 +470,18 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
+    fn parse_cli_with_stack() -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::parse_from(["tau-rs", "--onboard", "--onboard-non-interactive"]))
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
     fn test_cli() -> Cli {
-        Cli::parse_from(["tau-rs", "--onboard", "--onboard-non-interactive"])
+        parse_cli_with_stack()
     }
 
     fn apply_workspace_paths(cli: &mut Cli, workspace: &Path) {

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -16,6 +16,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.transport_health_inspect.is_some()
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect
+        || cli.gateway_status_inspect
     {
         execute_channel_store_admin_command(cli)?;
         return Ok(true);

--- a/crates/tau-coding-agent/testdata/gateway-contract/README.md
+++ b/crates/tau-coding-agent/testdata/gateway-contract/README.md
@@ -6,6 +6,7 @@ external API schema.
 ## Files
 
 - `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `rollout-pass.json`: success-only fixture for deterministic rollout/demo runs.
 - `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
 - `invalid-error-code.json`: regression fixture for unsupported `error_code`.
 

--- a/crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json
+++ b/crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "gateway-rollout-pass",
+  "description": "Success-only gateway fixture for rollout demos and guardrail validation.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "gateway-rollout-post-task",
+      "method": "POST",
+      "endpoint": "/v1/tasks",
+      "actor_id": "ops-release-bot",
+      "body": {
+        "task": "reindex"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "method": "POST",
+          "endpoint": "/v1/tasks",
+          "actor_id": "ops-release-bot"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "gateway-rollout-fetch-task",
+      "method": "GET",
+      "endpoint": "/v1/tasks/42",
+      "actor_id": "ops-release-bot",
+      "body": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "method": "GET",
+          "endpoint": "/v1/tasks/42",
+          "actor_id": "ops-release-bot"
+        }
+      }
+    }
+  ]
+}

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -1,0 +1,89 @@
+# Gateway Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven gateway runtime (`--gateway-contract-runner`).
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --transport-health-inspect gateway \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --gateway-status-inspect \
+  --gateway-status-json
+```
+
+Primary state files:
+
+- `.tau/gateway/state.json`
+- `.tau/gateway/runtime-events.jsonl`
+- `.tau/gateway/channel-store/gateway/<actor_id>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/gateway.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent gateway_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent gateway_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/gateway.sh`
+4. Verify transport health and status gate:
+   `--transport-health-inspect gateway --transport-health-json`
+   `--gateway-status-inspect --gateway-status-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`.
+
+## Rollback plan
+
+1. Stop invoking `--gateway-contract-runner`.
+2. Preserve `.tau/gateway/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and schema compatibility.
+- Symptom: health state `degraded` with `retry_attempted` or `retryable_failures_observed`.
+  Action: inspect fixture retry cases and confirm transient failure semantics.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated failures.
+- Symptom: `rollout_gate=hold` with low event volume.
+  Action: run deterministic demo to refresh state and verify signal freshness.
+- Symptom: non-zero `queue_depth`.
+  Action: reduce per-cycle fixture volume or split fixture runs into smaller batches.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -96,6 +96,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/all.sh --only multi-channel --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
+./scripts/demo/all.sh --only gateway --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -105,6 +106,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/multi-agent.sh
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
+./scripts/demo/gateway.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -216,6 +216,45 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/dashboard-ops.md`.
 
+## Gateway contract runner
+
+Use this fixture-driven runtime mode to validate Tau gateway request handling, retry outcomes,
+state persistence, and channel-store snapshots.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --gateway-contract-runner \
+  --gateway-fixture crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
+  --gateway-state-dir .tau/gateway
+```
+
+The runner writes state and observability output under:
+
+- `.tau/gateway/state.json`
+- `.tau/gateway/runtime-events.jsonl`
+- `.tau/gateway/channel-store/gateway/<actor_id>/...`
+
+Inspect gateway transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --transport-health-inspect gateway \
+  --transport-health-json
+```
+
+Inspect gateway rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --gateway-status-inspect \
+  --gateway-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/gateway-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -21,6 +21,7 @@ demo_scripts=(
   "multi-agent.sh"
   "memory.sh"
   "dashboard.sh"
+  "gateway.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -88,6 +89,10 @@ normalize_demo_name() {
       ;;
     dashboard|dashboard.sh)
       echo "dashboard.sh"
+      return 0
+      ;;
+    gateway|gateway.sh)
+      echo "gateway.sh"
       return 0
       ;;
     *)
@@ -200,14 +205,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/gateway.sh
+++ b/scripts/demo/gateway.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "gateway" "Run deterministic gateway runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json"
+demo_state_dir=".tau/demo-gateway"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "gateway-runner" \
+  --gateway-contract-runner \
+  --gateway-fixture ./crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
+  --gateway-state-dir "${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "transport-health-inspect-gateway" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --transport-health-inspect gateway \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "gateway-status-inspect" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-status-inspect \
+  --gateway-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-gateway-ops-release-bot" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect gateway/ops-release-bot
+
+tau_demo_common_finish


### PR DESCRIPTION
Closes #779

## Summary
- Added full gateway observability/admin surfaces:
  - `--transport-health-inspect gateway`
  - `--gateway-status-inspect` / `--gateway-status-json`
- Implemented gateway status report collection and rendering from:
  - `.tau/gateway/state.json`
  - `.tau/gateway/runtime-events.jsonl`
- Extended startup preflight to treat gateway status inspect as an admin preflight mode.
- Added deterministic gateway rollout fixture and demo wrapper:
  - `crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json`
  - `scripts/demo/gateway.sh`
- Added gateway section to demo orchestration (`scripts/demo/all.sh`) and updated demo CI test expectations.
- Added gateway operations runbook and docs wiring:
  - `docs/guides/gateway-ops.md`
  - `docs/guides/transports.md`, `docs/guides/quickstart.md`, `README.md`

## Risks / Compatibility
- CLI surface area increased with new gateway observability flags; conflicts and required-flag behavior are explicitly tested.
- Test harness stack pressure increased from clap parsing breadth; stabilized tests by parsing CLI args in dedicated larger-stack helper threads in test-only code paths.
- Demo inventory expanded from 8 to 9 wrappers, so downstream consumers of deterministic demo order/count must include `gateway.sh`.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -q -- --test-threads=1`
- `cargo test -p tau-coding-agent channel_store_admin -- --test-threads=1`
- `cargo test -p tau-coding-agent gateway_status -- --test-threads=1`
- `cargo test -p tau-coding-agent execute_channel_store_admin_gateway_status_inspect -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/gateway.sh --skip-build --binary ./target/debug/tau-coding-agent`
