### PR TITLE
feat(gateway): add OpenResponses /v1/responses endpoint subset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2606,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "axum",
  "base64",
  "chrono",
  "chrono-tz",
@@ -2557,6 +2627,7 @@ dependencies = [
  "tau-ai",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
@@ -2716,6 +2787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,6 +2839,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
+axum = { version = "0.8", features = ["json", "http1", "tokio"] }
 anyhow = "1"
 async-trait = "0.1"
 base64 = "0.22"
@@ -30,6 +31,7 @@ serde_json = "1"
 shell-words = "1.1"
 thiserror = "2"
 tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "process", "fs", "io-util", "io-std", "time", "signal"] }
+tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 jsonschema = "0.41"

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+axum.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
@@ -23,6 +24,7 @@ serde_json.workspace = true
 sha2.workspace = true
 shell-words.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -2260,6 +2260,41 @@ pub(crate) struct Cli {
     pub(crate) dashboard_retry_base_delay_ms: u64,
 
     #[arg(
+        long = "gateway-openresponses-server",
+        env = "TAU_GATEWAY_OPENRESPONSES_SERVER",
+        default_value_t = false,
+        help = "Run authenticated OpenResponses subset HTTP endpoint at POST /v1/responses"
+    )]
+    pub(crate) gateway_openresponses_server: bool,
+
+    #[arg(
+        long = "gateway-openresponses-bind",
+        env = "TAU_GATEWAY_OPENRESPONSES_BIND",
+        default_value = "127.0.0.1:8787",
+        requires = "gateway_openresponses_server",
+        help = "Socket address for --gateway-openresponses-server (host:port)"
+    )]
+    pub(crate) gateway_openresponses_bind: String,
+
+    #[arg(
+        long = "gateway-openresponses-auth-token",
+        env = "TAU_GATEWAY_OPENRESPONSES_AUTH_TOKEN",
+        requires = "gateway_openresponses_server",
+        help = "Bearer token required by --gateway-openresponses-server"
+    )]
+    pub(crate) gateway_openresponses_auth_token: Option<String>,
+
+    #[arg(
+        long = "gateway-openresponses-max-input-chars",
+        env = "TAU_GATEWAY_OPENRESPONSES_MAX_INPUT_CHARS",
+        default_value_t = 32_000,
+        value_parser = parse_positive_usize,
+        requires = "gateway_openresponses_server",
+        help = "Maximum translated input size accepted by /v1/responses"
+    )]
+    pub(crate) gateway_openresponses_max_input_chars: usize,
+
+    #[arg(
         long = "gateway-contract-runner",
         env = "TAU_GATEWAY_CONTRACT_RUNNER",
         default_value_t = false,

