### PR TITLE
feat: add custom-command observability surfaces and ops runbook

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -151,6 +151,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "custom-command.sh",
             ],
         )
 
@@ -212,6 +213,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "custom-command.sh",
             ):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
@@ -279,10 +281,10 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=9 passed=9 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=10 passed=10 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-            self.assertGreaterEqual(len(rows), 26)
+            self.assertGreaterEqual(len(rows), 30)
 
     def test_functional_all_script_only_runs_selected_demo_wrappers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -331,11 +333,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=9 passed=9 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=10 passed=10 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 9, "passed": 9, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 10, "passed": 10, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -348,6 +350,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "memory.sh",
                     "dashboard.sh",
                     "gateway.sh",
+                    "custom-command.sh",
                 ],
             )
             for entry in payload["demos"]:
@@ -424,6 +427,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [7] memory.sh", completed.stdout)
             self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
             self.assertIn("[demo:all] [9] gateway.sh", completed.stdout)
+            self.assertIn("[demo:all] [10] custom-command.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -446,6 +450,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "custom-command.sh",
             ],
         )
 
@@ -592,8 +597,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 9)
-            self.assertEqual(payload["summary"]["failed"], 9)
+            self.assertEqual(payload["summary"]["total"], 10)
+            self.assertEqual(payload["summary"]["failed"], 10)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
+./scripts/demo/all.sh --only custom-command --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -82,6 +83,7 @@ Run deterministic local demos:
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/custom-command.sh
 ```
 
 `all.sh --json` and `--report-file` entries include `duration_ms` per wrapper.

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -738,6 +738,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         value_name = "transport/channel_id",
         help = "Inspect ChannelStore state for one channel and exit"
     )]
@@ -751,6 +752,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         value_name = "transport/channel_id",
         help = "Repair malformed ChannelStore JSONL files for one channel and exit"
     )]
@@ -764,8 +766,9 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway, custom-command"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -790,6 +793,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         help = "Inspect dashboard runtime status/guardrail report and exit"
     )]
     pub(crate) dashboard_status_inspect: bool,
@@ -815,6 +819,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         help = "Inspect multi-agent runtime status/guardrail report and exit"
     )]
     pub(crate) multi_agent_status_inspect: bool,
@@ -840,6 +845,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
         help = "Inspect gateway runtime status/guardrail report and exit"
     )]
     pub(crate) gateway_status_inspect: bool,
@@ -856,6 +862,32 @@ pub(crate) struct Cli {
         help = "Emit --gateway-status-inspect output as pretty JSON"
     )]
     pub(crate) gateway_status_json: bool,
+
+    #[arg(
+        long = "custom-command-status-inspect",
+        env = "TAU_CUSTOM_COMMAND_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        help = "Inspect no-code custom command runtime status/guardrail report and exit"
+    )]
+    pub(crate) custom_command_status_inspect: bool,
+
+    #[arg(
+        long = "custom-command-status-json",
+        env = "TAU_CUSTOM_COMMAND_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "custom_command_status_inspect",
+        help = "Emit --custom-command-status-inspect output as pretty JSON"
+    )]
+    pub(crate) custom_command_status_json: bool,
 
     #[arg(
         long = "extension-exec-manifest",

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -17,6 +17,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect
         || cli.gateway_status_inspect
+        || cli.custom_command_status_inspect
     {
         execute_channel_store_admin_command(cli)?;
         return Ok(true);

--- a/crates/tau-coding-agent/testdata/custom-command-contract/README.md
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/README.md
@@ -6,6 +6,7 @@ and lifecycle operations.
 ## Files
 
 - `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `rollout-pass.json`: all-success fixture for deterministic demo and rollout checks.
 - `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
 - `invalid-error-code.json`: regression fixture for unsupported `error_code`.
 

--- a/crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-rollout-pass",
+  "description": "All-success fixture used for deterministic rollout demos and observability checks.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-create-pass",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "operation": "create",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-update-pass",
+      "operation": "update",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}} --safe",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "update",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-run-pass",
+      "operation": "run",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "run",
+          "command_name": "deploy_release",
+          "arguments": {
+            "env": "staging"
+          }
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-list-pass",
+      "operation": "list",
+      "command_name": "",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "list",
+          "commands": [
+            "deploy_release",
+            "triage_alerts"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/guides/custom-command-ops.md
+++ b/docs/guides/custom-command-ops.md
@@ -1,0 +1,91 @@
+# Custom Command Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven no-code custom command runtime
+(`--custom-command-contract-runner`).
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --custom-command-state-dir .tau/custom-command \
+  --transport-health-inspect custom-command \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --custom-command-state-dir .tau/custom-command \
+  --custom-command-status-inspect \
+  --custom-command-status-json
+```
+
+Primary state files:
+
+- `.tau/custom-command/state.json`
+- `.tau/custom-command/runtime-events.jsonl`
+- `.tau/custom-command/channel-store/custom-command/<command_name or registry>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+- `command_registry_mutated`
+- `command_runs_recorded`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/custom-command.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate contract fixtures and compatibility:
+   `cargo test -p tau-coding-agent custom_command_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent custom_command_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/custom-command.sh`
+4. Verify transport health and status gate:
+   `--transport-health-inspect custom-command --transport-health-json`
+   `--custom-command-status-inspect --custom-command-status-json`
+5. Promote by increasing fixture complexity while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
+   `reason_code_counts`.
+
+## Rollback plan
+
+1. Stop invoking `--custom-command-contract-runner`.
+2. Preserve `.tau/custom-command/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and schema compatibility.
+- Symptom: repeated `retry_attempted` or `retryable_failures_observed`.
+  Action: confirm transient failure semantics and retry configuration.
+- Symptom: rollout hold with `command_registry_mutated` missing when expecting changes.
+  Action: confirm fixture operations include `create`, `update`, or `delete`.
+- Symptom: high duplicate counts.
+  Action: inspect processed-case keys and verify fixture case identifiers are unique.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -97,6 +97,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only multi-channel --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
+./scripts/demo/all.sh --only custom-command --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -107,6 +108,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/custom-command.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -255,6 +255,49 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/gateway-ops.md`.
 
+## No-code custom command contract runner
+
+Use this fixture-driven runtime mode to validate no-code command registry lifecycle behavior,
+retry outcomes, state persistence, and channel-store snapshots.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --custom-command-contract-runner \
+  --custom-command-fixture crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json \
+  --custom-command-state-dir .tau/custom-command \
+  --custom-command-queue-limit 64 \
+  --custom-command-processed-case-cap 10000 \
+  --custom-command-retry-max-attempts 4 \
+  --custom-command-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/custom-command/state.json`
+- `.tau/custom-command/runtime-events.jsonl`
+- `.tau/custom-command/channel-store/custom-command/<command_name or registry>/...`
+
+Inspect custom-command transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --custom-command-state-dir .tau/custom-command \
+  --transport-health-inspect custom-command \
+  --transport-health-json
+```
+
+Inspect custom-command rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --custom-command-state-dir .tau/custom-command \
+  --custom-command-status-inspect \
+  --custom-command-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/custom-command-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -22,6 +22,7 @@ demo_scripts=(
   "memory.sh"
   "dashboard.sh"
   "gateway.sh"
+  "custom-command.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -93,6 +94,10 @@ normalize_demo_name() {
       ;;
     gateway|gateway.sh)
       echo "gateway.sh"
+      return 0
+      ;;
+    custom-command|customcommand|custom-command.sh|customcommand.sh)
+      echo "custom-command.sh"
       return 0
       ;;
     *)
@@ -205,14 +210,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway/custom-command) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway,custom-command)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/custom-command.sh
+++ b/scripts/demo/custom-command.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "custom-command" "Run deterministic no-code custom command runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json"
+demo_state_dir=".tau/demo-custom-command"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "custom-command-runner" \
+  --custom-command-contract-runner \
+  --custom-command-fixture ./crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json \
+  --custom-command-state-dir "${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "transport-health-inspect-custom-command" \
+  --custom-command-state-dir "${demo_state_dir}" \
+  --transport-health-inspect custom-command \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "custom-command-status-inspect" \
+  --custom-command-state-dir "${demo_state_dir}" \
+  --custom-command-status-inspect \
+  --custom-command-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-custom-command-deploy-release" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect custom-command/deploy_release
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- add custom-command observability surfaces:
  - `--transport-health-inspect custom-command`
  - `--custom-command-status-inspect` and `--custom-command-status-json`
- extend channel-store admin status report parsing/rendering for custom-command runtime state and cycle events
- wire startup preflight support for custom-command status inspect mode
- add deterministic rollout fixture and demo wrapper (`scripts/demo/custom-command.sh`), and include it in `scripts/demo/all.sh`
- add custom-command operations runbook and update transport/quickstart/README demo documentation
- expand test coverage for CLI parsing, admin execution, status reporting, startup preflight, and demo-suite inventory/order

## Risks and Compatibility
- introduces new status/inspect CLI flags and one additional transport-health target; existing options remain backward-compatible
- demo inventory grows from 9 to 10 wrappers, so downstream consumers parsing demo summaries should expect the new wrapper
- no behavior change to existing runtime paths unless custom-command flags are used

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent channel_store_admin -- --test-threads=1`
- `cargo test -p tau-coding-agent custom_command_runtime -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/custom-command.sh --skip-build --repo-root . --binary ./target/debug/tau-coding-agent`
- `cargo test --workspace -q -- --test-threads=1`

Closes #785
