### PR TITLE
feat: add deployment runtime execution path and integration (closes #796)

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -2061,6 +2061,67 @@ pub(crate) struct Cli {
     pub(crate) gateway_state_dir: PathBuf,
 
     #[arg(
+        long = "deployment-contract-runner",
+        env = "TAU_DEPLOYMENT_CONTRACT_RUNNER",
+        default_value_t = false,
+        help = "Run fixture-driven cloud deployment and WASM runtime contract scenarios"
+    )]
+    pub(crate) deployment_contract_runner: bool,
+
+    #[arg(
+        long = "deployment-fixture",
+        env = "TAU_DEPLOYMENT_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/deployment-contract/mixed-outcomes.json",
+        requires = "deployment_contract_runner",
+        help = "Path to cloud deployment + WASM runtime contract fixture JSON"
+    )]
+    pub(crate) deployment_fixture: PathBuf,
+
+    #[arg(
+        long = "deployment-state-dir",
+        env = "TAU_DEPLOYMENT_STATE_DIR",
+        default_value = ".tau/deployment",
+        help = "Directory for deployment runtime state and channel-store outputs"
+    )]
+    pub(crate) deployment_state_dir: PathBuf,
+
+    #[arg(
+        long = "deployment-queue-limit",
+        env = "TAU_DEPLOYMENT_QUEUE_LIMIT",
+        default_value_t = 64,
+        requires = "deployment_contract_runner",
+        help = "Maximum deployment fixture cases processed per runtime cycle"
+    )]
+    pub(crate) deployment_queue_limit: usize,
+
+    #[arg(
+        long = "deployment-processed-case-cap",
+        env = "TAU_DEPLOYMENT_PROCESSED_CASE_CAP",
+        default_value_t = 10_000,
+        requires = "deployment_contract_runner",
+        help = "Maximum processed-case keys retained for deployment duplicate suppression"
+    )]
+    pub(crate) deployment_processed_case_cap: usize,
+
+    #[arg(
+        long = "deployment-retry-max-attempts",
+        env = "TAU_DEPLOYMENT_RETRY_MAX_ATTEMPTS",
+        default_value_t = 4,
+        requires = "deployment_contract_runner",
+        help = "Maximum retry attempts for transient deployment runtime failures"
+    )]
+    pub(crate) deployment_retry_max_attempts: usize,
+
+    #[arg(
+        long = "deployment-retry-base-delay-ms",
+        env = "TAU_DEPLOYMENT_RETRY_BASE_DELAY_MS",
+        default_value_t = 0,
+        requires = "deployment_contract_runner",
+        help = "Base backoff delay in milliseconds for deployment runtime retries (0 disables delay)"
+    )]
+    pub(crate) deployment_retry_base_delay_ms: u64,
+
+    #[arg(
         long = "custom-command-contract-runner",
         env = "TAU_CUSTOM_COMMAND_CONTRACT_RUNNER",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/deployment_runtime.rs