--- a/crates/tau-coding-agent/src/gateway_openresponses.rs
+++ b/crates/tau-coding-agent/src/gateway_openresponses.rs
@@ -1,0 +1,1209 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tau_agent_core::{Agent, AgentConfig, AgentEvent};
+use tau_ai::{LlmClient, Message, MessageRole, StreamDeltaHandler};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::StreamExt;
+
+use crate::{current_unix_timestamp, persist_messages, SessionRuntime, SessionStore};
+
+const OPENRESPONSES_ENDPOINT: &str = "/v1/responses";
+const DEFAULT_SESSION_KEY: &str = "default";
+const INPUT_BODY_SIZE_MULTIPLIER: usize = 8;
+
+#[derive(Clone)]
+pub(crate) struct GatewayOpenResponsesServerConfig {
+    pub(crate) client: Arc<dyn LlmClient>,
+    pub(crate) model: String,
+    pub(crate) system_prompt: String,
+    pub(crate) max_turns: usize,
+    pub(crate) tool_policy: crate::tools::ToolPolicy,
+    pub(crate) turn_timeout_ms: u64,
+    pub(crate) session_lock_wait_ms: u64,
+    pub(crate) session_lock_stale_ms: u64,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) bind: String,
+    pub(crate) auth_token: String,
+    pub(crate) max_input_chars: usize,
+}
+
+#[derive(Clone)]
+struct GatewayOpenResponsesServerState {
+    config: GatewayOpenResponsesServerConfig,
+    response_sequence: Arc<AtomicU64>,
+}
+
+impl GatewayOpenResponsesServerState {
+    fn new(config: GatewayOpenResponsesServerConfig) -> Self {
+        Self {
+            config,
+            response_sequence: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn next_sequence(&self) -> u64 {
+        self.response_sequence.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn next_response_id(&self) -> String {
+        format!("resp_{:016x}", self.next_sequence())
+    }
+
+    fn next_output_message_id(&self) -> String {
+        format!("msg_{:016x}", self.next_sequence())
+    }
+}
+
+#[derive(Debug)]
+struct OpenResponsesApiError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+}
+
+impl OpenResponsesApiError {
+    fn new(status: StatusCode, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+
+    fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, code, message)
+    }
+
+    fn unauthorized() -> Self {
+        Self::new(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "missing or invalid bearer token",
+        )
+    }
+
+    fn payload_too_large(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::PAYLOAD_TOO_LARGE, "input_too_large", message)
+    }
+
+    fn timeout(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::REQUEST_TIMEOUT, "request_timeout", message)
+    }
+
+    fn gateway_failure(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_GATEWAY, "gateway_runtime_error", message)
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+    }
+}
+
+impl IntoResponse for OpenResponsesApiError {
+    fn into_response(self) -> Response {
+        let error_type = if self.status.is_client_error() {
+            "invalid_request_error"
+        } else {
+            "server_error"
+        };
+        (
+            self.status,
+            Json(json!({
+                "error": {
+                    "type": error_type,
+                    "code": self.code,
+                    "message": self.message,
+                }
+            })),
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenResponsesRequest {
+    #[allow(dead_code)]
+    model: Option<String>,
+    #[serde(default)]
+    input: Value,
+    #[serde(default)]
+    stream: bool,
+    instructions: Option<String>,
+    #[serde(default)]
+    metadata: Value,
+    #[serde(default)]
+    conversation: Option<String>,
+    #[serde(default, rename = "previous_response_id")]
+    previous_response_id: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug)]
+struct OpenResponsesPrompt {
+    prompt: String,
+    session_key: String,
+    ignored_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct OpenResponsesUsageSummary {
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenResponsesOutputTextItem {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenResponsesOutputItem {
+    id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    role: &'static str,
+    content: Vec<OpenResponsesOutputTextItem>,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenResponsesUsage {
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenResponsesResponse {
+    id: String,
+    object: &'static str,
+    created: u64,
+    status: &'static str,
+    model: String,
+    output: Vec<OpenResponsesOutputItem>,
+    output_text: String,
+    usage: OpenResponsesUsage,
+    ignored_fields: Vec<String>,
+}
+
+#[derive(Debug)]
+struct OpenResponsesExecutionResult {
+    response: OpenResponsesResponse,
+}
+
+#[derive(Debug)]
+enum SseFrame {
+    Json { event: &'static str, payload: Value },
+    Done,
+}
+
+impl SseFrame {
+    fn into_event(self) -> Event {
+        match self {
+            Self::Json { event, payload } => {
+                Event::default().event(event).data(payload.to_string())
+            }
+            Self::Done => Event::default().event("done").data("[DONE]"),
+        }
+    }
+}
+
+pub(crate) async fn run_gateway_openresponses_server(
+    config: GatewayOpenResponsesServerConfig,
+) -> Result<()> {
+    std::fs::create_dir_all(&config.state_dir)
+        .with_context(|| format!("failed to create {}", config.state_dir.display()))?;
+
+    let bind_addr = config
+        .bind
+        .parse::<SocketAddr>()
+        .with_context(|| format!("invalid --gateway-openresponses-bind '{}'", config.bind))?;
+
+    let service_report = crate::gateway_runtime::start_gateway_service_mode(&config.state_dir)?;
+    println!(
+        "{}",
+        crate::gateway_runtime::render_gateway_service_status_report(&service_report)
+    );
+
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .with_context(|| format!("failed to bind gateway openresponses server on {bind_addr}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("failed to resolve bound openresponses server address")?;
+
+    println!(
+        "gateway openresponses server listening: endpoint={} addr={} state_dir={}",
+        OPENRESPONSES_ENDPOINT,
+        local_addr,
+        config.state_dir.display()
+    );
+
+    let state_dir = config.state_dir.clone();
+    let state = Arc::new(GatewayOpenResponsesServerState::new(config));
+    let app = build_gateway_openresponses_router(state);
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await
+        .context("gateway openresponses server exited unexpectedly")?;
+
+    let stop_report = crate::gateway_runtime::stop_gateway_service_mode(
+        &state_dir,
+        Some("openresponses_server_shutdown"),
+    );
+    if let Ok(report) = stop_report {
+        println!(
+            "{}",
+            crate::gateway_runtime::render_gateway_service_status_report(&report)
+        );
+    }
+
+    Ok(())
+}
+
+fn build_gateway_openresponses_router(state: Arc<GatewayOpenResponsesServerState>) -> Router {
+    Router::new()
+        .route(OPENRESPONSES_ENDPOINT, post(handle_openresponses))
+        .with_state(state)
+}
+
+async fn handle_openresponses(
+    State(state): State<Arc<GatewayOpenResponsesServerState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if !authorization_is_valid(&headers, &state.config.auth_token) {
+        return OpenResponsesApiError::unauthorized().into_response();
+    }
+
+    let body_limit = state
+        .config
+        .max_input_chars
+        .saturating_mul(INPUT_BODY_SIZE_MULTIPLIER)
+        .max(state.config.max_input_chars);
+    if body.len() > body_limit {
+        return OpenResponsesApiError::payload_too_large(format!(
+            "request body exceeds max size of {} bytes",
+            body_limit
+        ))
+        .into_response();
+    }
+
+    let request = match serde_json::from_slice::<OpenResponsesRequest>(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return OpenResponsesApiError::bad_request(
+                "malformed_json",
+                format!("failed to parse request body: {error}"),
+            )
+            .into_response();
+        }
+    };
+
+    if request.stream {
+        return stream_openresponses(state, request).await;
+    }
+
+    match execute_openresponses_request(state, request, None).await {
+        Ok(result) => (StatusCode::OK, Json(result.response)).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn stream_openresponses(
+    state: Arc<GatewayOpenResponsesServerState>,
+    request: OpenResponsesRequest,
+) -> Response {
+    let (tx, rx) = mpsc::unbounded_channel::<SseFrame>();
+    tokio::spawn(async move {
+        match execute_openresponses_request(state, request, Some(tx.clone())).await {
+            Ok(result) => {
+                let response = result.response;
+                let _ = tx.send(SseFrame::Json {
+                    event: "response.output_text.done",
+                    payload: json!({
+                        "type": "response.output_text.done",
+                        "response_id": response.id,
+                        "text": response.output_text,
+                    }),
+                });
+                let _ = tx.send(SseFrame::Json {
+                    event: "response.completed",
+                    payload: json!({
+                        "type": "response.completed",
+                        "response": response,
+                    }),
+                });
+                let _ = tx.send(SseFrame::Done);
+            }
+            Err(error) => {
+                let _ = tx.send(SseFrame::Json {
+                    event: "response.failed",
+                    payload: json!({
+                        "type": "response.failed",
+                        "error": {
+                            "code": error.code,
+                            "message": error.message,
+                        }
+                    }),
+                });
+                let _ = tx.send(SseFrame::Done);
+            }
+        }
+    });
+
+    let stream =
+        UnboundedReceiverStream::new(rx).map(|frame| Ok::<Event, Infallible>(frame.into_event()));
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+async fn execute_openresponses_request(
+    state: Arc<GatewayOpenResponsesServerState>,
+    request: OpenResponsesRequest,
+    stream_sender: Option<mpsc::UnboundedSender<SseFrame>>,
+) -> Result<OpenResponsesExecutionResult, OpenResponsesApiError> {
+    let mut translated = translate_openresponses_request(&request, state.config.max_input_chars)?;
+    if request.model.is_some() {
+        translated.ignored_fields.push("model".to_string());
+    }
+
+    let response_id = state.next_response_id();
+    let created = current_unix_timestamp();
+
+    if let Some(sender) = &stream_sender {
+        let _ = sender.send(SseFrame::Json {
+            event: "response.created",
+            payload: json!({
+                "type": "response.created",
+                "response": {
+                    "id": response_id,
+                    "object": "response",
+                    "status": "in_progress",
+                    "model": state.config.model,
+                    "created": created,
+                }
+            }),
+        });
+    }
+
+    let mut agent = Agent::new(
+        state.config.client.clone(),
+        AgentConfig {
+            model: state.config.model.clone(),
+            system_prompt: state.config.system_prompt.clone(),
+            max_turns: state.config.max_turns,
+            temperature: Some(0.0),
+            max_tokens: None,
+        },
+    );
+    crate::tools::register_builtin_tools(&mut agent, state.config.tool_policy.clone());
+
+    let usage = Arc::new(Mutex::new(OpenResponsesUsageSummary::default()));
+    agent.subscribe({
+        let usage = usage.clone();
+        move |event| {
+            if let AgentEvent::TurnEnd {
+                usage: turn_usage, ..
+            } = event
+            {
+                if let Ok(mut guard) = usage.lock() {
+                    guard.input_tokens = guard.input_tokens.saturating_add(turn_usage.input_tokens);
+                    guard.output_tokens =
+                        guard.output_tokens.saturating_add(turn_usage.output_tokens);
+                    guard.total_tokens = guard.total_tokens.saturating_add(turn_usage.total_tokens);
+                }
+            }
+        }
+    });
+
+    let session_path = gateway_session_path(&state.config.state_dir, &translated.session_key);
+    let mut session_runtime = Some(
+        initialize_gateway_session_runtime(
+            &session_path,
+            &state.config.system_prompt,
+            state.config.session_lock_wait_ms,
+            state.config.session_lock_stale_ms,
+            &mut agent,
+        )
+        .map_err(|error| {
+            OpenResponsesApiError::internal(format!(
+                "failed to initialize gateway session runtime: {error}"
+            ))
+        })?,
+    );
+
+    let start_index = agent.messages().len();
+    let stream_handler = stream_sender.as_ref().map(|sender| {
+        let sender = sender.clone();
+        let response_id = response_id.clone();
+        Arc::new(move |delta: String| {
+            if delta.is_empty() {
+                return;
+            }
+            let _ = sender.send(SseFrame::Json {
+                event: "response.output_text.delta",
+                payload: json!({
+                    "type": "response.output_text.delta",
+                    "response_id": response_id,
+                    "delta": delta,
+                }),
+            });
+        }) as StreamDeltaHandler
+    });
+
+    let prompt_result = if state.config.turn_timeout_ms == 0 {
+        agent
+            .prompt_with_stream(&translated.prompt, stream_handler)
+            .await
+    } else {
+        match tokio::time::timeout(
+            Duration::from_millis(state.config.turn_timeout_ms),
+            agent.prompt_with_stream(&translated.prompt, stream_handler),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                return Err(OpenResponsesApiError::timeout(
+                    "response generation timed out before completion",
+                ));
+            }
+        }
+    };
+
+    let new_messages = prompt_result.map_err(|error| {
+        OpenResponsesApiError::gateway_failure(format!("gateway runtime failed: {error}"))
+    })?;
+    persist_messages(&mut session_runtime, &new_messages).map_err(|error| {
+        OpenResponsesApiError::internal(format!(
+            "failed to persist gateway session messages: {error}"
+        ))
+    })?;
+
+    let output_text = collect_assistant_reply(&agent.messages()[start_index..]);
+    let usage = usage
+        .lock()
+        .map_err(|_| OpenResponsesApiError::internal("prompt usage lock is poisoned"))?
+        .clone();
+
+    let mut ignored = BTreeSet::new();
+    for field in translated.ignored_fields {
+        if !field.trim().is_empty() {
+            ignored.insert(field);
+        }
+    }
+
+    let response = OpenResponsesResponse {
+        id: response_id,
+        object: "response",
+        created,
+        status: "completed",
+        model: state.config.model.clone(),
+        output: vec![OpenResponsesOutputItem {
+            id: state.next_output_message_id(),
+            kind: "message",
+            role: "assistant",
+            content: vec![OpenResponsesOutputTextItem {
+                kind: "output_text",
+                text: output_text.clone(),
+            }],
+        }],
+        output_text,
+        usage: OpenResponsesUsage {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+        },
+        ignored_fields: ignored.into_iter().collect(),
+    };
+
+    Ok(OpenResponsesExecutionResult { response })
+}
+
+fn translate_openresponses_request(
+    request: &OpenResponsesRequest,
+    max_input_chars: usize,
+) -> Result<OpenResponsesPrompt, OpenResponsesApiError> {
+    let mut ignored_fields = request.extra.keys().cloned().collect::<Vec<_>>();
+    ignored_fields.sort();
+
+    let mut segments = Vec::new();
+    if let Some(instructions) = non_empty_trimmed(request.instructions.as_deref()) {
+        segments.push(format!("System instructions:\n{instructions}"));
+    }
+
+    if let Some(previous_response_id) = non_empty_trimmed(request.previous_response_id.as_deref()) {
+        segments.push(format!(
+            "Continuation context (previous_response_id):\n{previous_response_id}"
+        ));
+    }
+
+    let mut extracted = 0usize;
+    extract_openresponses_input_segments(
+        &request.input,
+        &mut segments,
+        &mut extracted,
+        &mut ignored_fields,
+    )?;
+
+    if extracted == 0 {
+        return Err(OpenResponsesApiError::bad_request(
+            "missing_input",
+            "input must include at least one textual message or function_call_output item",
+        ));
+    }
+
+    let prompt = segments
+        .iter()
+        .filter_map(|segment| {
+            let trimmed = segment.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if prompt.is_empty() {
+        return Err(OpenResponsesApiError::bad_request(
+            "missing_input",
+            "input did not contain usable text",
+        ));
+    }
+
+    if prompt.chars().count() > max_input_chars {
+        return Err(OpenResponsesApiError::payload_too_large(format!(
+            "translated input exceeds max {} characters",
+            max_input_chars
+        )));
+    }
+
+    let session_seed = metadata_string(&request.metadata, "session_id")
+        .or_else(|| non_empty_trimmed(request.conversation.as_deref()))
+        .or_else(|| non_empty_trimmed(request.previous_response_id.as_deref()))
+        .unwrap_or(DEFAULT_SESSION_KEY);
+
+    Ok(OpenResponsesPrompt {
+        prompt,
+        session_key: sanitize_session_key(session_seed),
+        ignored_fields,
+    })
+}
+
+fn extract_openresponses_input_segments(
+    input: &Value,
+    segments: &mut Vec<String>,
+    extracted: &mut usize,
+    ignored_fields: &mut Vec<String>,
+) -> Result<(), OpenResponsesApiError> {
+    match input {
+        Value::Null => Err(OpenResponsesApiError::bad_request(
+            "missing_input",
+            "input is required",
+        )),
+        Value::String(text) => {
+            let text = text.trim();
+            if !text.is_empty() {
+                segments.push(format!("User:\n{text}"));
+                *extracted = extracted.saturating_add(1);
+            }
+            Ok(())
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                extract_openresponses_item(item, index, segments, extracted, ignored_fields)?;
+            }
+            Ok(())
+        }
+        Value::Object(_) => {
+            extract_openresponses_item(input, 0, segments, extracted, ignored_fields)
+        }
+        _ => Err(OpenResponsesApiError::bad_request(
+            "invalid_input",
+            "input must be a string, object, or array",
+        )),
+    }
+}
+
+fn extract_openresponses_item(
+    item: &Value,
+    index: usize,
+    segments: &mut Vec<String>,
+    extracted: &mut usize,
+    ignored_fields: &mut Vec<String>,
+) -> Result<(), OpenResponsesApiError> {
+    match item {
+        Value::String(text) => {
+            let text = text.trim();
+            if !text.is_empty() {
+                segments.push(format!("User:\n{text}"));
+                *extracted = extracted.saturating_add(1);
+            }
+            Ok(())
+        }
+        Value::Object(map) => {
+            let item_type = map.get("type").and_then(Value::as_str).unwrap_or_default();
+            if item_type == "function_call_output" {
+                let output = stringify_output(map.get("output").unwrap_or(&Value::Null));
+                if output.is_empty() {
+                    return Err(OpenResponsesApiError::bad_request(
+                        "invalid_function_call_output",
+                        format!(
+                            "input[{index}] function_call_output item requires non-empty output"
+                        ),
+                    ));
+                }
+                let call_id = map
+                    .get("call_id")
+                    .or_else(|| map.get("id"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("unknown");
+                segments.push(format!("Function output (call_id={call_id}):\n{output}"));
+                *extracted = extracted.saturating_add(1);
+                return Ok(());
+            }
+
+            if item_type == "message" || map.contains_key("role") || map.contains_key("content") {
+                let role = map.get("role").and_then(Value::as_str).unwrap_or("user");
+                let text = extract_message_content_text(map.get("content"));
+                if !text.is_empty() {
+                    segments.push(format!("{}:\n{}", role_label(role), text));
+                    *extracted = extracted.saturating_add(1);
+                } else {
+                    ignored_fields.push(format!("input[{index}].content"));
+                }
+                return Ok(());
+            }
+
+            ignored_fields.push(format!("input[{index}]"));
+            Ok(())
+        }
+        _ => {
+            ignored_fields.push(format!("input[{index}]"));
+            Ok(())
+        }
+    }
+}
+
+fn extract_message_content_text(content: Option<&Value>) -> String {
+    let Some(content) = content else {
+        return String::new();
+    };
+
+    match content {
+        Value::String(text) => text.trim().to_string(),
+        Value::Array(parts) => {
+            let mut segments = Vec::new();
+            for part in parts {
+                if let Some(text) = extract_message_content_part(part) {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        segments.push(trimmed.to_string());
+                    }
+                }
+            }
+            segments.join("\n")
+        }
+        Value::Object(_) => extract_message_content_part(content).unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+fn extract_message_content_part(part: &Value) -> Option<String> {
+    match part {
+        Value::String(text) => Some(text.to_string()),
+        Value::Object(map) => {
+            let part_type = map.get("type").and_then(Value::as_str).unwrap_or("text");
+            match part_type {
+                "input_text" | "output_text" | "text" => map
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(|value| value.to_string()),
+                "function_call_output" => {
+                    let output = stringify_output(map.get("output").unwrap_or(&Value::Null));
+                    if output.trim().is_empty() {
+                        return None;
+                    }
+                    let call_id = map
+                        .get("call_id")
+                        .or_else(|| map.get("id"))
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("unknown");
+                    Some(format!("Function output (call_id={call_id}):\n{output}"))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn stringify_output(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(text) => text.trim().to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+fn role_label(role: &str) -> &'static str {
+    match role.trim().to_ascii_lowercase().as_str() {
+        "assistant" => "Assistant context",
+        "system" => "System context",
+        "tool" => "Tool context",
+        _ => "User",
+    }
+}
+
+fn metadata_string<'a>(metadata: &'a Value, key: &str) -> Option<&'a str> {
+    metadata
+        .as_object()?
+        .get(key)?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn non_empty_trimmed(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn sanitize_session_key(raw: &str) -> String {
+    let mut normalized = String::new();
+    for ch in raw.trim().chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            normalized.push(ch);
+        } else {
+            normalized.push('_');
+        }
+    }
+    let normalized = normalized.trim_matches('_').to_string();
+    if normalized.is_empty() {
+        DEFAULT_SESSION_KEY.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn gateway_session_path(state_dir: &Path, session_key: &str) -> PathBuf {
+    state_dir
+        .join("openresponses")
+        .join("sessions")
+        .join(format!("{session_key}.jsonl"))
+}
+
+fn initialize_gateway_session_runtime(
+    session_path: &Path,
+    system_prompt: &str,
+    lock_wait_ms: u64,
+    lock_stale_ms: u64,
+    agent: &mut Agent,
+) -> Result<SessionRuntime> {
+    if let Some(parent) = session_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    let mut store = SessionStore::load(session_path)?;
+    store.set_lock_policy(lock_wait_ms.max(1), lock_stale_ms);
+    let active_head = store.ensure_initialized(system_prompt)?;
+    let lineage = store.lineage_messages(active_head)?;
+    if !lineage.is_empty() {
+        agent.replace_messages(lineage);
+    }
+    Ok(SessionRuntime { store, active_head })
+}
+
+fn collect_assistant_reply(messages: &[Message]) -> String {
+    let content = messages
+        .iter()
+        .filter(|message| message.role == MessageRole::Assistant)
+        .map(Message::text_content)
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if content.trim().is_empty() {
+        "I couldn't generate a textual response for this request.".to_string()
+    } else {
+        content
+    }
+}
+
+fn authorization_is_valid(headers: &HeaderMap, auth_token: &str) -> bool {
+    let Some(header) = headers.get(AUTHORIZATION) else {
+        return false;
+    };
+    let Ok(raw) = header.to_str() else {
+        return false;
+    };
+    let Some(token) = raw.strip_prefix("Bearer ") else {
+        return false;
+    };
+    token.trim() == auth_token
+}
+
+pub(crate) fn validate_gateway_openresponses_bind(bind: &str) -> Result<SocketAddr> {
+    bind.parse::<SocketAddr>()
+        .with_context(|| format!("invalid gateway socket address '{bind}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use reqwest::Client;
+    use serde_json::Value;
+    use tau_ai::{ChatRequest, ChatResponse, ChatUsage, TauAiError};
+    use tempfile::tempdir;
+
+    #[derive(Clone, Default)]
+    struct MockGatewayLlmClient {
+        request_message_counts: Arc<Mutex<Vec<usize>>>,
+    }
+
+    #[async_trait]
+    impl LlmClient for MockGatewayLlmClient {
+        async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, TauAiError> {
+            self.complete_with_stream(request, None).await
+        }
+
+        async fn complete_with_stream(
+            &self,
+            request: ChatRequest,
+            on_delta: Option<StreamDeltaHandler>,
+        ) -> Result<ChatResponse, TauAiError> {
+            let message_count = request.messages.len();
+            if let Ok(mut counts) = self.request_message_counts.lock() {
+                counts.push(message_count);
+            }
+            if let Some(handler) = on_delta {
+                handler("messages=".to_string());
+                handler(message_count.to_string());
+            }
+            let reply = format!("messages={message_count}");
+            Ok(ChatResponse {
+                message: Message::assistant_text(reply),
+                finish_reason: Some("stop".to_string()),
+                usage: ChatUsage {
+                    input_tokens: message_count as u64,
+                    output_tokens: 2,
+                    total_tokens: message_count as u64 + 2,
+                },
+            })
+        }
+    }
+
+    fn test_state(
+        root: &Path,
+        max_input_chars: usize,
+        token: &str,
+    ) -> Arc<GatewayOpenResponsesServerState> {
+        Arc::new(GatewayOpenResponsesServerState::new(
+            GatewayOpenResponsesServerConfig {
+                client: Arc::new(MockGatewayLlmClient::default()),
+                model: "openai/gpt-4o-mini".to_string(),
+                system_prompt: "You are Tau.".to_string(),
+                max_turns: 4,
+                tool_policy: crate::tools::ToolPolicy::new(Vec::new()),
+                turn_timeout_ms: 0,
+                session_lock_wait_ms: 500,
+                session_lock_stale_ms: 10_000,
+                state_dir: root.join(".tau/gateway"),
+                bind: "127.0.0.1:0".to_string(),
+                auth_token: token.to_string(),
+                max_input_chars,
+            },
+        ))
+    }
+
+    async fn spawn_test_server(
+        state: Arc<GatewayOpenResponsesServerState>,
+    ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind ephemeral listener")?;
+        let addr = listener.local_addr().context("resolve listener addr")?;
+        let app = build_gateway_openresponses_router(state);
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        Ok((addr, handle))
+    }
+
+    #[test]
+    fn unit_translate_openresponses_request_supports_item_input_and_function_call_output() {
+        let request = OpenResponsesRequest {
+            model: None,
+            input: json!([
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Please summarize."}]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_123",
+                    "output": "tool result"
+                }
+            ]),
+            stream: false,
+            instructions: Some("be concise".to_string()),
+            metadata: json!({"session_id": "issue-42"}),
+            conversation: None,
+            previous_response_id: None,
+            extra: BTreeMap::from([("temperature".to_string(), json!(0.0))]),
+        };
+
+        let translated =
+            translate_openresponses_request(&request, 10_000).expect("translate request");
+        assert!(translated.prompt.contains("System instructions"));
+        assert!(translated.prompt.contains("Please summarize."));
+        assert!(translated
+            .prompt
+            .contains("Function output (call_id=call_123):"));
+        assert_eq!(translated.session_key, "issue-42");
+        assert_eq!(translated.ignored_fields, vec!["temperature".to_string()]);
+    }
+
+    #[test]
+    fn unit_translate_openresponses_request_rejects_invalid_input_shape() {
+        let request = OpenResponsesRequest {
+            model: None,
+            input: json!(42),
+            stream: false,
+            instructions: None,
+            metadata: json!({}),
+            conversation: None,
+            previous_response_id: None,
+            extra: BTreeMap::new(),
+        };
+
+        let error =
+            translate_openresponses_request(&request, 1024).expect_err("invalid input should fail");
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn functional_openresponses_endpoint_rejects_unauthorized_requests() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 10_000, "secret");
+        let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+
+        let client = Client::new();
+        let response = client
+            .post(format!("http://{addr}/v1/responses"))
+            .json(&json!({"input":"hello"}))
+            .send()
+            .await
+            .expect("send request");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn functional_openresponses_endpoint_returns_non_stream_response() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 10_000, "secret");
+        let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+
+        let client = Client::new();
+        let response = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .json(&json!({"input":"hello"}))
+            .send()
+            .await
+            .expect("send request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = response
+            .json::<serde_json::Value>()
+            .await
+            .expect("parse response json");
+        assert_eq!(payload["object"], "response");
+        assert_eq!(payload["status"], "completed");
+        assert!(payload["output_text"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("messages="));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn functional_openresponses_endpoint_streams_sse_for_stream_true() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 10_000, "secret");
+        let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+
+        let client = Client::new();
+        let response = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .json(&json!({"input":"hello", "stream": true}))
+            .send()
+            .await
+            .expect("send request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(content_type.contains("text/event-stream"));
+
+        let body = response.text().await.expect("read sse body");
+        assert!(body.contains("event: response.created"));
+        assert!(body.contains("event: response.output_text.delta"));
+        assert!(body.contains("event: response.completed"));
+        assert!(body.contains("event: done"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn integration_openresponses_http_roundtrip_persists_session_state() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 10_000, "secret");
+        let (addr, handle) = spawn_test_server(state.clone())
+            .await
+            .expect("spawn server");
+
+        let client = Client::new();
+        let response_one = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .json(&json!({
+                "input": "first",
+                "metadata": {"session_id": "http-integration"}
+            }))
+            .send()
+            .await
+            .expect("send first request")
+            .json::<Value>()
+            .await
+            .expect("parse first response");
+        let first_count = response_one["output_text"]
+            .as_str()
+            .unwrap_or_default()
+            .trim_start_matches("messages=")
+            .parse::<usize>()
+            .expect("parse first count");
+
+        let response_two = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .json(&json!({
+                "input": "second",
+                "metadata": {"session_id": "http-integration"}
+            }))
+            .send()
+            .await
+            .expect("send second request")
+            .json::<Value>()
+            .await
+            .expect("parse second response");
+        let second_count = response_two["output_text"]
+            .as_str()
+            .unwrap_or_default()
+            .trim_start_matches("messages=")
+            .parse::<usize>()
+            .expect("parse second count");
+
+        assert!(second_count > first_count);
+
+        let session_path = gateway_session_path(
+            &state.config.state_dir,
+            &sanitize_session_key("http-integration"),
+        );
+        assert!(session_path.exists());
+        let raw = std::fs::read_to_string(&session_path).expect("read session file");
+        assert!(raw.lines().count() >= 4);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn regression_openresponses_endpoint_rejects_malformed_json_body() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 10_000, "secret");
+        let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+
+        let client = Client::new();
+        let response = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .header("content-type", "application/json")
+            .body("{invalid")
+            .send()
+            .await
+            .expect("send malformed request");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn regression_openresponses_endpoint_rejects_oversized_input() {
+        let temp = tempdir().expect("tempdir");
+        let state = test_state(temp.path(), 8, "secret");
+        let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+
+        let client = Client::new();
+        let response = client
+            .post(format!("http://{addr}/v1/responses"))
+            .bearer_auth("secret")
+            .json(&json!({"input": "this request is too large"}))
+            .send()
+            .await
+            .expect("send oversized request");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        handle.abort();
+    }
+
+    #[test]
+    fn regression_validate_gateway_openresponses_bind_rejects_invalid_socket_address() {
+        let error = validate_gateway_openresponses_bind("invalid-bind")
+            .expect_err("invalid bind should fail");
+        assert!(error
+            .to_string()
+            .contains("invalid gateway socket address 'invalid-bind'"));
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -23,6 +23,7 @@ mod diagnostics_commands;
 mod events;
 mod extension_manifest;
 mod gateway_contract;
+mod gateway_openresponses;
 mod gateway_runtime;
 mod gemini_cli_client;
 mod github_issues;
@@ -263,7 +264,8 @@ pub(crate) use crate::rpc_protocol::{
 pub(crate) use crate::runtime_cli_validation::{
     validate_custom_command_contract_runner_cli, validate_dashboard_contract_runner_cli,
     validate_deployment_contract_runner_cli, validate_event_webhook_ingest_cli,
-    validate_events_runner_cli, validate_gateway_contract_runner_cli, validate_gateway_service_cli,
+    validate_events_runner_cli, validate_gateway_contract_runner_cli,
+    validate_gateway_openresponses_server_cli, validate_gateway_service_cli,
     validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
     validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
     validate_multi_channel_live_ingest_cli, validate_multi_channel_live_runner_cli,

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -80,32 +80,33 @@ use super::{
     validate_branch_alias_name, validate_custom_command_contract_runner_cli,
     validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
-    validate_gateway_contract_runner_cli, validate_gateway_service_cli,
-    validate_github_issues_bridge_cli, validate_macro_command_entry, validate_macro_name,
-    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
-    validate_multi_channel_contract_runner_cli, validate_multi_channel_live_ingest_cli,
-    validate_multi_channel_live_runner_cli, validate_profile_name, validate_rpc_frame_file,
-    validate_session_file, validate_skills_prune_file_name, validate_slack_bridge_cli,
-    validate_voice_contract_runner_cli, AuthCommand, AuthCommandConfig, BranchAliasCommand,
-    BranchAliasFile, Cli, CliBashProfile, CliCommandFileErrorMode,
-    CliCredentialStoreEncryptionMode, CliEventTemplateSchedule, CliMultiChannelTransport,
-    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
-    CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute, CommandAction,
-    CommandExecutionContext, CommandFileEntry, CommandFileReport, CredentialStoreData,
-    CredentialStoreEncryptionMode, DoctorCheckOptions, DoctorCheckResult, DoctorCommandArgs,
-    DoctorCommandConfig, DoctorCommandOutputFormat, DoctorMultiChannelReadinessConfig,
-    DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient, IntegrationAuthCommand,
-    IntegrationCredentialStoreRecord, MacroCommand, MacroFile, MultiAgentRouteTable,
-    ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
-    ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions, RuntimeExtensionHooksConfig,
-    SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry, SessionDiffReport,
-    SessionGraphFormat, SessionRuntime, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
-    SkillsPruneMode, SkillsSyncCommandConfig, SkillsVerifyEntry, SkillsVerifyReport,
-    SkillsVerifyStatus, SkillsVerifySummary, SkillsVerifyTrustSummary, ToolAuditLogger,
-    TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION,
-    MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
-    SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
-    SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
+    validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
+    validate_gateway_service_cli, validate_github_issues_bridge_cli, validate_macro_command_entry,
+    validate_macro_name, validate_memory_contract_runner_cli,
+    validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
+    validate_multi_channel_live_ingest_cli, validate_multi_channel_live_runner_cli,
+    validate_profile_name, validate_rpc_frame_file, validate_session_file,
+    validate_skills_prune_file_name, validate_slack_bridge_cli, validate_voice_contract_runner_cli,
+    AuthCommand, AuthCommandConfig, BranchAliasCommand, BranchAliasFile, Cli, CliBashProfile,
+    CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliEventTemplateSchedule,
+    CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
+    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute,
+    CommandAction, CommandExecutionContext, CommandFileEntry, CommandFileReport,
+    CredentialStoreData, CredentialStoreEncryptionMode, DoctorCheckOptions, DoctorCheckResult,
+    DoctorCommandArgs, DoctorCommandConfig, DoctorCommandOutputFormat,
+    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus, DoctorStatus,
+    FallbackRoutingClient, IntegrationAuthCommand, IntegrationCredentialStoreRecord, MacroCommand,
+    MacroFile, MultiAgentRouteTable, ProfileCommand, ProfileDefaults, ProfileStoreFile,
+    PromptRunStatus, PromptTelemetryLogger, ProviderAuthMethod, ProviderCredentialStoreRecord,
+    RenderOptions, RuntimeExtensionHooksConfig, SessionBookmarkCommand, SessionBookmarkFile,
+    SessionDiffEntry, SessionDiffReport, SessionGraphFormat, SessionRuntime, SessionSearchArgs,
+    SessionStats, SessionStatsOutputFormat, SkillsPruneMode, SkillsSyncCommandConfig,
+    SkillsVerifyEntry, SkillsVerifyReport, SkillsVerifyStatus, SkillsVerifySummary,
+    SkillsVerifyTrustSummary, ToolAuditLogger, TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION,
+    BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION, MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE,
+    SESSION_BOOKMARK_SCHEMA_VERSION, SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS,
+    SESSION_SEARCH_PREVIEW_CHARS, SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE,
+    SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
 };
 use crate::auth_commands::{
     auth_availability_counts, auth_mode_counts, auth_provider_counts, auth_revoked_counts,
@@ -523,6 +524,10 @@ fn test_cli() -> Cli {
         dashboard_processed_case_cap: 10_000,
         dashboard_retry_max_attempts: 4,
         dashboard_retry_base_delay_ms: 0,
+        gateway_openresponses_server: false,
+        gateway_openresponses_bind: "127.0.0.1:8787".to_string(),
+        gateway_openresponses_auth_token: None,
+        gateway_openresponses_max_input_chars: 32_000,
         gateway_contract_runner: false,
         gateway_fixture: PathBuf::from(
             "crates/tau-coding-agent/testdata/gateway-contract/mixed-outcomes.json",
@@ -1757,6 +1762,10 @@ fn regression_cli_dashboard_fixture_requires_dashboard_runner_flag() {
 #[test]
 fn unit_cli_gateway_runner_flags_default_to_disabled() {
     let cli = parse_cli_with_stack(["tau-rs"]);
+    assert!(!cli.gateway_openresponses_server);
+    assert_eq!(cli.gateway_openresponses_bind, "127.0.0.1:8787");
+    assert!(cli.gateway_openresponses_auth_token.is_none());
+    assert_eq!(cli.gateway_openresponses_max_input_chars, 32_000);
     assert!(!cli.gateway_contract_runner);
     assert_eq!(
         cli.gateway_fixture,
@@ -1765,6 +1774,48 @@ fn unit_cli_gateway_runner_flags_default_to_disabled() {
     assert_eq!(cli.gateway_state_dir, PathBuf::from(".tau/gateway"));
     assert_eq!(cli.gateway_guardrail_failure_streak_threshold, 2);
     assert_eq!(cli.gateway_guardrail_retryable_failures_threshold, 2);
+}
+
+#[test]
+fn functional_cli_gateway_openresponses_flags_accept_explicit_overrides() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--gateway-openresponses-server",
+        "--gateway-openresponses-bind",
+        "127.0.0.1:8899",
+        "--gateway-openresponses-auth-token",
+        "secret-token",
+        "--gateway-openresponses-max-input-chars",
+        "24000",
+    ]);
+    assert!(cli.gateway_openresponses_server);
+    assert_eq!(cli.gateway_openresponses_bind, "127.0.0.1:8899");
+    assert_eq!(
+        cli.gateway_openresponses_auth_token.as_deref(),
+        Some("secret-token")
+    );
+    assert_eq!(cli.gateway_openresponses_max_input_chars, 24_000);
+}
+
+#[test]
+fn regression_cli_gateway_openresponses_bind_requires_server_flag() {
+    let parse =
+        try_parse_cli_with_stack(["tau-rs", "--gateway-openresponses-bind", "127.0.0.1:8899"]);
+    let error = parse.expect_err("bind override should require gateway openresponses server mode");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn regression_cli_gateway_openresponses_max_input_chars_requires_server_flag() {
+    let parse =
+        try_parse_cli_with_stack(["tau-rs", "--gateway-openresponses-max-input-chars", "24000"]);
+    let error =
+        parse.expect_err("max input override should require gateway openresponses server mode");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
 }
 
 #[test]
@@ -14228,6 +14279,98 @@ fn regression_validate_gateway_service_cli_rejects_whitespace_stop_reason() {
     assert!(error
         .to_string()
         .contains("--gateway-service-stop-reason cannot be empty or whitespace"));
+}
+
+#[test]
+fn unit_validate_gateway_openresponses_server_cli_accepts_minimum_configuration() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+
+    validate_gateway_openresponses_server_cli(&cli)
+        .expect("gateway openresponses server config should validate");
+}
+
+#[test]
+fn functional_validate_gateway_openresponses_server_cli_rejects_prompt_conflicts() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+    cli.prompt = Some("conflict".to_string());
+
+    let error =
+        validate_gateway_openresponses_server_cli(&cli).expect_err("prompt conflict should fail");
+    assert!(error
+        .to_string()
+        .contains("--gateway-openresponses-server cannot be combined"));
+}
+
+#[test]
+fn integration_validate_gateway_openresponses_server_cli_rejects_transport_conflicts() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+    cli.github_issues_bridge = true;
+
+    let error = validate_gateway_openresponses_server_cli(&cli)
+        .expect_err("transport conflict should fail");
+    assert!(error.to_string().contains(
+        "--gateway-openresponses-server cannot be combined with gateway service commands or other active transport runtime flags"
+    ));
+}
+
+#[test]
+fn regression_validate_gateway_openresponses_server_cli_requires_auth_token() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = None;
+
+    let error = validate_gateway_openresponses_server_cli(&cli)
+        .expect_err("missing auth token should fail");
+    assert!(error.to_string().contains(
+        "--gateway-openresponses-auth-token is required when --gateway-openresponses-server is set"
+    ));
+}
+
+#[test]
+fn regression_validate_gateway_openresponses_server_cli_rejects_whitespace_auth_token() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("   ".to_string());
+
+    let error = validate_gateway_openresponses_server_cli(&cli)
+        .expect_err("whitespace auth token should fail");
+    assert!(error.to_string().contains(
+        "--gateway-openresponses-auth-token is required when --gateway-openresponses-server is set"
+    ));
+}
+
+#[test]
+fn regression_validate_gateway_openresponses_server_cli_rejects_zero_max_input_chars() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+    cli.gateway_openresponses_max_input_chars = 0;
+
+    let error = validate_gateway_openresponses_server_cli(&cli)
+        .expect_err("zero max input chars should fail");
+    assert!(error
+        .to_string()
+        .contains("--gateway-openresponses-max-input-chars must be greater than 0"));
+}
+
+#[test]
+fn regression_validate_gateway_openresponses_server_cli_rejects_invalid_bind() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+    cli.gateway_openresponses_bind = "invalid-bind".to_string();
+
+    let error =
+        validate_gateway_openresponses_server_cli(&cli).expect_err("invalid bind should fail");
+    assert!(error
+        .to_string()
+        .contains("invalid gateway socket address 'invalid-bind'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an authenticated OpenResponses-compatible HTTP gateway endpoint at `POST /v1/responses` behind `--gateway-openresponses-server`
- support both non-stream JSON responses and SSE stream mode (`stream=true`) with session continuity and persisted message history
- add request translation support for string input, message arrays, and `function_call_output` continuation payloads
- add strict CLI validation + startup wiring for openresponses server mode, including runtime-mode conflict checks
- document operational usage and compatibility notes in gateway runbook

## Risks and Compatibility Notes
- the endpoint is intentionally a subset of OpenResponses; unsupported fields are ignored and surfaced in `ignored_fields`
- request payload `model` is accepted for compatibility but ignored; runtime model is determined by Tau CLI startup configuration
- enabling `--gateway-openresponses-server` is mutually exclusive with other transport runtime modes and gateway service lifecycle commands

## Validation Evidence
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent gateway_openresponses -- --test-threads=1`
- `cargo test --workspace`

Closes #847
