### PR TITLE
feat: add raw multichannel live-ingest adapters for Telegram/Discord/WhatsApp

### DIFF
--- a/.github/demo-smoke-manifest.json
+++ b/.github/demo-smoke-manifest.json
@@ -58,11 +58,50 @@
       ]
     },
     {
+      "name": "multi-channel-live-ingest-telegram",
+      "args": [
+        "--multi-channel-live-ingest-file",
+        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json",
+        "--multi-channel-live-ingest-transport",
+        "telegram",
+        "--multi-channel-live-ingest-provider",
+        "telegram-bot-api",
+        "--multi-channel-live-ingest-dir",
+        ".tau/ci-smoke/multi-channel/live-ingress"
+      ]
+    },
+    {
+      "name": "multi-channel-live-ingest-discord",
+      "args": [
+        "--multi-channel-live-ingest-file",
+        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/discord-message.json",
+        "--multi-channel-live-ingest-transport",
+        "discord",
+        "--multi-channel-live-ingest-provider",
+        "discord-gateway",
+        "--multi-channel-live-ingest-dir",
+        ".tau/ci-smoke/multi-channel/live-ingress"
+      ]
+    },
+    {
+      "name": "multi-channel-live-ingest-whatsapp",
+      "args": [
+        "--multi-channel-live-ingest-file",
+        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/whatsapp-message.json",
+        "--multi-channel-live-ingest-transport",
+        "whatsapp",
+        "--multi-channel-live-ingest-provider",
+        "whatsapp-cloud-api",
+        "--multi-channel-live-ingest-dir",
+        ".tau/ci-smoke/multi-channel/live-ingress"
+      ]
+    },
+    {
       "name": "multi-channel-live-runner",
       "args": [
         "--multi-channel-live-runner",
         "--multi-channel-live-ingress-dir",
-        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/smoke",
+        ".tau/ci-smoke/multi-channel/live-ingress",
         "--multi-channel-state-dir",
         ".tau/ci-smoke/multi-channel"
       ]

--- a/.github/scripts/test_demo_smoke_runner.py
+++ b/.github/scripts/test_demo_smoke_runner.py
@@ -38,6 +38,9 @@ class DemoSmokeRunnerTests(unittest.TestCase):
     def test_unit_repository_manifest_includes_live_mode_and_gateway_diagnostics(self):
         commands = demo_smoke_runner.load_manifest(DEFAULT_MANIFEST)
         names = [command.name for command in commands]
+        self.assertIn("multi-channel-live-ingest-telegram", names)
+        self.assertIn("multi-channel-live-ingest-discord", names)
+        self.assertIn("multi-channel-live-ingest-whatsapp", names)
         self.assertIn("multi-channel-live-runner", names)
         self.assertIn("multi-channel-transport-health", names)
         self.assertIn("multi-channel-status-inspect", names)

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -4,9 +4,9 @@ use clap::{ArgAction, Parser};
 
 use crate::{
     release_channel_commands::RELEASE_LOOKUP_CACHE_TTL_MS, CliBashProfile, CliCommandFileErrorMode,
-    CliCredentialStoreEncryptionMode, CliEventTemplateSchedule, CliOrchestratorMode,
-    CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset,
-    CliWebhookSignatureAlgorithm,
+    CliCredentialStoreEncryptionMode, CliEventTemplateSchedule, CliMultiChannelTransport,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {
@@ -1960,6 +1960,40 @@ pub(crate) struct Cli {
         help = "Run live-ingress multi-channel runtime using local adapter inbox files for Telegram/Discord/WhatsApp"
     )]
     pub(crate) multi_channel_live_runner: bool,
+
+    #[arg(
+        long = "multi-channel-live-ingest-file",
+        env = "TAU_MULTI_CHANNEL_LIVE_INGEST_FILE",
+        help = "One-shot provider payload ingestion: normalize a Telegram/Discord/WhatsApp payload file into live-ingress NDJSON and exit"
+    )]
+    pub(crate) multi_channel_live_ingest_file: Option<PathBuf>,
+
+    #[arg(
+        long = "multi-channel-live-ingest-transport",
+        env = "TAU_MULTI_CHANNEL_LIVE_INGEST_TRANSPORT",
+        value_enum,
+        requires = "multi_channel_live_ingest_file",
+        help = "Transport for --multi-channel-live-ingest-file (telegram, discord, whatsapp)"
+    )]
+    pub(crate) multi_channel_live_ingest_transport: Option<CliMultiChannelTransport>,
+
+    #[arg(
+        long = "multi-channel-live-ingest-provider",
+        env = "TAU_MULTI_CHANNEL_LIVE_INGEST_PROVIDER",
+        default_value = "native-ingress",
+        requires = "multi_channel_live_ingest_file",
+        help = "Provider identifier recorded in normalized live-ingress envelopes"
+    )]
+    pub(crate) multi_channel_live_ingest_provider: String,
+
+    #[arg(
+        long = "multi-channel-live-ingest-dir",
+        env = "TAU_MULTI_CHANNEL_LIVE_INGEST_DIR",
+        default_value = ".tau/multi-channel/live-ingress",
+        requires = "multi_channel_live_ingest_file",
+        help = "Directory where one-shot live-ingest writes transport-specific NDJSON inbox files"
+    )]
+    pub(crate) multi_channel_live_ingest_dir: PathBuf,
 
     #[arg(
         long = "multi-channel-live-readiness-preflight",

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -1,6 +1,7 @@
 use clap::ValueEnum;
 
 use crate::events::WebhookSignatureAlgorithm;
