### PR TITLE
feat: add voice runtime contract runner integration

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -2088,6 +2088,67 @@ pub(crate) struct Cli {
     pub(crate) custom_command_retry_base_delay_ms: u64,
 
     #[arg(
+        long = "voice-contract-runner",
+        env = "TAU_VOICE_CONTRACT_RUNNER",
+        default_value_t = false,
+        help = "Run fixture-driven voice interaction and wake-word runtime contract scenarios"
+    )]
+    pub(crate) voice_contract_runner: bool,
+
+    #[arg(
+        long = "voice-fixture",
+        env = "TAU_VOICE_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/voice-contract/mixed-outcomes.json",
+        requires = "voice_contract_runner",
+        help = "Path to voice interaction and wake-word runtime contract fixture JSON"
+    )]
+    pub(crate) voice_fixture: PathBuf,
+
+    #[arg(
+        long = "voice-state-dir",
+        env = "TAU_VOICE_STATE_DIR",
+        default_value = ".tau/voice",
+        help = "Directory for voice runtime state and channel-store outputs"
+    )]
+    pub(crate) voice_state_dir: PathBuf,
+
+    #[arg(
+        long = "voice-queue-limit",
+        env = "TAU_VOICE_QUEUE_LIMIT",
+        default_value_t = 64,
+        requires = "voice_contract_runner",
+        help = "Maximum voice fixture cases processed per runtime cycle"
+    )]
+    pub(crate) voice_queue_limit: usize,
+
+    #[arg(
+        long = "voice-processed-case-cap",
+        env = "TAU_VOICE_PROCESSED_CASE_CAP",
+        default_value_t = 10_000,
+        requires = "voice_contract_runner",
+        help = "Maximum processed-case keys retained for voice duplicate suppression"
+    )]
+    pub(crate) voice_processed_case_cap: usize,
+
+    #[arg(
+        long = "voice-retry-max-attempts",
+        env = "TAU_VOICE_RETRY_MAX_ATTEMPTS",
+        default_value_t = 4,
+        requires = "voice_contract_runner",
+        help = "Maximum retry attempts for transient voice runtime failures"
+    )]
+    pub(crate) voice_retry_max_attempts: usize,
+
+    #[arg(
+        long = "voice-retry-base-delay-ms",
+        env = "TAU_VOICE_RETRY_BASE_DELAY_MS",
+        default_value_t = 0,
+        requires = "voice_contract_runner",
+        help = "Base backoff delay in milliseconds for voice runtime retries (0 disables delay)"
+    )]
+    pub(crate) voice_retry_base_delay_ms: u64,
+
+    #[arg(
         long = "github-issues-bridge",
         env = "TAU_GITHUB_ISSUES_BRIDGE",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -82,6 +82,7 @@ mod transport_conformance;
 mod transport_health;
 mod trust_roots;
 mod voice_contract;
