### PR TITLE
feat: deployment observability, docs, and demo rollout (closes #797)

### DIFF
--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -151,6 +151,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
             ],
@@ -214,6 +215,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
             ):
@@ -283,7 +285,7 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=11 passed=11 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=12 passed=12 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 30)
@@ -335,11 +337,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=11 passed=11 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=12 passed=12 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 11, "passed": 11, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 12, "passed": 12, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -352,6 +354,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "memory.sh",
                     "dashboard.sh",
                     "gateway.sh",
+                    "deployment.sh",
                     "custom-command.sh",
                     "voice.sh",
                 ],
@@ -430,8 +433,9 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [7] memory.sh", completed.stdout)
             self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
             self.assertIn("[demo:all] [9] gateway.sh", completed.stdout)
-            self.assertIn("[demo:all] [10] custom-command.sh", completed.stdout)
-            self.assertIn("[demo:all] [11] voice.sh", completed.stdout)
+            self.assertIn("[demo:all] [10] deployment.sh", completed.stdout)
+            self.assertIn("[demo:all] [11] custom-command.sh", completed.stdout)
+            self.assertIn("[demo:all] [12] voice.sh", completed.stdout)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(
@@ -454,6 +458,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
             ],
@@ -602,8 +607,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 11)
-            self.assertEqual(payload["summary"]["failed"], 11)
+            self.assertEqual(payload["summary"]["total"], 12)
+            self.assertEqual(payload["summary"]["failed"], 12)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Run deterministic local demos:
 ./scripts/demo/all.sh --only local,rpc --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
+./scripts/demo/all.sh --only deployment --fail-fast
 ./scripts/demo/all.sh --only custom-command --fail-fast
 ./scripts/demo/all.sh --only voice --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
