### PR TITLE
feat: add multi-channel live ingress parser and live runner

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1869,9 +1869,19 @@ pub(crate) struct Cli {
         long = "multi-channel-contract-runner",
         env = "TAU_MULTI_CHANNEL_CONTRACT_RUNNER",
         default_value_t = false,
+        conflicts_with = "multi_channel_live_runner",
         help = "Run fixture-driven multi-channel runtime for Telegram/Discord/WhatsApp contracts"
     )]
     pub(crate) multi_channel_contract_runner: bool,
+
+    #[arg(
+        long = "multi-channel-live-runner",
+        env = "TAU_MULTI_CHANNEL_LIVE_RUNNER",
+        default_value_t = false,
+        conflicts_with = "multi_channel_contract_runner",
+        help = "Run live-ingress multi-channel runtime using local adapter inbox files for Telegram/Discord/WhatsApp"
+    )]
+    pub(crate) multi_channel_live_runner: bool,
 
     #[arg(
         long = "multi-channel-fixture",
@@ -1881,6 +1891,15 @@ pub(crate) struct Cli {
         help = "Path to multi-channel contract fixture JSON"
     )]
     pub(crate) multi_channel_fixture: PathBuf,
+
+    #[arg(
+        long = "multi-channel-live-ingress-dir",
+        env = "TAU_MULTI_CHANNEL_LIVE_INGRESS_DIR",
+        default_value = ".tau/multi-channel/live-ingress",
+        requires = "multi_channel_live_runner",
+        help = "Directory containing transport-specific live ingress NDJSON inbox files (telegram.ndjson, discord.ndjson, whatsapp.ndjson)"
+    )]
+    pub(crate) multi_channel_live_ingress_dir: PathBuf,
 
     #[arg(
         long = "multi-channel-state-dir",
@@ -1894,8 +1913,7 @@ pub(crate) struct Cli {
         long = "multi-channel-queue-limit",
         env = "TAU_MULTI_CHANNEL_QUEUE_LIMIT",
         default_value_t = 64,
-        requires = "multi_channel_contract_runner",
-        help = "Maximum fixture events processed per runtime cycle"
+        help = "Maximum inbound events processed per runtime cycle"
     )]
     pub(crate) multi_channel_queue_limit: usize,
 
@@ -1903,7 +1921,6 @@ pub(crate) struct Cli {
         long = "multi-channel-processed-event-cap",
         env = "TAU_MULTI_CHANNEL_PROCESSED_EVENT_CAP",
         default_value_t = 10_000,
-        requires = "multi_channel_contract_runner",
         help = "Maximum processed-event keys retained for duplicate suppression"
     )]
     pub(crate) multi_channel_processed_event_cap: usize,
@@ -1912,7 +1929,6 @@ pub(crate) struct Cli {
         long = "multi-channel-retry-max-attempts",
         env = "TAU_MULTI_CHANNEL_RETRY_MAX_ATTEMPTS",
         default_value_t = 4,
-        requires = "multi_channel_contract_runner",
         help = "Maximum retry attempts for transient multi-channel runtime failures"
     )]
     pub(crate) multi_channel_retry_max_attempts: usize,
@@ -1921,7 +1937,6 @@ pub(crate) struct Cli {
         long = "multi-channel-retry-base-delay-ms",
         env = "TAU_MULTI_CHANNEL_RETRY_BASE_DELAY_MS",
         default_value_t = 0,
-        requires = "multi_channel_contract_runner",
         help = "Base backoff delay in milliseconds for multi-channel runtime retries (0 disables delay)"
     )]
     pub(crate) multi_channel_retry_base_delay_ms: u64,

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -37,6 +37,7 @@ mod multi_agent_contract;
 mod multi_agent_router;
 mod multi_agent_runtime;
 mod multi_channel_contract;
+mod multi_channel_live_ingress;
 mod multi_channel_runtime;
 mod observability_loggers;
 mod onboarding;
