### PR TITLE
feat: gateway service lifecycle commands and rollout status parity (#840)

### DIFF
--- a/.github/demo-smoke-manifest.json
+++ b/.github/demo-smoke-manifest.json
@@ -114,6 +114,33 @@
         "--gateway-status-inspect",
         "--gateway-status-json"
       ]
+    },
+    {
+      "name": "gateway-service-start",
+      "args": [
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-service",
+        "--gateway-service-start"
+      ]
+    },
+    {
+      "name": "gateway-service-status",
+      "args": [
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-service",
+        "--gateway-service-status",
+        "--gateway-service-status-json"
+      ]
+    },
+    {
+      "name": "gateway-service-stop",
+      "args": [
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-service",
+        "--gateway-service-stop",
+        "--gateway-service-stop-reason",
+        "ci_smoke_complete"
+      ]
     }
   ]
 }

--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -486,9 +486,23 @@ class DemoScriptsTests(unittest.TestCase):
             trace_rows = step_trace_path.read_text(encoding="utf-8").splitlines()
             labels = [row.split("\t", 1)[0] for row in trace_rows]
 
+            self.assertIn("gateway-service-start", labels)
             self.assertIn("gateway-runner", labels)
             self.assertIn("transport-health-inspect-gateway", labels)
-            self.assertIn("gateway-status-inspect", labels)
+            self.assertIn("gateway-status-inspect-running", labels)
+            self.assertIn("gateway-service-stop", labels)
+            self.assertIn("gateway-service-status-stopped", labels)
+            self.assertIn("gateway-status-inspect-stopped", labels)
+
+            start_index = labels.index("gateway-service-start")
+            runner_index = labels.index("gateway-runner")
+            stop_index = labels.index("gateway-service-stop")
+            stopped_status_index = labels.index("gateway-service-status-stopped")
+            stopped_inspect_index = labels.index("gateway-status-inspect-stopped")
+            self.assertLess(start_index, runner_index)
+            self.assertLess(runner_index, stop_index)
+            self.assertLess(stop_index, stopped_status_index)
+            self.assertLess(stopped_status_index, stopped_inspect_index)
 
     def test_integration_all_script_list_json_reports_canonical_order(self) -> None:
         completed = subprocess.run(

--- a/.github/scripts/test_demo_smoke_runner.py
+++ b/.github/scripts/test_demo_smoke_runner.py
@@ -44,6 +44,9 @@ class DemoSmokeRunnerTests(unittest.TestCase):
         self.assertIn("gateway-contract-runner", names)
         self.assertIn("gateway-transport-health", names)
         self.assertIn("gateway-status-inspect", names)
+        self.assertIn("gateway-service-start", names)
+        self.assertIn("gateway-service-status", names)
+        self.assertIn("gateway-service-stop", names)
 
     def test_unit_load_manifest_accepts_valid_schema_and_commands(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -911,6 +911,84 @@ pub(crate) struct Cli {
     pub(crate) gateway_status_json: bool,
 
     #[arg(
+        long = "gateway-service-start",
+        env = "TAU_GATEWAY_SERVICE_START",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        conflicts_with = "gateway_service_stop",
+        conflicts_with = "gateway_service_status",
+        help = "Start gateway service mode and persist lifecycle state"
+    )]
+    pub(crate) gateway_service_start: bool,
+
+    #[arg(
+        long = "gateway-service-stop",
+        env = "TAU_GATEWAY_SERVICE_STOP",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        conflicts_with = "gateway_service_start",
+        conflicts_with = "gateway_service_status",
+        help = "Stop gateway service mode and persist lifecycle state"
+    )]
+    pub(crate) gateway_service_stop: bool,
+
+    #[arg(
+        long = "gateway-service-stop-reason",
+        env = "TAU_GATEWAY_SERVICE_STOP_REASON",
+        requires = "gateway_service_stop",
+        help = "Optional reason code/message recorded with --gateway-service-stop"
+    )]
+    pub(crate) gateway_service_stop_reason: Option<String>,
+
+    #[arg(
+        long = "gateway-service-status",
+        env = "TAU_GATEWAY_SERVICE_STATUS",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        conflicts_with = "gateway_service_start",
+        conflicts_with = "gateway_service_stop",
+        help = "Inspect gateway service lifecycle state and exit"
+    )]
+    pub(crate) gateway_service_status: bool,
+
+    #[arg(
+        long = "gateway-service-status-json",
+        env = "TAU_GATEWAY_SERVICE_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "gateway_service_status",
+        help = "Emit --gateway-service-status output as pretty JSON"
+    )]
+    pub(crate) gateway_service_status_json: bool,
+
+    #[arg(
         long = "deployment-status-inspect",
         env = "TAU_DEPLOYMENT_STATUS_INSPECT",
         conflicts_with = "channel_store_inspect",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -262,7 +262,7 @@ pub(crate) use crate::rpc_protocol::{
 pub(crate) use crate::runtime_cli_validation::{
     validate_custom_command_contract_runner_cli, validate_dashboard_contract_runner_cli,
     validate_deployment_contract_runner_cli, validate_event_webhook_ingest_cli,
-    validate_events_runner_cli, validate_gateway_contract_runner_cli,
+    validate_events_runner_cli, validate_gateway_contract_runner_cli, validate_gateway_service_cli,
     validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
     validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
     validate_multi_channel_live_runner_cli, validate_slack_bridge_cli,

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -26,6 +26,47 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.gateway_service_start || cli.gateway_service_stop || cli.gateway_service_status {
+        validate_gateway_service_cli(cli)?;
+        if cli.gateway_service_start {
+            let report =
+                crate::gateway_runtime::start_gateway_service_mode(&cli.gateway_state_dir)?;
+            println!(
+                "{}",
+                crate::gateway_runtime::render_gateway_service_status_report(&report)
+            );
+            return Ok(true);
+        }
+        if cli.gateway_service_stop {
+            let report = crate::gateway_runtime::stop_gateway_service_mode(
+                &cli.gateway_state_dir,
+                cli.gateway_service_stop_reason.as_deref(),
+            )?;
+            println!(
+                "{}",
+                crate::gateway_runtime::render_gateway_service_status_report(&report)
+            );
+            return Ok(true);
+        }
+        if cli.gateway_service_status {
+            let report =
+                crate::gateway_runtime::inspect_gateway_service_mode(&cli.gateway_state_dir)?;
+            if cli.gateway_service_status_json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .context("failed to render gateway service status json")?
+                );
+            } else {
+                println!(
+                    "{}",
+                    crate::gateway_runtime::render_gateway_service_status_report(&report)
+                );
+            }
+            return Ok(true);
+        }
+    }
+
     if cli.multi_channel_live_readiness_preflight {
         execute_multi_channel_live_readiness_preflight_command(cli)?;
         return Ok(true);

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -4,7 +4,38 @@ Run all commands from repository root.
 
 ## Scope
 
-This runbook covers the fixture-driven gateway runtime (`--gateway-contract-runner`).
+This runbook covers:
+
+- fixture-driven gateway runtime (`--gateway-contract-runner`)
+- gateway service lifecycle control (`--gateway-service-start|stop|status`)
+
+## Service lifecycle commands
+
+Start service mode (persists lifecycle posture):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --gateway-service-start
+```
+
+Stop service mode with an explicit reason:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --gateway-service-stop \
+  --gateway-service-stop-reason maintenance_window
+```
+
+Inspect lifecycle posture:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-state-dir .tau/gateway \
+  --gateway-service-status \
+  --gateway-service-status-json
+```
 
 ## Health and observability signals
 
@@ -46,6 +77,7 @@ Guardrail interpretation:
 
 - `rollout_gate=pass`: guardrail thresholds are satisfied, promotion can continue.
 - `rollout_gate=hold`: a guardrail threshold is breached; inspect `rollout_reason_code`.
+- `rollout_reason_code=service_stopped`: lifecycle stop posture is forcing rollout hold.
 
 Configurable guardrail thresholds (runner flags):
 
@@ -64,17 +96,20 @@ Configurable guardrail thresholds (runner flags):
    `cargo test -p tau-coding-agent gateway_contract -- --test-threads=1`
 2. Validate runtime behavior coverage:
    `cargo test -p tau-coding-agent gateway_runtime -- --test-threads=1`
-3. Run deterministic demo:
+3. Start service lifecycle posture:
+   `--gateway-service-start`
+4. Run deterministic demo:
    `./scripts/demo/gateway.sh`
-4. Verify transport health and status gate:
+5. Verify transport health and status gate:
    `--transport-health-inspect gateway --transport-health-json`
    `--gateway-status-inspect --gateway-status-json`
-5. Promote by increasing fixture complexity gradually while monitoring:
+6. Promote by increasing fixture complexity gradually while monitoring:
    `failure_streak`, `last_cycle_failed`, `last_retryable_failures`, `queue_depth`, `rollout_gate`, `rollout_reason_code`.
 
 ## Rollback plan
 
-1. Stop invoking `--gateway-contract-runner`.
+1. Stop service lifecycle posture:
+   `--gateway-service-stop --gateway-service-stop-reason emergency_rollback`
 2. Preserve `.tau/gateway/` for incident analysis.
 3. Revert to last known-good revision:
    `git revert <commit>`

--- a/scripts/demo/gateway.sh
+++ b/scripts/demo/gateway.sh
@@ -23,6 +23,11 @@ tau_demo_common_prepare_binary
 rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
 
 tau_demo_common_run_step \
+  "gateway-service-start" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-service-start
+
+tau_demo_common_run_step \
   "gateway-runner" \
   --gateway-contract-runner \
   --gateway-fixture ./crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
@@ -35,7 +40,25 @@ tau_demo_common_run_step \
   --transport-health-json
 
 tau_demo_common_run_step \
-  "gateway-status-inspect" \
+  "gateway-status-inspect-running" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-status-inspect \
+  --gateway-status-json
+
+tau_demo_common_run_step \
+  "gateway-service-stop" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-service-stop \
+  --gateway-service-stop-reason demo_complete
+
+tau_demo_common_run_step \
+  "gateway-service-status-stopped" \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-service-status \
+  --gateway-service-status-json
+
+tau_demo_common_run_step \
+  "gateway-status-inspect-stopped" \
   --gateway-state-dir "${demo_state_dir}" \
   --gateway-status-inspect \
   --gateway-status-json


### PR DESCRIPTION
## Summary
- add gateway lifecycle CLI surfaces for live mode: `--gateway-service-start`, `--gateway-service-stop`, `--gateway-service-status`, and `--gateway-service-status-json`
- persist lifecycle posture in gateway state with startup attempts, stop reason, transition timestamps, and startup-error context fields
- integrate lifecycle posture into gateway status inspect so rollout gate reflects both guardrails and service status (`service_stopped` forces hold)
- extend startup preflight routing and validation for deterministic lifecycle command handling
- update gateway demo, codex-light smoke manifest, and helper-script tests to cover lifecycle start/status/stop flows
- update gateway operations runbook with lifecycle command workflows and rollout guidance

## Risks and Compatibility
- low risk: additive command surfaces and state fields; existing gateway contract-runner behavior remains intact
- state schema remains version 1 and uses backward-compatible defaults for legacy state files missing `service`
- gateway status inspect output now includes additional lifecycle/guardrail fields; existing fields are preserved

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_demo*.py"`
- `scripts/demo/gateway.sh --skip-build --repo-root . --binary target/debug/tau-coding-agent`
- `python3 .github/scripts/demo_smoke_runner.py --repo-root . --manifest .github/demo-smoke-manifest.json --binary target/debug/tau-coding-agent --log-dir /tmp/tau-demo-smoke-issue840 --build`

Closes #840
