### PR TITLE
feat: add fail-closed multi-channel readiness preflight

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1884,6 +1884,29 @@ pub(crate) struct Cli {
     pub(crate) multi_channel_live_runner: bool,
 
     #[arg(
+        long = "multi-channel-live-readiness-preflight",
+        env = "TAU_MULTI_CHANNEL_LIVE_READINESS_PREFLIGHT",
+        default_value_t = false,
+        conflicts_with = "multi_channel_contract_runner",
+        conflicts_with = "multi_channel_live_runner",
+        help = "Run multi-channel live readiness preflight checks for Telegram/Discord/WhatsApp and exit"
+    )]
+    pub(crate) multi_channel_live_readiness_preflight: bool,
+
+    #[arg(
+        long = "multi-channel-live-readiness-json",
+        env = "TAU_MULTI_CHANNEL_LIVE_READINESS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "multi_channel_live_readiness_preflight",
+        help = "Emit --multi-channel-live-readiness-preflight output as pretty JSON"
+    )]
+    pub(crate) multi_channel_live_readiness_json: bool,
+
+    #[arg(
         long = "multi-channel-fixture",
         env = "TAU_MULTI_CHANNEL_FIXTURE",
         default_value = "crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json",

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -582,6 +582,7 @@ pub(crate) fn handle_command(
             skills_dir: PathBuf::from(".tau/skills"),
             skills_lock_path: PathBuf::from(".tau/skills/skills.lock.json"),
             trust_root_path: None,
+            multi_channel_live_readiness: DoctorMultiChannelReadinessConfig::default(),
         },
     };
     let profile_defaults = ProfileDefaults {

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -153,18 +153,18 @@ pub(crate) use crate::credentials::{
 };
 pub(crate) use crate::diagnostics_commands::{
     build_doctor_command_config, execute_audit_summary_command, execute_doctor_cli_command,
-    execute_policy_command,
+    execute_multi_channel_live_readiness_preflight_command, execute_policy_command,
+};
+#[cfg(test)]
+pub(crate) use crate::diagnostics_commands::{
+    evaluate_multi_channel_live_readiness, parse_doctor_command_args, percentile_duration_ms,
+    render_audit_summary, render_doctor_report, render_doctor_report_json, run_doctor_checks,
+    run_doctor_checks_with_lookup, summarize_audit_file, DoctorCheckOptions, DoctorCheckResult,
+    DoctorCommandArgs, DoctorCommandOutputFormat, DoctorStatus,
 };
 #[cfg(test)]
 pub(crate) use crate::diagnostics_commands::{
     execute_doctor_command, execute_doctor_command_with_options,
-};
-#[cfg(test)]
-pub(crate) use crate::diagnostics_commands::{
-    parse_doctor_command_args, percentile_duration_ms, render_audit_summary, render_doctor_report,
-    render_doctor_report_json, run_doctor_checks, run_doctor_checks_with_lookup,
-    summarize_audit_file, DoctorCheckOptions, DoctorCheckResult, DoctorCommandArgs,
-    DoctorCommandOutputFormat, DoctorStatus,
 };
 use crate::events::{
     execute_events_dry_run_command, execute_events_inspect_command,
@@ -279,9 +279,10 @@ pub(crate) use crate::runtime_output::{
     event_to_json, persist_messages, print_assistant_messages, summarize_message,
 };
 pub(crate) use crate::runtime_types::{
-    AuthCommandConfig, CommandExecutionContext, DoctorCommandConfig, DoctorProviderKeyStatus,
-    ProfileAuthDefaults, ProfileDefaults, ProfileMcpDefaults, ProfilePolicyDefaults,
-    ProfileSessionDefaults, RenderOptions, SessionRuntime, SkillsSyncCommandConfig,
+    AuthCommandConfig, CommandExecutionContext, DoctorCommandConfig,
+    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus, ProfileAuthDefaults,
+    ProfileDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
+    RenderOptions, SessionRuntime, SkillsSyncCommandConfig,
 };
 use crate::session::{SessionImportMode, SessionStore};
 #[cfg(test)]

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -38,6 +38,33 @@ pub(crate) struct DoctorProviderKeyStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorMultiChannelReadinessConfig {
+    pub(crate) ingress_dir: PathBuf,
+    pub(crate) credential_store_path: PathBuf,
+    pub(crate) credential_store_encryption: CredentialStoreEncryptionMode,
+    pub(crate) credential_store_key: Option<String>,
+    pub(crate) telegram_bot_token: Option<String>,
+    pub(crate) discord_bot_token: Option<String>,
+    pub(crate) whatsapp_access_token: Option<String>,
+    pub(crate) whatsapp_phone_number_id: Option<String>,
+}
+
+impl Default for DoctorMultiChannelReadinessConfig {
+    fn default() -> Self {
+        Self {
+            ingress_dir: PathBuf::from(".tau/multi-channel/live-ingress"),
+            credential_store_path: PathBuf::from(".tau/credentials.json"),
+            credential_store_encryption: CredentialStoreEncryptionMode::None,
+            credential_store_key: None,
+            telegram_bot_token: None,
+            discord_bot_token: None,
+            whatsapp_access_token: None,
+            whatsapp_phone_number_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DoctorCommandConfig {
     pub(crate) model: String,
     pub(crate) provider_keys: Vec<DoctorProviderKeyStatus>,
@@ -49,6 +76,7 @@ pub(crate) struct DoctorCommandConfig {
     pub(crate) skills_dir: PathBuf,
     pub(crate) skills_lock_path: PathBuf,
     pub(crate) trust_root_path: Option<PathBuf>,
+    pub(crate) multi_channel_live_readiness: DoctorMultiChannelReadinessConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -26,6 +26,11 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.multi_channel_live_readiness_preflight {
+        execute_multi_channel_live_readiness_preflight_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.extension_exec_manifest.is_some() {
         execute_extension_exec_command(cli)?;
         return Ok(true);

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -62,6 +62,44 @@ Primary state files:
 Each line must be one normalized provider envelope JSON object. Invalid lines are skipped with
 explicit parse diagnostics in stderr; valid lines continue processing.
 
+## Live readiness preflight
+
+Run this gate before enabling `--multi-channel-live-runner`:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-readiness-preflight
+```
+
+Machine-readable output:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-readiness-preflight \
+  --multi-channel-live-readiness-json
+```
+
+Fail-closed behavior:
+
+- Exit code is non-zero when required prerequisites fail
+- Output includes deterministic reason codes (`key:code`) for remediation
+
+Required channel prerequisites:
+
+- Telegram: `TAU_TELEGRAM_BOT_TOKEN` or integration id `telegram-bot-token`
+- Discord: `TAU_DISCORD_BOT_TOKEN` or integration id `discord-bot-token`
+- WhatsApp token: `TAU_WHATSAPP_ACCESS_TOKEN` or integration id `whatsapp-access-token`
+- WhatsApp phone id: `TAU_WHATSAPP_PHONE_NUMBER_ID` or integration id `whatsapp-phone-number-id`
+
+Channel secrets can be seeded via integration store:
+
+```bash
+/integration-auth set telegram-bot-token <secret>
+/integration-auth set discord-bot-token <secret>
+/integration-auth set whatsapp-access-token <secret>
+/integration-auth set whatsapp-phone-number-id <value>
+```
+
 ## Rollout plan with guardrails
 
 1. Validate fixture/live runtime locally:

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -118,6 +118,35 @@ Ingress directory layout:
 
 Each line is one normalized provider envelope JSON object.
 
+Run readiness preflight before enabling live mode (fails closed on required gaps):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-readiness-preflight
+```
+
+JSON output mode:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-readiness-preflight \
+  --multi-channel-live-readiness-json
+```
+
+Readiness checks cover:
+
+- Credential store readability (`--credential-store`)
+- Live ingress directory path + per-channel inbox files
+- Channel prerequisites for Telegram/Discord/WhatsApp via env var or integration secret
+  (`/integration-auth set <integration-id> <secret>`)
+
+Required channel secrets:
+
+- Telegram: `TAU_TELEGRAM_BOT_TOKEN` or integration id `telegram-bot-token`
+- Discord: `TAU_DISCORD_BOT_TOKEN` or integration id `discord-bot-token`
+- WhatsApp access token: `TAU_WHATSAPP_ACCESS_TOKEN` or integration id `whatsapp-access-token`
+- WhatsApp phone number id: `TAU_WHATSAPP_PHONE_NUMBER_ID` or integration id `whatsapp-phone-number-id`
+
 ```bash
 cargo run -p tau-coding-agent -- \
   --model openai/gpt-4o-mini \


### PR DESCRIPTION
## Summary
- add a dedicated multi-channel live readiness preflight mode: `--multi-channel-live-readiness-preflight`
- add optional machine-readable output: `--multi-channel-live-readiness-json`
- gate live readiness on deterministic checks for Telegram/Discord/WhatsApp prerequisites:
  - credential store health
  - live ingress directory health
  - per-channel inbox and secret readiness
- support secret resolution from either env vars or integration credential ids
- enforce fail-closed behavior (non-zero exit when required readiness checks fail)
- route readiness preflight through startup preflight handling
- document new readiness workflow in transport and multi-channel ops guides
- expand unit/functional/integration/regression coverage for readiness and doctor output

## Risks And Compatibility Notes
- `doctor` now includes additional multi-channel readiness checks; summary totals and key inventory are expanded.
- new CLI flags are additive and conflict-scoped to avoid mode ambiguity.
- readiness preflight is intentionally strict for required prerequisites; operators must satisfy channel secrets before promotion.

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent --tests -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`

## Issue Link
Closes #834
