### PR TITLE
feat: voice observability rollout surfaces (closes #791)

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -152,6 +152,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "dashboard.sh",
                 "gateway.sh",
                 "custom-command.sh",
+                "voice.sh",
             ],
         )
 
@@ -214,6 +215,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "dashboard.sh",
                 "gateway.sh",
                 "custom-command.sh",
+                "voice.sh",
             ):
                 completed = run_demo_script(script_name, binary_path, trace_path)
                 self.assertEqual(
@@ -281,7 +283,7 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=10 passed=10 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=11 passed=11 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 30)
@@ -333,11 +335,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=10 passed=10 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=11 passed=11 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 10, "passed": 10, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 11, "passed": 11, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -351,6 +353,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "dashboard.sh",
                     "gateway.sh",
                     "custom-command.sh",
+                    "voice.sh",
                 ],
             )
             for entry in payload["demos"]:
@@ -428,6 +431,7 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
             self.assertIn("[demo:all] [9] gateway.sh", completed.stdout)
             self.assertIn("[demo:all] [10] custom-command.sh", completed.stdout)
+            self.assertIn("[demo:all] [11] voice.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -451,6 +455,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "dashboard.sh",
                 "gateway.sh",
                 "custom-command.sh",
+                "voice.sh",
             ],
         )
 
@@ -597,8 +602,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 10)
-            self.assertEqual(payload["summary"]["failed"], 10)
+            self.assertEqual(payload["summary"]["total"], 11)
+            self.assertEqual(payload["summary"]["failed"], 11)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
 ./scripts/demo/all.sh --only custom-command --fail-fast
+./scripts/demo/all.sh --only voice --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -84,6 +85,7 @@ Run deterministic local demos:
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
 ./scripts/demo/custom-command.sh
+./scripts/demo/voice.sh
 ```
 
 `all.sh --json` and `--report-file` entries include `duration_ms` per wrapper.

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -739,6 +739,7 @@ pub(crate) struct Cli {
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         value_name = "transport/channel_id",
         help = "Inspect ChannelStore state for one channel and exit"
     )]
@@ -753,6 +754,7 @@ pub(crate) struct Cli {
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         value_name = "transport/channel_id",
         help = "Repair malformed ChannelStore JSONL files for one channel and exit"
     )]
@@ -767,8 +769,9 @@ pub(crate) struct Cli {
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway, custom-command"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway, custom-command, voice"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -794,6 +797,7 @@ pub(crate) struct Cli {
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         help = "Inspect dashboard runtime status/guardrail report and exit"
     )]
     pub(crate) dashboard_status_inspect: bool,
@@ -820,6 +824,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "gateway_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         help = "Inspect multi-agent runtime status/guardrail report and exit"
     )]
     pub(crate) multi_agent_status_inspect: bool,
@@ -846,6 +851,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
         help = "Inspect gateway runtime status/guardrail report and exit"
     )]
     pub(crate) gateway_status_inspect: bool,
@@ -872,6 +878,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "voice_status_inspect",
         help = "Inspect no-code custom command runtime status/guardrail report and exit"
     )]
     pub(crate) custom_command_status_inspect: bool,
@@ -888,6 +895,33 @@ pub(crate) struct Cli {
         help = "Emit --custom-command-status-inspect output as pretty JSON"
     )]
     pub(crate) custom_command_status_json: bool,
+
+    #[arg(
+        long = "voice-status-inspect",
+        env = "TAU_VOICE_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        help = "Inspect voice runtime status/guardrail report and exit"
+    )]
+    pub(crate) voice_status_inspect: bool,
+
+    #[arg(
+        long = "voice-status-json",
+        env = "TAU_VOICE_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "voice_status_inspect",
+        help = "Emit --voice-status-inspect output as pretty JSON"
+    )]
+    pub(crate) voice_status_json: bool,
 
     #[arg(
         long = "extension-exec-manifest",

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -18,6 +18,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.multi_agent_status_inspect
         || cli.gateway_status_inspect
         || cli.custom_command_status_inspect
+        || cli.voice_status_inspect
     {
         execute_channel_store_admin_command(cli)?;
         return Ok(true);

--- a/crates/tau-coding-agent/testdata/voice-contract/README.md
+++ b/crates/tau-coding-agent/testdata/voice-contract/README.md
@@ -6,6 +6,7 @@ wake-word pipeline.
 ## Files
 
 - `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