+mod voice_runtime;
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -261,6 +262,7 @@ pub(crate) use crate::runtime_cli_validation::{
     validate_gateway_contract_runner_cli, validate_github_issues_bridge_cli,
     validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
     validate_multi_channel_contract_runner_cli, validate_slack_bridge_cli,
+    validate_voice_contract_runner_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -377,6 +379,7 @@ use memory_runtime::{run_memory_contract_runner, MemoryRuntimeConfig};
 use multi_agent_runtime::{run_multi_agent_contract_runner, MultiAgentRuntimeConfig};
 use multi_channel_runtime::{run_multi_channel_contract_runner, MultiChannelRuntimeConfig};
 use slack::{run_slack_bridge, SlackBridgeRuntimeConfig};
+use voice_runtime::{run_voice_contract_runner, VoiceRuntimeConfig};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -390,6 +390,54 @@ pub(crate) fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<(
     Ok(())
 }
 
+pub(crate) fn validate_voice_contract_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.voice_contract_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--voice-contract-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--voice-contract-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.multi_channel_contract_runner
+        || cli.multi_agent_contract_runner
+        || cli.memory_contract_runner
+        || cli.dashboard_contract_runner
+        || cli.gateway_contract_runner
+        || cli.custom_command_contract_runner
+    {
+        bail!("--voice-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-agent-contract-runner, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, or --custom-command-contract-runner");
+    }
+    if cli.voice_queue_limit == 0 {
+        bail!("--voice-queue-limit must be greater than 0");
+    }
+    if cli.voice_processed_case_cap == 0 {
+        bail!("--voice-processed-case-cap must be greater than 0");
+    }
+    if cli.voice_retry_max_attempts == 0 {
+        bail!("--voice-retry-max-attempts must be greater than 0");
+    }
+    if !cli.voice_fixture.exists() {
+        bail!(
+            "--voice-fixture '{}' does not exist",
+            cli.voice_fixture.display()
+        );
+    }
+    if !cli.voice_fixture.is_file() {
+        bail!(
+            "--voice-fixture '{}' must point to a file",
+            cli.voice_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.event_webhook_ingest_file.is_none() {
         return Ok(());

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -17,6 +17,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_dashboard_contract_runner_cli(cli)?;
     validate_gateway_contract_runner_cli(cli)?;
     validate_custom_command_contract_runner_cli(cli)?;
+    validate_voice_contract_runner_cli(cli)?;
 
     if cli.github_issues_bridge {
         let repo_slug = cli.github_repo.clone().ok_or_else(|| {
@@ -215,6 +216,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_case_cap: cli.custom_command_processed_case_cap.max(1),
             retry_max_attempts: cli.custom_command_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.custom_command_retry_base_delay_ms,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.voice_contract_runner {
+        run_voice_contract_runner(VoiceRuntimeConfig {
+            fixture_path: cli.voice_fixture.clone(),
+            state_dir: cli.voice_state_dir.clone(),
+            queue_limit: cli.voice_queue_limit.max(1),
+            processed_case_cap: cli.voice_processed_case_cap.max(1),
+            retry_max_attempts: cli.voice_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.voice_retry_base_delay_ms,
         })
         .await?;
         return Ok(true);

--- a/crates/tau-coding-agent/src/voice_runtime.rs
+++ b/crates/tau-coding-agent/src/voice_runtime.rs
@@ -1,0 +1,937 @@
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
+use crate::voice_contract::{
+    evaluate_voice_case, load_voice_contract_fixture, validate_voice_case_result_against_contract,
+    VoiceContractCase, VoiceContractFixture, VoiceReplayResult, VoiceReplayStep,
+};
+use crate::{current_unix_timestamp_ms, write_text_atomic, TransportHealthSnapshot};
+
+const VOICE_RUNTIME_STATE_SCHEMA_VERSION: u32 = 1;
+const VOICE_RUNTIME_EVENTS_LOG_FILE: &str = "runtime-events.jsonl";
+
+fn voice_runtime_state_schema_version() -> u32 {
+    VOICE_RUNTIME_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VoiceRuntimeConfig {
+    pub(crate) fixture_path: PathBuf,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) queue_limit: usize,
+    pub(crate) processed_case_cap: usize,
+    pub(crate) retry_max_attempts: usize,
+    pub(crate) retry_base_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct VoiceRuntimeSummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) queued_cases: usize,
+    pub(crate) applied_cases: usize,
+    pub(crate) duplicate_skips: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+    pub(crate) retry_attempts: usize,
+    pub(crate) failed_cases: usize,
+    pub(crate) wake_word_detections: usize,
+    pub(crate) handled_turns: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VoiceRuntimeCycleReport {
+    timestamp_unix_ms: u64,
+    health_state: String,
+    health_reason: String,
+    reason_codes: Vec<String>,
+    discovered_cases: usize,
+    queued_cases: usize,
+    applied_cases: usize,
+    duplicate_skips: usize,
+    malformed_cases: usize,
+    retryable_failures: usize,
+    retry_attempts: usize,
+    failed_cases: usize,
+    wake_word_detections: usize,
+    handled_turns: usize,
+    backlog_cases: usize,
+    failure_streak: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct VoiceInteractionRecord {
+    case_key: String,
+    case_id: String,
+    mode: String,
+    wake_word: String,
+    locale: String,
+    speaker_id: String,
+    utterance: String,
+    last_status_code: u16,
+    last_outcome: String,
+    run_count: u64,
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VoiceRuntimeState {
+    #[serde(default = "voice_runtime_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    processed_case_keys: Vec<String>,
+    #[serde(default)]
+    interactions: Vec<VoiceInteractionRecord>,
+    #[serde(default)]
+    health: TransportHealthSnapshot,
+}
+
+impl Default for VoiceRuntimeState {
+    fn default() -> Self {
+        Self {
+            schema_version: VOICE_RUNTIME_STATE_SCHEMA_VERSION,
+            processed_case_keys: Vec::new(),
+            interactions: Vec::new(),
+            health: TransportHealthSnapshot::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct VoiceMutationCounts {
+    wake_word_detections: usize,
+    handled_turns: usize,
+}
+
+pub(crate) async fn run_voice_contract_runner(config: VoiceRuntimeConfig) -> Result<()> {
+    let fixture = load_voice_contract_fixture(&config.fixture_path)?;
+    let mut runtime = VoiceRuntime::new(config)?;
+    let summary = runtime.run_once(&fixture).await?;
+    let health = runtime.transport_health().clone();
+    let classification = health.classify();
+
+    println!(
+        "voice runner summary: discovered={} queued={} applied={} duplicate_skips={} malformed={} retryable_failures={} retries={} failed={} wake_word_detections={} handled_turns={}",
+        summary.discovered_cases,
+        summary.queued_cases,
+        summary.applied_cases,
+        summary.duplicate_skips,
+        summary.malformed_cases,
+        summary.retryable_failures,
+        summary.retry_attempts,
+        summary.failed_cases,
+        summary.wake_word_detections,
+        summary.handled_turns
+    );
+    println!(
+        "voice runner health: state={} failure_streak={} queue_depth={} reason={}",
+        classification.state.as_str(),
+        health.failure_streak,
+        health.queue_depth,
+        classification.reason
+    );
+
+    Ok(())
+}
+
+struct VoiceRuntime {
+    config: VoiceRuntimeConfig,
+    state: VoiceRuntimeState,
+    processed_case_keys: HashSet<String>,
+}
+
+impl VoiceRuntime {
+    fn new(config: VoiceRuntimeConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)
+            .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+        let mut state = load_voice_runtime_state(&config.state_dir.join("state.json"))?;
+        state.processed_case_keys =
+            normalize_processed_case_keys(&state.processed_case_keys, config.processed_case_cap);
+        state
+            .interactions
+            .sort_by(|left, right| left.speaker_id.cmp(&right.speaker_id));
+        let processed_case_keys = state.processed_case_keys.iter().cloned().collect();
+        Ok(Self {
+            config,
+            state,
+            processed_case_keys,
+        })
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.config.state_dir.join("state.json")
+    }
+
+    fn transport_health(&self) -> &TransportHealthSnapshot {
+        &self.state.health
+    }
+
+    async fn run_once(&mut self, fixture: &VoiceContractFixture) -> Result<VoiceRuntimeSummary> {
+        let cycle_started = Instant::now();
+        let mut summary = VoiceRuntimeSummary {
+            discovered_cases: fixture.cases.len(),
+            ..VoiceRuntimeSummary::default()
+        };
+
+        let mut queued_cases = fixture.cases.clone();
+        queued_cases.truncate(self.config.queue_limit);
+        summary.queued_cases = queued_cases.len();
+
+        for case in queued_cases {
+            let case_key = case_runtime_key(&case);
+            if self.processed_case_keys.contains(&case_key) {
+                summary.duplicate_skips = summary.duplicate_skips.saturating_add(1);
+                continue;
+            }
+
+            let mut attempt = 1usize;
+            loop {
+                let result = evaluate_voice_case(&case);
+                validate_voice_case_result_against_contract(&case, &result)?;
+
+                match result.step {
+                    VoiceReplayStep::Success => {
+                        let mutation = self.persist_success_result(&case, &case_key, &result)?;
+                        summary.applied_cases = summary.applied_cases.saturating_add(1);
+                        summary.wake_word_detections = summary
+                            .wake_word_detections
+                            .saturating_add(mutation.wake_word_detections);
+                        summary.handled_turns =
+                            summary.handled_turns.saturating_add(mutation.handled_turns);
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    VoiceReplayStep::MalformedInput => {
+                        summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+                        self.persist_non_success_result(&case, &case_key, &result)?;
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    VoiceReplayStep::RetryableFailure => {
+                        summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+                        if attempt >= self.config.retry_max_attempts {
+                            summary.failed_cases = summary.failed_cases.saturating_add(1);
+                            self.persist_non_success_result(&case, &case_key, &result)?;
+                            break;
+                        }
+                        summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                        apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                        attempt = attempt.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        let cycle_duration_ms =
+            u64::try_from(cycle_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let health = build_transport_health_snapshot(
+            &summary,
+            cycle_duration_ms,
+            self.state.health.failure_streak,
+        );
+        let classification = health.classify();
+        let reason_codes = cycle_reason_codes(&summary);
+        self.state.health = health.clone();
+
+        save_voice_runtime_state(&self.state_path(), &self.state)?;
+        append_voice_cycle_report(
+            &self.config.state_dir.join(VOICE_RUNTIME_EVENTS_LOG_FILE),
+            &summary,
+            &health,
+            &classification.reason,
+            &reason_codes,
+        )?;
+
+        Ok(summary)
+    }
+
+    fn persist_success_result(
+        &mut self,
+        case: &VoiceContractCase,
+        case_key: &str,
+        result: &VoiceReplayResult,
+    ) -> Result<VoiceMutationCounts> {
+        let mode = case.mode.as_str().to_string();
+        let wake_word = case.wake_word.trim().to_ascii_lowercase();
+        let locale = case.locale.trim().to_string();
+        let speaker_id = normalized_speaker_id(case);
+        let timestamp_unix_ms = current_unix_timestamp_ms();
+        let utterance = result
+            .response_body
+            .get("utterance")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let run_count = self
+            .state
+            .interactions
+            .iter()
+            .find(|existing| existing.case_key == case_key)
+            .map_or(0, |existing| existing.run_count)
+            .saturating_add(1);
+
+        let record = VoiceInteractionRecord {
+            case_key: case_key.to_string(),
+            case_id: case.case_id.clone(),
+            mode: mode.clone(),
+            wake_word: wake_word.clone(),
+            locale: locale.clone(),
+            speaker_id: speaker_id.clone(),
+            utterance: utterance.clone(),
+            last_status_code: result.status_code,
+            last_outcome: "success".to_string(),
+            run_count,
+            updated_unix_ms: timestamp_unix_ms,
+        };
+
+        if let Some(existing) = self
+            .state
+            .interactions
+            .iter_mut()
+            .find(|existing| existing.case_key == case_key)
+        {
+            *existing = record;
+        } else {
+            self.state.interactions.push(record);
+        }
+        self.state
+            .interactions
+            .sort_by(|left, right| left.speaker_id.cmp(&right.speaker_id));
+
+        let mutation = if mode == "wake_word" {
+            VoiceMutationCounts {
+                wake_word_detections: 1,
+                handled_turns: 0,
+            }
+        } else {
+            VoiceMutationCounts {
+                wake_word_detections: 0,
+                handled_turns: 1,
+            }
+        };
+
+        if let Some(store) = self.scope_channel_store(case)? {
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-voice-runner".to_string(),
+                payload: json!({
+                    "outcome":"success",
+                    "case_id": case.case_id,
+                    "mode": mode,
+                    "speaker_id": speaker_id,
+                    "wake_word": wake_word,
+                    "locale": locale,
+                    "utterance": utterance,
+                    "status_code": result.status_code,
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "voice case {} applied mode={} speaker={} status={}",
+                    case.case_id,
+                    case.mode.as_str(),
+                    normalized_speaker_id(case),
+                    result.status_code
+                ),
+            })?;
+            store.write_memory(&render_voice_snapshot(
+                &self.state.interactions,
+                &channel_id_for_case(case),
+            ))?;
+        }
+        Ok(mutation)
+    }
+
+    fn persist_non_success_result(
+        &self,
+        case: &VoiceContractCase,
+        case_key: &str,
+        result: &VoiceReplayResult,
+    ) -> Result<()> {
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            let outcome = outcome_name(result.step);
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-voice-runner".to_string(),
+                payload: json!({
+                    "outcome": outcome,
+                    "case_id": case.case_id,
+                    "mode": case.mode.as_str(),
+                    "speaker_id": normalized_speaker_id(case),
+                    "wake_word": case.wake_word.trim().to_ascii_lowercase(),
+                    "status_code": result.status_code,
+                    "error_code": result.error_code.clone().unwrap_or_default(),
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "voice case {} outcome={} error_code={} status={}",
+                    case.case_id,
+                    outcome,
+                    result.error_code.clone().unwrap_or_default(),
+                    result.status_code
+                ),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn scope_channel_store(&self, case: &VoiceContractCase) -> Result<Option<ChannelStore>> {
+        let channel_id = channel_id_for_case(case);
+        let store = ChannelStore::open(
+            &self.config.state_dir.join("channel-store"),
+            "voice",
+            &channel_id,
+        )?;
+        Ok(Some(store))
+    }
+
+    fn record_processed_case(&mut self, case_key: &str) {
+        if self.processed_case_keys.contains(case_key) {
+            return;
+        }
+        self.state.processed_case_keys.push(case_key.to_string());
+        self.processed_case_keys.insert(case_key.to_string());
+        if self.state.processed_case_keys.len() > self.config.processed_case_cap {
+            let overflow = self
+                .state
+                .processed_case_keys
+                .len()
+                .saturating_sub(self.config.processed_case_cap);
+            let removed = self.state.processed_case_keys.drain(0..overflow);
+            for key in removed {
+                self.processed_case_keys.remove(&key);
+            }
+        }
+    }
+}
+
+fn normalized_speaker_id(case: &VoiceContractCase) -> String {
+    let speaker_id = case.speaker_id.trim();
+    if speaker_id.is_empty() {
+        return "voice".to_string();
+    }
+    if speaker_id
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '-' || character == '_')
+    {
+        return speaker_id.to_string();
+    }
+    "voice".to_string()
+}
+
+fn channel_id_for_case(case: &VoiceContractCase) -> String {
+    normalized_speaker_id(case)
+}
+
+fn case_runtime_key(case: &VoiceContractCase) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        case.mode.as_str(),
+        case.wake_word.trim().to_ascii_lowercase(),
+        normalized_speaker_id(case),
+        case.case_id.trim()
+    )
+}
+
+fn outcome_name(step: VoiceReplayStep) -> &'static str {
+    match step {
+        VoiceReplayStep::Success => "success",
+        VoiceReplayStep::MalformedInput => "malformed_input",
+        VoiceReplayStep::RetryableFailure => "retryable_failure",
+    }
+}
+
+fn build_transport_health_snapshot(
+    summary: &VoiceRuntimeSummary,
+    cycle_duration_ms: u64,
+    previous_failure_streak: usize,
+) -> TransportHealthSnapshot {
+    let backlog_cases = summary
+        .discovered_cases
+        .saturating_sub(summary.queued_cases);
+    let failure_streak = if summary.failed_cases > 0 {
+        previous_failure_streak.saturating_add(1)
+    } else {
+        0
+    };
+
+    TransportHealthSnapshot {
+        updated_unix_ms: current_unix_timestamp_ms(),
+        cycle_duration_ms,
+        queue_depth: backlog_cases,
+        active_runs: 0,
+        failure_streak,
+        last_cycle_discovered: summary.discovered_cases,
+        last_cycle_processed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases)
+            .saturating_add(summary.failed_cases)
+            .saturating_add(summary.duplicate_skips),
+        last_cycle_completed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases),
+        last_cycle_failed: summary.failed_cases,
+        last_cycle_duplicates: summary.duplicate_skips,
+    }
+}
+
+fn cycle_reason_codes(summary: &VoiceRuntimeSummary) -> Vec<String> {
+    let mut codes = Vec::new();
+    if summary.discovered_cases > summary.queued_cases {
+        codes.push("queue_backpressure_applied".to_string());
+    }
+    if summary.duplicate_skips > 0 {
+        codes.push("duplicate_cases_skipped".to_string());
+    }
+    if summary.malformed_cases > 0 {
+        codes.push("malformed_inputs_observed".to_string());
+    }
+    if summary.retry_attempts > 0 {
+        codes.push("retry_attempted".to_string());
+    }
+    if summary.retryable_failures > 0 {
+        codes.push("retryable_failures_observed".to_string());
+    }
+    if summary.failed_cases > 0 {
+        codes.push("case_processing_failed".to_string());
+    }
+    if summary.wake_word_detections > 0 {
+        codes.push("wake_word_detected".to_string());
+    }
+    if summary.handled_turns > 0 {
+        codes.push("turns_handled".to_string());
+    }
+    if codes.is_empty() {
+        codes.push("healthy_cycle".to_string());
+    }
+    codes
+}
+
+fn append_voice_cycle_report(
+    path: &Path,
+    summary: &VoiceRuntimeSummary,
+    health: &TransportHealthSnapshot,
+    health_reason: &str,
+    reason_codes: &[String],
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    let payload = VoiceRuntimeCycleReport {
+        timestamp_unix_ms: current_unix_timestamp_ms(),
+        health_state: health.classify().state.as_str().to_string(),
+        health_reason: health_reason.to_string(),
+        reason_codes: reason_codes.to_vec(),
+        discovered_cases: summary.discovered_cases,
+        queued_cases: summary.queued_cases,
+        applied_cases: summary.applied_cases,
+        duplicate_skips: summary.duplicate_skips,
+        malformed_cases: summary.malformed_cases,
+        retryable_failures: summary.retryable_failures,
+        retry_attempts: summary.retry_attempts,
+        failed_cases: summary.failed_cases,
+        wake_word_detections: summary.wake_word_detections,
+        handled_turns: summary.handled_turns,
+        backlog_cases: summary
+            .discovered_cases
+            .saturating_sub(summary.queued_cases),
+        failure_streak: health.failure_streak,
+    };
+    let line = serde_json::to_string(&payload).context("serialize voice runtime report")?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+fn render_voice_snapshot(records: &[VoiceInteractionRecord], channel_id: &str) -> String {
+    let filtered = if channel_id == "voice" {
+        records.iter().collect::<Vec<_>>()
+    } else {
+        records
+            .iter()
+            .filter(|record| record.speaker_id == channel_id)
+            .collect::<Vec<_>>()
+    };
+
+    if filtered.is_empty() {
+        return format!("# Tau Voice Snapshot ({channel_id})\n\n- No voice interactions");
+    }
+
+    let mut lines = vec![
+        format!("# Tau Voice Snapshot ({channel_id})"),
+        String::new(),
+    ];
+    for record in filtered {
+        lines.push(format!(
+            "- speaker={} mode={} wake_word={} status={} utterance={}",
+            record.speaker_id,
+            record.mode,
+            record.wake_word,
+            record.last_status_code,
+            if record.utterance.is_empty() {
+                "-".to_string()
+            } else {
+                record.utterance.clone()
+            }
+        ));
+    }
+    lines.join("\n")
+}
+
+fn normalize_processed_case_keys(raw: &[String], cap: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for key in raw {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.insert(owned.clone()) {
+            normalized.push(owned);
+        }
+    }
+    if cap == 0 {
+        return Vec::new();
+    }
+    if normalized.len() > cap {
+        normalized.drain(0..normalized.len().saturating_sub(cap));
+    }
+    normalized
+}
+
+fn retry_delay_ms(base_delay_ms: u64, attempt: usize) -> u64 {
+    if base_delay_ms == 0 {
+        return 0;
+    }
+    let exponent = attempt.saturating_sub(1).min(10) as u32;
+    base_delay_ms.saturating_mul(1_u64 << exponent)
+}
+
+async fn apply_retry_delay(base_delay_ms: u64, attempt: usize) {
+    let delay_ms = retry_delay_ms(base_delay_ms, attempt);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    }
+}
+
+fn load_voice_runtime_state(path: &Path) -> Result<VoiceRuntimeState> {
+    if !path.exists() {
+        return Ok(VoiceRuntimeState::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed = match serde_json::from_str::<VoiceRuntimeState>(&raw) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "voice runner: failed to parse state file {} ({error}); starting fresh",
+                path.display()
+            );
+            return Ok(VoiceRuntimeState::default());
+        }
+    };
+    if parsed.schema_version != VOICE_RUNTIME_STATE_SCHEMA_VERSION {
+        eprintln!(
+            "voice runner: unsupported state schema {} in {}; starting fresh",
+            parsed.schema_version,
+            path.display()
+        );
+        return Ok(VoiceRuntimeState::default());
+    }
+    Ok(parsed)
+}
+
+fn save_voice_runtime_state(path: &Path, state: &VoiceRuntimeState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("serialize voice state")?;
+    write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::{
+        load_voice_runtime_state, retry_delay_ms, VoiceRuntime, VoiceRuntimeConfig,
+        VOICE_RUNTIME_EVENTS_LOG_FILE,
+    };
+    use crate::channel_store::ChannelStore;
+    use crate::transport_health::TransportHealthState;
+    use crate::voice_contract::{load_voice_contract_fixture, parse_voice_contract_fixture};
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("voice-contract")
+            .join(name)
+    }
+
+    fn build_config(root: &Path) -> VoiceRuntimeConfig {
+        VoiceRuntimeConfig {
+            fixture_path: fixture_path("mixed-outcomes.json"),
+            state_dir: root.join(".tau/voice"),
+            queue_limit: 64,
+            processed_case_cap: 10_000,
+            retry_max_attempts: 2,
+            retry_base_delay_ms: 0,
+        }
+    }
+
+    #[test]
+    fn unit_retry_delay_ms_scales_with_attempt_number() {
+        assert_eq!(retry_delay_ms(0, 1), 0);
+        assert_eq!(retry_delay_ms(10, 1), 10);
+        assert_eq!(retry_delay_ms(10, 2), 20);
+        assert_eq!(retry_delay_ms(10, 3), 40);
+    }
+
+    #[tokio::test]
+    async fn functional_runner_processes_fixture_and_persists_voice_snapshot() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_voice_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = VoiceRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 3);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.retryable_failures, 2);
+        assert_eq!(summary.retry_attempts, 1);
+        assert_eq!(summary.failed_cases, 1);
+        assert_eq!(summary.wake_word_detections, 0);
+        assert_eq!(summary.handled_turns, 1);
+        assert_eq!(summary.duplicate_skips, 0);
+
+        let state =
+            load_voice_runtime_state(&config.state_dir.join("state.json")).expect("load state");
+        assert_eq!(state.interactions.len(), 1);
+        assert_eq!(state.processed_case_keys.len(), 2);
+        assert_eq!(state.health.last_cycle_discovered, 3);
+        assert_eq!(state.health.last_cycle_failed, 1);
+        assert_eq!(state.health.failure_streak, 1);
+        assert_eq!(
+            state.health.classify().state,
+            TransportHealthState::Degraded
+        );
+
+        let events_log =
+            std::fs::read_to_string(config.state_dir.join(VOICE_RUNTIME_EVENTS_LOG_FILE))
+                .expect("read runtime events");
+        assert!(events_log.contains("retryable_failures_observed"));
+        assert!(events_log.contains("case_processing_failed"));
+        assert!(events_log.contains("turns_handled"));
+
+        let store = ChannelStore::open(&config.state_dir.join("channel-store"), "voice", "ops-1")
+            .expect("open channel store");
+        let memory = store
+            .load_memory()
+            .expect("load memory")
+            .expect("memory should exist");
+        assert!(memory.contains("Tau Voice Snapshot (ops-1)"));
+        assert!(memory.contains("open dashboard"));
+    }
+
+    #[tokio::test]
+    async fn integration_runner_respects_queue_limit_for_backpressure() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.queue_limit = 2;
+        let fixture =
+            load_voice_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = VoiceRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 2);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.failed_cases, 0);
+        assert_eq!(summary.retryable_failures, 0);
+
+        let state =
+            load_voice_runtime_state(&config.state_dir.join("state.json")).expect("load state");
+        assert_eq!(state.interactions.len(), 1);
+        assert_eq!(state.health.queue_depth, 1);
+        assert_eq!(state.health.classify().state, TransportHealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn integration_runner_skips_processed_cases_but_retries_unresolved_failures() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_voice_contract_fixture(&config.fixture_path).expect("fixture should load");
+
+        let mut first_runtime = VoiceRuntime::new(config.clone()).expect("first runtime");
+        let first = first_runtime.run_once(&fixture).await.expect("first run");
+        assert_eq!(first.applied_cases, 1);
+        assert_eq!(first.malformed_cases, 1);
+        assert_eq!(first.failed_cases, 1);
+
+        let mut second_runtime = VoiceRuntime::new(config).expect("second runtime");
+        let second = second_runtime.run_once(&fixture).await.expect("second run");
+        assert_eq!(second.duplicate_skips, 2);
+        assert_eq!(second.applied_cases, 0);
+        assert_eq!(second.malformed_cases, 0);
+        assert_eq!(second.failed_cases, 1);
+    }
+
+    #[tokio::test]
+    async fn regression_runner_rejects_contract_drift_between_expected_and_runtime_result() {
+        let temp = tempdir().expect("tempdir");
+        let mut fixture = load_voice_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture should load");
+        let success_case = fixture
+            .cases
+            .iter_mut()
+            .find(|case| case.case_id == "voice-success-turn")
+            .expect("success case");
+        success_case.expected.response_body = json!({
+            "status":"accepted",
+            "mode":"turn",
+            "wake_word":"tau",
+            "utterance":"unexpected",
+            "locale":"en-US",
+            "speaker_id":"ops-1"
+        });
+
+        let fixture_path = temp.path().join("drift-fixture.json");
+        std::fs::write(
+            &fixture_path,
+            serde_json::to_string_pretty(&fixture).expect("serialize"),
+        )
+        .expect("write fixture");
+
+        let mut config = build_config(temp.path());
+        config.fixture_path = fixture_path;
+
+        let mut runtime = VoiceRuntime::new(config).expect("runtime");
+        let drift_fixture =
+            load_voice_contract_fixture(&runtime.config.fixture_path).expect("fixture should load");
+        let error = runtime
+            .run_once(&drift_fixture)
+            .await
+            .expect_err("drift should fail");
+        assert!(error.to_string().contains("expected response_body"));
+    }
+
+    #[tokio::test]
+    async fn regression_runner_failure_streak_resets_after_successful_cycle() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.retry_max_attempts = 1;
+
+        let failing_fixture = parse_voice_contract_fixture(
+            r#"{
+  "schema_version": 1,
+  "name": "retry-only-failure",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "voice-retry-only",
+      "mode": "turn",
+      "wake_word": "tau",
+      "transcript": "tau summarize exposure",
+      "locale": "en-US",
+      "speaker_id": "ops-r",
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "voice_backend_unavailable",
+        "response_body": {"status":"retryable","reason":"backend_unavailable"}
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("parse failing fixture");
+
+        let success_fixture = parse_voice_contract_fixture(
+            r#"{
+  "schema_version": 1,
+  "name": "single-success",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "voice-success-only",
+      "mode": "turn",
+      "wake_word": "tau",
+      "transcript": "tau open status board",
+      "locale": "en-US",
+      "speaker_id": "ops-r",
+      "expected": {
+        "outcome": "success",
+        "status_code": 202,
+        "response_body": {
+          "status":"accepted",
+          "mode":"turn",
+          "wake_word":"tau",
+          "utterance":"open status board",
+          "locale":"en-US",
+          "speaker_id":"ops-r"
+        }
+      }
+    }
+  ]
+}"#,
+        )
+        .expect("parse success fixture");
+
+        let mut runtime = VoiceRuntime::new(config.clone()).expect("runtime");
+        let failed = runtime
+            .run_once(&failing_fixture)
+            .await
+            .expect("failed cycle");
+        assert_eq!(failed.failed_cases, 1);
+        let state_after_fail = load_voice_runtime_state(&config.state_dir.join("state.json"))
+            .expect("load state after fail");
+        assert_eq!(state_after_fail.health.failure_streak, 1);
+
+        let success = runtime
+            .run_once(&success_fixture)
+            .await
+            .expect("success cycle");
+        assert_eq!(success.failed_cases, 0);
+        assert_eq!(success.applied_cases, 1);
+        let state_after_success = load_voice_runtime_state(&config.state_dir.join("state.json"))
+            .expect("load state after success");
+        assert_eq!(state_after_success.health.failure_streak, 0);
+        assert_eq!(
+            state_after_success.health.classify().state,
+            TransportHealthState::Healthy
+        );
+    }
+}


### PR DESCRIPTION
Closes #790

## Summary of behavior changes
- added `voice_runtime` with deterministic queue processing, retry/backoff behavior, duplicate suppression, persisted state, runtime cycle reports, and channel-store writes
- integrated startup dispatch path for `--voice-contract-runner` in transport mode startup routing
- added CLI flags for voice runtime contract execution (`--voice-contract-runner`, fixture/state/queue/retry controls)
- added strict runtime CLI validation for voice runner conflicts, limits, and fixture checks
- expanded tests across runtime execution paths and CLI parse/validation coverage

## Risks and compatibility notes
- this introduces a new optional runner path and does not change default interactive runtime behavior
- voice runner currently uses fixture-driven deterministic contract execution and local state under `.tau/voice`
- observability/admin status surfaces and docs/demo rollout are intentionally deferred to #791

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent voice_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent voice_contract_runner -- --test-threads=1`
- `cargo test --workspace -q -- --test-threads=1`