+++ b/crates/tau-coding-agent/src/deployment_runtime.rs
@@ -1,0 +1,972 @@
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
+use crate::deployment_contract::{
+    evaluate_deployment_case, load_deployment_contract_fixture,
+    validate_deployment_case_result_against_contract, DeploymentContractCase,
+    DeploymentContractFixture, DeploymentReplayResult, DeploymentReplayStep,
+};
+use crate::{current_unix_timestamp_ms, write_text_atomic, TransportHealthSnapshot};
+
+const DEPLOYMENT_RUNTIME_STATE_SCHEMA_VERSION: u32 = 1;
+const DEPLOYMENT_RUNTIME_EVENTS_LOG_FILE: &str = "runtime-events.jsonl";
+
+fn deployment_runtime_state_schema_version() -> u32 {
+    DEPLOYMENT_RUNTIME_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DeploymentRuntimeConfig {
+    pub(crate) fixture_path: PathBuf,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) queue_limit: usize,
+    pub(crate) processed_case_cap: usize,
+    pub(crate) retry_max_attempts: usize,
+    pub(crate) retry_base_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DeploymentRuntimeSummary {
+    pub(crate) discovered_cases: usize,
+    pub(crate) queued_cases: usize,
+    pub(crate) applied_cases: usize,
+    pub(crate) duplicate_skips: usize,
+    pub(crate) malformed_cases: usize,
+    pub(crate) retryable_failures: usize,
+    pub(crate) retry_attempts: usize,
+    pub(crate) failed_cases: usize,
+    pub(crate) upserted_rollouts: usize,
+    pub(crate) wasm_rollouts: usize,
+    pub(crate) cloud_rollouts: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeploymentRuntimeCycleReport {
+    timestamp_unix_ms: u64,
+    health_state: String,
+    health_reason: String,
+    reason_codes: Vec<String>,
+    discovered_cases: usize,
+    queued_cases: usize,
+    applied_cases: usize,
+    duplicate_skips: usize,
+    malformed_cases: usize,
+    retryable_failures: usize,
+    retry_attempts: usize,
+    failed_cases: usize,
+    upserted_rollouts: usize,
+    wasm_rollouts: usize,
+    cloud_rollouts: usize,
+    backlog_cases: usize,
+    failure_streak: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct DeploymentPlanRecord {
+    case_key: String,
+    case_id: String,
+    deploy_target: String,
+    runtime_profile: String,
+    blueprint_id: String,
+    environment: String,
+    region: String,
+    artifact: String,
+    replicas: u16,
+    rollout_strategy: String,
+    status_code: u16,
+    outcome: String,
+    error_code: String,
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DeploymentRuntimeState {
+    #[serde(default = "deployment_runtime_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    processed_case_keys: Vec<String>,
+    #[serde(default)]
+    rollouts: Vec<DeploymentPlanRecord>,
+    #[serde(default)]
+    health: TransportHealthSnapshot,
+}
+
+impl Default for DeploymentRuntimeState {
+    fn default() -> Self {
+        Self {
+            schema_version: DEPLOYMENT_RUNTIME_STATE_SCHEMA_VERSION,
+            processed_case_keys: Vec::new(),
+            rollouts: Vec::new(),
+            health: TransportHealthSnapshot::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct DeploymentMutationCounts {
+    upserted_rollouts: usize,
+    wasm_rollouts: usize,
+    cloud_rollouts: usize,
+}
+
+pub(crate) async fn run_deployment_contract_runner(config: DeploymentRuntimeConfig) -> Result<()> {
+    let fixture = load_deployment_contract_fixture(&config.fixture_path)?;
+    let mut runtime = DeploymentRuntime::new(config)?;
+    let summary = runtime.run_once(&fixture).await?;
+    let health = runtime.transport_health().clone();
+    let classification = health.classify();
+
+    println!(
+        "deployment runner summary: discovered={} queued={} applied={} duplicate_skips={} malformed={} retryable_failures={} retries={} failed={} upserted_rollouts={} wasm_rollouts={} cloud_rollouts={}",
+        summary.discovered_cases,
+        summary.queued_cases,
+        summary.applied_cases,
+        summary.duplicate_skips,
+        summary.malformed_cases,
+        summary.retryable_failures,
+        summary.retry_attempts,
+        summary.failed_cases,
+        summary.upserted_rollouts,
+        summary.wasm_rollouts,
+        summary.cloud_rollouts
+    );
+    println!(
+        "deployment runner health: state={} failure_streak={} queue_depth={} reason={}",
+        classification.state.as_str(),
+        health.failure_streak,
+        health.queue_depth,
+        classification.reason
+    );
+
+    Ok(())
+}
+
+struct DeploymentRuntime {
+    config: DeploymentRuntimeConfig,
+    state: DeploymentRuntimeState,
+    processed_case_keys: HashSet<String>,
+}
+
+impl DeploymentRuntime {
+    fn new(config: DeploymentRuntimeConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)
+            .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+        let mut state = load_deployment_runtime_state(&config.state_dir.join("state.json"))?;
+        state.processed_case_keys =
+            normalize_processed_case_keys(&state.processed_case_keys, config.processed_case_cap);
+        state
+            .rollouts
+            .sort_by(|left, right| left.case_key.cmp(&right.case_key));
+
+        let processed_case_keys = state.processed_case_keys.iter().cloned().collect();
+        Ok(Self {
+            config,
+            state,
+            processed_case_keys,
+        })
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.config.state_dir.join("state.json")
+    }
+
+    fn transport_health(&self) -> &TransportHealthSnapshot {
+        &self.state.health
+    }
+
+    async fn run_once(
+        &mut self,
+        fixture: &DeploymentContractFixture,
+    ) -> Result<DeploymentRuntimeSummary> {
+        let cycle_started = Instant::now();
+        let mut summary = DeploymentRuntimeSummary {
+            discovered_cases: fixture.cases.len(),
+            ..DeploymentRuntimeSummary::default()
+        };
+
+        let mut queued_cases = fixture.cases.clone();
+        queued_cases.sort_by(|left, right| {
+            left.case_id
+                .cmp(&right.case_id)
+                .then_with(|| left.blueprint_id.cmp(&right.blueprint_id))
+                .then_with(|| left.deploy_target.cmp(&right.deploy_target))
+        });
+        queued_cases.truncate(self.config.queue_limit);
+        summary.queued_cases = queued_cases.len();
+
+        for case in queued_cases {
+            let case_key = case_runtime_key(&case);
+            if self.processed_case_keys.contains(&case_key) {
+                summary.duplicate_skips = summary.duplicate_skips.saturating_add(1);
+                continue;
+            }
+
+            let mut attempt = 1usize;
+            loop {
+                let result = evaluate_deployment_case(&case);
+                validate_deployment_case_result_against_contract(&case, &result)?;
+                match result.step {
+                    DeploymentReplayStep::Success => {
+                        let mutation = self.persist_success_result(&case, &case_key, &result)?;
+                        summary.applied_cases = summary.applied_cases.saturating_add(1);
+                        summary.upserted_rollouts = summary
+                            .upserted_rollouts
+                            .saturating_add(mutation.upserted_rollouts);
+                        summary.wasm_rollouts =
+                            summary.wasm_rollouts.saturating_add(mutation.wasm_rollouts);
+                        summary.cloud_rollouts = summary
+                            .cloud_rollouts
+                            .saturating_add(mutation.cloud_rollouts);
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    DeploymentReplayStep::MalformedInput => {
+                        summary.malformed_cases = summary.malformed_cases.saturating_add(1);
+                        self.persist_non_success_result(&case, &case_key, &result)?;
+                        self.record_processed_case(&case_key);
+                        break;
+                    }
+                    DeploymentReplayStep::RetryableFailure => {
+                        summary.retryable_failures = summary.retryable_failures.saturating_add(1);
+                        if attempt >= self.config.retry_max_attempts {
+                            summary.failed_cases = summary.failed_cases.saturating_add(1);
+                            self.persist_non_success_result(&case, &case_key, &result)?;
+                            break;
+                        }
+                        summary.retry_attempts = summary.retry_attempts.saturating_add(1);
+                        apply_retry_delay(self.config.retry_base_delay_ms, attempt).await;
+                        attempt = attempt.saturating_add(1);
+                    }
+                }
+            }
+        }
+
+        let cycle_duration_ms =
+            u64::try_from(cycle_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let health = build_transport_health_snapshot(
+            &summary,
+            cycle_duration_ms,
+            self.state.health.failure_streak,
+        );
+        let classification = health.classify();
+        let reason_codes = cycle_reason_codes(&summary);
+        self.state.health = health.clone();
+
+        save_deployment_runtime_state(&self.state_path(), &self.state)?;
+        append_deployment_cycle_report(
+            &self
+                .config
+                .state_dir
+                .join(DEPLOYMENT_RUNTIME_EVENTS_LOG_FILE),
+            &summary,
+            &health,
+            &classification.reason,
+            &reason_codes,
+        )?;
+
+        Ok(summary)
+    }
+
+    fn persist_success_result(
+        &mut self,
+        case: &DeploymentContractCase,
+        case_key: &str,
+        result: &DeploymentReplayResult,
+    ) -> Result<DeploymentMutationCounts> {
+        let deploy_target = case.deploy_target.trim().to_ascii_lowercase();
+        let runtime_profile = case.runtime_profile.trim().to_ascii_lowercase();
+        let blueprint_id = case.blueprint_id.trim().to_string();
+        let environment = case.environment.trim().to_ascii_lowercase();
+        let region = case.region.trim().to_string();
+        let artifact = result
+            .response_body
+            .get("artifact")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let rollout_strategy = result
+            .response_body
+            .get("rollout_strategy")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let record = DeploymentPlanRecord {
+            case_key: case_key.to_string(),
+            case_id: case.case_id.clone(),
+            deploy_target: deploy_target.clone(),
+            runtime_profile: runtime_profile.clone(),
+            blueprint_id: blueprint_id.clone(),
+            environment,
+            region,
+            artifact: artifact.clone(),
+            replicas: case.replicas,
+            rollout_strategy: rollout_strategy.clone(),
+            status_code: result.status_code,
+            outcome: outcome_name(result.step).to_string(),
+            error_code: String::new(),
+            updated_unix_ms: current_unix_timestamp_ms(),
+        };
+
+        if let Some(existing) = self
+            .state
+            .rollouts
+            .iter_mut()
+            .find(|existing| existing.case_key == record.case_key)
+        {
+            *existing = record;
+        } else {
+            self.state.rollouts.push(record);
+        }
+        self.state
+            .rollouts
+            .sort_by(|left, right| left.case_key.cmp(&right.case_key));
+
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-deployment-runner".to_string(),
+                payload: json!({
+                    "outcome": "success",
+                    "case_id": case.case_id,
+                    "deploy_target": deploy_target,
+                    "runtime_profile": runtime_profile,
+                    "blueprint_id": blueprint_id,
+                    "status_code": result.status_code,
+                    "artifact": artifact,
+                    "rollout_strategy": rollout_strategy,
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "deployment case {} applied target={} runtime={} status={}",
+                    case.case_id, case.deploy_target, case.runtime_profile, result.status_code
+                ),
+            })?;
+            store.write_memory(&render_deployment_snapshot(
+                &self.state.rollouts,
+                case.blueprint_id.trim(),
+            ))?;
+        }
+
+        Ok(DeploymentMutationCounts {
+            upserted_rollouts: 1,
+            wasm_rollouts: usize::from(deploy_target == "wasm"),
+            cloud_rollouts: usize::from(deploy_target != "wasm"),
+        })
+    }
+
+    fn persist_non_success_result(
+        &self,
+        case: &DeploymentContractCase,
+        case_key: &str,
+        result: &DeploymentReplayResult,
+    ) -> Result<()> {
+        if let Some(store) = self.scope_channel_store(case)? {
+            let timestamp_unix_ms = current_unix_timestamp_ms();
+            let outcome = outcome_name(result.step);
+            store.append_log_entry(&ChannelLogEntry {
+                timestamp_unix_ms,
+                direction: "system".to_string(),
+                event_key: Some(case_key.to_string()),
+                source: "tau-deployment-runner".to_string(),
+                payload: json!({
+                    "outcome": outcome,
+                    "case_id": case.case_id,
+                    "deploy_target": case.deploy_target.trim().to_ascii_lowercase(),
+                    "runtime_profile": case.runtime_profile.trim().to_ascii_lowercase(),
+                    "blueprint_id": case.blueprint_id.trim(),
+                    "status_code": result.status_code,
+                    "error_code": result.error_code.clone().unwrap_or_default(),
+                }),
+            })?;
+            store.append_context_entry(&ChannelContextEntry {
+                timestamp_unix_ms,
+                role: "system".to_string(),
+                text: format!(
+                    "deployment case {} outcome={} error_code={} status={}",
+                    case.case_id,
+                    outcome,
+                    result.error_code.clone().unwrap_or_default(),
+                    result.status_code
+                ),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn scope_channel_store(&self, case: &DeploymentContractCase) -> Result<Option<ChannelStore>> {
+        let channel_id = channel_id_for_case(case);
+        if channel_id.is_empty() {
+            return Ok(None);
+        }
+        let store = ChannelStore::open(
+            &self.config.state_dir.join("channel-store"),
+            "deployment",
+            &channel_id,
+        )?;
+        Ok(Some(store))
+    }
+
+    fn record_processed_case(&mut self, case_key: &str) {
+        if self.processed_case_keys.contains(case_key) {
+            return;
+        }
+        self.state.processed_case_keys.push(case_key.to_string());
+        self.processed_case_keys.insert(case_key.to_string());
+        if self.state.processed_case_keys.len() > self.config.processed_case_cap {
+            let overflow = self
+                .state
+                .processed_case_keys
+                .len()
+                .saturating_sub(self.config.processed_case_cap);
+            let removed = self.state.processed_case_keys.drain(0..overflow);
+            for key in removed {
+                self.processed_case_keys.remove(&key);
+            }
+        }
+    }
+}
+
+fn normalized_blueprint_channel_id(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "deployment".to_string();
+    }
+    if trimmed
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '-' || character == '_')
+    {
+        return trimmed.to_string();
+    }
+    "deployment".to_string()
+}
+
+fn channel_id_for_case(case: &DeploymentContractCase) -> String {
+    normalized_blueprint_channel_id(&case.blueprint_id)
+}
+
+fn case_runtime_key(case: &DeploymentContractCase) -> String {
+    format!(
+        "{}:{}:{}:{}:{}",
+        case.deploy_target.trim().to_ascii_lowercase(),
+        case.runtime_profile.trim().to_ascii_lowercase(),
+        case.environment.trim().to_ascii_lowercase(),
+        case.blueprint_id.trim().to_ascii_lowercase(),
+        case.case_id.trim()
+    )
+}
+
+fn outcome_name(step: DeploymentReplayStep) -> &'static str {
+    match step {
+        DeploymentReplayStep::Success => "success",
+        DeploymentReplayStep::MalformedInput => "malformed_input",
+        DeploymentReplayStep::RetryableFailure => "retryable_failure",
+    }
+}
+
+fn build_transport_health_snapshot(
+    summary: &DeploymentRuntimeSummary,
+    cycle_duration_ms: u64,
+    previous_failure_streak: usize,
+) -> TransportHealthSnapshot {
+    let backlog_cases = summary
+        .discovered_cases
+        .saturating_sub(summary.queued_cases);
+    let failure_streak = if summary.failed_cases > 0 {
+        previous_failure_streak.saturating_add(1)
+    } else {
+        0
+    };
+    TransportHealthSnapshot {
+        updated_unix_ms: current_unix_timestamp_ms(),
+        cycle_duration_ms,
+        queue_depth: backlog_cases,
+        active_runs: 0,
+        failure_streak,
+        last_cycle_discovered: summary.discovered_cases,
+        last_cycle_processed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases)
+            .saturating_add(summary.failed_cases)
+            .saturating_add(summary.duplicate_skips),
+        last_cycle_completed: summary
+            .applied_cases
+            .saturating_add(summary.malformed_cases),
+        last_cycle_failed: summary.failed_cases,
+        last_cycle_duplicates: summary.duplicate_skips,
+    }
+}
+
+fn cycle_reason_codes(summary: &DeploymentRuntimeSummary) -> Vec<String> {
+    let mut codes = Vec::new();
+    if summary.discovered_cases > summary.queued_cases {
+        codes.push("queue_backpressure_applied".to_string());
+    }
+    if summary.duplicate_skips > 0 {
+        codes.push("duplicate_cases_skipped".to_string());
+    }
+    if summary.malformed_cases > 0 {
+        codes.push("malformed_inputs_observed".to_string());
+    }
+    if summary.retry_attempts > 0 {
+        codes.push("retry_attempted".to_string());
+    }
+    if summary.retryable_failures > 0 {
+        codes.push("retryable_failures_observed".to_string());
+    }
+    if summary.failed_cases > 0 {
+        codes.push("case_processing_failed".to_string());
+    }
+    if summary.wasm_rollouts > 0 {
+        codes.push("wasm_rollout_applied".to_string());
+    }
+    if summary.cloud_rollouts > 0 {
+        codes.push("cloud_rollout_applied".to_string());
+    }
+    if codes.is_empty() {
+        codes.push("healthy_cycle".to_string());
+    }
+    codes
+}
+
+fn append_deployment_cycle_report(
+    path: &Path,
+    summary: &DeploymentRuntimeSummary,
+    health: &TransportHealthSnapshot,
+    health_reason: &str,
+    reason_codes: &[String],
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    let payload = DeploymentRuntimeCycleReport {
+        timestamp_unix_ms: current_unix_timestamp_ms(),
+        health_state: health.classify().state.as_str().to_string(),
+        health_reason: health_reason.to_string(),
+        reason_codes: reason_codes.to_vec(),
+        discovered_cases: summary.discovered_cases,
+        queued_cases: summary.queued_cases,
+        applied_cases: summary.applied_cases,
+        duplicate_skips: summary.duplicate_skips,
+        malformed_cases: summary.malformed_cases,
+        retryable_failures: summary.retryable_failures,
+        retry_attempts: summary.retry_attempts,
+        failed_cases: summary.failed_cases,
+        upserted_rollouts: summary.upserted_rollouts,
+        wasm_rollouts: summary.wasm_rollouts,
+        cloud_rollouts: summary.cloud_rollouts,
+        backlog_cases: summary
+            .discovered_cases
+            .saturating_sub(summary.queued_cases),
+        failure_streak: health.failure_streak,
+    };
+    let line = serde_json::to_string(&payload).context("serialize deployment runtime report")?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+fn render_deployment_snapshot(records: &[DeploymentPlanRecord], blueprint_id: &str) -> String {
+    let filtered = records
+        .iter()
+        .filter(|record| record.blueprint_id == blueprint_id)
+        .collect::<Vec<_>>();
+    if filtered.is_empty() {
+        return format!("# Tau Deployment Snapshot ({blueprint_id})\n\n- No persisted rollouts");
+    }
+
+    let mut lines = vec![
+        format!("# Tau Deployment Snapshot ({blueprint_id})"),
+        String::new(),
+    ];
+    for record in filtered {
+        lines.push(format!(
+            "- {} target={} runtime={} artifact={} replicas={} status={} outcome={}",
+            record.case_id,
+            record.deploy_target,
+            record.runtime_profile,
+            record.artifact,
+            record.replicas,
+            record.status_code,
+            record.outcome
+        ));
+    }
+    lines.join("\n")
+}
+
+fn normalize_processed_case_keys(raw: &[String], cap: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for key in raw {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.insert(owned.clone()) {
+            normalized.push(owned);
+        }
+    }
+    if cap == 0 {
+        return Vec::new();
+    }
+    if normalized.len() > cap {
+        normalized.drain(0..normalized.len().saturating_sub(cap));
+    }
+    normalized
+}
+
+fn retry_delay_ms(base_delay_ms: u64, attempt: usize) -> u64 {
+    if base_delay_ms == 0 {
+        return 0;
+    }
+    let exponent = attempt.saturating_sub(1).min(10) as u32;
+    base_delay_ms.saturating_mul(1_u64 << exponent)
+}
+
+async fn apply_retry_delay(base_delay_ms: u64, attempt: usize) {
+    let delay_ms = retry_delay_ms(base_delay_ms, attempt);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    }
+}
+
+fn load_deployment_runtime_state(path: &Path) -> Result<DeploymentRuntimeState> {
+    if !path.exists() {
+        return Ok(DeploymentRuntimeState::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed = match serde_json::from_str::<DeploymentRuntimeState>(&raw) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "deployment runner: failed to parse state file {} ({error}); starting fresh",
+                path.display()
+            );
+            return Ok(DeploymentRuntimeState::default());
+        }
+    };
+    if parsed.schema_version != DEPLOYMENT_RUNTIME_STATE_SCHEMA_VERSION {
+        eprintln!(
+            "deployment runner: unsupported state schema {} in {}; starting fresh",
+            parsed.schema_version,
+            path.display()
+        );
+        return Ok(DeploymentRuntimeState::default());
+    }
+    Ok(parsed)
+}
+
+fn save_deployment_runtime_state(path: &Path, state: &DeploymentRuntimeState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("serialize deployment state")?;
+    write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::json;
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::{
+        load_deployment_runtime_state, retry_delay_ms, DeploymentRuntime, DeploymentRuntimeConfig,
+        DEPLOYMENT_RUNTIME_EVENTS_LOG_FILE,
+    };
+    use crate::channel_store::ChannelStore;
+    use crate::deployment_contract::{
+        load_deployment_contract_fixture, parse_deployment_contract_fixture,
+    };
+    use crate::transport_health::TransportHealthState;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("deployment-contract")
+            .join(name)
+    }
+
+    fn build_config(root: &Path) -> DeploymentRuntimeConfig {
+        DeploymentRuntimeConfig {
+            fixture_path: fixture_path("mixed-outcomes.json"),
+            state_dir: root.join(".tau/deployment"),
+            queue_limit: 64,
+            processed_case_cap: 10_000,
+            retry_max_attempts: 2,
+            retry_base_delay_ms: 0,
+        }
+    }
+
+    #[test]
+    fn unit_retry_delay_ms_scales_with_attempt_number() {
+        assert_eq!(retry_delay_ms(0, 1), 0);
+        assert_eq!(retry_delay_ms(10, 1), 10);
+        assert_eq!(retry_delay_ms(10, 2), 20);
+        assert_eq!(retry_delay_ms(10, 3), 40);
+    }
+
+    #[tokio::test]
+    async fn functional_runner_processes_fixture_and_persists_deployment_snapshot() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_deployment_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = DeploymentRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 3);
+        assert_eq!(summary.applied_cases, 1);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.retryable_failures, 2);
+        assert_eq!(summary.retry_attempts, 1);
+        assert_eq!(summary.failed_cases, 1);
+        assert_eq!(summary.upserted_rollouts, 1);
+        assert_eq!(summary.wasm_rollouts, 1);
+        assert_eq!(summary.cloud_rollouts, 0);
+        assert_eq!(summary.duplicate_skips, 0);
+
+        let state =
+            load_deployment_runtime_state(&config.state_dir.join("state.json")).expect("state");
+        assert_eq!(state.rollouts.len(), 1);
+        assert_eq!(state.processed_case_keys.len(), 2);
+        assert_eq!(state.health.last_cycle_discovered, 3);
+        assert_eq!(state.health.last_cycle_failed, 1);
+        assert_eq!(state.health.failure_streak, 1);
+        assert_eq!(
+            state.health.classify().state,
+            TransportHealthState::Degraded
+        );
+
+        let events_log =
+            std::fs::read_to_string(config.state_dir.join(DEPLOYMENT_RUNTIME_EVENTS_LOG_FILE))
+                .expect("read events log");
+        assert!(events_log.contains("retryable_failures_observed"));
+        assert!(events_log.contains("case_processing_failed"));
+        assert!(events_log.contains("wasm_rollout_applied"));
+
+        let store = ChannelStore::open(
+            &config.state_dir.join("channel-store"),
+            "deployment",
+            "edge-wasm",
+        )
+        .expect("open channel store");
+        let memory = store
+            .load_memory()
+            .expect("load memory")
+            .expect("memory should exist");
+        assert!(memory.contains("Tau Deployment Snapshot (edge-wasm)"));
+        assert!(memory.contains("deployment-success-wasm"));
+    }
+
+    #[tokio::test]
+    async fn integration_runner_respects_queue_limit_for_backpressure() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+        config.queue_limit = 2;
+        let fixture =
+            load_deployment_contract_fixture(&config.fixture_path).expect("fixture should load");
+        let mut runtime = DeploymentRuntime::new(config.clone()).expect("runtime");
+        let summary = runtime.run_once(&fixture).await.expect("run once");
+
+        assert_eq!(summary.discovered_cases, 3);
+        assert_eq!(summary.queued_cases, 2);
+        assert_eq!(summary.applied_cases, 0);
+        assert_eq!(summary.malformed_cases, 1);
+        assert_eq!(summary.failed_cases, 1);
+        let state =
+            load_deployment_runtime_state(&config.state_dir.join("state.json")).expect("state");
+        assert!(state.rollouts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn integration_runner_skips_processed_cases_but_retries_unresolved_failures() {
+        let temp = tempdir().expect("tempdir");
+        let config = build_config(temp.path());
+        let fixture =
+            load_deployment_contract_fixture(&config.fixture_path).expect("fixture should load");
+
+        let mut first_runtime = DeploymentRuntime::new(config.clone()).expect("first runtime");
+        let first = first_runtime.run_once(&fixture).await.expect("first run");
+        assert_eq!(first.applied_cases, 1);
+        assert_eq!(first.malformed_cases, 1);
+
+        let mut second_runtime = DeploymentRuntime::new(config).expect("second runtime");
+        let second = second_runtime.run_once(&fixture).await.expect("second run");
+        assert_eq!(second.duplicate_skips, 2);
+        assert_eq!(second.applied_cases, 0);
+        assert_eq!(second.malformed_cases, 0);
+        assert_eq!(second.failed_cases, 1);
+    }
+
+    #[tokio::test]
+    async fn regression_runner_rejects_contract_drift_between_expected_and_runtime_result() {
+        let temp = tempdir().expect("tempdir");
+        let mut fixture = load_deployment_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture");
+        let success_case = fixture
+            .cases
+            .iter_mut()
+            .find(|case| case.case_id == "deployment-success-wasm")
+            .expect("success case");
+        success_case.expected.response_body = json!({
+            "status":"accepted",
+            "blueprint_id":"edge-wasm",
+            "deploy_target":"wasm",
+            "runtime_profile":"wasm_wasi",
+            "environment":"staging",
+            "region":"iad",
+            "artifact":"edge/runtime-v2.wasm",
+            "replicas":2,
+            "rollout_strategy":"canary"
+        });
+        let fixture_path = temp.path().join("drift-fixture.json");
+        std::fs::write(
+            &fixture_path,
+            serde_json::to_string_pretty(&fixture).expect("serialize fixture"),
+        )
+        .expect("write fixture");
+
+        let mut config = build_config(temp.path());
+        config.fixture_path = fixture_path;
+
+        let mut runtime = DeploymentRuntime::new(config).expect("runtime");
+        let error = runtime
+            .run_once(&fixture)
+            .await
+            .expect_err("contract drift should fail");
+        assert!(error.to_string().contains("expected response_body"));
+    }
+
+    #[tokio::test]
+    async fn regression_runner_failure_streak_resets_after_successful_cycle() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = build_config(temp.path());
+
+        let fixture_fail = load_deployment_contract_fixture(&fixture_path("mixed-outcomes.json"))
+            .expect("fixture");
+        let mut runtime_fail = DeploymentRuntime::new(config.clone()).expect("runtime fail");
+        let fail_summary = runtime_fail
+            .run_once(&fixture_fail)
+            .await
+            .expect("run fail");
+        assert_eq!(fail_summary.failed_cases, 1);
+
+        let state_after_fail =
+            load_deployment_runtime_state(&config.state_dir.join("state.json")).expect("state");
+        assert_eq!(state_after_fail.health.failure_streak, 1);
+
+        let fixture_success = load_deployment_contract_fixture(&fixture_path("rollout-pass.json"))
+            .expect("fixture success");
+        config.fixture_path = fixture_path("rollout-pass.json");
+        let mut runtime_success = DeploymentRuntime::new(config.clone()).expect("runtime success");
+        let success_summary = runtime_success
+            .run_once(&fixture_success)
+            .await
+            .expect("run success");
+        assert_eq!(success_summary.failed_cases, 0);
+        assert!(success_summary.applied_cases > 0);
+
+        let state_after_success =
+            load_deployment_runtime_state(&config.state_dir.join("state.json")).expect("state");
+        assert_eq!(state_after_success.health.failure_streak, 0);
+        assert_eq!(
+            state_after_success.health.classify().state,
+            TransportHealthState::Healthy
+        );
+    }
+
+    #[test]
+    fn regression_load_state_recovers_from_invalid_json() {
+        let temp = tempdir().expect("tempdir");
+        let state_path = temp.path().join("state.json");
+        std::fs::write(&state_path, "{not-json").expect("write invalid json");
+
+        let state = load_deployment_runtime_state(&state_path).expect("load state");
+        assert!(state.rollouts.is_empty());
+        assert!(state.processed_case_keys.is_empty());
+    }
+
+    #[test]
+    fn regression_parse_fixture_rejects_runtime_mismatch_for_non_malformed() {
+        let raw = r#"{
+  "schema_version": 1,
+  "name": "invalid-runtime-mismatch",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "bad",
+      "deploy_target": "wasm",
+      "runtime_profile": "native",
+      "blueprint_id": "edge",
+      "environment": "staging",
+      "region": "iad",
+      "wasm_module": "edge/runtime.wasm",
+      "replicas": 1,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status":"accepted",
+          "blueprint_id":"edge",
+          "deploy_target":"wasm",
+          "runtime_profile":"native",
+          "environment":"staging",
+          "region":"iad",
+          "artifact":"edge/runtime.wasm",
+          "replicas":1,
+          "rollout_strategy":"canary"
+        }
+      }
+    }
+  ]
+}"#;
+        let error =
+            parse_deployment_contract_fixture(raw).expect_err("runtime mismatch should fail");
+        assert!(error.to_string().contains("uses unsupported runtime"));
+    }
+
+    #[test]
+    fn integration_events_log_lines_are_valid_json_objects() {
+        let temp = tempdir().expect("tempdir");
+        let state_dir = temp.path().join(".tau/deployment");
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        let log_path = state_dir.join(DEPLOYMENT_RUNTIME_EVENTS_LOG_FILE);
+        std::fs::write(
+            &log_path,
+            r#"{"health_state":"healthy","reason_codes":["healthy_cycle"]}
+{"health_state":"degraded","reason_codes":["retry_attempted"]}
+"#,
+        )
+        .expect("write events log");
+
+        let raw = std::fs::read_to_string(&log_path).expect("read events log");
+        for line in raw.lines() {
+            let parsed: Value = serde_json::from_str(line).expect("line should parse");
+            assert!(parsed.is_object());
+        }
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -18,6 +18,7 @@ mod custom_command_runtime;
 mod dashboard_contract;
 mod dashboard_runtime;
 mod deployment_contract;
+mod deployment_runtime;
 mod diagnostics_commands;
 mod events;
 mod extension_manifest;
@@ -259,11 +260,11 @@ pub(crate) use crate::rpc_protocol::{
 };
 pub(crate) use crate::runtime_cli_validation::{
     validate_custom_command_contract_runner_cli, validate_dashboard_contract_runner_cli,
-    validate_event_webhook_ingest_cli, validate_events_runner_cli,
-    validate_gateway_contract_runner_cli, validate_github_issues_bridge_cli,
-    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
-    validate_multi_channel_contract_runner_cli, validate_slack_bridge_cli,
-    validate_voice_contract_runner_cli,
+    validate_deployment_contract_runner_cli, validate_event_webhook_ingest_cli,
+    validate_events_runner_cli, validate_gateway_contract_runner_cli,
+    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
+    validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
+    validate_slack_bridge_cli, validate_voice_contract_runner_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -374,6 +375,7 @@ pub(crate) use crate::trust_roots::{
 };
 use custom_command_runtime::{run_custom_command_contract_runner, CustomCommandRuntimeConfig};
 use dashboard_runtime::{run_dashboard_contract_runner, DashboardRuntimeConfig};
+use deployment_runtime::{run_deployment_contract_runner, DeploymentRuntimeConfig};
 use gateway_runtime::{run_gateway_contract_runner, GatewayRuntimeConfig};
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use memory_runtime::{run_memory_contract_runner, MemoryRuntimeConfig};

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -343,6 +343,55 @@ pub(crate) fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_deployment_contract_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.deployment_contract_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--deployment-contract-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--deployment-contract-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.multi_channel_contract_runner
+        || cli.multi_agent_contract_runner
+        || cli.memory_contract_runner
+        || cli.dashboard_contract_runner
+        || cli.gateway_contract_runner
+        || cli.custom_command_contract_runner
+        || cli.voice_contract_runner
+    {
+        bail!("--deployment-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-agent-contract-runner, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --custom-command-contract-runner, or --voice-contract-runner");
+    }
+    if cli.deployment_queue_limit == 0 {
+        bail!("--deployment-queue-limit must be greater than 0");
+    }
+    if cli.deployment_processed_case_cap == 0 {
+        bail!("--deployment-processed-case-cap must be greater than 0");
+    }
+    if cli.deployment_retry_max_attempts == 0 {
+        bail!("--deployment-retry-max-attempts must be greater than 0");
+    }
+    if !cli.deployment_fixture.exists() {
+        bail!(
+            "--deployment-fixture '{}' does not exist",
+            cli.deployment_fixture.display()
+        );
+    }
+    if !cli.deployment_fixture.is_file() {
+        bail!(
+            "--deployment-fixture '{}' must point to a file",
+            cli.deployment_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.custom_command_contract_runner {
         return Ok(());

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -16,6 +16,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_memory_contract_runner_cli(cli)?;
     validate_dashboard_contract_runner_cli(cli)?;
     validate_gateway_contract_runner_cli(cli)?;
+    validate_deployment_contract_runner_cli(cli)?;
     validate_custom_command_contract_runner_cli(cli)?;
     validate_voice_contract_runner_cli(cli)?;
 
@@ -203,6 +204,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_case_cap: 10_000,
             retry_max_attempts: 4,
             retry_base_delay_ms: 0,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.deployment_contract_runner {
+        run_deployment_contract_runner(DeploymentRuntimeConfig {
+            fixture_path: cli.deployment_fixture.clone(),
+            state_dir: cli.deployment_state_dir.clone(),
+            queue_limit: cli.deployment_queue_limit.max(1),
+            processed_case_cap: cli.deployment_processed_case_cap.max(1),
+            retry_max_attempts: cli.deployment_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.deployment_retry_base_delay_ms,
         })
         .await?;
         return Ok(true);

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -92,6 +92,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
+- `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).
 - `memory_contract.rs`: semantic-memory fixture/schema contract definitions and validators.
 - `memory_runtime.rs`: semantic-memory runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `multi_channel_contract.rs`: multi-channel (Telegram/Discord/WhatsApp) fixture/schema contract.
@@ -127,6 +128,7 @@ Use this area for narrow utility behavior reused across startup/runtime modules.
 - `dashboard_contract.rs`: dashboard contract schema/fixture validation and replay contract tests.
 - `dashboard_runtime.rs`: dashboard runtime tests for queueing, retries, idempotency, and health signals.
 - `deployment_contract.rs`: deployment/WASM fixture/schema compatibility and replay contract tests.
+- `deployment_runtime.rs`: deployment/WASM runtime tests for retries, idempotency, and health signals.
 - `memory_contract.rs`: semantic-memory schema/fixture compatibility and replay contract tests.
 - `memory_runtime.rs`: semantic-memory runtime tests for retries, idempotency, and health signals.
 - `transport_conformance.rs`: replay conformance fixtures for bridge/scheduler flows.


### PR DESCRIPTION
## Summary
- add `deployment_runtime` with deterministic queueing, retry, idempotency, channel-store persistence, runtime state, and cycle-report health updates
- wire deployment runtime mode into startup transport dispatch (`--deployment-contract-runner`) and runtime CLI validation
- add deployment runtime CLI surfaces:
  - `--deployment-contract-runner`
  - `--deployment-fixture`
  - `--deployment-state-dir`
  - `--deployment-queue-limit`
  - `--deployment-processed-case-cap`
  - `--deployment-retry-max-attempts`
  - `--deployment-retry-base-delay-ms`
- add tests for deployment runtime behavior and deployment runner CLI/validation paths across unit, functional, integration, and regression coverage
- update internal code map to include deployment runtime ownership

## Risks and compatibility
- additive runtime mode; no default-path behavior change unless deployment runner flags are set
- runtime validator enforces fail-closed constraints on fixture existence and non-zero limits
- deployment runner is mutually exclusive with existing transport/contract runner modes

## Validation evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent deployment_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent deployment -- --test-threads=1`
- `cargo run -p tau-coding-agent -- --deployment-contract-runner --deployment-fixture crates/tau-coding-agent/testdata/deployment-contract/mixed-outcomes.json --deployment-state-dir .tau/demo-deployment --deployment-queue-limit 64 --deployment-processed-case-cap 10000 --deployment-retry-max-attempts 2 --deployment-retry-base-delay-ms 0`
- `cargo test --workspace -- --test-threads=1`

Closes #796