+- `rollout-pass.json`: all-success fixture for deterministic demo and rollout checks.
 - `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
 - `invalid-error-code.json`: regression fixture for unsupported `error_code`.
 

--- a/crates/tau-coding-agent/testdata/voice-contract/rollout-pass.json
+++ b/crates/tau-coding-agent/testdata/voice-contract/rollout-pass.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "name": "voice-rollout-pass",
+  "description": "Deterministic all-success fixture for voice observability rollout and demo validation.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "voice-wake-word-detected",
+      "mode": "wake_word",
+      "wake_word": "tau",
+      "transcript": "Tau are you online",
+      "locale": "en-US",
+      "speaker_id": "ops-1",
+      "expected": {
+        "outcome": "success",
+        "status_code": 202,
+        "response_body": {
+          "status": "accepted",
+          "mode": "wake_word",
+          "wake_word": "tau",
+          "wake_detected": true
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "voice-turn-open-dashboard",
+      "mode": "turn",
+      "wake_word": "tau",
+      "transcript": "tau open dashboard status",
+      "locale": "en-US",
+      "speaker_id": "ops-1",
+      "expected": {
+        "outcome": "success",
+        "status_code": 202,
+        "response_body": {
+          "status": "accepted",
+          "mode": "turn",
+          "wake_word": "tau",
+          "utterance": "open dashboard status",
+          "locale": "en-US",
+          "speaker_id": "ops-1"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "voice-turn-open-orders",
+      "mode": "turn",
+      "wake_word": "tau",
+      "transcript": "tau summarize open orders",
+      "locale": "en-US",
+      "speaker_id": "ops-2",
+      "expected": {
+        "outcome": "success",
+        "status_code": 202,
+        "response_body": {
+          "status": "accepted",
+          "mode": "turn",
+          "wake_word": "tau",
+          "utterance": "summarize open orders",
+          "locale": "en-US",
+          "speaker_id": "ops-2"
+        }
+      }
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This index maps Tau documentation by audience and task.
 | Audience | Start Here | Scope |
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
-| Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, RPC, ChannelStore admin |
+| Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |
 | Contributor to `tau-coding-agent` internals | [Code Map](tau-coding-agent/code-map.md) | Module ownership and architecture navigation |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -98,6 +98,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
 ./scripts/demo/all.sh --only custom-command --fail-fast
+./scripts/demo/all.sh --only voice --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
 ./scripts/demo/local.sh
 ./scripts/demo/rpc.sh
@@ -109,6 +110,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
 ./scripts/demo/custom-command.sh
+./scripts/demo/voice.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -298,6 +298,49 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/custom-command-ops.md`.
 
+## Voice interaction and wake-word contract runner
+
+Use this fixture-driven runtime mode to validate voice wake-word detection, turn handling,
+retry outcomes, state persistence, and channel-store snapshots.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --voice-contract-runner \
+  --voice-fixture crates/tau-coding-agent/testdata/voice-contract/rollout-pass.json \
+  --voice-state-dir .tau/voice \
+  --voice-queue-limit 64 \
+  --voice-processed-case-cap 10000 \
+  --voice-retry-max-attempts 4 \
+  --voice-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/voice/state.json`
+- `.tau/voice/runtime-events.jsonl`
+- `.tau/voice/channel-store/voice/<speaker_id>/...`
+
+Inspect voice transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice \
+  --transport-health-inspect voice \
+  --transport-health-json
+```
+
+Inspect voice rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice \
+  --voice-status-inspect \
+  --voice-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/voice-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/docs/guides/voice-ops.md
+++ b/docs/guides/voice-ops.md
@@ -1,0 +1,95 @@
+# Voice Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven voice runtime (`--voice-contract-runner`) for wake-word
+detection and turn handling.
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice \
+  --transport-health-inspect voice \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice \
+  --voice-status-inspect \
+  --voice-status-json
+```
+
+Primary state files:
+
+- `.tau/voice/state.json`
+- `.tau/voice/runtime-events.jsonl`
+- `.tau/voice/channel-store/voice/<speaker_id>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+- `wake_word_detected`
+- `turns_handled`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/voice.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent voice_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent voice_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/voice.sh`
+4. Verify health and status gate:
+   `--transport-health-inspect voice --transport-health-json`
+   `--voice-status-inspect --voice-status-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
+   `wake_word_detected`, and `turns_handled`.
+
+## Rollback plan
+
+1. Stop invoking `--voice-contract-runner`.
+2. Preserve `.tau/voice/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then validate fixture schema and expected payloads.
+- Symptom: health state `degraded` with `malformed_inputs_observed`.
+  Action: inspect transcript, wake-word, and locale fields for malformed fixture cases.
+- Symptom: health state `degraded` with `retry_attempted` or `retryable_failures_observed`.
+  Action: verify transient failure simulation and retry policy settings.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated failures.
+- Symptom: `rollout_gate=hold` with stale state.
+  Action: run deterministic demo and re-check `voice-status-inspect` freshness fields.
+- Symptom: non-zero `queue_depth`.
+  Action: reduce per-cycle fixture volume or increase `--voice-queue-limit`.

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -95,6 +95,8 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `memory_runtime.rs`: semantic-memory runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) fixture/schema contract.
 - `multi_channel_runtime.rs`: multi-channel runtime loop (queueing, retry, dedupe, channel-store writes).
+- `voice_contract.rs`: voice interaction + wake-word fixture/schema contract definitions and validators.
+- `voice_runtime.rs`: voice runtime loop (wake-word/turn replay, retries, dedupe, channel-store writes).
 - `runtime_cli_validation.rs`: validation for integration runtime flags.
 - `startup_transport_modes.rs`: transport mode dispatch entry.
 
@@ -128,6 +130,8 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) schema and fixture validation contract.
 - `multi_channel_runtime.rs`: fixture-driven runtime tests covering queueing, retries, and replay idempotency.
+- `voice_contract.rs`: voice fixture/schema compatibility and replay contract tests.
+- `voice_runtime.rs`: fixture-driven voice runtime tests covering queueing, retries, and replay idempotency.
 - `#[cfg(test)]` exports in `main.rs`: test-only visibility for parser/helpers.
 
 Prefer adding tests next to the module behavior being changed, plus regression coverage in `tests.rs` when behavior spans modules.

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -23,6 +23,7 @@ demo_scripts=(
   "dashboard.sh"
   "gateway.sh"
   "custom-command.sh"
+  "voice.sh"
 )
 
 declare -A selected_demo_lookup=()
