### PR TITLE
feat: live-mode demo smoke coverage for multi-channel and gateway (#835)

### DIFF
--- a/.github/demo-smoke-manifest.json
+++ b/.github/demo-smoke-manifest.json
@@ -56,6 +56,64 @@
       "args": [
         "--rpc-capabilities"
       ]
+    },
+    {
+      "name": "multi-channel-live-runner",
+      "args": [
+        "--multi-channel-live-runner",
+        "--multi-channel-live-ingress-dir",
+        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke",
+        "--multi-channel-state-dir",
+        ".tau/ci-smoke/multi-channel"
+      ]
+    },
+    {
+      "name": "multi-channel-transport-health",
+      "args": [
+        "--multi-channel-state-dir",
+        ".tau/ci-smoke/multi-channel",
+        "--transport-health-inspect",
+        "multi-channel",
+        "--transport-health-json"
+      ]
+    },
+    {
+      "name": "multi-channel-status-inspect",
+      "args": [
+        "--multi-channel-state-dir",
+        ".tau/ci-smoke/multi-channel",
+        "--multi-channel-status-inspect",
+        "--multi-channel-status-json"
+      ]
+    },
+    {
+      "name": "gateway-contract-runner",
+      "args": [
+        "--gateway-contract-runner",
+        "--gateway-fixture",
+        "./crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json",
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway"
+      ]
+    },
+    {
+      "name": "gateway-transport-health",
+      "args": [
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway",
+        "--transport-health-inspect",
+        "gateway",
+        "--transport-health-json"
+      ]
+    },
+    {
+      "name": "gateway-status-inspect",
+      "args": [
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway",
+        "--gateway-status-inspect",
+        "--gateway-status-json"
+      ]
     }
   ]
 }

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/discord.ndjson
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/discord.ndjson
@@ -1,0 +1,1 @@
+{"schema_version":1,"transport":"discord","provider":"discord-gateway","payload":{"id":"discord-msg-1","channel_id":"discord-channel-88","timestamp":"2026-01-10T12:00:00Z","content":"/status","author":{"id":"discord-user-3","username":"bot-operator"},"attachments":[]}}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/telegram.ndjson
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/telegram.ndjson
@@ -1,0 +1,1 @@
+{"schema_version":1,"transport":"telegram","provider":"telegram-bot-api","payload":{"update_id":9001,"message":{"message_id":42,"chat":{"id":"chat-100"},"from":{"id":"user-7","username":"alice"},"date":1760100000,"text":"hello from telegram","attachments":[{"id":"att-1","url":"https://example.com/image.png","content_type":"image/png","name":"image.png","size_bytes":12}]}}}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/whatsapp.ndjson
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke/whatsapp.ndjson
@@ -1,0 +1,1 @@
+{"schema_version":1,"transport":"whatsapp","provider":"whatsapp-cloud-api","payload":{"metadata":{"phone_number_id":"phone-55"},"messages":[{"id":"wamid.HBg123","from":"15551234567","timestamp":"1760300000","text":{"body":"hello from whatsapp"}}]}}

--- a/scripts/demo/multi-channel.sh
+++ b/scripts/demo/multi-channel.sh
@@ -82,6 +82,18 @@ tau_demo_common_run_step \
   --multi-channel-retry-base-delay-ms 0
 
 tau_demo_common_run_step \
+  "transport-health-inspect-multi-channel-live" \
+  --multi-channel-state-dir "${demo_state_dir}" \
+  --transport-health-inspect multi-channel \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "multi-channel-status-inspect-live" \
+  --multi-channel-state-dir "${demo_state_dir}" \
+  --multi-channel-status-inspect \
+  --multi-channel-status-json
+
+tau_demo_common_run_step \
   "channel-store-inspect-telegram" \
   --channel-store-root "${demo_state_dir}/channel-store" \
   --channel-store-inspect telegram/chat-100


### PR DESCRIPTION
## Summary\n- expand codex-light demo smoke manifest with deterministic live-mode and gateway diagnostics commands\n- add smoke NDJSON ingress fixtures for telegram, discord, and whatsapp live-mode coverage\n- extend multi-channel demo script to include live transport-health and status inspection steps\n- add helper-script tests for manifest coverage, command uniqueness, and demo step ordering\n\n## Risks and Compatibility\n- low risk: changes are additive to demo/test paths and do not alter production request handling\n- manifest command set grows in codex-light CI profile; runtime remains offline/deterministic fixtures only\n- no provider/API credential requirements introduced\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace -- --test-threads=1\n- python3 -m unittest discover -s .github/scripts -p "test_demo*.py"\n- scripts/demo/multi-channel.sh --skip-build --repo-root . --binary target/debug/tau-coding-agent\n- scripts/demo/gateway.sh --skip-build --repo-root . --binary target/debug/tau-coding-agent\n\nCloses #835