### PR TITLE
feat: implement no-code custom command runtime integration

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1995,6 +1995,67 @@ pub(crate) struct Cli {
     pub(crate) gateway_state_dir: PathBuf,
 
     #[arg(
+        long = "custom-command-contract-runner",
+        env = "TAU_CUSTOM_COMMAND_CONTRACT_RUNNER",
+        default_value_t = false,
+        help = "Run fixture-driven no-code custom command runtime contract scenarios"
+    )]
+    pub(crate) custom_command_contract_runner: bool,
+
+    #[arg(
+        long = "custom-command-fixture",
+        env = "TAU_CUSTOM_COMMAND_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/custom-command-contract/mixed-outcomes.json",
+        requires = "custom_command_contract_runner",
+        help = "Path to no-code custom command runtime contract fixture JSON"
+    )]
+    pub(crate) custom_command_fixture: PathBuf,
+
+    #[arg(
+        long = "custom-command-state-dir",
+        env = "TAU_CUSTOM_COMMAND_STATE_DIR",
+        default_value = ".tau/custom-command",
+        help = "Directory for no-code custom command runtime state and channel-store outputs"
+    )]
+    pub(crate) custom_command_state_dir: PathBuf,
+
+    #[arg(
+        long = "custom-command-queue-limit",
+        env = "TAU_CUSTOM_COMMAND_QUEUE_LIMIT",
+        default_value_t = 64,
+        requires = "custom_command_contract_runner",
+        help = "Maximum no-code custom command fixture cases processed per runtime cycle"
+    )]
+    pub(crate) custom_command_queue_limit: usize,
+
+    #[arg(
+        long = "custom-command-processed-case-cap",
+        env = "TAU_CUSTOM_COMMAND_PROCESSED_CASE_CAP",
+        default_value_t = 10_000,
+        requires = "custom_command_contract_runner",
+        help = "Maximum processed-case keys retained for no-code custom command duplicate suppression"
+    )]
+    pub(crate) custom_command_processed_case_cap: usize,
+
+    #[arg(
+        long = "custom-command-retry-max-attempts",
+        env = "TAU_CUSTOM_COMMAND_RETRY_MAX_ATTEMPTS",
+        default_value_t = 4,
+        requires = "custom_command_contract_runner",
+        help = "Maximum retry attempts for transient no-code custom command runtime failures"
+    )]
+    pub(crate) custom_command_retry_max_attempts: usize,
+
+    #[arg(
+        long = "custom-command-retry-base-delay-ms",
+        env = "TAU_CUSTOM_COMMAND_RETRY_BASE_DELAY_MS",
+        default_value_t = 0,
+        requires = "custom_command_contract_runner",
+        help = "Base backoff delay in milliseconds for no-code custom command runtime retries (0 disables delay)"
+    )]
+    pub(crate) custom_command_retry_base_delay_ms: u64,
+
+    #[arg(
         long = "github-issues-bridge",
         env = "TAU_GITHUB_ISSUES_BRIDGE",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/custom_command_runtime.rs
