### PR TITLE
feat: add no-code custom command contract schema and fixtures

### DIFF
--- a/crates/tau-coding-agent/src/custom_command_contract.rs
+++ b/crates/tau-coding-agent/src/custom_command_contract.rs
@@ -1,0 +1,604 @@
+#![allow(dead_code)]
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+pub(crate) const CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+pub(crate) const CUSTOM_COMMAND_ERROR_INVALID_OPERATION: &str = "custom_command_invalid_operation";
+pub(crate) const CUSTOM_COMMAND_ERROR_INVALID_NAME: &str = "custom_command_invalid_name";
+pub(crate) const CUSTOM_COMMAND_ERROR_INVALID_TEMPLATE: &str = "custom_command_invalid_template";
+pub(crate) const CUSTOM_COMMAND_ERROR_BACKEND_UNAVAILABLE: &str =
+    "custom_command_backend_unavailable";
+
+fn custom_command_contract_schema_version() -> u32 {
+    CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CustomCommandOutcomeKind {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct CustomCommandCaseExpectation {
+    pub(crate) outcome: CustomCommandOutcomeKind,
+    pub(crate) status_code: u16,
+    #[serde(default)]
+    pub(crate) error_code: String,
+    #[serde(default)]
+    pub(crate) response_body: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct CustomCommandContractCase {
+    #[serde(default = "custom_command_contract_schema_version")]
+    pub(crate) schema_version: u32,
+    pub(crate) case_id: String,
+    pub(crate) operation: String,
+    #[serde(default)]
+    pub(crate) command_name: String,
+    #[serde(default)]
+    pub(crate) template: String,
+    #[serde(default)]
+    pub(crate) arguments: serde_json::Value,
+    #[serde(default)]
+    pub(crate) simulate_retryable_failure: bool,
+    pub(crate) expected: CustomCommandCaseExpectation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct CustomCommandContractFixture {
+    pub(crate) schema_version: u32,
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) description: String,
+    pub(crate) cases: Vec<CustomCommandContractCase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CustomCommandContractCapabilities {
+    pub(crate) schema_version: u32,
+    pub(crate) supported_outcomes: BTreeSet<CustomCommandOutcomeKind>,
+    pub(crate) supported_error_codes: BTreeSet<String>,
+    pub(crate) supported_operations: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CustomCommandReplayStep {
+    Success,
+    MalformedInput,
+    RetryableFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CustomCommandReplayResult {
+    pub(crate) step: CustomCommandReplayStep,
+    pub(crate) status_code: u16,
+    pub(crate) error_code: Option<String>,
+    pub(crate) response_body: serde_json::Value,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CustomCommandReplaySummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) success_cases: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+}
+
+#[cfg(test)]
+pub(crate) trait CustomCommandContractDriver {
+    fn apply_case(&mut self, case: &CustomCommandContractCase)
+        -> Result<CustomCommandReplayResult>;
+}
+
+pub(crate) fn parse_custom_command_contract_fixture(
+    raw: &str,
+) -> Result<CustomCommandContractFixture> {
+    let fixture = serde_json::from_str::<CustomCommandContractFixture>(raw)
+        .context("failed to parse custom-command contract fixture")?;
+    validate_custom_command_contract_fixture(&fixture)?;
+    Ok(fixture)
+}
+
+pub(crate) fn load_custom_command_contract_fixture(
+    path: &Path,
+) -> Result<CustomCommandContractFixture> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    parse_custom_command_contract_fixture(&raw)
+        .with_context(|| format!("invalid fixture {}", path.display()))
+}
+
+pub(crate) fn custom_command_contract_capabilities() -> CustomCommandContractCapabilities {
+    CustomCommandContractCapabilities {
+        schema_version: CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION,
+        supported_outcomes: [
+            CustomCommandOutcomeKind::Success,
+            CustomCommandOutcomeKind::MalformedInput,
+            CustomCommandOutcomeKind::RetryableFailure,
+        ]
+        .into_iter()
+        .collect(),
+        supported_error_codes: supported_error_codes()
+            .iter()
+            .map(|code| (*code).to_string())
+            .collect(),
+        supported_operations: supported_operations()
+            .iter()
+            .map(|operation| (*operation).to_string())
+            .collect(),
+    }
+}
+
+pub(crate) fn validate_custom_command_contract_compatibility(
+    fixture: &CustomCommandContractFixture,
+) -> Result<()> {
+    let capabilities = custom_command_contract_capabilities();
+    if fixture.schema_version != capabilities.schema_version {
+        bail!(
+            "unsupported custom-command contract schema version {} (expected {})",
+            fixture.schema_version,
+            capabilities.schema_version
+        );
+    }
+
+    for case in &fixture.cases {
+        if !capabilities
+            .supported_outcomes
+            .contains(&case.expected.outcome)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported outcome {:?}",
+                case.case_id,
+                case.expected.outcome
+            );
+        }
+
+        let expected_code = case.expected.error_code.trim();
+        if !expected_code.is_empty() && !capabilities.supported_error_codes.contains(expected_code)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported error_code '{}'",
+                case.case_id,
+                expected_code
+            );
+        }
+
+        let operation = normalize_operation(&case.operation);
+        if case.expected.outcome != CustomCommandOutcomeKind::MalformedInput
+            && !capabilities.supported_operations.contains(&operation)
+        {
+            bail!(
+                "fixture case '{}' uses unsupported operation '{}' for non-malformed outcome",
+                case.case_id,
+                case.operation
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_custom_command_contract_fixture(
+    fixture: &CustomCommandContractFixture,
+) -> Result<()> {
+    if fixture.schema_version != CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "unsupported custom-command contract schema version {} (expected {})",
+            fixture.schema_version,
+            CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if fixture.name.trim().is_empty() {
+        bail!("fixture name cannot be empty");
+    }
+    if fixture.cases.is_empty() {
+        bail!("fixture must include at least one case");
+    }
+
+    let mut case_ids = HashSet::new();
+    for (index, case) in fixture.cases.iter().enumerate() {
+        validate_custom_command_case(case, index)?;
+        let case_id = case.case_id.trim().to_string();
+        if !case_ids.insert(case_id.clone()) {
+            bail!("fixture contains duplicate case_id '{}'", case_id);
+        }
+    }
+
+    validate_custom_command_contract_compatibility(fixture)?;
+    Ok(())
+}
+
+pub(crate) fn evaluate_custom_command_case(
+    case: &CustomCommandContractCase,
+) -> CustomCommandReplayResult {
+    if case.simulate_retryable_failure {
+        return CustomCommandReplayResult {
+            step: CustomCommandReplayStep::RetryableFailure,
+            status_code: 503,
+            error_code: Some(CUSTOM_COMMAND_ERROR_BACKEND_UNAVAILABLE.to_string()),
+            response_body: json!({"status":"retryable","reason":"backend_unavailable"}),
+        };
+    }
+
+    let operation = normalize_operation(&case.operation);
+    if !supported_operations().contains(&operation.as_str()) {
+        return CustomCommandReplayResult {
+            step: CustomCommandReplayStep::MalformedInput,
+            status_code: 400,
+            error_code: Some(CUSTOM_COMMAND_ERROR_INVALID_OPERATION.to_string()),
+            response_body: json!({"status":"rejected","reason":"invalid_operation"}),
+        };
+    }
+
+    let command_name = case.command_name.trim();
+    if operation != "LIST" && !is_valid_command_name(command_name) {
+        return CustomCommandReplayResult {
+            step: CustomCommandReplayStep::MalformedInput,
+            status_code: 400,
+            error_code: Some(CUSTOM_COMMAND_ERROR_INVALID_NAME.to_string()),
+            response_body: json!({"status":"rejected","reason":"invalid_name"}),
+        };
+    }
+
+    if (operation == "CREATE" || operation == "UPDATE") && case.template.trim().is_empty() {
+        return CustomCommandReplayResult {
+            step: CustomCommandReplayStep::MalformedInput,
+            status_code: 422,
+            error_code: Some(CUSTOM_COMMAND_ERROR_INVALID_TEMPLATE.to_string()),
+            response_body: json!({"status":"rejected","reason":"invalid_template"}),
+        };
+    }
+
+    let status_code = if operation == "CREATE" { 201 } else { 200 };
+    let response_body = if operation == "LIST" {
+        json!({
+            "status": "accepted",
+            "operation": "list",
+            "commands": ["deploy_release", "triage_alerts"]
+        })
+    } else if operation == "RUN" {
+        json!({
+            "status": "accepted",
+            "operation": "run",
+            "command_name": command_name,
+            "arguments": case.arguments,
+        })
+    } else {
+        json!({
+            "status": "accepted",
+            "operation": operation.to_ascii_lowercase(),
+            "command_name": command_name,
+        })
+    };
+
+    CustomCommandReplayResult {
+        step: CustomCommandReplayStep::Success,
+        status_code,
+        error_code: None,
+        response_body,
+    }
+}
+
+pub(crate) fn validate_custom_command_case_result_against_contract(
+    case: &CustomCommandContractCase,
+    result: &CustomCommandReplayResult,
+) -> Result<()> {
+    let expected_step = match case.expected.outcome {
+        CustomCommandOutcomeKind::Success => CustomCommandReplayStep::Success,
+        CustomCommandOutcomeKind::MalformedInput => CustomCommandReplayStep::MalformedInput,
+        CustomCommandOutcomeKind::RetryableFailure => CustomCommandReplayStep::RetryableFailure,
+    };
+    if result.step != expected_step {
+        bail!(
+            "case '{}' expected step {:?} but observed {:?}",
+            case.case_id,
+            expected_step,
+            result.step
+        );
+    }
+
+    if result.status_code != case.expected.status_code {
+        bail!(
+            "case '{}' expected status_code {} but observed {}",
+            case.case_id,
+            case.expected.status_code,
+            result.status_code
+        );
+    }
+
+    match case.expected.outcome {
+        CustomCommandOutcomeKind::Success => {
+            if result.error_code.is_some() {
+                bail!(
+                    "case '{}' expected empty error_code for success but observed {:?}",
+                    case.case_id,
+                    result.error_code
+                );
+            }
+        }
+        CustomCommandOutcomeKind::MalformedInput | CustomCommandOutcomeKind::RetryableFailure => {
+            let expected_code = case.expected.error_code.trim();
+            if result.error_code.as_deref() != Some(expected_code) {
+                bail!(
+                    "case '{}' expected error_code '{}' but observed {:?}",
+                    case.case_id,
+                    expected_code,
+                    result.error_code
+                );
+            }
+        }
+    }
+
+    if result.response_body != case.expected.response_body {
+        bail!(
+            "case '{}' expected response_body {} but observed {}",
+            case.case_id,
+            case.expected.response_body,
+            result.response_body
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn run_custom_command_contract_replay<D: CustomCommandContractDriver>(
+    fixture: &CustomCommandContractFixture,
+    driver: &mut D,
+) -> Result<CustomCommandReplaySummary> {
+    validate_custom_command_contract_fixture(fixture)?;
+
+    let mut summary = CustomCommandReplaySummary {
+        discovered_cases: fixture.cases.len(),
+        ..CustomCommandReplaySummary::default()
+    };
+    for case in &fixture.cases {
+        let result = driver.apply_case(case)?;
+        validate_custom_command_case_result_against_contract(case, &result)?;
+        match result.step {
+            CustomCommandReplayStep::Success => {
+                summary.success_cases = summary.success_cases.saturating_add(1)
+            }
+            CustomCommandReplayStep::MalformedInput => {
+                summary.malformed_cases = summary.malformed_cases.saturating_add(1)
+            }
+            CustomCommandReplayStep::RetryableFailure => {
+                summary.retryable_failures = summary.retryable_failures.saturating_add(1)
+            }
+        }
+    }
+    Ok(summary)
+}
+
+fn validate_custom_command_case(case: &CustomCommandContractCase, index: usize) -> Result<()> {
+    if case.schema_version != CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION {
+        bail!(
+            "case index {} has unsupported schema version {} (expected {})",
+            index,
+            case.schema_version,
+            CUSTOM_COMMAND_CONTRACT_SCHEMA_VERSION
+        );
+    }
+    if case.case_id.trim().is_empty() {
+        bail!("case index {} has empty case_id", index);
+    }
+    if case.operation.trim().is_empty() {
+        bail!("case '{}' has empty operation", case.case_id);
+    }
+    if case.expected.status_code == 0 {
+        bail!("case '{}' has invalid expected.status_code=0", case.case_id);
+    }
+    validate_custom_command_expectation(case)?;
+    Ok(())
+}
+
+fn validate_custom_command_expectation(case: &CustomCommandContractCase) -> Result<()> {
+    match case.expected.outcome {
+        CustomCommandOutcomeKind::Success => {
+            if !case.expected.error_code.trim().is_empty() {
+                bail!(
+                    "case '{}' expects success but provides error_code '{}'",
+                    case.case_id,
+                    case.expected.error_code
+                );
+            }
+        }
+        CustomCommandOutcomeKind::MalformedInput | CustomCommandOutcomeKind::RetryableFailure => {
+            if case.expected.error_code.trim().is_empty() {
+                bail!(
+                    "case '{}' expects {:?} but does not provide error_code",
+                    case.case_id,
+                    case.expected.outcome
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn supported_operations() -> &'static [&'static str] {
+    &["CREATE", "UPDATE", "DELETE", "RUN", "LIST"]
+}
+
+fn supported_error_codes() -> &'static [&'static str] {
+    &[
+        CUSTOM_COMMAND_ERROR_INVALID_OPERATION,
+        CUSTOM_COMMAND_ERROR_INVALID_NAME,
+        CUSTOM_COMMAND_ERROR_INVALID_TEMPLATE,
+        CUSTOM_COMMAND_ERROR_BACKEND_UNAVAILABLE,
+    ]
+}
+
+fn normalize_operation(raw: &str) -> String {
+    raw.trim().to_ascii_uppercase()
+}
+
+fn is_valid_command_name(raw: &str) -> bool {
+    if raw.is_empty() {
+        return false;
+    }
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        evaluate_custom_command_case, load_custom_command_contract_fixture,
+        parse_custom_command_contract_fixture, run_custom_command_contract_replay,
+        CustomCommandContractCase, CustomCommandContractDriver, CustomCommandReplayResult,
+        CustomCommandReplayStep,
+    };
+    use anyhow::Result;
+    use std::path::PathBuf;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("custom-command-contract")
+            .join(name)
+    }
+
+    struct StaticDriver;
+
+    impl CustomCommandContractDriver for StaticDriver {
+        fn apply_case(
+            &mut self,
+            case: &CustomCommandContractCase,
+        ) -> Result<CustomCommandReplayResult> {
+            Ok(evaluate_custom_command_case(case))
+        }
+    }
+
+    #[test]
+    fn unit_parse_custom_command_contract_fixture_rejects_unsupported_schema() {
+        let raw = r#"{
+  "schema_version": 9,
+  "name": "custom-command-invalid-schema",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "x",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {"status":"accepted","operation":"create","command_name":"deploy_release"}
+      }
+    }
+  ]
+}"#;
+        let error = parse_custom_command_contract_fixture(raw).expect_err("schema should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported custom-command contract schema version"));
+    }
+
+    #[test]
+    fn unit_validate_custom_command_contract_fixture_rejects_duplicate_case_id() {
+        let error =
+            load_custom_command_contract_fixture(&fixture_path("invalid-duplicate-case-id.json"))
+                .expect_err("duplicate case id should fail");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("fixture contains duplicate case_id"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn functional_fixture_loads_success_malformed_and_retryable_cases() {
+        let fixture = load_custom_command_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture should load");
+        assert_eq!(fixture.cases.len(), 3);
+        assert_eq!(fixture.cases[0].case_id, "custom-command-create-success");
+        assert_eq!(
+            fixture.cases[1].case_id,
+            "custom-command-malformed-invalid-operation"
+        );
+        assert_eq!(
+            fixture.cases[2].case_id,
+            "custom-command-retryable-run-backend"
+        );
+    }
+
+    #[test]
+    fn integration_custom_command_contract_replay_is_deterministic_across_reloads() {
+        let fixture_path = fixture_path("mixed-outcomes.json");
+        let fixture_a =
+            load_custom_command_contract_fixture(&fixture_path).expect("load fixture a");
+        let fixture_b =
+            load_custom_command_contract_fixture(&fixture_path).expect("load fixture b");
+
+        let mut driver_a = StaticDriver;
+        let mut driver_b = StaticDriver;
+        let summary_a = run_custom_command_contract_replay(&fixture_a, &mut driver_a)
+            .expect("replay fixture a");
+        let summary_b = run_custom_command_contract_replay(&fixture_b, &mut driver_b)
+            .expect("replay fixture b");
+        assert_eq!(summary_a, summary_b);
+        assert_eq!(summary_a.discovered_cases, 3);
+        assert_eq!(summary_a.success_cases, 1);
+        assert_eq!(summary_a.malformed_cases, 1);
+        assert_eq!(summary_a.retryable_failures, 1);
+    }
+
+    #[test]
+    fn regression_fixture_rejects_unsupported_error_code() {
+        let error = load_custom_command_contract_fixture(&fixture_path("invalid-error-code.json"))
+            .expect_err("unsupported error code should fail");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("uses unsupported error_code"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn regression_custom_command_contract_replay_rejects_mismatched_expected_response_body() {
+        let mut fixture =
+            load_custom_command_contract_fixture(&fixture_path("mixed-outcomes.json"))
+                .expect("fixture should load");
+        fixture.cases[0].expected.response_body = serde_json::json!({
+            "status": "accepted",
+            "operation": "create",
+            "command_name": "unexpected"
+        });
+
+        let mut driver = StaticDriver;
+        let error = run_custom_command_contract_replay(&fixture, &mut driver)
+            .expect_err("replay should fail");
+        assert!(error.to_string().contains("expected response_body"));
+    }
+
+    #[test]
+    fn regression_custom_command_contract_evaluator_marks_unsupported_operation_as_malformed() {
+        let fixture = load_custom_command_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture should load");
+        let result = evaluate_custom_command_case(&fixture.cases[1]);
+        assert_eq!(result.step, CustomCommandReplayStep::MalformedInput);
+        assert_eq!(result.status_code, 400);
+        assert_eq!(
+            result.error_code.as_deref(),
+            Some("custom_command_invalid_operation")
+        );
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -13,6 +13,7 @@ mod cli_types;
 mod codex_cli_client;
 mod commands;
 mod credentials;
+mod custom_command_contract;
 mod dashboard_contract;
 mod dashboard_runtime;
 mod diagnostics_commands;

--- a/crates/tau-coding-agent/testdata/custom-command-contract/README.md
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/README.md
@@ -1,0 +1,21 @@
+# Custom Command Contract Fixtures
+
+This fixture corpus defines deterministic contract coverage for no-code custom command authoring
+and lifecycle operations.
+
+## Files
+
+- `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
+- `invalid-error-code.json`: regression fixture for unsupported `error_code`.
+
+## Schema Notes
+
+- Fixture schema version: `1`.
+- Supported operations: `create`, `update`, `delete`, `run`, `list`.
+- Outcome coverage: `success`, `malformed_input`, `retryable_failure`.
+- Supported deterministic error codes:
+  - `custom_command_invalid_operation`
+  - `custom_command_invalid_name`
+  - `custom_command_invalid_template`
+  - `custom_command_backend_unavailable`

--- a/crates/tau-coding-agent/testdata/custom-command-contract/invalid-duplicate-case-id.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/invalid-duplicate-case-id.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-invalid-duplicate-case-id",
+  "description": "Fixture with duplicate case ids for regression testing.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "operation": "create",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "duplicate-case",
+      "operation": "delete",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "delete",
+          "command_name": "deploy_release"
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/custom-command-contract/invalid-error-code.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/invalid-error-code.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-invalid-error-code",
+  "description": "Fixture with unsupported error code for regression coverage.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-invalid-error-code",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 422,
+        "error_code": "custom_command_unknown_error",
+        "response_body": {
+          "status": "rejected",
+          "reason": "invalid_template"
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/custom-command-contract/mixed-outcomes.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/mixed-outcomes.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-mixed-outcomes",
+  "description": "Deterministic custom command contract replay matrix with success, malformed input, and retryable failure outcomes.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-create-success",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {
+        "env": "prod"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "operation": "create",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-malformed-invalid-operation",
+      "operation": "shipit",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 400,
+        "error_code": "custom_command_invalid_operation",
+        "response_body": {
+          "status": "rejected",
+          "reason": "invalid_operation"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-retryable-run-backend",
+      "operation": "run",
+      "command_name": "triage_alerts",
+      "template": "",
+      "arguments": {
+        "severity": "high"
+      },
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "custom_command_backend_unavailable",
+        "response_body": {
+          "status": "retryable",
+          "reason": "backend_unavailable"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #783

## Summary
- Added new contract module: `crates/tau-coding-agent/src/custom_command_contract.rs`.
- Implemented schema types, parser/validator, compatibility checks, deterministic evaluator, and replay assertions for no-code custom command lifecycle cases.
- Added fixture corpus:
  - `crates/tau-coding-agent/testdata/custom-command-contract/mixed-outcomes.json`
  - `crates/tau-coding-agent/testdata/custom-command-contract/invalid-duplicate-case-id.json`
  - `crates/tau-coding-agent/testdata/custom-command-contract/invalid-error-code.json`
  - `crates/tau-coding-agent/testdata/custom-command-contract/README.md`
- Wired module into crate via `mod custom_command_contract;` in `crates/tau-coding-agent/src/main.rs`.

## Risks / Compatibility
- Contract module is intentionally scoped to schema/fixture/replay artifacts for this task; runtime wiring is deferred to implementation tasks under #784.
- Added `#![allow(dead_code)]` within the contract module to keep strict clippy green until runtime integration consumes all exported items.
- Fixture expectations are deterministic and strict; future runtime must match exact response/error contract semantics.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent custom_command_contract -- --test-threads=1`
- `cargo test --workspace -q -- --test-threads=1`
