### PR TITLE
feat: enforce multichannel pairing/allowlist policy (#845)

### DIFF
--- a/crates/tau-coding-agent/src/pairing.rs
+++ b/crates/tau-coding-agent/src/pairing.rs
@@ -79,7 +79,11 @@ pub(crate) fn default_pairing_policy_config() -> Result<PairingPolicyConfig> {
 pub(crate) fn pairing_policy_for_state_dir(state_dir: &Path) -> PairingPolicyConfig {
     let state_name = state_dir.file_name().and_then(|value| value.to_str());
     let tau_root = match state_name {
-        Some("github") | Some("slack") | Some("events") | Some("channel-store") => state_dir
+        Some("github")
+        | Some("slack")
+        | Some("events")
+        | Some("channel-store")
+        | Some("multi-channel") => state_dir
             .parent()
             .filter(|path| !path.as_os_str().is_empty())
             .unwrap_or(state_dir),
@@ -728,6 +732,13 @@ mod tests {
         let transport_policy = pairing_policy_for_state_dir(&transport_root);
         assert_eq!(
             transport_policy.registry_path,
+            PathBuf::from(".tau/security/pairings.json")
+        );
+
+        let multi_channel_root = PathBuf::from(".tau/multi-channel");
+        let multi_channel_policy = pairing_policy_for_state_dir(&multi_channel_root);
+        assert_eq!(
+            multi_channel_policy.registry_path,
             PathBuf::from(".tau/security/pairings.json")
         );
 

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -44,6 +44,33 @@ Primary state files:
 - `retry_attempted`
 - `transient_failures_observed`
 - `event_processing_failed`
+- `pairing_policy_permissive`
+- `pairing_policy_enforced`
+- `pairing_policy_denied_events`
+
+## Pairing and allowlist policy
+
+The multi-channel runtime evaluates pairing/allowlist policy per inbound event before generating a
+response.
+
+Policy files:
+
+- `.tau/security/allowlist.json`
+- `.tau/security/pairings.json`
+
+Policy channel key format used by Telegram/Discord/WhatsApp:
+
+- `<transport>:<conversation_id>`
+
+Examples:
+
+- `telegram:chat-100`
+- `discord:discord-channel-88`
+- `whatsapp:phone-55:15551234567`
+
+When strict policy is active, unknown actors are denied with deterministic reason codes
+(`deny_actor_not_paired_or_allowlisted`, `deny_actor_id_missing`). Denied events are recorded in
+channel-store logs and runtime cycle reason codes.
 
 ## Deterministic demo path
 


### PR DESCRIPTION
Closes #845

## Summary
- enforce pairing/allowlist decisions for Telegram/Discord/WhatsApp in multichannel runtime processing
- evaluate policy per inbound event using `<transport>:<conversation_id>` channel keys and fail closed on policy evaluation errors
- persist pairing allow/deny decision metadata into channel-store inbound/outbound log payloads
- add runtime summary/cycle metrics for policy checks and denied events with reason codes
- align pairing policy root resolution for `.tau/multi-channel` to `.tau/security/*`
- extend runbook with pairing policy files, channel key format, and new runtime reason codes

## Risks and compatibility
- behavior change: strict allowlist/pairing policy now actively gates multichannel runtime events (denied actors no longer produce assistant responses)
- runtime-events reason codes now include pairing policy signals (`pairing_policy_permissive`, `pairing_policy_enforced`, `pairing_policy_denied_events`)
- channel-store inbound payloads now include a `pairing` metadata object and denied events emit outbound denial log entries

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent multi_channel_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent pairing -- --test-threads=1`
- `cargo test --workspace -- --test-threads=1`
- `./scripts/demo/multi-channel.sh --skip-build --repo-root . --binary target/debug/tau-coding-agent`
- `python3 .github/scripts/demo_smoke_runner.py --repo-root . --manifest .github/demo-smoke-manifest.json --binary target/debug/tau-coding-agent --log-dir /tmp/tau-demo-smoke-issue845`