+use crate::multi_channel_contract::MultiChannelTransport;
 use crate::session::SessionImportMode;
 use crate::tools::{BashCommandProfile, OsSandboxMode, ToolPolicyPreset};
 use crate::ProviderAuthMethod;
@@ -131,4 +132,21 @@ pub(crate) enum CliCredentialStoreEncryptionMode {
 pub(crate) enum CliOrchestratorMode {
     Off,
     PlanFirst,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliMultiChannelTransport {
+    Telegram,
+    Discord,
+    Whatsapp,
+}
+
+impl From<CliMultiChannelTransport> for MultiChannelTransport {
+    fn from(value: CliMultiChannelTransport) -> Self {
+        match value {
+            CliMultiChannelTransport::Telegram => MultiChannelTransport::Telegram,
+            CliMultiChannelTransport::Discord => MultiChannelTransport::Discord,
+            CliMultiChannelTransport::Whatsapp => MultiChannelTransport::Whatsapp,
+        }
+    }
 }

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -126,8 +126,8 @@ pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
-    CliEventTemplateSchedule, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
-    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliEventTemplateSchedule, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
+    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
@@ -265,8 +265,8 @@ pub(crate) use crate::runtime_cli_validation::{
     validate_events_runner_cli, validate_gateway_contract_runner_cli, validate_gateway_service_cli,
     validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
     validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
-    validate_multi_channel_live_runner_cli, validate_slack_bridge_cli,
-    validate_voice_contract_runner_cli,
+    validate_multi_channel_live_ingest_cli, validate_multi_channel_live_runner_cli,
+    validate_slack_bridge_cli, validate_voice_contract_runner_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -231,6 +231,67 @@ pub(crate) fn validate_multi_channel_live_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_multi_channel_live_ingest_cli(cli: &Cli) -> Result<()> {
+    if cli.multi_channel_live_ingest_file.is_none() {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--multi-channel-live-ingest-file cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--multi-channel-live-ingest-file cannot be used together with --no-session");
+    }
+    if cli.multi_channel_contract_runner || cli.multi_channel_live_runner {
+        bail!("--multi-channel-live-ingest-file cannot be combined with --multi-channel-contract-runner or --multi-channel-live-runner");
+    }
+    if cli.multi_channel_live_readiness_preflight {
+        bail!(
+            "--multi-channel-live-ingest-file cannot be combined with --multi-channel-live-readiness-preflight"
+        );
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.memory_contract_runner
+    {
+        bail!("--multi-channel-live-ingest-file cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, or --memory-contract-runner");
+    }
+
+    let ingest_file = cli
+        .multi_channel_live_ingest_file
+        .as_ref()
+        .ok_or_else(|| anyhow!("--multi-channel-live-ingest-file is required"))?;
+    if !ingest_file.exists() {
+        bail!(
+            "--multi-channel-live-ingest-file '{}' does not exist",
+            ingest_file.display()
+        );
+    }
+    if !ingest_file.is_file() {
+        bail!(
+            "--multi-channel-live-ingest-file '{}' must point to a file",
+            ingest_file.display()
+        );
+    }
+    if cli.multi_channel_live_ingest_transport.is_none() {
+        bail!(
+            "--multi-channel-live-ingest-transport is required when --multi-channel-live-ingest-file is set"
+        );
+    }
+    if cli.multi_channel_live_ingest_provider.trim().is_empty() {
+        bail!("--multi-channel-live-ingest-provider cannot be empty");
+    }
+    if cli.multi_channel_live_ingest_dir.exists() && !cli.multi_channel_live_ingest_dir.is_dir() {
+        bail!(
+            "--multi-channel-live-ingest-dir '{}' must point to a directory when it exists",
+            cli.multi_channel_live_ingest_dir.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_multi_agent_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.multi_agent_contract_runner {
         return Ok(());

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/README.md
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/README.md
@@ -24,3 +24,8 @@ Files:
 - `whatsapp-valid.json`: valid WhatsApp envelope.
 - `invalid-unsupported-transport.json`: unsupported transport regression sample.
 - `invalid-discord-missing-author.json`: missing required `payload.author` regression sample.
+
+Raw provider payload fixtures (for one-shot ingest command):
+- `raw/telegram-update.json`
+- `raw/discord-message.json`
+- `raw/whatsapp-message.json`

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/discord-message.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/discord-message.json
@@ -1,0 +1,11 @@
+{
+  "id": "discord-msg-1",
+  "channel_id": "discord-channel-88",
+  "timestamp": "2026-01-10T12:00:00Z",
+  "content": "/status",
+  "author": {
+    "id": "discord-user-3",
+    "username": "bot-operator"
+  },
+  "attachments": []
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json
@@ -1,0 +1,24 @@
+{
+  "update_id": 9001,
+  "message": {
+    "message_id": 42,
+    "chat": {
+      "id": "chat-100"
+    },
+    "from": {
+      "id": "user-7",
+      "username": "alice"
+    },
+    "date": 1760100000,
+    "text": "hello from telegram",
+    "attachments": [
+      {
+        "id": "att-1",
+        "url": "https://example.com/image.png",
+        "content_type": "image/png",
+        "name": "image.png",
+        "size_bytes": 12
+      }
+    ]
+  }
+}

--- a/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/whatsapp-message.json
+++ b/crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/whatsapp-message.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "phone_number_id": "phone-55"
+  },
+  "messages": [
+    {
+      "id": "wamid.HBg123",
+      "from": "15551234567",
+      "timestamp": "1760300000",
+      "text": {
+        "body": "hello from whatsapp"
+      }
+    }
+  ]
+}

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -62,6 +62,19 @@ Primary state files:
 Each line must be one normalized provider envelope JSON object. Invalid lines are skipped with
 explicit parse diagnostics in stderr; valid lines continue processing.
 
+One-shot raw provider ingest command (appends normalized envelopes to live-ingress files):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-ingest-file ./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json \
+  --multi-channel-live-ingest-transport telegram \
+  --multi-channel-live-ingest-provider telegram-bot-api \
+  --multi-channel-live-ingest-dir .tau/multi-channel/live-ingress
+```
+
+Use the same command for `discord` and `whatsapp` payloads by changing
+`--multi-channel-live-ingest-transport` and `--multi-channel-live-ingest-file`.
+
 ## Live readiness preflight
 
 Run this gate before enabling `--multi-channel-live-runner`:

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -147,6 +147,28 @@ Required channel secrets:
 - WhatsApp access token: `TAU_WHATSAPP_ACCESS_TOKEN` or integration id `whatsapp-access-token`
 - WhatsApp phone number id: `TAU_WHATSAPP_PHONE_NUMBER_ID` or integration id `whatsapp-phone-number-id`
 
+One-shot provider payload ingest (raw payload -> live ingress NDJSON):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-ingest-file ./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json \
+  --multi-channel-live-ingest-transport telegram \
+  --multi-channel-live-ingest-provider telegram-bot-api \
+  --multi-channel-live-ingest-dir .tau/multi-channel/live-ingress
+```
+
+Supported ingest transports:
+
+- `telegram`
+- `discord`
+- `whatsapp`
+
+The command validates payload shape and appends one normalized envelope line to:
+
+- `<ingest-dir>/telegram.ndjson`
+- `<ingest-dir>/discord.ndjson`
+- `<ingest-dir>/whatsapp.ndjson`
+
 ```bash
 cargo run -p tau-coding-agent -- \
   --model openai/gpt-4o-mini \


### PR DESCRIPTION
## Summary
- add a new one-shot multichannel ingest surface for raw provider payloads:
  - `--multi-channel-live-ingest-file`
  - `--multi-channel-live-ingest-transport`
  - `--multi-channel-live-ingest-provider`
  - `--multi-channel-live-ingest-dir`
- add runtime validation + startup preflight execution for live ingest mode with fail-closed behavior
- add raw payload adapter normalization and append-to-NDJSON ingestion path for Telegram/Discord/WhatsApp
- extend tests across unit/functional/integration/regression for parser, CLI, validation, and startup preflight flows
- update multi-channel demo + demo smoke manifest to exercise the new ingest path before live runner
- document the new ingest workflow in transport and multi-channel ops guides

## Risks / Compatibility
- new CLI flags are additive and backward compatible
- live-runner behavior is unchanged when ingest mode is not used
- startup preflight now handles ingest mode as an explicit one-shot command path; conflicting mode combinations are rejected

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent multi_channel_live_ingress -- --test-threads=1`
- `cargo test -p tau-coding-agent multi_channel_live_ingest -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p "test_demo*.py"`
- `./scripts/demo/multi-channel.sh --skip-build --repo-root . --binary target/debug/tau-coding-agent`
- `python3 .github/scripts/demo_smoke_runner.py --repo-root . --manifest .github/demo-smoke-manifest.json --binary target/debug/tau-coding-agent --log-dir /tmp/tau-demo-smoke-issue843`

Closes #843