@@ -84,6 +85,7 @@ Run deterministic local demos:
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh
 ```

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -738,6 +738,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         value_name = "transport/channel_id",
@@ -753,6 +754,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         value_name = "transport/channel_id",
@@ -768,10 +770,11 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         value_name = "target",
-        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway, custom-command, voice"
+        help = "Inspect transport health snapshot(s) and exit. Targets: slack, github, github:owner/repo, multi-channel, multi-agent, memory, dashboard, gateway, deployment, custom-command, voice"
     )]
     pub(crate) transport_health_inspect: Option<String>,
 
@@ -796,6 +799,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         help = "Inspect dashboard runtime status/guardrail report and exit"
@@ -823,6 +827,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         help = "Inspect multi-agent runtime status/guardrail report and exit"
@@ -850,6 +855,7 @@ pub(crate) struct Cli {
         conflicts_with = "transport_health_inspect",
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
         help = "Inspect gateway runtime status/guardrail report and exit"
@@ -870,6 +876,34 @@ pub(crate) struct Cli {
     pub(crate) gateway_status_json: bool,
 
     #[arg(
+        long = "deployment-status-inspect",
+        env = "TAU_DEPLOYMENT_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        help = "Inspect deployment runtime status/guardrail report and exit"
+    )]
+    pub(crate) deployment_status_inspect: bool,
+
+    #[arg(
+        long = "deployment-status-json",
+        env = "TAU_DEPLOYMENT_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "deployment_status_inspect",
+        help = "Emit --deployment-status-inspect output as pretty JSON"
+    )]
+    pub(crate) deployment_status_json: bool,
+
+    #[arg(
         long = "custom-command-status-inspect",
         env = "TAU_CUSTOM_COMMAND_STATUS_INSPECT",
         conflicts_with = "channel_store_inspect",
@@ -878,6 +912,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "voice_status_inspect",
         help = "Inspect no-code custom command runtime status/guardrail report and exit"
     )]
@@ -905,6 +940,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
         conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         help = "Inspect voice runtime status/guardrail report and exit"
     )]

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -17,6 +17,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect
         || cli.gateway_status_inspect
+        || cli.deployment_status_inspect
         || cli.custom_command_status_inspect
         || cli.voice_status_inspect
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This index maps Tau documentation by audience and task.
 | Audience | Start Here | Scope |
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
-| Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/custom-command/voice), RPC, ChannelStore admin |
+| Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |
 | Contributor to `tau-coding-agent` internals | [Code Map](tau-coding-agent/code-map.md) | Module ownership and architecture navigation |

--- a/docs/guides/deployment-ops.md
+++ b/docs/guides/deployment-ops.md
@@ -1,0 +1,95 @@
+# Deployment Operations Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers the fixture-driven deployment runtime (`--deployment-contract-runner`) for
+cloud and WASM rollout validation.
+
+## Health and observability signals
+
+Primary transport health signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --deployment-state-dir .tau/deployment \
+  --transport-health-inspect deployment \
+  --transport-health-json
+```
+
+Primary operator status/guardrail signal:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --deployment-state-dir .tau/deployment \
+  --deployment-status-inspect \
+  --deployment-status-json
+```
+
+Primary state files:
+
+- `.tau/deployment/state.json`
+- `.tau/deployment/runtime-events.jsonl`
+- `.tau/deployment/channel-store/deployment/<blueprint_id>/...`
+
+`runtime-events.jsonl` reason codes:
+
+- `healthy_cycle`
+- `queue_backpressure_applied`
+- `duplicate_cases_skipped`
+- `malformed_inputs_observed`
+- `retry_attempted`
+- `retryable_failures_observed`
+- `case_processing_failed`
+- `cloud_rollout_applied`
+- `wasm_rollout_applied`
+
+Guardrail interpretation:
+
+- `rollout_gate=pass`: health is `healthy`, promotion can continue.
+- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+
+## Deterministic demo path
+
+```bash
+./scripts/demo/deployment.sh
+```
+
+## Rollout plan with guardrails
+
+1. Validate fixture contract and runtime locally:
+   `cargo test -p tau-coding-agent deployment_contract -- --test-threads=1`
+2. Validate runtime behavior coverage:
+   `cargo test -p tau-coding-agent deployment_runtime -- --test-threads=1`
+3. Run deterministic demo:
+   `./scripts/demo/deployment.sh`
+4. Verify transport health and status gate:
+   `--transport-health-inspect deployment --transport-health-json`
+   `--deployment-status-inspect --deployment-status-json`
+5. Promote by increasing fixture complexity gradually while monitoring:
+   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
+   `wasm_rollout_count`, and `cloud_rollout_count`.
+
+## Rollback plan
+
+1. Stop invoking `--deployment-contract-runner`.
+2. Preserve `.tau/deployment/` for incident analysis.
+3. Revert to last known-good revision:
+   `git revert <commit>`
+4. Re-run validation matrix before re-enable.
+
+## Troubleshooting
+
+- Symptom: health state `degraded` with `case_processing_failed`.
+  Action: inspect `runtime-events.jsonl`, then verify fixture expectations and runtime support.
+- Symptom: health state `degraded` with `malformed_inputs_observed`.
+  Action: inspect fixture records for invalid deploy target/runtime combinations.
+- Symptom: health state `degraded` with `retry_attempted` or `retryable_failures_observed`.
+  Action: verify retryable failure simulation and retry policy settings.
+- Symptom: health state `failing` (`failure_streak >= 3`).
+  Action: treat as rollout gate failure; pause promotion and investigate repeated failures.
+- Symptom: `rollout_gate=hold` with stale state.
+  Action: run deterministic demo and re-check `deployment-status-inspect` freshness fields.
+- Symptom: non-zero `queue_depth`.
+  Action: reduce per-cycle fixture volume or increase `--deployment-queue-limit`.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -97,6 +97,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/all.sh --only multi-channel --fail-fast
 ./scripts/demo/all.sh --only multi-agent --fail-fast
 ./scripts/demo/all.sh --only gateway --fail-fast
+./scripts/demo/all.sh --only deployment --fail-fast
 ./scripts/demo/all.sh --only custom-command --fail-fast
 ./scripts/demo/all.sh --only voice --fail-fast
 ./scripts/demo/all.sh --only local --timeout-seconds 30 --fail-fast
@@ -109,6 +110,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh
 ```

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -255,6 +255,49 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/gateway-ops.md`.
 
+## Deployment contract runner (cloud + WASM)
+
+Use this fixture-driven runtime mode to validate cloud deployment and WASM rollout paths,
+retry outcomes, state persistence, and channel-store snapshots.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --deployment-contract-runner \
+  --deployment-fixture crates/tau-coding-agent/testdata/deployment-contract/rollout-pass.json \
+  --deployment-state-dir .tau/deployment \
+  --deployment-queue-limit 64 \
+  --deployment-processed-case-cap 10000 \
+  --deployment-retry-max-attempts 4 \
+  --deployment-retry-base-delay-ms 0
+```
+
+The runner writes state and observability output under:
+
+- `.tau/deployment/state.json`
+- `.tau/deployment/runtime-events.jsonl`
+- `.tau/deployment/channel-store/deployment/<blueprint_id>/...`
+
+Inspect deployment transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --deployment-state-dir .tau/deployment \
+  --transport-health-inspect deployment \
+  --transport-health-json
+```
+
+Inspect deployment rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --deployment-state-dir .tau/deployment \
+  --deployment-status-inspect \
+  --deployment-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/deployment-ops.md`.
+
 ## No-code custom command contract runner
 
 Use this fixture-driven runtime mode to validate no-code command registry lifecycle behavior,

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -22,6 +22,7 @@ demo_scripts=(
   "memory.sh"
   "dashboard.sh"
   "gateway.sh"
+  "deployment.sh"
   "custom-command.sh"
   "voice.sh"
 )