@@ -264,7 +265,8 @@ pub(crate) use crate::runtime_cli_validation::{
     validate_events_runner_cli, validate_gateway_contract_runner_cli,
     validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
     validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
-    validate_slack_bridge_cli, validate_voice_contract_runner_cli,
+    validate_multi_channel_live_runner_cli, validate_slack_bridge_cli,
+    validate_voice_contract_runner_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
@@ -380,7 +382,10 @@ use gateway_runtime::{run_gateway_contract_runner, GatewayRuntimeConfig};
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use memory_runtime::{run_memory_contract_runner, MemoryRuntimeConfig};
 use multi_agent_runtime::{run_multi_agent_contract_runner, MultiAgentRuntimeConfig};
-use multi_channel_runtime::{run_multi_channel_contract_runner, MultiChannelRuntimeConfig};
+use multi_channel_runtime::{
+    run_multi_channel_contract_runner, run_multi_channel_live_runner,
+    MultiChannelLiveRuntimeConfig, MultiChannelRuntimeConfig,
+};
 use slack::{run_slack_bridge, SlackBridgeRuntimeConfig};
 use voice_runtime::{run_voice_contract_runner, VoiceRuntimeConfig};
 

--- a/crates/tau-coding-agent/src/multi_channel_live_ingress.rs
+++ b/crates/tau-coding-agent/src/multi_channel_live_ingress.rs
@@ -1,0 +1,701 @@
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+#[cfg(test)]
+use std::path::Path;
+
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::multi_channel_contract::{
+    validate_multi_channel_inbound_event, MultiChannelAttachment, MultiChannelEventKind,
+    MultiChannelInboundEvent, MultiChannelTransport, MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MultiChannelLiveIngressReasonCode {
+    InvalidJson,
+    UnsupportedSchemaVersion,
+    MissingTransport,
+    UnsupportedTransport,
+    MissingPayload,
+    MissingField,
+    InvalidFieldType,
+    InvalidTimestamp,
+    EmptyContent,
+    InvalidNormalizedEvent,
+}
+
+impl MultiChannelLiveIngressReasonCode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidJson => "invalid_json",
+            Self::UnsupportedSchemaVersion => "unsupported_schema_version",
+            Self::MissingTransport => "missing_transport",
+            Self::UnsupportedTransport => "unsupported_transport",
+            Self::MissingPayload => "missing_payload",
+            Self::MissingField => "missing_field",
+            Self::InvalidFieldType => "invalid_field_type",
+            Self::InvalidTimestamp => "invalid_timestamp",
+            Self::EmptyContent => "empty_content",
+            Self::InvalidNormalizedEvent => "invalid_normalized_event",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MultiChannelLiveIngressParseError {
+    pub(crate) code: MultiChannelLiveIngressReasonCode,
+    pub(crate) message: String,
+}
+
+impl Display for MultiChannelLiveIngressParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for MultiChannelLiveIngressParseError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct MultiChannelLiveInboundEnvelope {
+    #[serde(default = "multi_channel_live_ingress_schema_version")]
+    pub(crate) schema_version: u32,
+    #[serde(default)]
+    pub(crate) transport: String,
+    #[serde(default)]
+    pub(crate) provider: String,
+    #[serde(default)]
+    pub(crate) payload: Value,
+}
+
+fn multi_channel_live_ingress_schema_version() -> u32 {
+    MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION
+}
+
+pub(crate) fn parse_multi_channel_live_inbound_envelope(
+    raw: &str,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    let envelope =
+        serde_json::from_str::<MultiChannelLiveInboundEnvelope>(raw).map_err(|error| {
+            parse_error(
+                MultiChannelLiveIngressReasonCode::InvalidJson,
+                error.to_string(),
+            )
+        })?;
+    parse_multi_channel_live_inbound_envelope_value(&envelope)
+}
+
+pub(crate) fn parse_multi_channel_live_inbound_envelope_value(
+    envelope: &MultiChannelLiveInboundEnvelope,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    if envelope.schema_version != MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION {
+        return Err(parse_error(
+            MultiChannelLiveIngressReasonCode::UnsupportedSchemaVersion,
+            format!(
+                "expected schema_version {} but found {}",
+                MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION, envelope.schema_version
+            ),
+        ));
+    }
+    let transport = parse_transport(&envelope.transport)?;
+    let event = match transport {
+        MultiChannelTransport::Telegram => parse_telegram_event(envelope)?,
+        MultiChannelTransport::Discord => parse_discord_event(envelope)?,
+        MultiChannelTransport::Whatsapp => parse_whatsapp_event(envelope)?,
+    };
+
+    if event.text.trim().is_empty() && event.attachments.is_empty() {
+        return Err(parse_error(
+            MultiChannelLiveIngressReasonCode::EmptyContent,
+            "normalized event must include non-empty text or at least one attachment",
+        ));
+    }
+
+    validate_multi_channel_inbound_event(&event).map_err(|error| {
+        parse_error(
+            MultiChannelLiveIngressReasonCode::InvalidNormalizedEvent,
+            error.to_string(),
+        )
+    })?;
+
+    Ok(event)
+}
+
+#[cfg(test)]
+pub(crate) fn load_multi_channel_live_inbound_envelope_fixture(
+    path: &Path,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        parse_error(
+            MultiChannelLiveIngressReasonCode::InvalidJson,
+            format!("failed to read {} ({error})", path.display()),
+        )
+    })?;
+    parse_multi_channel_live_inbound_envelope(&raw)
+}
+
+fn parse_transport(
+    raw_transport: &str,
+) -> Result<MultiChannelTransport, MultiChannelLiveIngressParseError> {
+    let normalized = raw_transport.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err(parse_error(
+            MultiChannelLiveIngressReasonCode::MissingTransport,
+            "transport cannot be empty",
+        ));
+    }
+    match normalized.as_str() {
+        "telegram" => Ok(MultiChannelTransport::Telegram),
+        "discord" => Ok(MultiChannelTransport::Discord),
+        "whatsapp" => Ok(MultiChannelTransport::Whatsapp),
+        unsupported => Err(parse_error(
+            MultiChannelLiveIngressReasonCode::UnsupportedTransport,
+            format!(
+                "unsupported transport '{}' (expected telegram, discord, or whatsapp)",
+                unsupported
+            ),
+        )),
+    }
+}
+
+fn parse_telegram_event(
+    envelope: &MultiChannelLiveInboundEnvelope,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    let payload = as_object(
+        &envelope.payload,
+        MultiChannelLiveIngressReasonCode::MissingPayload,
+        "payload must be a JSON object",
+    )?;
+    let message = object_field(
+        payload,
+        "message",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.message",
+    )?;
+    let chat = object_field(
+        message,
+        "chat",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.message.chat",
+    )?;
+    let from = object_field(
+        message,
+        "from",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.message.from",
+    )?;
+
+    let event_id = optional_string_field(message, "message_id")
+        .or_else(|| optional_string_field(payload, "update_id"))
+        .ok_or_else(|| {
+            parse_error(
+                MultiChannelLiveIngressReasonCode::MissingField,
+                "payload.message.message_id or payload.update_id is required",
+            )
+        })?;
+
+    let timestamp_secs = required_u64_field(
+        message,
+        "date",
+        MultiChannelLiveIngressReasonCode::InvalidTimestamp,
+        "payload.message.date",
+    )?;
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "ingress_provider".to_string(),
+        Value::String(envelope.provider.trim().to_string()),
+    );
+    if let Some(update_id) = optional_string_field(payload, "update_id") {
+        metadata.insert("telegram_update_id".to_string(), Value::String(update_id));
+    }
+
+    Ok(MultiChannelInboundEvent {
+        schema_version: MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION,
+        transport: MultiChannelTransport::Telegram,
+        event_kind: detect_event_kind(optional_string_field(message, "text").as_deref()),
+        event_id,
+        conversation_id: required_string_field(
+            chat,
+            "id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.message.chat.id",
+        )?,
+        thread_id: optional_string_field(message, "message_thread_id").unwrap_or_default(),
+        actor_id: required_string_field(
+            from,
+            "id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.message.from.id",
+        )?,
+        actor_display: optional_string_field(from, "username")
+            .or_else(|| optional_string_field(from, "first_name"))
+            .unwrap_or_default(),
+        timestamp_ms: timestamp_secs.saturating_mul(1000),
+        text: optional_string_field(message, "text").unwrap_or_default(),
+        attachments: parse_attachments(message.get("attachments"))?,
+        metadata,
+    })
+}
+
+fn parse_discord_event(
+    envelope: &MultiChannelLiveInboundEnvelope,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    let payload = as_object(
+        &envelope.payload,
+        MultiChannelLiveIngressReasonCode::MissingPayload,
+        "payload must be a JSON object",
+    )?;
+    let author = object_field(
+        payload,
+        "author",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.author",
+    )?;
+
+    let timestamp_raw = required_string_field(
+        payload,
+        "timestamp",
+        MultiChannelLiveIngressReasonCode::InvalidTimestamp,
+        "payload.timestamp",
+    )?;
+    let timestamp_ms = parse_rfc3339_to_unix_ms(&timestamp_raw).ok_or_else(|| {
+        parse_error(
+            MultiChannelLiveIngressReasonCode::InvalidTimestamp,
+            format!("payload.timestamp '{}' is not valid RFC3339", timestamp_raw),
+        )
+    })?;
+
+    let thread_id = optional_object_field(payload, "thread")
+        .and_then(|thread| optional_string_field(thread, "id"))
+        .or_else(|| optional_string_field(payload, "thread_id"))
+        .unwrap_or_default();
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "ingress_provider".to_string(),
+        Value::String(envelope.provider.trim().to_string()),
+    );
+
+    Ok(MultiChannelInboundEvent {
+        schema_version: MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION,
+        transport: MultiChannelTransport::Discord,
+        event_kind: detect_event_kind(optional_string_field(payload, "content").as_deref()),
+        event_id: required_string_field(
+            payload,
+            "id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.id",
+        )?,
+        conversation_id: required_string_field(
+            payload,
+            "channel_id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.channel_id",
+        )?,
+        thread_id,
+        actor_id: required_string_field(
+            author,
+            "id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.author.id",
+        )?,
+        actor_display: optional_string_field(author, "username").unwrap_or_default(),
+        timestamp_ms,
+        text: optional_string_field(payload, "content").unwrap_or_default(),
+        attachments: parse_attachments(payload.get("attachments"))?,
+        metadata,
+    })
+}
+
+fn parse_whatsapp_event(
+    envelope: &MultiChannelLiveInboundEnvelope,
+) -> Result<MultiChannelInboundEvent, MultiChannelLiveIngressParseError> {
+    let payload = as_object(
+        &envelope.payload,
+        MultiChannelLiveIngressReasonCode::MissingPayload,
+        "payload must be a JSON object",
+    )?;
+    let messages = array_field(
+        payload,
+        "messages",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.messages",
+    )?;
+    let first = messages.first().ok_or_else(|| {
+        parse_error(
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.messages must include at least one message object",
+        )
+    })?;
+    let message = as_object(
+        first,
+        MultiChannelLiveIngressReasonCode::InvalidFieldType,
+        "payload.messages[0] must be an object",
+    )?;
+    let metadata_object = object_field(
+        payload,
+        "metadata",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.metadata",
+    )?;
+    let phone_number_id = required_string_field(
+        metadata_object,
+        "phone_number_id",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.metadata.phone_number_id",
+    )?;
+
+    let timestamp_secs = required_u64_field(
+        message,
+        "timestamp",
+        MultiChannelLiveIngressReasonCode::InvalidTimestamp,
+        "payload.messages[0].timestamp",
+    )?;
+    let actor_id = required_string_field(
+        message,
+        "from",
+        MultiChannelLiveIngressReasonCode::MissingField,
+        "payload.messages[0].from",
+    )?;
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "ingress_provider".to_string(),
+        Value::String(envelope.provider.trim().to_string()),
+    );
+    metadata.insert(
+        "whatsapp_phone_number_id".to_string(),
+        Value::String(phone_number_id.clone()),
+    );
+
+    let text = message
+        .get("text")
+        .and_then(|raw| {
+            as_object(raw, MultiChannelLiveIngressReasonCode::InvalidFieldType, "").ok()
+        })
+        .and_then(|raw| optional_string_field(raw, "body"))
+        .unwrap_or_default();
+
+    Ok(MultiChannelInboundEvent {
+        schema_version: MULTI_CHANNEL_CONTRACT_SCHEMA_VERSION,
+        transport: MultiChannelTransport::Whatsapp,
+        event_kind: detect_event_kind(Some(text.as_str())),
+        event_id: required_string_field(
+            message,
+            "id",
+            MultiChannelLiveIngressReasonCode::MissingField,
+            "payload.messages[0].id",
+        )?,
+        conversation_id: format!("{phone_number_id}:{actor_id}"),
+        thread_id: String::new(),
+        actor_id,
+        actor_display: String::new(),
+        timestamp_ms: timestamp_secs.saturating_mul(1000),
+        text,
+        attachments: parse_attachments(message.get("attachments"))?,
+        metadata,
+    })
+}
+
+fn parse_attachments(
+    raw_value: Option<&Value>,
+) -> Result<Vec<MultiChannelAttachment>, MultiChannelLiveIngressParseError> {
+    let Some(value) = raw_value else {
+        return Ok(Vec::new());
+    };
+    let rows = value.as_array().ok_or_else(|| {
+        parse_error(
+            MultiChannelLiveIngressReasonCode::InvalidFieldType,
+            "attachments must be an array",
+        )
+    })?;
+    let mut attachments = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
+        let row = as_object(
+            row,
+            MultiChannelLiveIngressReasonCode::InvalidFieldType,
+            &format!("attachments[{index}] must be an object"),
+        )?;
+        attachments.push(MultiChannelAttachment {
+            attachment_id: required_string_value(
+                row.get("attachment_id").or_else(|| row.get("id")),
+                MultiChannelLiveIngressReasonCode::MissingField,
+                &format!("attachments[{index}].attachment_id"),
+            )?,
+            url: required_string_value(
+                row.get("url"),
+                MultiChannelLiveIngressReasonCode::MissingField,
+                &format!("attachments[{index}].url"),
+            )?,
+            content_type: optional_string_value(row.get("content_type")).unwrap_or_default(),
+            file_name: optional_string_value(row.get("file_name").or_else(|| row.get("name")))
+                .unwrap_or_default(),
+            size_bytes: optional_u64_value(row.get("size_bytes")).unwrap_or(0),
+        });
+    }
+    Ok(attachments)
+}
+
+fn detect_event_kind(text: Option<&str>) -> MultiChannelEventKind {
+    if text
+        .map(str::trim)
+        .map(|value| value.starts_with('/'))
+        .unwrap_or(false)
+    {
+        MultiChannelEventKind::Command
+    } else {
+        MultiChannelEventKind::Message
+    }
+}
+
+fn as_object<'a>(
+    value: &'a Value,
+    code: MultiChannelLiveIngressReasonCode,
+    detail: &str,
+) -> Result<&'a Map<String, Value>, MultiChannelLiveIngressParseError> {
+    value.as_object().ok_or_else(|| parse_error(code, detail))
+}
+
+fn object_field<'a>(
+    parent: &'a Map<String, Value>,
+    key: &str,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<&'a Map<String, Value>, MultiChannelLiveIngressParseError> {
+    let value = parent
+        .get(key)
+        .ok_or_else(|| parse_error(code, format!("{field_name} is required")))?;
+    as_object(
+        value,
+        MultiChannelLiveIngressReasonCode::InvalidFieldType,
+        &format!("{field_name} must be an object"),
+    )
+}
+
+fn optional_object_field<'a>(
+    parent: &'a Map<String, Value>,
+    key: &str,
+) -> Option<&'a Map<String, Value>> {
+    parent.get(key).and_then(Value::as_object)
+}
+
+fn array_field<'a>(
+    parent: &'a Map<String, Value>,
+    key: &str,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<&'a Vec<Value>, MultiChannelLiveIngressParseError> {
+    parent
+        .get(key)
+        .ok_or_else(|| parse_error(code, format!("{field_name} is required")))?
+        .as_array()
+        .ok_or_else(|| {
+            parse_error(
+                MultiChannelLiveIngressReasonCode::InvalidFieldType,
+                format!("{field_name} must be an array"),
+            )
+        })
+}
+
+fn required_string_field(
+    object: &Map<String, Value>,
+    key: &str,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<String, MultiChannelLiveIngressParseError> {
+    required_string_value(object.get(key), code, field_name)
+}
+
+fn required_u64_field(
+    object: &Map<String, Value>,
+    key: &str,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<u64, MultiChannelLiveIngressParseError> {
+    required_u64_value(object.get(key), code, field_name)
+}
+
+fn required_string_value(
+    value: Option<&Value>,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<String, MultiChannelLiveIngressParseError> {
+    let parsed = optional_string_value(value);
+    let Some(parsed) = parsed else {
+        return Err(parse_error(code, format!("{field_name} is required")));
+    };
+    if parsed.trim().is_empty() {
+        return Err(parse_error(code, format!("{field_name} cannot be empty")));
+    }
+    Ok(parsed)
+}
+
+fn required_u64_value(
+    value: Option<&Value>,
+    code: MultiChannelLiveIngressReasonCode,
+    field_name: &str,
+) -> Result<u64, MultiChannelLiveIngressParseError> {
+    let parsed = optional_u64_value(value);
+    let Some(parsed) = parsed else {
+        return Err(parse_error(code, format!("{field_name} is required")));
+    };
+    if parsed == 0 {
+        return Err(parse_error(
+            code,
+            format!("{field_name} must be greater than 0"),
+        ));
+    }
+    Ok(parsed)
+}
+
+fn optional_string_field(object: &Map<String, Value>, key: &str) -> Option<String> {
+    optional_string_value(object.get(key))
+}
+
+fn optional_string_value(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    match value {
+        Value::String(raw) => Some(raw.trim().to_string()),
+        Value::Number(raw) => Some(raw.to_string()),
+        _ => None,
+    }
+}
+
+fn optional_u64_value(value: Option<&Value>) -> Option<u64> {
+    let value = value?;
+    match value {
+        Value::Number(raw) => raw.as_u64(),
+        Value::String(raw) => raw.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn parse_rfc3339_to_unix_ms(raw: &str) -> Option<u64> {
+    let parsed = DateTime::parse_from_rfc3339(raw).ok()?;
+    u64::try_from(parsed.timestamp_millis()).ok()
+}
+
+fn parse_error(
+    code: MultiChannelLiveIngressReasonCode,
+    message: impl Into<String>,
+) -> MultiChannelLiveIngressParseError {
+    MultiChannelLiveIngressParseError {
+        code,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    use crate::multi_channel_contract::MultiChannelTransport;
+
+    use super::{
+        load_multi_channel_live_inbound_envelope_fixture,
+        parse_multi_channel_live_inbound_envelope, MultiChannelLiveIngressReasonCode,
+    };
+
+    fn fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("multi-channel-live-ingress")
+            .join(name)
+    }
+
+    fn fixture_raw(name: &str) -> String {
+        std::fs::read_to_string(fixture_path(name)).expect("fixture should load")
+    }
+
+    #[test]
+    fn unit_parse_telegram_envelope_maps_expected_fields() {
+        let event = parse_multi_channel_live_inbound_envelope(&fixture_raw("telegram-valid.json"))
+            .expect("telegram fixture should parse");
+        assert_eq!(event.transport, MultiChannelTransport::Telegram);
+        assert_eq!(event.event_id, "42");
+        assert_eq!(event.conversation_id, "chat-100");
+        assert_eq!(event.actor_id, "user-7");
+        assert_eq!(event.text, "hello from telegram");
+        assert_eq!(event.timestamp_ms, 1_760_100_000_000);
+    }
+
+    #[test]
+    fn unit_parse_discord_envelope_maps_expected_fields() {
+        let event = parse_multi_channel_live_inbound_envelope(&fixture_raw("discord-valid.json"))
+            .expect("discord fixture should parse");
+        assert_eq!(event.transport, MultiChannelTransport::Discord);
+        assert_eq!(event.event_id, "discord-msg-1");
+        assert_eq!(event.conversation_id, "discord-channel-88");
+        assert_eq!(event.actor_id, "discord-user-3");
+        assert_eq!(event.text, "/status");
+        assert!(event.timestamp_ms > 0);
+    }
+
+    #[test]
+    fn unit_parse_whatsapp_envelope_maps_expected_fields() {
+        let event = parse_multi_channel_live_inbound_envelope(&fixture_raw("whatsapp-valid.json"))
+            .expect("whatsapp fixture should parse");
+        assert_eq!(event.transport, MultiChannelTransport::Whatsapp);
+        assert_eq!(event.event_id, "wamid.HBg123");
+        assert_eq!(event.conversation_id, "phone-55:15551234567");
+        assert_eq!(event.actor_id, "15551234567");
+        assert_eq!(event.text, "hello from whatsapp");
+        assert_eq!(event.timestamp_ms, 1_760_300_000_000);
+    }
+
+    #[test]
+    fn functional_live_ingress_fixtures_cover_all_supported_transports() {
+        let parsed = [
+            load_multi_channel_live_inbound_envelope_fixture(&fixture_path("telegram-valid.json"))
+                .expect("telegram fixture should parse"),
+            load_multi_channel_live_inbound_envelope_fixture(&fixture_path("discord-valid.json"))
+                .expect("discord fixture should parse"),
+            load_multi_channel_live_inbound_envelope_fixture(&fixture_path("whatsapp-valid.json"))
+                .expect("whatsapp fixture should parse"),
+        ];
+        let transports = parsed
+            .iter()
+            .map(|event| event.transport)
+            .collect::<HashSet<_>>();
+        assert_eq!(transports.len(), 3);
+        assert!(transports.contains(&MultiChannelTransport::Telegram));
+        assert!(transports.contains(&MultiChannelTransport::Discord));
+        assert!(transports.contains(&MultiChannelTransport::Whatsapp));
+    }
+
+    #[test]
+    fn integration_live_ingress_parser_is_deterministic_across_reloads() {
+        let raw = fixture_raw("telegram-valid.json");
+        let first =
+            parse_multi_channel_live_inbound_envelope(&raw).expect("first parse should pass");
+        let second =
+            parse_multi_channel_live_inbound_envelope(&raw).expect("second parse should pass");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn regression_rejects_unsupported_transport_with_reason_code() {
+        let error = parse_multi_channel_live_inbound_envelope(&fixture_raw(
+            "invalid-unsupported-transport.json",
+        ))
+        .expect_err("unsupported transport should fail");
+        assert_eq!(
+            error.code,
+            MultiChannelLiveIngressReasonCode::UnsupportedTransport
+        );
+    }
+
+    #[test]
+    fn regression_rejects_missing_discord_author_with_reason_code() {
+        let error = parse_multi_channel_live_inbound_envelope(&fixture_raw(
+            "invalid-discord-missing-author.json",
+        ))
+        .expect_err("missing discord author should fail");
+        assert_eq!(error.code, MultiChannelLiveIngressReasonCode::MissingField);
+        assert!(error.message.contains("payload.author"));
+    }
+}

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -12,6 +12,7 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_slack_bridge_cli(cli)?;
     validate_events_runner_cli(cli)?;
     validate_multi_channel_contract_runner_cli(cli)?;
+    validate_multi_channel_live_runner_cli(cli)?;
     validate_multi_agent_contract_runner_cli(cli)?;
     validate_memory_contract_runner_cli(cli)?;
     validate_dashboard_contract_runner_cli(cli)?;
@@ -147,6 +148,19 @@ pub(crate) async fn run_transport_mode_if_requested(
     if cli.multi_channel_contract_runner {
         run_multi_channel_contract_runner(MultiChannelRuntimeConfig {
             fixture_path: cli.multi_channel_fixture.clone(),
+            state_dir: cli.multi_channel_state_dir.clone(),
+            queue_limit: cli.multi_channel_queue_limit.max(1),
+            processed_event_cap: cli.multi_channel_processed_event_cap.max(1),
+            retry_max_attempts: cli.multi_channel_retry_max_attempts.max(1),
+            retry_base_delay_ms: cli.multi_channel_retry_base_delay_ms,
+        })
+        .await?;
+        return Ok(true);
+    }
+
+    if cli.multi_channel_live_runner {
+        run_multi_channel_live_runner(MultiChannelLiveRuntimeConfig {
+            ingress_dir: cli.multi_channel_live_ingress_dir.clone(),
             state_dir: cli.multi_channel_state_dir.clone(),
             queue_limit: cli.multi_channel_queue_limit.max(1),
             processed_event_cap: cli.multi_channel_processed_event_cap.max(1),

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/README.md
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/README.md
@@ -1,0 +1,26 @@
+# Multi-Channel Live Ingress Fixtures
+
+These fixtures model normalized provider envelopes for live ingress parsing.
+
+Supported transports:
+- `telegram`
+- `discord`
+- `whatsapp`
+
+Each envelope uses this top-level shape:
+
+```json
+{
+  "schema_version": 1,
+  "transport": "telegram|discord|whatsapp",
+  "provider": "provider-name",
+  "payload": { "... provider payload ..." }
+}
+```
+
+Files:
+- `telegram-valid.json`: valid Telegram envelope.
+- `discord-valid.json`: valid Discord envelope.
+- `whatsapp-valid.json`: valid WhatsApp envelope.
+- `invalid-unsupported-transport.json`: unsupported transport regression sample.
+- `invalid-discord-missing-author.json`: missing required `payload.author` regression sample.

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/discord-valid.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/discord-valid.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "transport": "discord",
+  "provider": "discord-gateway",
+  "payload": {
+    "id": "discord-msg-1",
+    "channel_id": "discord-channel-88",
+    "timestamp": "2026-01-10T12:00:00Z",
+    "content": "/status",
+    "author": {
+      "id": "discord-user-3",
+      "username": "bot-operator"
+    },
+    "attachments": []
+  }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/invalid-discord-missing-author.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/invalid-discord-missing-author.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "transport": "discord",
+  "provider": "discord-gateway",
+  "payload": {
+    "id": "discord-msg-2",
+    "channel_id": "discord-channel-99",
+    "timestamp": "2026-01-10T13:00:00Z",
+    "content": "hello"
+  }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/invalid-unsupported-transport.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/invalid-unsupported-transport.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "transport": "slack",
+  "provider": "slack-events-api",
+  "payload": {
+    "event_id": "evt-1",
+    "text": "not supported"
+  }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/telegram-valid.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/telegram-valid.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "transport": "telegram",
+  "provider": "telegram-bot-api",
+  "payload": {
+    "update_id": 9001,
+    "message": {
+      "message_id": 42,
+      "chat": {
+        "id": "chat-100"
+      },
+      "from": {
+        "id": "user-7",
+        "username": "alice"
+      },
+      "date": 1760100000,
+      "text": "hello from telegram",
+      "attachments": [
+        {
+          "id": "att-1",
+          "url": "https://example.com/image.png",
+          "content_type": "image/png",
+          "name": "image.png",
+          "size_bytes": 12
+        }
+      ]
+    }
+  }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/whatsapp-valid.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/whatsapp-valid.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "transport": "whatsapp",
+  "provider": "whatsapp-cloud-api",
+  "payload": {
+    "metadata": {
+      "phone_number_id": "phone-55"
+    },
+    "messages": [
+      {
+        "id": "wamid.HBg123",
+        "from": "15551234567",
+        "timestamp": "1760300000",
+        "text": {
+          "body": "hello from whatsapp"
+        }
+      }
+    ]
+  }
+}

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -4,7 +4,7 @@ Run all commands from repository root.
 
 ## Scope
 
-This runbook covers the fixture-driven Multi-channel runtime for:
+This runbook covers Multi-channel runtime operations for:
 
 - Telegram
 - Discord
@@ -51,11 +51,22 @@ Primary state files:
 ./scripts/demo/multi-channel.sh
 ```
 
+## Live ingress directory contract
+
+`--multi-channel-live-runner` consumes local inbox files:
+
+- `.tau/multi-channel/live-ingress/telegram.ndjson`
+- `.tau/multi-channel/live-ingress/discord.ndjson`
+- `.tau/multi-channel/live-ingress/whatsapp.ndjson`
+
+Each line must be one normalized provider envelope JSON object. Invalid lines are skipped with
+explicit parse diagnostics in stderr; valid lines continue processing.
+
 ## Rollout plan with guardrails
 
-1. Validate fixture contract and runtime locally:
+1. Validate fixture/live runtime locally:
    `cargo test -p tau-coding-agent multi_channel -- --nocapture`
-2. Run deterministic demo:
+2. Run deterministic demo (contract + live ingress path):
    `./scripts/demo/multi-channel.sh`
 3. Confirm health snapshot is `healthy` before promotion:
    `--transport-health-inspect multi-channel --transport-health-json`
@@ -66,7 +77,7 @@ Primary state files:
 
 ## Rollback plan
 
-1. Stop invoking `--multi-channel-contract-runner`.
+1. Stop invoking `--multi-channel-contract-runner` and `--multi-channel-live-runner`.
 2. Preserve `.tau/multi-channel/` for incident analysis.
 3. Revert to last known-good revision:
    `git revert <commit>`

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -105,6 +105,37 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/multi-channel-ops.md`.
 
+## Multi-channel live runner (Telegram, Discord, WhatsApp)
+
+Use this deterministic live-ingress mode to process local adapter inbox files without external
+provider calls.
+
+Ingress directory layout:
+
+- `.tau/multi-channel/live-ingress/telegram.ndjson`
+- `.tau/multi-channel/live-ingress/discord.ndjson`
+- `.tau/multi-channel/live-ingress/whatsapp.ndjson`
+
+Each line is one normalized provider envelope JSON object.
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --multi-channel-live-runner \
+  --multi-channel-live-ingress-dir .tau/multi-channel/live-ingress \
+  --multi-channel-state-dir .tau/multi-channel \
+  --multi-channel-queue-limit 64 \
+  --multi-channel-processed-event-cap 10000 \
+  --multi-channel-retry-max-attempts 4 \
+  --multi-channel-retry-base-delay-ms 0
+```
+
+The live runner writes to the same state and channel-store paths as contract mode:
+
+- `.tau/multi-channel/state.json`
+- `.tau/multi-channel/runtime-events.jsonl`
+- `.tau/multi-channel/channel-store/<transport>/<channel>/...`
+
 ## Multi-agent contract runner
 
 Use this fixture-driven runtime mode to validate planner/delegated/review route selection,

--- a/scripts/demo/multi-channel.sh
+++ b/scripts/demo/multi-channel.sh
@@ -15,12 +15,39 @@ if [[ "${init_rc}" -ne 0 ]]; then
 fi
 
 fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json"
+live_fixture_dir="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/multi-channel-live-ingress"
 demo_state_dir=".tau/demo-multi-channel"
+live_ingress_dir="${demo_state_dir}/live-ingress"
 
 tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_require_file "${live_fixture_dir}/telegram-valid.json"
+tau_demo_common_require_file "${live_fixture_dir}/discord-valid.json"
+tau_demo_common_require_file "${live_fixture_dir}/whatsapp-valid.json"
 tau_demo_common_prepare_binary
 
 rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+mkdir -p "${TAU_DEMO_REPO_ROOT}/${live_ingress_dir}"
+
+tau_demo_write_ndjson() {
+  local source_json="$1"
+  local destination_ndjson="$2"
+  python3 - "$source_json" "$destination_ndjson" <<'PY'
+import json
+import sys
+
+source = sys.argv[1]
+destination = sys.argv[2]
+with open(source, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+with open(destination, "w", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload, separators=(",", ":")))
+    handle.write("\n")
+PY
+}
+
+tau_demo_write_ndjson "${live_fixture_dir}/telegram-valid.json" "${TAU_DEMO_REPO_ROOT}/${live_ingress_dir}/telegram.ndjson"
+tau_demo_write_ndjson "${live_fixture_dir}/discord-valid.json" "${TAU_DEMO_REPO_ROOT}/${live_ingress_dir}/discord.ndjson"
+tau_demo_write_ndjson "${live_fixture_dir}/whatsapp-valid.json" "${TAU_DEMO_REPO_ROOT}/${live_ingress_dir}/whatsapp.ndjson"
 
 tau_demo_common_run_step \
   "multi-channel-runner" \
@@ -45,8 +72,18 @@ tau_demo_common_run_step \
   --multi-channel-status-json
 
 tau_demo_common_run_step \
+  "multi-channel-live-runner" \
+  --multi-channel-live-runner \
+  --multi-channel-live-ingress-dir "${live_ingress_dir}" \
+  --multi-channel-state-dir "${demo_state_dir}" \
+  --multi-channel-queue-limit 64 \
+  --multi-channel-processed-event-cap 10000 \
+  --multi-channel-retry-max-attempts 4 \
+  --multi-channel-retry-base-delay-ms 0
+
+tau_demo_common_run_step \
   "channel-store-inspect-telegram" \
   --channel-store-root "${demo_state_dir}/channel-store" \
-  --channel-store-inspect telegram/telegram-chat-42
+  --channel-store-inspect telegram/chat-100
 
 tau_demo_common_finish


### PR DESCRIPTION
## Summary
- Add a new multi-channel live-ingress parser module for Telegram/Discord/WhatsApp envelopes with deterministic reason-coded validation failures.
- Add `--multi-channel-live-runner` and `--multi-channel-live-ingress-dir` runtime mode to ingest local NDJSON inbox files (`telegram.ndjson`, `discord.ndjson`, `whatsapp.ndjson`) and persist channel-store/runtime state.
- Keep `--multi-channel-contract-runner` behavior intact while reusing runtime dedupe/retry/health/state logic for live ingress.
- Extend CLI/runtime validation and startup transport-mode dispatch for live runner conflicts, prerequisites, and safe failure behavior.
- Add live-ingress fixture corpus, runtime tests, docs/runbook updates, and demo script coverage.

Closes #830
Closes #831

## Risks and Compatibility
- Compatibility: existing contract-runner and status-inspect workflows remain supported and unchanged.
- Runtime behavior: live runner skips malformed ingress rows and continues processing valid envelopes; this is fail-soft by design and surfaces explicit stderr reason codes.
- CLI surface: new flags are additive; contract and live runner modes are mutually exclusive.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent multi_channel -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `python3 .github/scripts/test_demo_scripts.py`
- `./scripts/demo/multi-channel.sh --skip-build --binary target/debug/tau-coding-agent`
- `./scripts/demo/all.sh --skip-build --binary target/debug/tau-coding-agent --only multi-channel --json`
