### PR TITLE
feat(issue-833): add gateway rollout guardrail thresholds and status diagnostics

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -2150,6 +2150,24 @@ pub(crate) struct Cli {
     pub(crate) gateway_state_dir: PathBuf,
 
     #[arg(
+        long = "gateway-guardrail-failure-streak-threshold",
+        env = "TAU_GATEWAY_GUARDRAIL_FAILURE_STREAK_THRESHOLD",
+        default_value_t = 2,
+        requires = "gateway_contract_runner",
+        help = "Failure streak threshold that forces gateway rollout gate to hold"
+    )]
+    pub(crate) gateway_guardrail_failure_streak_threshold: usize,
+
+    #[arg(
+        long = "gateway-guardrail-retryable-failures-threshold",
+        env = "TAU_GATEWAY_GUARDRAIL_RETRYABLE_FAILURES_THRESHOLD",
+        default_value_t = 2,
+        requires = "gateway_contract_runner",
+        help = "Per-cycle retryable failure threshold that forces gateway rollout gate to hold"
+    )]
+    pub(crate) gateway_guardrail_retryable_failures_threshold: usize,
+
+    #[arg(
         long = "deployment-contract-runner",
         env = "TAU_DEPLOYMENT_CONTRACT_RUNNER",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -396,6 +396,12 @@ pub(crate) fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
             cli.gateway_fixture.display()
         );
     }
+    if cli.gateway_guardrail_failure_streak_threshold == 0 {
+        bail!("--gateway-guardrail-failure-streak-threshold must be greater than 0");
+    }
+    if cli.gateway_guardrail_retryable_failures_threshold == 0 {
+        bail!("--gateway-guardrail-retryable-failures-threshold must be greater than 0");
+    }
 
     Ok(())
 }

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -218,6 +218,12 @@ pub(crate) async fn run_transport_mode_if_requested(
             processed_case_cap: 10_000,
             retry_max_attempts: 4,
             retry_base_delay_ms: 0,
+            guardrail_failure_streak_threshold: cli
+                .gateway_guardrail_failure_streak_threshold
+                .max(1),
+            guardrail_retryable_failures_threshold: cli
+                .gateway_guardrail_retryable_failures_threshold
+                .max(1),
         })
         .await?;
         return Ok(true);

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -44,8 +44,13 @@ Primary state files:
 
 Guardrail interpretation:
 
-- `rollout_gate=pass`: health is `healthy`, promotion can continue.
-- `rollout_gate=hold`: health is `degraded` or `failing`, pause promotion and investigate.
+- `rollout_gate=pass`: guardrail thresholds are satisfied, promotion can continue.
+- `rollout_gate=hold`: a guardrail threshold is breached; inspect `rollout_reason_code`.
+
+Configurable guardrail thresholds (runner flags):
+
+- `--gateway-guardrail-failure-streak-threshold` (default `2`)
+- `--gateway-guardrail-retryable-failures-threshold` (default `2`)
 
 ## Deterministic demo path
 
@@ -65,7 +70,7 @@ Guardrail interpretation:
    `--transport-health-inspect gateway --transport-health-json`
    `--gateway-status-inspect --gateway-status-json`
 5. Promote by increasing fixture complexity gradually while monitoring:
-   `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`.
+   `failure_streak`, `last_cycle_failed`, `last_retryable_failures`, `queue_depth`, `rollout_gate`, `rollout_reason_code`.
 
 ## Rollback plan
 

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -266,7 +266,9 @@ cargo run -p tau-coding-agent -- \
   --model openai/gpt-4o-mini \
   --gateway-contract-runner \
   --gateway-fixture crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
-  --gateway-state-dir .tau/gateway
+  --gateway-state-dir .tau/gateway \
+  --gateway-guardrail-failure-streak-threshold 2 \
+  --gateway-guardrail-retryable-failures-threshold 2
 ```
 
 The runner writes state and observability output under:


### PR DESCRIPTION
Closes #833

## Summary of behavior changes
- Add gateway runner guardrail threshold flags for failure streak and retryable failures.
- Persist a rollout guardrail snapshot in gateway runtime state with gate, reason code, thresholds, and cycle counters.
- Emit rollout guardrail fields in gateway runtime events for rollout diagnostics.
- Extend gateway status inspect output/json with rollout reason code and guardrail threshold/counter fields.
- Validate gateway guardrail CLI thresholds are greater than zero and add regression coverage.
- Update gateway/transports docs with new guardrail controls and rollout monitoring fields.

## Risks and compatibility notes
- Backward compatible with existing state files via serde defaults for missing guardrail fields.
- Status inspect fallback behavior still derives a pass/hold gate from health when guardrail state is absent.
- Existing gateway fixtures and demo scripts continue to run with default threshold values.

## Validation evidence
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-coding-agent gateway_runtime -- --test-threads=1
- cargo test -p tau-coding-agent channel_store_admin -- --test-threads=1
- cargo test -p tau-coding-agent gateway_guardrail -- --test-threads=1
- cargo test -p tau-coding-agent validate_gateway_contract_runner_cli_rejects_zero_guardrail_thresholds -- --test-threads=1
- cargo test --workspace -- --test-threads=1
- python3 .github/scripts/test_demo_scripts.py
- ./scripts/demo/gateway.sh --skip-build --binary target/debug/tau-coding-agent
- ./scripts/demo/all.sh --skip-build --binary target/debug/tau-coding-agent --only gateway --json