@@ -98,6 +99,10 @@ normalize_demo_name() {
       ;;
     custom-command|customcommand|custom-command.sh|customcommand.sh)
       echo "custom-command.sh"
+      return 0
+      ;;
+    voice|voice.sh)
+      echo "voice.sh"
       return 0
       ;;
     *)
@@ -210,14 +215,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway/custom-command) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway/custom-command/voice) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway,custom-command)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway,custom-command,voice)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/voice.sh
+++ b/scripts/demo/voice.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "voice" "Run deterministic voice runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/voice-contract/rollout-pass.json"
+demo_state_dir=".tau/demo-voice"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "voice-runner" \
+  --voice-contract-runner \
+  --voice-fixture ./crates/tau-coding-agent/testdata/voice-contract/rollout-pass.json \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-queue-limit 64 \
+  --voice-processed-case-cap 10000 \
+  --voice-retry-max-attempts 4 \
+  --voice-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-voice" \
+  --voice-state-dir "${demo_state_dir}" \
+  --transport-health-inspect voice \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "voice-status-inspect" \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-status-inspect \
+  --voice-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-voice-ops-1" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect voice/ops-1
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- add voice health/status inspect surfaces in `tau-coding-agent` (`--transport-health-inspect voice`, `--voice-status-inspect`, `--voice-status-json`)
- add voice observability/reporting tests across parser, admin preflight, transport-health, and status-report paths
- add deterministic all-success rollout fixture and new `scripts/demo/voice.sh` wrapper
- wire voice into `scripts/demo/all.sh` inventory, ordering, aliases, and deterministic summary output
- add voice runbook and transport/quickstart/readme/code-map doc updates for rollout + rollback operations

## Risks and compatibility
- low runtime risk: changes are additive CLI/reporting and demo/docs only; no behavior changes to existing transport modes
- compatibility impact: `all.sh` demo inventory now includes `voice.sh` (totals/order updated accordingly)
- operator impact: new voice status command requires `state.json` presence, failing closed when missing

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent voice_ -- --test-threads=1`
- `cargo test -p tau-coding-agent transport_health_inspect -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_scripts.py"`
- `./scripts/demo/voice.sh --skip-build --repo-root /Users/n/RustroverProjects/rust_pi --binary /Users/n/RustroverProjects/rust_pi/target/debug/tau-coding-agent`
- `./scripts/demo/all.sh --skip-build --repo-root /Users/n/RustroverProjects/rust_pi --binary /Users/n/RustroverProjects/rust_pi/target/debug/tau-coding-agent --only voice --json`
- `cargo test --workspace -- --test-threads=1`

Closes #791