@@ -95,6 +96,10 @@ normalize_demo_name() {
       ;;
     gateway|gateway.sh)
       echo "gateway.sh"
+      return 0
+      ;;
+    deployment|deployment.sh)
+      echo "deployment.sh"
       return 0
       ;;
     custom-command|customcommand|custom-command.sh|customcommand.sh)
@@ -215,14 +220,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway/custom-command/voice) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway,custom-command,voice)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,memory,dashboard,gateway,deployment,custom-command,voice)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/deployment.sh
+++ b/scripts/demo/deployment.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "deployment" "Run deterministic deployment runtime, health, and status-inspection demo commands against checked-in fixtures." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/deployment-contract/rollout-pass.json"
+demo_state_dir=".tau/demo-deployment"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "deployment-runner" \
+  --deployment-contract-runner \
+  --deployment-fixture ./crates/tau-coding-agent/testdata/deployment-contract/rollout-pass.json \
+  --deployment-state-dir "${demo_state_dir}" \
+  --deployment-queue-limit 64 \
+  --deployment-processed-case-cap 10000 \
+  --deployment-retry-max-attempts 4 \
+  --deployment-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
+  "transport-health-inspect-deployment" \
+  --deployment-state-dir "${demo_state_dir}" \
+  --transport-health-inspect deployment \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "deployment-status-inspect" \
+  --deployment-state-dir "${demo_state_dir}" \
+  --deployment-status-inspect \
+  --deployment-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-deployment-edge-wasm" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect deployment/edge-wasm
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary of Behavior Changes
- Added deployment admin/observability parity in tau-coding-agent:
  - transport-health target support for deployment
  - deployment status inspect + JSON report surfaces
  - deployment status aggregation in channel-store admin (rollout mix, runtime/env counts, status/error distributions, reason-code summaries)
- Wired deployment status inspect through startup preflight admin-mode dispatch.
- Added deterministic deployment demo wrapper: scripts/demo/deployment.sh.
- Integrated deployment wrapper into scripts/demo/all.sh inventory/filtering/canonical order.
- Expanded docs with deployment operations runbook and references:
  - docs/guides/deployment-ops.md
  - docs/guides/transports.md
  - docs/guides/quickstart.md
  - docs/README.md
  - README.md
- Extended demo-script CI tests for deployment wrapper and updated expected totals/order.

## Risks and Compatibility Notes
- CLI surface change: new deployment status flags and transport-health target.
- Conflict matrix expanded to keep status-inspect/admin commands mutually exclusive.
- Demo inventory expanded from 11 to 12 wrappers; downstream consumers parsing demo summaries should expect the new total and wrapper name.
- Deployment status parsing remains backward-compatible with legacy state files missing health fields (defaults applied).

## Validation Evidence
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent channel_store_admin -- --test-threads=1
- cargo test -p tau-coding-agent deployment_runtime -- --test-threads=1
- cargo test -p tau-coding-agent deployment_contract -- --test-threads=1
- python3 .github/scripts/test_demo_scripts.py
- cargo test --workspace -- --test-threads=1
- ./scripts/demo/deployment.sh --skip-build --binary target/debug/tau-coding-agent
- ./scripts/demo/all.sh --skip-build --binary target/debug/tau-coding-agent --only deployment --json

Closes #797