+++ b/crates/tau-coding-agent/src/custom_command_runtime.rs
@@ -1,0 +1,977 @@
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
+use crate::custom_command_contract::{
+    evaluate_custom_command_case, load_custom_command_contract_fixture,
+    validate_custom_command_case_result_against_contract, CustomCommandContractCase,
+    CustomCommandContractFixture, CustomCommandReplayResult, CustomCommandReplayStep,
+};
+use crate::{current_unix_timestamp_ms, write_text_atomic, TransportHealthSnapshot};
+
+const CUSTOM_COMMAND_RUNTIME_STATE_SCHEMA_VERSION: u32 = 1;
+const CUSTOM_COMMAND_RUNTIME_EVENTS_LOG_FILE: &str = "runtime-events.jsonl";
+
+fn custom_command_runtime_state_schema_version() -> u32 {
+    CUSTOM_COMMAND_RUNTIME_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CustomCommandRuntimeConfig {
+    pub(crate) fixture_path: PathBuf,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) queue_limit: usize,
+    pub(crate) processed_case_cap: usize,
+    pub(crate) retry_max_attempts: usize,
+    pub(crate) retry_base_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CustomCommandRuntimeSummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) queued_cases: usize,
+    pub(crate) applied_cases: usize,
+    pub(crate) duplicate_skips: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+    pub(crate) retry_attempts: usize,
+    pub(crate) failed_cases: usize,
+    pub(crate) upserted_commands: usize,
+    pub(crate) deleted_commands: usize,
+    pub(crate) executed_runs: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CustomCommandRuntimeCycleReport {
+    timestamp_unix_ms: u64,
+    health_state: String,
+    health_reason: String,
+    reason_codes: Vec<String>,
+    discovered_cases: usize,
+    queued_cases: usize,
+    applied_cases: usize,
+    duplicate_skips: usize,
+    malformed_cases: usize,
+    retryable_failures: usize,
+    retry_attempts: usize,
+    failed_cases: usize,
+    upserted_commands: usize,
+    deleted_commands: usize,
+    executed_runs: usize,
+    backlog_cases: usize,
+    failure_streak: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CustomCommandRecord {
+    case_key: String,
+    case_id: String,
+    command_name: String,
+    template: String,
+    operation: String,
+    last_status_code: u16,
+    last_outcome: String,
+    run_count: u64,
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CustomCommandRuntimeState {
+    #[serde(default = "custom_command_runtime_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    processed_case_keys: Vec<String>,
+    #[serde(default)]
+    commands: Vec<CustomCommandRecord>,
+    #[serde(default)]
+    health: TransportHealthSnapshot,
+}
+
+impl Default for CustomCommandRuntimeState {
+    fn default() -> Self {
+        Self {
+            schema_version: CUSTOM_COMMAND_RUNTIME_STATE_SCHEMA_VERSION,
+            processed_case_keys: Vec::new(),
+            commands: Vec::new(),
+            health: TransportHealthSnapshot::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CustomCommandMutationCounts {
+    upserted_commands: usize,
+    deleted_commands: usize,
+    executed_runs: usize,
+}
+
+pub(crate) async fn run_custom_command_contract_runner(
+    config: CustomCommandRuntimeConfig,
+) -> Result<()> {
+    let fixture = load_custom_command_contract_fixture(&config.fixture_path)?;
+    let mut runtime = CustomCommandRuntime::new(config)?;
+    let summary = runtime.run_once(&fixture).await?;
+    let health = runtime.transport_health().clone();
+    let classification = health.classify();
+
+    println!(
+        "custom-command runner summary: discovered={} queued={} applied={} duplicate_skips={} malformed={} retryable_failures={} retries={} failed={} upserted_commands={} deleted_commands={} executed_runs={}",
+        summary.discovered_cases,
+        summary.queued_cases,
+        summary.applied_cases,
+        summary.duplicate_skips,
+        summary.malformed_cases,
+        summary.retryable_failures,
+        summary.retry_attempts,
+        summary.failed_cases,
+        summary.upserted_commands,
+        summary.deleted_commands,
+        summary.executed_runs
+    );
+    println!(
+        "custom-command runner health: state={} failure_streak={} queue_depth={} reason={}",
+        classification.state.as_str(),
+        health.failure_streak,
+        health.queue_depth,
+        classification.reason
+    );
+
+    Ok(())
+}
+
+struct CustomCommandRuntime {
+    config: CustomCommandRuntimeConfig,
+    state: CustomCommandRuntimeState,
+    processed_case_keys: HashSet<String>,
+}
+
+impl CustomCommandRuntime {
+    fn new(config: CustomCommandRuntimeConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)
+            .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+        let mut state = load_custom_command_runtime_state(&config.state_dir.join("state.json"))?;
+        state.processed_case_keys =
+            normalize_processed_case_keys(&state.processed_case_keys, config.processed_case_cap);
+        state
+            .commands
+            .sort_by(|left, right| left.command_name.cmp(&right.command_name));
+        let processed_case_keys = state.processed_case_keys.iter().cloned().collect();
+        Ok(Self {
+            config,
+            state,
+            processed_case_keys,
+        })
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.config.state_dir.join("state.json")
+    }
+
+    fn transport_health(&self) -> &TransportHealthSnapshot {
+        &self.state.health
+    }
+
+    async fn run_once(
+        &mut self,
+        fixture: &CustomCommandContractFixture,
+    ) -> Result<CustomCommandRuntimeSummary> {
+        let cycle_started = Instant::now();
+        let mut summary = CustomCommandRuntimeSummary {
+            discovered_cases: fixture.cases.len(),
+            ..CustomCommandRuntimeSummary::default()
+        };
+
+        let mut queued_cases = fixture.cases.clone();
+        queued_cases.sort_by(|left, right| {
+            left.case_id
+                .cmp(&right.case_id)
+                .then_with(|| left.operation.cmp(&right.operation))
+                .then_with(|| left.command_name.cmp(&right.command_name))
+        });
+        queued_cases.truncate(self.config.queue_limit);
+        summary.queued_cases = queued_cases.len();
+
+        for case in queued_cases {
+            let case_key = case_runtime_key(&case);
+            if self.processed_case_keys.contains(&case_key) {
+                summary.duplicate_skips = summary.duplicate_skips.saturating_add(1);
+                continue;
+            }
+
+            let mut attempt = 1usize;
+            loop {
+                let result = evaluate_custom_command_case(&case);
+                validate_custom_command_case_result_against_contract(&case, &result)?;
+                match result.step {
+                    CustomCommandReplayStep::Success => {
+                        let mutation = self.persist_success_result(&case, &case_key, &result)?;
+                        summary.applied_cases = summary.applied_cases.saturating_add(1);
+                        summary.upserted_commands = summary
+                            .upserted_commands
+                            .saturating_add(mutation.upserted_commands);
+                        summary.deleted_commands = summary
+                            .deleted_commands
+                            .saturating_add(mutation.deleted_commands);
+                        summary.executed_runs =
+                            summary.executed_runs.saturating_add(mutation.executed_runs);
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    CustomCommandReplayStep::MalformedInput => {
+                        summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+                        self.persist_non_success_result(&case, &case_key, &result)?;
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    CustomCommandReplayStep::RetryableFailure => {
+                        summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+                        if attempt >= self.config.retry_max_attempts {
+                            summary.failed_cases = summary.failed_cases.saturating_add(1);
+                            self.persist_non_success_result(&case, &case_key, &result)?;
+                            break;
+                        }
+                        summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                        apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                        attempt = attempt.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        let cycle_duration_ms =
+            u64::try_from(cycle_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let health = build_transport_health_snapshot(
+            &summary,
+            cycle_duration_ms,
+            self.state.health.failure_streak,
+        );
+        let classification = health.classify();
+        let reason_codes = cycle_reason_codes(&summary);
+        self.state.health = health.clone();
+
+        save_custom_command_runtime_state(&self.state_path(), &self.state)?;
+        append_custom_command_cycle_report(
+            &self
+                .config
+                .state_dir
+                .join(CUSTOM_COMMAND_RUNTIME_EVENTS_LOG_FILE),
+            &summary,
+            &health,
+            &classification.reason,
+            &reason_codes,
+        )?;
+
+        Ok(summary)
+    }
+
+    fn persist_success_result(
+        &mut self,
+        case: &CustomCommandContractCase,
+        case_key: &str,
+        result: &CustomCommandReplayResult,
+    ) -> Result<CustomCommandMutationCounts> {
+        let operation = normalize_operation(&case.operation);
+        let command_name = case.command_name.trim().to_string();
+        let timestamp_unix_ms = current_unix_timestamp_ms();
+        let mut mutation = CustomCommandMutationCounts::default();
+
+        match operation.as_str() {
+            "CREATE" | "UPDATE" => {
+                let record = CustomCommandRecord {
+                    case_key: case_key.to_string(),
+                    case_id: case.case_id.clone(),
+                    command_name: command_name.clone(),
+                    template: case.template.trim().to_string(),
+                    operation: operation.clone(),
+                    last_status_code: result.status_code,
+                    last_outcome: "success".to_string(),
+                    run_count: self
+                        .state
+                        .commands
+                        .iter()
+                        .find(|existing| existing.command_name == command_name)
+                        .map_or(0, |existing| existing.run_count),
+                    updated_unix_ms: timestamp_unix_ms,
+                };
+                if let Some(existing) = self
+                    .state
+                    .commands
+                    .iter_mut()
+                    .find(|existing| existing.command_name == command_name)
+                {
+                    *existing = record;
+                } else {
+                    self.state.commands.push(record);
+                }
+                mutation.upserted_commands = 1;
+            }
+            "DELETE" => {
+                let before = self.state.commands.len();
+                self.state
+                    .commands
+                    .retain(|existing| existing.command_name != command_name);
+                mutation.deleted_commands = before.saturating_sub(self.state.commands.len());
+            }
+            "RUN" => {
+                if let Some(existing) = self
+                    .state
+                    .commands
+                    .iter_mut()
+                    .find(|existing| existing.command_name == command_name)
+                {
+                    existing.case_key = case_key.to_string();
+                    existing.case_id = case.case_id.clone();
+                    existing.operation = operation.clone();
+                    existing.last_status_code = result.status_code;
+                    existing.last_outcome = "success".to_string();
+                    existing.run_count = existing.run_count.saturating_add(1);
+                    existing.updated_unix_ms = timestamp_unix_ms;
+                } else {
+                    self.state.commands.push(CustomCommandRecord {
+                        case_key: case_key.to_string(),
+                        case_id: case.case_id.clone(),
+                        command_name: command_name.clone(),
+                        template: String::new(),
+                        operation: operation.clone(),
+                        last_status_code: result.status_code,
+                        last_outcome: "success".to_string(),
+                        run_count: 1,
+                        updated_unix_ms: timestamp_unix_ms,
+                    });
+                    mutation.upserted_commands = 1;
+                }
+                mutation.executed_runs = 1;
+            }
+            "LIST" => {}
+            _ => {}
+        }
+
+        self.state
+            .commands
+            .sort_by(|left, right| left.command_name.cmp(&right.command_name));
+
+        if let Some(store) = self.scope_channel_store(case)? {
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-custom-command-runner".to_string(),
+                payload: json!({
+                    "outcome": "success",
+                    "operation": operation.to_ascii_lowercase(),
+                    "case_id": case.case_id,
+                    "command_name": command_name,
+                    "status_code": result.status_code,
+                    "upserted_commands": mutation.upserted_commands,
+                    "deleted_commands": mutation.deleted_commands,
+                    "executed_runs": mutation.executed_runs,
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "custom-command case {} applied operation={} command={} status={}",
+                    case.case_id,
+                    operation.to_ascii_lowercase(),
+                    channel_id_for_case(case),
+                    result.status_code
+                ),
+            })?;
+            store.write_memory(&render_custom_command_snapshot(
+                &self.state.commands,
+                &channel_id_for_case(case),
+            ))?;
+        }
+
+        Ok(mutation)
+    }
+
+    fn persist_non_success_result(
+        &self,
+        case: &CustomCommandContractCase,
+        case_key: &str,
+        result: &CustomCommandReplayResult,
+    ) -> Result<()> {
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            let outcome = outcome_name(result.step);
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-custom-command-runner".to_string(),
+                payload: json!({
+                    "outcome": outcome,
+                    "case_id": case.case_id,
+                    "operation": normalize_operation(&case.operation).to_ascii_lowercase(),
+                    "command_name": case.command_name.trim(),
+                    "status_code": result.status_code,
+                    "error_code": result.error_code.clone().unwrap_or_default(),
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "custom-command case {} outcome={} error_code={} status={}",
+                    case.case_id,
+                    outcome,
+                    result.error_code.clone().unwrap_or_default(),
+                    result.status_code
+                ),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn scope_channel_store(
+        &self,
+        case: &CustomCommandContractCase,
+    ) -> Result<Option<ChannelStore>> {
+        let channel_id = channel_id_for_case(case);
+        let store = ChannelStore::open(
+            &self.config.state_dir.join("channel-store"),
+            "custom-command",
+            &channel_id,
+        )?;
+        Ok(Some(store))
+    }
+
+    fn record_processed_case(&mut self, case_key: &str) {
+        if self.processed_case_keys.contains(case_key) {
+            return;
+        }
+        self.state.processed_case_keys.push(case_key.to_string());
+        self.processed_case_keys.insert(case_key.to_string());
+        if self.state.processed_case_keys.len() > self.config.processed_case_cap {
+            let overflow = self
+                .state
+                .processed_case_keys
+                .len()
+                .saturating_sub(self.config.processed_case_cap);
+            let removed = self.state.processed_case_keys.drain(0..overflow);
+            for key in removed {
+                self.processed_case_keys.remove(&key);
+            }
+        }
+    }
+}
+
+fn normalize_operation(raw: &str) -> String {
+    raw.trim().to_ascii_uppercase()
+}
+
+fn channel_id_for_case(case: &CustomCommandContractCase) -> String {
+    let trimmed = case.command_name.trim();
+    if trimmed.is_empty() {
+        return "registry".to_string();
+    }
+    if trimmed
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '-')
+    {
+        return trimmed.to_string();
+    }
+    "registry".to_string()
+}
+
+fn case_runtime_key(case: &CustomCommandContractCase) -> String {
+    format!(
+        "{}:{}:{}",
+        normalize_operation(&case.operation),
+        case.command_name.trim(),
+        case.case_id.trim()
+    )
+}
+
+fn outcome_name(step: CustomCommandReplayStep) -> &'static str {
+    match step {
+        CustomCommandReplayStep::Success => "success",
+        CustomCommandReplayStep::MalformedInput => "malformed_input",
+        CustomCommandReplayStep::RetryableFailure => "retryable_failure",
+    }
+}
+
+fn build_transport_health_snapshot(
+    summary: &CustomCommandRuntimeSummary,
+    cycle_duration_ms: u64,
+    previous_failure_streak: usize,
+) -> TransportHealthSnapshot {
+    let backlog_cases = summary
+        .discovered_cases
+        .saturating_sub(summary.queued_cases);
+    let failure_streak = if summary.failed_cases > 0 {
+        previous_failure_streak.saturating_add(1)
+    } else {
+        0
+    };
+    TransportHealthSnapshot {
+        updated_unix_ms: current_unix_timestamp_ms(),
+        cycle_duration_ms,
+        queue_depth: backlog_cases,
+        active_runs: 0,
+        failure_streak,
+        last_cycle_discovered: summary.discovered_cases,
+        last_cycle_processed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases)
+            .saturating_add(summary.failed_cases)
+            .saturating_add(summary.duplicate_skips),
+        last_cycle_completed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases),
+        last_cycle_failed: summary.failed_cases,
+        last_cycle_duplicates: summary.duplicate_skips,
+    }
+}
+
+fn cycle_reason_codes(summary: &CustomCommandRuntimeSummary) -> Vec<String> {
+    let mut codes = Vec::new();
+    if summary.discovered_cases > summary.queued_cases {
+        codes.push("queue_backpressure_applied".to_string());
+    }
+    if summary.duplicate_skips > 0 {
+        codes.push("duplicate_cases_skipped".to_string());
+    }
+    if summary.malformed_cases > 0 {
+        codes.push("malformed_inputs_observed".to_string());
+    }
+    if summary.retry_attempts > 0 {
+        codes.push("retry_attempted".to_string());
+    }
+    if summary.retryable_failures > 0 {
+        codes.push("retryable_failures_observed".to_string());
+    }
+    if summary.failed_cases > 0 {
+        codes.push("case_processing_failed".to_string());
+    }
+    if summary.upserted_commands > 0 || summary.deleted_commands > 0 {
+        codes.push("command_registry_mutated".to_string());
+    }
+    if summary.executed_runs > 0 {
+        codes.push("command_runs_recorded".to_string());
+    }
+    if codes.is_empty() {
+        codes.push("healthy_cycle".to_string());
+    }
+    codes
+}
+
+fn append_custom_command_cycle_report(
+    path: &Path,
+    summary: &CustomCommandRuntimeSummary,
+    health: &TransportHealthSnapshot,
+    health_reason: &str,
+    reason_codes: &[String],
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    let payload = CustomCommandRuntimeCycleReport {
+        timestamp_unix_ms: current_unix_timestamp_ms(),
+        health_state: health.classify().state.as_str().to_string(),
+        health_reason: health_reason.to_string(),
+        reason_codes: reason_codes.to_vec(),
+        discovered_cases: summary.discovered_cases,
+        queued_cases: summary.queued_cases,
+        applied_cases: summary.applied_cases,
+        duplicate_skips: summary.duplicate_skips,
+        malformed_cases: summary.malformed_cases,
+        retryable_failures: summary.retryable_failures,
+        retry_attempts: summary.retry_attempts,
+        failed_cases: summary.failed_cases,
+        upserted_commands: summary.upserted_commands,
+        deleted_commands: summary.deleted_commands,
+        executed_runs: summary.executed_runs,
+        backlog_cases: summary
+            .discovered_cases
+            .saturating_sub(summary.queued_cases),
+        failure_streak: health.failure_streak,
+    };
+    let line =
+        serde_json::to_string(&payload).context("serialize custom-command runtime report")?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+fn render_custom_command_snapshot(records: &[CustomCommandRecord], channel_id: &str) -> String {
+    let filtered = if channel_id == "registry" {
+        records.iter().collect::<Vec<_>>()
+    } else {
+        records
+            .iter()
+            .filter(|record| record.command_name == channel_id)
+            .collect::<Vec<_>>()
+    };
+
+    if filtered.is_empty() {
+        return format!("# Tau Custom Command Snapshot ({channel_id})\n\n- No registered commands");
+    }
+
+    let mut lines = vec![
+        format!("# Tau Custom Command Snapshot ({channel_id})"),
+        String::new(),
+    ];
+    for record in filtered {
+        lines.push(format!(
+            "- {} op={} status={} runs={} template={}",
+            record.command_name,
+            record.operation.to_ascii_lowercase(),
+            record.last_status_code,
+            record.run_count,
+            record.template
+        ));
+    }
+    lines.join("\n")
+}
+
+fn normalize_processed_case_keys(raw: &[String], cap: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for key in raw {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.insert(owned.clone()) {
+            normalized.push(owned);
+        }
+    }
+    if cap == 0 {
+        return Vec::new();
+    }
+    if normalized.len() > cap {
+        normalized.drain(0..normalized.len().saturating_sub(cap));
+    }
+    normalized
+}
+
+fn retry_delay_ms(base_delay_ms: u64, attempt: usize) -> u64 {
+    if base_delay_ms == 0 {
+        return 0;
+    }
+    let exponent = attempt.saturating_sub(1).min(10) as u32;
+    base_delay_ms.saturating_mul(1_u64 << exponent)
+}
+
+async fn apply_retry_delay(base_delay_ms: u64, attempt: usize) {
+    let delay_ms = retry_delay_ms(base_delay_ms, attempt);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    }
+}
+
+fn load_custom_command_runtime_state(path: &Path) -> Result<CustomCommandRuntimeState> {
+    if !path.exists() {
+        return Ok(CustomCommandRuntimeState::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed = match serde_json::from_str::<CustomCommandRuntimeState>(&raw) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "custom-command runner: failed to parse state file {} ({error}); starting fresh",
+                path.display()
+            );
+            return Ok(CustomCommandRuntimeState::default());
+        }
+    };
+    if parsed.schema_version != CUSTOM_COMMAND_RUNTIME_STATE_SCHEMA_VERSION {
+        eprintln!(
+            "custom-command runner: unsupported state schema {} in {}; starting fresh",
+            parsed.schema_version,
+            path.display()
+        );
+        return Ok(CustomCommandRuntimeState::default());
+    }
+    Ok(parsed)
+}
+
+fn save_custom_command_runtime_state(path: &Path, state: &CustomCommandRuntimeState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("serialize custom-command state")?;
+    write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::{
+        load_custom_command_runtime_state, retry_delay_ms, CustomCommandRuntime,
+        CustomCommandRuntimeConfig, CUSTOM_COMMAND_RUNTIME_EVENTS_LOG_FILE,
+    };
+    use crate::channel_store::ChannelStore;
+    use crate::custom_command_contract::{
+        load_custom_command_contract_fixture, parse_custom_command_contract_fixture,
+    };
+    use crate::transport_health::TransportHealthState;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("custom-command-contract")
+            .join(name)
+    }
+
+    fn build_config(root: &Path) -> CustomCommandRuntimeConfig {
+        CustomCommandRuntimeConfig {
+            fixture_path: fixture_path("mixed-outcomes.json"),
+            state_dir: root.join(".tau/custom-command"),
+            queue_limit: 64,
+            processed_case_cap: 10_000,
+            retry_max_attempts: 2,
+            retry_base_delay_ms: 0,
+        }
+    }
+
+    #[test]
+    fn unit_retry_delay_ms_scales_with_attempt_number() {
+        assert_eq!(retry_delay_ms(0, 1), 0);
+        assert_eq!(retry_delay_ms(10, 1), 10);
+        assert_eq!(retry_delay_ms(10, 2), 20);
+        assert_eq!(retry_delay_ms(10, 3), 40);
+    }
+
+    #[tokio::test]
+    async fn functional_runner_processes_fixture_and_persists_custom_command_snapshot() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture = load_custom_command_contract_fixture(&config.fixture_path)
+            .expect("fixture should load");
+        let mut runtime = CustomCommandRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 3);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.retryable_failures, 2);
+        assert_eq!(summary.retry_attempts, 1);
+        assert_eq!(summary.failed_cases, 1);
+        assert_eq!(summary.upserted_commands, 1);
+        assert_eq!(summary.deleted_commands, 0);
+        assert_eq!(summary.executed_runs, 0);
+        assert_eq!(summary.duplicate_skips, 0);
+
+        let state = load_custom_command_runtime_state(&config.state_dir.join("state.json"))
+            .expect("load state");
+        assert_eq!(state.commands.len(), 1);
+        assert_eq!(state.processed_case_keys.len(), 2);
+        assert_eq!(state.health.last_cycle_discovered, 3);
+        assert_eq!(state.health.last_cycle_failed, 1);
+        assert_eq!(state.health.failure_streak, 1);
+        assert_eq!(
+            state.health.classify().state,
+            TransportHealthState::Degraded
+        );
+
+        let events_log = std::fs::read_to_string(
+            config
+                .state_dir
+                .join(CUSTOM_COMMAND_RUNTIME_EVENTS_LOG_FILE),
+        )
+        .expect("read runtime events");
+        assert!(events_log.contains("retryable_failures_observed"));
+        assert!(events_log.contains("case_processing_failed"));
+
+        let store = ChannelStore::open(
+            &config.state_dir.join("channel-store"),
+            "custom-command",
+            "deploy_release",
+        )
+        .expect("open channel store");
+        let memory = store
+            .load_memory()
+            .expect("load memory")
+            .expect("memory should exist");
+        assert!(memory.contains("Tau Custom Command Snapshot (deploy_release)"));
+        assert!(memory.contains("deploy_release"));
+    }
+
+    #[tokio::test]
+    async fn integration_runner_respects_queue_limit_for_backpressure() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.queue_limit = 2;
+        let fixture = load_custom_command_contract_fixture(&config.fixture_path)
+            .expect("fixture should load");
+        let mut runtime = CustomCommandRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 2);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.failed_cases, 0);
+        assert_eq!(summary.retryable_failures, 0);
+
+        let state = load_custom_command_runtime_state(&config.state_dir.join("state.json"))
+            .expect("load state");
+        assert_eq!(state.commands.len(), 1);
+        assert_eq!(state.health.queue_depth, 1);
+        assert_eq!(state.health.classify().state, TransportHealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn integration_runner_skips_processed_cases_but_retries_unresolved_failures() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture = load_custom_command_contract_fixture(&config.fixture_path)
+            .expect("fixture should load");
+
+        let mut first_runtime = CustomCommandRuntime::new(config.clone()).expect("first runtime");
+        let first = first_runtime.run_once(&fixture).await.expect("first run");
+        assert_eq!(first.applied_cases, 1);
+        assert_eq!(first.malformed_cases, 1);
+        assert_eq!(first.failed_cases, 1);
+
+        let mut second_runtime = CustomCommandRuntime::new(config).expect("second runtime");
+        let second = second_runtime.run_once(&fixture).await.expect("second run");
+        assert_eq!(second.duplicate_skips, 2);
+        assert_eq!(second.applied_cases, 0);
+        assert_eq!(second.malformed_cases, 0);
+        assert_eq!(second.failed_cases, 1);
+    }
+
+    #[tokio::test]
+    async fn regression_runner_rejects_contract_drift_between_expected_and_runtime_result() {
+        let temp = tempdir().expect("tempdir");
+        let mut fixture =
+            load_custom_command_contract_fixture(&fixture_path("mixed-outcomes.json"))
+                .expect("fixture should load");
+        let success_case = fixture
+            .cases
+            .iter_mut()
+            .find(|case| case.case_id == "custom-command-create-success")
+            .expect("success case");
+        success_case.expected.response_body = json!({
+            "status":"accepted",
+            "operation":"create",
+            "command_name":"unexpected"
+        });
+        let fixture_path = temp.path().join("drift-fixture.json");
+        std::fs::write(
+            &fixture_path,
+            serde_json::to_string_pretty(&fixture).expect("serialize"),
+        )
+        .expect("write fixture");
+
+        let mut config = build_config(temp.path());
+        config.fixture_path = fixture_path;
+
+        let mut runtime = CustomCommandRuntime::new(config).expect("runtime");
+        let drift_fixture = load_custom_command_contract_fixture(&runtime.config.fixture_path)
+            .expect("fixture should load");
+        let error = runtime
+            .run_once(&drift_fixture)
+            .await
+            .expect_err("drift should fail");
+        assert!(error.to_string().contains("expected response_body"));
+    }
+
+    #[tokio::test]
+    async fn regression_runner_failure_streak_resets_after_successful_cycle() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.retry_max_attempts = 1;
+
+        let failing_fixture = parse_custom_command_contract_fixture(
+            r#"{
+  "schema_version": 1,
+  "name": "retry-only-failure",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-retry-only",
+      "operation": "run",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {"env":"staging"},
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "custom_command_backend_unavailable",
+        "response_body": {"status":"retryable","reason":"backend_unavailable"}
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("parse failing fixture");
+        let success_fixture = parse_custom_command_contract_fixture(
+            r#"{
+  "schema_version": 1,
+  "name": "single-success",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-create-only",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {"env":"staging"},
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status":"accepted",
+          "operation":"create",
+          "command_name":"deploy_release"
+        }
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("parse success fixture");
+
+        let mut runtime = CustomCommandRuntime::new(config.clone()).expect("runtime");
+        let failed = runtime
+            .run_once(&failing_fixture)
+            .await
+            .expect("failed cycle");
+        assert_eq!(failed.failed_cases, 1);
+        let state_after_fail =
+            load_custom_command_runtime_state(&config.state_dir.join("state.json"))
+                .expect("load state after fail");
+        assert_eq!(state_after_fail.health.failure_streak, 1);
+
+        let success = runtime
+            .run_once(&success_fixture)
+            .await
+            .expect("success cycle");
+        assert_eq!(success.failed_cases, 0);
+        assert_eq!(success.applied_cases, 1);
+        let state_after_success =
+            load_custom_command_runtime_state(&config.state_dir.join("state.json"))
+                .expect("load state after success");
+        assert_eq!(state_after_success.health.failure_streak, 0);
+        assert_eq!(
+            state_after_success.health.classify().state,
+            TransportHealthState::Healthy
+        );
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -14,6 +14,7 @@ mod codex_cli_client;
 mod commands;
 mod credentials;
 mod custom_command_contract;
+mod custom_command_runtime;
 mod dashboard_contract;
 mod dashboard_runtime;
 mod diagnostics_commands;
@@ -254,11 +255,11 @@ pub(crate) use crate::rpc_protocol::{
     execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
 };
 pub(crate) use crate::runtime_cli_validation::{
-    validate_dashboard_contract_runner_cli, validate_event_webhook_ingest_cli,
-    validate_events_runner_cli, validate_gateway_contract_runner_cli,
-    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
-    validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
-    validate_slack_bridge_cli,
+    validate_custom_command_contract_runner_cli, validate_dashboard_contract_runner_cli,
+    validate_event_webhook_ingest_cli, validate_events_runner_cli,
+    validate_gateway_contract_runner_cli, validate_github_issues_bridge_cli,
+    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
+    validate_multi_channel_contract_runner_cli, validate_slack_bridge_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -367,6 +368,7 @@ pub(crate) use crate::trust_roots::{
     apply_trust_root_mutation_specs, apply_trust_root_mutations, load_trust_root_records,
     parse_trust_rotation_spec, parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
 };
+use custom_command_runtime::{run_custom_command_contract_runner, CustomCommandRuntimeConfig};
 use dashboard_runtime::{run_dashboard_contract_runner, DashboardRuntimeConfig};
 use gateway_runtime::{run_gateway_contract_runner, GatewayRuntimeConfig};
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -343,6 +343,53 @@ pub(crate) fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.custom_command_contract_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--custom-command-contract-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--custom-command-contract-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.multi_channel_contract_runner
+        || cli.multi_agent_contract_runner
+        || cli.memory_contract_runner
+        || cli.dashboard_contract_runner
+        || cli.gateway_contract_runner
+    {
+        bail!("--custom-command-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-agent-contract-runner, --memory-contract-runner, --dashboard-contract-runner, or --gateway-contract-runner");
+    }
+    if cli.custom_command_queue_limit == 0 {
+        bail!("--custom-command-queue-limit must be greater than 0");
+    }
+    if cli.custom_command_processed_case_cap == 0 {
+        bail!("--custom-command-processed-case-cap must be greater than 0");
+    }
+    if cli.custom_command_retry_max_attempts == 0 {
+        bail!("--custom-command-retry-max-attempts must be greater than 0");
+    }
+    if !cli.custom_command_fixture.exists() {
+        bail!(
+            "--custom-command-fixture '{}' does not exist",
+            cli.custom_command_fixture.display()
+        );
+    }
+    if !cli.custom_command_fixture.is_file() {
+        bail!(
+            "--custom-command-fixture '{}' must point to a file",
+            cli.custom_command_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.event_webhook_ingest_file.is_none() {
         return Ok(());

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -16,6 +16,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_memory_contract_runner_cli(cli)?;
     validate_dashboard_contract_runner_cli(cli)?;
     validate_gateway_contract_runner_cli(cli)?;
+    validate_custom_command_contract_runner_cli(cli)?;
 
     if cli.github_issues_bridge {
         let repo_slug = cli.github_repo.clone().ok_or_else(|| {
@@ -201,6 +202,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_case_cap: 10_000,
             retry_max_attempts: 4,
             retry_base_delay_ms: 0,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.custom_command_contract_runner {
+        run_custom_command_contract_runner(CustomCommandRuntimeConfig {
+            fixture_path: cli.custom_command_fixture.clone(),
+            state_dir: cli.custom_command_state_dir.clone(),
+            queue_limit: cli.custom_command_queue_limit.max(1),
+            processed_case_cap: cli.custom_command_processed_case_cap.max(1),
+            retry_max_attempts: cli.custom_command_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.custom_command_retry_base_delay_ms,
         })
         .await?;
         return Ok(true);


### PR DESCRIPTION
## Summary
- implement `custom_command_runtime` with deterministic queueing, idempotent processed-case tracking, retry handling, and persisted state/events
- wire new runtime mode into startup transport dispatch via `--custom-command-contract-runner`
- add CLI flags for fixture/state/retry/backpressure knobs and add runtime CLI validation for conflicts and fixture checks
- extend test coverage for CLI parsing defaults/overrides and runtime validation paths, plus runtime unit/functional/integration/regression tests

## Risks and Compatibility
- adds a new transport-mode surface; existing modes are unchanged unless `--custom-command-contract-runner` is enabled
- introduces new state directory default `.tau/custom-command`; no migration needed for existing state files
- validation now rejects mixed custom-command mode with other transport runners to keep deterministic single-runner semantics

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent custom_command_runtime -- --test-threads=1`
- `cargo test --workspace -q -- --test-threads=1`
- `cargo run -p tau-coding-agent -- --custom-command-contract-runner --custom-command-state-dir <tmpdir> --custom-command-fixture crates/tau-coding-agent/testdata/custom-command-contract/mixed-outcomes.json`

Closes #784
