### PR TITLE
feat: multichannel outbound delivery adapters for telegram/discord/whatsapp

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -4,9 +4,9 @@ use clap::{ArgAction, Parser};
 
 use crate::{
     release_channel_commands::RELEASE_LOOKUP_CACHE_TTL_MS, CliBashProfile, CliCommandFileErrorMode,
-    CliCredentialStoreEncryptionMode, CliEventTemplateSchedule, CliMultiChannelTransport,
-    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
-    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliCredentialStoreEncryptionMode, CliEventTemplateSchedule, CliMultiChannelOutboundMode,
+    CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
+    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {
@@ -2106,6 +2106,94 @@ pub(crate) struct Cli {
         help = "Base backoff delay in milliseconds for multi-channel runtime retries (0 disables delay)"
     )]
     pub(crate) multi_channel_retry_base_delay_ms: u64,
+
+    #[arg(
+        long = "multi-channel-retry-jitter-ms",
+        env = "TAU_MULTI_CHANNEL_RETRY_JITTER_MS",
+        default_value_t = 0,
+        help = "Deterministic jitter upper-bound in milliseconds added to multi-channel runtime retry delays (0 disables jitter)"
+    )]
+    pub(crate) multi_channel_retry_jitter_ms: u64,
+
+    #[arg(
+        long = "multi-channel-outbound-mode",
+        env = "TAU_MULTI_CHANNEL_OUTBOUND_MODE",
+        value_enum,
+        default_value_t = CliMultiChannelOutboundMode::ChannelStore,
+        help = "Outbound delivery mode for multi-channel runtime (channel-store, dry-run, provider)"
+    )]
+    pub(crate) multi_channel_outbound_mode: CliMultiChannelOutboundMode,
+
+    #[arg(
+        long = "multi-channel-outbound-max-chars",
+        env = "TAU_MULTI_CHANNEL_OUTBOUND_MAX_CHARS",
+        default_value_t = 1200,
+        help = "Maximum outbound response chunk size in characters before provider-safe chunk splitting"
+    )]
+    pub(crate) multi_channel_outbound_max_chars: usize,
+
+    #[arg(
+        long = "multi-channel-outbound-http-timeout-ms",
+        env = "TAU_MULTI_CHANNEL_OUTBOUND_HTTP_TIMEOUT_MS",
+        default_value_t = 5000,
+        help = "Provider HTTP timeout in milliseconds for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_outbound_http_timeout_ms: u64,
+
+    #[arg(
+        long = "multi-channel-telegram-api-base",
+        env = "TAU_MULTI_CHANNEL_TELEGRAM_API_BASE",
+        default_value = "https://api.telegram.org",
+        help = "Telegram provider API base URL for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_telegram_api_base: String,
+
+    #[arg(
+        long = "multi-channel-discord-api-base",
+        env = "TAU_MULTI_CHANNEL_DISCORD_API_BASE",
+        default_value = "https://discord.com/api/v10",
+        help = "Discord provider API base URL for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_discord_api_base: String,
+
+    #[arg(
+        long = "multi-channel-whatsapp-api-base",
+        env = "TAU_MULTI_CHANNEL_WHATSAPP_API_BASE",
+        default_value = "https://graph.facebook.com/v20.0",
+        help = "WhatsApp provider API base URL for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_whatsapp_api_base: String,
+
+    #[arg(
+        long = "multi-channel-telegram-bot-token",
+        env = "TAU_TELEGRAM_BOT_TOKEN",
+        hide_env_values = true,
+        help = "Telegram bot token for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_telegram_bot_token: Option<String>,
+
+    #[arg(
+        long = "multi-channel-discord-bot-token",
+        env = "TAU_DISCORD_BOT_TOKEN",
+        hide_env_values = true,
+        help = "Discord bot token for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_discord_bot_token: Option<String>,
+
+    #[arg(
+        long = "multi-channel-whatsapp-access-token",
+        env = "TAU_WHATSAPP_ACCESS_TOKEN",
+        hide_env_values = true,
+        help = "WhatsApp access token for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_whatsapp_access_token: Option<String>,
+
+    #[arg(
+        long = "multi-channel-whatsapp-phone-number-id",
+        env = "TAU_WHATSAPP_PHONE_NUMBER_ID",
+        help = "WhatsApp phone number id for multi-channel outbound mode=provider"
+    )]
+    pub(crate) multi_channel_whatsapp_phone_number_id: Option<String>,
 
     #[arg(
         long = "multi-agent-contract-runner",

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 
 use crate::events::WebhookSignatureAlgorithm;
 use crate::multi_channel_contract::MultiChannelTransport;
+use crate::multi_channel_outbound::MultiChannelOutboundMode;
 use crate::session::SessionImportMode;
 use crate::tools::{BashCommandProfile, OsSandboxMode, ToolPolicyPreset};
 use crate::ProviderAuthMethod;
@@ -147,6 +148,23 @@ impl From<CliMultiChannelTransport> for MultiChannelTransport {
             CliMultiChannelTransport::Telegram => MultiChannelTransport::Telegram,
             CliMultiChannelTransport::Discord => MultiChannelTransport::Discord,
             CliMultiChannelTransport::Whatsapp => MultiChannelTransport::Whatsapp,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliMultiChannelOutboundMode {
+    ChannelStore,
+    DryRun,
+    Provider,
+}
+
+impl From<CliMultiChannelOutboundMode> for MultiChannelOutboundMode {
+    fn from(value: CliMultiChannelOutboundMode) -> Self {
+        match value {
+            CliMultiChannelOutboundMode::ChannelStore => MultiChannelOutboundMode::ChannelStore,
+            CliMultiChannelOutboundMode::DryRun => MultiChannelOutboundMode::DryRun,
+            CliMultiChannelOutboundMode::Provider => MultiChannelOutboundMode::Provider,
         }
     }
 }

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -39,6 +39,7 @@ mod multi_agent_router;
 mod multi_agent_runtime;
 mod multi_channel_contract;
 mod multi_channel_live_ingress;
+mod multi_channel_outbound;
 mod multi_channel_policy;
 mod multi_channel_routing;
 mod multi_channel_runtime;
@@ -129,8 +130,9 @@ pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
-    CliEventTemplateSchedule, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliEventTemplateSchedule, CliMultiChannelOutboundMode, CliMultiChannelTransport,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;

--- a/crates/tau-coding-agent/src/multi_channel_outbound.rs
+++ b/crates/tau-coding-agent/src/multi_channel_outbound.rs
@@ -1,0 +1,721 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::multi_channel_contract::{MultiChannelInboundEvent, MultiChannelTransport};
+
+const TELEGRAM_SAFE_MAX_CHARS: usize = 4096;
+const DISCORD_SAFE_MAX_CHARS: usize = 2000;
+const WHATSAPP_SAFE_MAX_CHARS: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MultiChannelOutboundMode {
+    ChannelStore,
+    DryRun,
+    Provider,
+}
+
+impl MultiChannelOutboundMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ChannelStore => "channel_store",
+            Self::DryRun => "dry_run",
+            Self::Provider => "provider",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiChannelOutboundConfig {
+    pub(crate) mode: MultiChannelOutboundMode,
+    pub(crate) max_chars: usize,
+    pub(crate) http_timeout_ms: u64,
+    pub(crate) telegram_api_base: String,
+    pub(crate) discord_api_base: String,
+    pub(crate) whatsapp_api_base: String,
+    pub(crate) telegram_bot_token: Option<String>,
+    pub(crate) discord_bot_token: Option<String>,
+    pub(crate) whatsapp_access_token: Option<String>,
+    pub(crate) whatsapp_phone_number_id: Option<String>,
+}
+
+impl Default for MultiChannelOutboundConfig {
+    fn default() -> Self {
+        Self {
+            mode: MultiChannelOutboundMode::ChannelStore,
+            max_chars: 1200,
+            http_timeout_ms: 5000,
+            telegram_api_base: "https://api.telegram.org".to_string(),
+            discord_api_base: "https://discord.com/api/v10".to_string(),
+            whatsapp_api_base: "https://graph.facebook.com/v20.0".to_string(),
+            telegram_bot_token: None,
+            discord_bot_token: None,
+            whatsapp_access_token: None,
+            whatsapp_phone_number_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MultiChannelOutboundDeliveryReceipt {
+    pub(crate) transport: String,
+    pub(crate) mode: String,
+    pub(crate) status: String,
+    pub(crate) chunk_index: usize,
+    pub(crate) chunk_count: usize,
+    pub(crate) endpoint: String,
+    pub(crate) request_body: Value,
+    pub(crate) reason_code: Option<String>,
+    pub(crate) detail: Option<String>,
+    pub(crate) retryable: bool,
+    pub(crate) http_status: Option<u16>,
+    pub(crate) provider_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MultiChannelOutboundDeliveryResult {
+    pub(crate) mode: String,
+    pub(crate) chunk_count: usize,
+    pub(crate) receipts: Vec<MultiChannelOutboundDeliveryReceipt>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiChannelOutboundDeliveryError {
+    pub(crate) reason_code: String,
+    pub(crate) detail: String,
+    pub(crate) retryable: bool,
+    pub(crate) chunk_index: usize,
+    pub(crate) chunk_count: usize,
+    pub(crate) endpoint: String,
+    pub(crate) request_body: Option<String>,
+    pub(crate) http_status: Option<u16>,
+}
+
+impl std::fmt::Display for MultiChannelOutboundDeliveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "reason_code={} retryable={} chunk={}/{} endpoint={} detail={}",
+            self.reason_code,
+            self.retryable,
+            self.chunk_index,
+            self.chunk_count,
+            self.endpoint,
+            self.detail
+        )
+    }
+}
+
+impl std::error::Error for MultiChannelOutboundDeliveryError {}
+
+#[derive(Debug, Clone)]
+struct MultiChannelOutboundRequest {
+    transport: MultiChannelTransport,
+    endpoint: String,
+    headers: Vec<(String, String)>,
+    body: Value,
+    chunk_index: usize,
+    chunk_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiChannelOutboundDispatcher {
+    config: MultiChannelOutboundConfig,
+    client: Option<reqwest::Client>,
+}
+
+impl MultiChannelOutboundDispatcher {
+    pub(crate) fn new(config: MultiChannelOutboundConfig) -> Result<Self> {
+        if config.max_chars == 0 {
+            return Err(anyhow!(
+                "multi-channel outbound max chars must be greater than 0"
+            ));
+        }
+        if config.mode == MultiChannelOutboundMode::Provider && config.http_timeout_ms == 0 {
+            return Err(anyhow!(
+                "multi-channel outbound provider mode requires http timeout > 0"
+            ));
+        }
+        let client = if config.mode == MultiChannelOutboundMode::Provider {
+            Some(
+                reqwest::Client::builder()
+                    .timeout(Duration::from_millis(config.http_timeout_ms))
+                    .build()
+                    .context("failed to build multi-channel outbound http client")?,
+            )
+        } else {
+            None
+        };
+        Ok(Self { config, client })
+    }
+
+    pub(crate) fn mode(&self) -> MultiChannelOutboundMode {
+        self.config.mode
+    }
+
+    pub(crate) async fn deliver(
+        &self,
+        event: &MultiChannelInboundEvent,
+        response_text: &str,
+    ) -> Result<MultiChannelOutboundDeliveryResult, MultiChannelOutboundDeliveryError> {
+        if self.config.mode == MultiChannelOutboundMode::ChannelStore {
+            return Ok(MultiChannelOutboundDeliveryResult {
+                mode: self.config.mode.as_str().to_string(),
+                chunk_count: 0,
+                receipts: Vec::new(),
+            });
+        }
+
+        let requests = self.build_requests(event, response_text)?;
+        if requests.is_empty() {
+            return Ok(MultiChannelOutboundDeliveryResult {
+                mode: self.config.mode.as_str().to_string(),
+                chunk_count: 0,
+                receipts: Vec::new(),
+            });
+        }
+
+        let mut receipts = Vec::with_capacity(requests.len());
+        for request in requests {
+            match self.config.mode {
+                MultiChannelOutboundMode::DryRun => {
+                    receipts.push(MultiChannelOutboundDeliveryReceipt {
+                        transport: request.transport.as_str().to_string(),
+                        mode: self.config.mode.as_str().to_string(),
+                        status: "dry_run".to_string(),
+                        chunk_index: request.chunk_index,
+                        chunk_count: request.chunk_count,
+                        endpoint: request.endpoint.clone(),
+                        request_body: request.body.clone(),
+                        reason_code: None,
+                        detail: None,
+                        retryable: false,
+                        http_status: None,
+                        provider_message_id: None,
+                    });
+                }
+                MultiChannelOutboundMode::Provider => {
+                    let receipt = self.send_request(&request).await?;
+                    receipts.push(receipt);
+                }
+                MultiChannelOutboundMode::ChannelStore => {}
+            }
+        }
+
+        Ok(MultiChannelOutboundDeliveryResult {
+            mode: self.config.mode.as_str().to_string(),
+            chunk_count: receipts.len(),
+            receipts,
+        })
+    }
+
+    fn build_requests(
+        &self,
+        event: &MultiChannelInboundEvent,
+        response_text: &str,
+    ) -> Result<Vec<MultiChannelOutboundRequest>, MultiChannelOutboundDeliveryError> {
+        let trimmed = response_text.trim();
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let safe_max_chars = self.safe_max_chars(event.transport);
+        let chunk_max = self.config.max_chars.min(safe_max_chars).max(1);
+        let chunks = chunk_text(trimmed, chunk_max);
+        let chunk_count = chunks.len();
+        if chunk_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        chunks
+            .into_iter()
+            .enumerate()
+            .map(|(index, chunk)| {
+                let chunk_index = index + 1;
+                self.build_request_for_chunk(event, chunk, chunk_index, chunk_count)
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn safe_max_chars(&self, transport: MultiChannelTransport) -> usize {
+        match transport {
+            MultiChannelTransport::Telegram => TELEGRAM_SAFE_MAX_CHARS,
+            MultiChannelTransport::Discord => DISCORD_SAFE_MAX_CHARS,
+            MultiChannelTransport::Whatsapp => WHATSAPP_SAFE_MAX_CHARS,
+        }
+    }
+
+    fn build_request_for_chunk(
+        &self,
+        event: &MultiChannelInboundEvent,
+        chunk: String,
+        chunk_index: usize,
+        chunk_count: usize,
+    ) -> Result<MultiChannelOutboundRequest, MultiChannelOutboundDeliveryError> {
+        match event.transport {
+            MultiChannelTransport::Telegram => {
+                let token = self
+                    .config
+                    .telegram_bot_token
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        if self.config.mode == MultiChannelOutboundMode::DryRun {
+                            Some("dry-run-telegram-token".to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| MultiChannelOutboundDeliveryError {
+                        reason_code: "delivery_missing_telegram_bot_token".to_string(),
+                        detail: "Telegram outbound requires TAU_TELEGRAM_BOT_TOKEN or credential-store integration id telegram-bot-token".to_string(),
+                        retryable: false,
+                        chunk_index,
+                        chunk_count,
+                        endpoint: "".to_string(),
+                        request_body: None,
+                        http_status: None,
+                    })?;
+                let endpoint = format!(
+                    "{}/bot{}/sendMessage",
+                    self.config.telegram_api_base.trim_end_matches('/'),
+                    token
+                );
+                Ok(MultiChannelOutboundRequest {
+                    transport: event.transport,
+                    endpoint,
+                    headers: Vec::new(),
+                    body: json!({
+                        "chat_id": event.conversation_id.trim(),
+                        "text": chunk,
+                        "disable_web_page_preview": true
+                    }),
+                    chunk_index,
+                    chunk_count,
+                })
+            }
+            MultiChannelTransport::Discord => {
+                let token = self
+                    .config
+                    .discord_bot_token
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        if self.config.mode == MultiChannelOutboundMode::DryRun {
+                            Some("dry-run-discord-token".to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| MultiChannelOutboundDeliveryError {
+                        reason_code: "delivery_missing_discord_bot_token".to_string(),
+                        detail: "Discord outbound requires TAU_DISCORD_BOT_TOKEN or credential-store integration id discord-bot-token".to_string(),
+                        retryable: false,
+                        chunk_index,
+                        chunk_count,
+                        endpoint: "".to_string(),
+                        request_body: None,
+                        http_status: None,
+                    })?;
+                let endpoint = format!(
+                    "{}/channels/{}/messages",
+                    self.config.discord_api_base.trim_end_matches('/'),
+                    event.conversation_id.trim()
+                );
+                Ok(MultiChannelOutboundRequest {
+                    transport: event.transport,
+                    endpoint,
+                    headers: vec![("Authorization".to_string(), format!("Bot {}", token))],
+                    body: json!({
+                        "content": chunk
+                    }),
+                    chunk_index,
+                    chunk_count,
+                })
+            }
+            MultiChannelTransport::Whatsapp => {
+                let access_token = self
+                    .config
+                    .whatsapp_access_token
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        if self.config.mode == MultiChannelOutboundMode::DryRun {
+                            Some("dry-run-whatsapp-token".to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| MultiChannelOutboundDeliveryError {
+                        reason_code: "delivery_missing_whatsapp_access_token".to_string(),
+                        detail: "WhatsApp outbound requires TAU_WHATSAPP_ACCESS_TOKEN or credential-store integration id whatsapp-access-token".to_string(),
+                        retryable: false,
+                        chunk_index,
+                        chunk_count,
+                        endpoint: "".to_string(),
+                        request_body: None,
+                        http_status: None,
+                    })?;
+                let phone_number_id = self
+                    .config
+                    .whatsapp_phone_number_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| {
+                        event
+                            .metadata
+                            .get("whatsapp_phone_number_id")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                    })
+                    .or_else(|| {
+                        if self.config.mode == MultiChannelOutboundMode::DryRun {
+                            Some("dry-run-phone-number-id")
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| MultiChannelOutboundDeliveryError {
+                        reason_code: "delivery_missing_whatsapp_phone_number_id".to_string(),
+                        detail: "WhatsApp outbound requires TAU_WHATSAPP_PHONE_NUMBER_ID, credential-store integration id whatsapp-phone-number-id, or inbound metadata.whatsapp_phone_number_id".to_string(),
+                        retryable: false,
+                        chunk_index,
+                        chunk_count,
+                        endpoint: "".to_string(),
+                        request_body: None,
+                        http_status: None,
+                    })?;
+                let recipient = event
+                    .actor_id
+                    .trim()
+                    .split(':')
+                    .next_back()
+                    .unwrap_or_default()
+                    .trim();
+                if recipient.is_empty() && self.config.mode != MultiChannelOutboundMode::DryRun {
+                    return Err(MultiChannelOutboundDeliveryError {
+                        reason_code: "delivery_missing_whatsapp_recipient".to_string(),
+                        detail: "WhatsApp outbound requires a non-empty actor_id".to_string(),
+                        retryable: false,
+                        chunk_index,
+                        chunk_count,
+                        endpoint: "".to_string(),
+                        request_body: None,
+                        http_status: None,
+                    });
+                }
+                let recipient = if recipient.is_empty() {
+                    "dry-run-recipient"
+                } else {
+                    recipient
+                };
+                let endpoint = format!(
+                    "{}/{}/messages",
+                    self.config.whatsapp_api_base.trim_end_matches('/'),
+                    phone_number_id
+                );
+                Ok(MultiChannelOutboundRequest {
+                    transport: event.transport,
+                    endpoint,
+                    headers: vec![(
+                        "Authorization".to_string(),
+                        format!("Bearer {}", access_token),
+                    )],
+                    body: json!({
+                        "messaging_product": "whatsapp",
+                        "to": recipient,
+                        "type": "text",
+                        "text": {
+                            "body": chunk
+                        }
+                    }),
+                    chunk_index,
+                    chunk_count,
+                })
+            }
+        }
+    }
+
+    async fn send_request(
+        &self,
+        request: &MultiChannelOutboundRequest,
+    ) -> Result<MultiChannelOutboundDeliveryReceipt, MultiChannelOutboundDeliveryError> {
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| MultiChannelOutboundDeliveryError {
+                reason_code: "delivery_provider_client_unavailable".to_string(),
+                detail: "provider mode requested without initialized HTTP client".to_string(),
+                retryable: false,
+                chunk_index: request.chunk_index,
+                chunk_count: request.chunk_count,
+                endpoint: request.endpoint.clone(),
+                request_body: Some(compact_request_body(&request.body)),
+                http_status: None,
+            })?;
+        let mut http_request = client.post(request.endpoint.as_str());
+        for (header, value) in &request.headers {
+            http_request = http_request.header(header, value);
+        }
+        let response = http_request
+            .json(&request.body)
+            .send()
+            .await
+            .map_err(|error| MultiChannelOutboundDeliveryError {
+                reason_code: "delivery_transport_error".to_string(),
+                detail: error.to_string(),
+                retryable: true,
+                chunk_index: request.chunk_index,
+                chunk_count: request.chunk_count,
+                endpoint: request.endpoint.clone(),
+                request_body: Some(compact_request_body(&request.body)),
+                http_status: None,
+            })?;
+        let status = response.status();
+        let body_raw = response.text().await.unwrap_or_default();
+        let body_json = serde_json::from_str::<Value>(&body_raw).unwrap_or(Value::Null);
+        if status.is_success() {
+            return Ok(MultiChannelOutboundDeliveryReceipt {
+                transport: request.transport.as_str().to_string(),
+                mode: self.config.mode.as_str().to_string(),
+                status: "sent".to_string(),
+                chunk_index: request.chunk_index,
+                chunk_count: request.chunk_count,
+                endpoint: request.endpoint.clone(),
+                request_body: request.body.clone(),
+                reason_code: None,
+                detail: None,
+                retryable: false,
+                http_status: Some(status.as_u16()),
+                provider_message_id: extract_provider_message_id(request.transport, &body_json),
+            });
+        }
+
+        let (reason_code, retryable) = classify_provider_status(status);
+        Err(MultiChannelOutboundDeliveryError {
+            reason_code: reason_code.to_string(),
+            detail: truncate_detail(&body_raw),
+            retryable,
+            chunk_index: request.chunk_index,
+            chunk_count: request.chunk_count,
+            endpoint: request.endpoint.clone(),
+            request_body: Some(compact_request_body(&request.body)),
+            http_status: Some(status.as_u16()),
+        })
+    }
+}
+
+fn classify_provider_status(status: StatusCode) -> (&'static str, bool) {
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return ("delivery_rate_limited", true);
+    }
+    if status.is_server_error() {
+        return ("delivery_provider_unavailable", true);
+    }
+    if status.is_client_error() {
+        return ("delivery_request_rejected", false);
+    }
+    ("delivery_unknown_http_failure", true)
+}
+
+fn extract_provider_message_id(
+    transport: MultiChannelTransport,
+    payload: &Value,
+) -> Option<String> {
+    match transport {
+        MultiChannelTransport::Telegram => payload
+            .get("result")
+            .and_then(|value| value.get("message_id"))
+            .and_then(|value| value.as_i64())
+            .map(|value| value.to_string()),
+        MultiChannelTransport::Discord => payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|value| value.to_string()),
+        MultiChannelTransport::Whatsapp => payload
+            .get("messages")
+            .and_then(Value::as_array)
+            .and_then(|items| items.first())
+            .and_then(|value| value.get("id"))
+            .and_then(Value::as_str)
+            .map(|value| value.to_string()),
+    }
+}
+
+fn truncate_detail(raw: &str) -> String {
+    const LIMIT: usize = 512;
+    let trimmed = raw.trim();
+    if trimmed.chars().count() <= LIMIT {
+        return trimmed.to_string();
+    }
+    let mut output = String::new();
+    for ch in trimmed.chars().take(LIMIT) {
+        output.push(ch);
+    }
+    output.push_str("...");
+    output
+}
+
+fn compact_request_body(value: &Value) -> String {
+    const LIMIT: usize = 512;
+    let serialized = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
+    if serialized.chars().count() <= LIMIT {
+        return serialized;
+    }
+    let mut output = String::new();
+    for ch in serialized.chars().take(LIMIT) {
+        output.push(ch);
+    }
+    output.push_str("...");
+    output
+}
+
+fn chunk_text(text: &str, max_chars: usize) -> Vec<String> {
+    if text.is_empty() || max_chars == 0 {
+        return Vec::new();
+    }
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0usize;
+    for ch in text.chars() {
+        current.push(ch);
+        current_len = current_len.saturating_add(1);
+        if current_len >= max_chars {
+            chunks.push(current);
+            current = String::new();
+            current_len = 0;
+        }
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::Method::POST;
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    use super::{
+        chunk_text, MultiChannelOutboundConfig, MultiChannelOutboundDispatcher,
+        MultiChannelOutboundMode,
+    };
+    use crate::multi_channel_contract::{
+        MultiChannelEventKind, MultiChannelInboundEvent, MultiChannelTransport,
+    };
+    use std::collections::BTreeMap;
+
+    fn sample_event(transport: MultiChannelTransport) -> MultiChannelInboundEvent {
+        MultiChannelInboundEvent {
+            schema_version: 1,
+            transport,
+            event_kind: MultiChannelEventKind::Message,
+            event_id: "event-1".to_string(),
+            conversation_id: "chat-1".to_string(),
+            thread_id: String::new(),
+            actor_id: "15551234567".to_string(),
+            actor_display: String::new(),
+            timestamp_ms: 1_760_200_000_000,
+            text: "hello".to_string(),
+            attachments: Vec::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn unit_chunk_text_respects_max_chars() {
+        let chunks = chunk_text("abcdefghijk", 4);
+        assert_eq!(
+            chunks,
+            vec!["abcd".to_string(), "efgh".to_string(), "ijk".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn functional_dry_run_shapes_discord_payload_and_chunking() {
+        let dispatcher = MultiChannelOutboundDispatcher::new(MultiChannelOutboundConfig {
+            mode: MultiChannelOutboundMode::DryRun,
+            max_chars: 5,
+            discord_bot_token: Some("token".to_string()),
+            ..MultiChannelOutboundConfig::default()
+        })
+        .expect("dispatcher");
+        let mut event = sample_event(MultiChannelTransport::Discord);
+        event.conversation_id = "room-88".to_string();
+        let result = dispatcher
+            .deliver(&event, "abcdefghijklmnopqrstuvwxyz")
+            .await
+            .expect("dry-run should succeed");
+        assert_eq!(result.mode, "dry_run");
+        assert_eq!(result.chunk_count, 6);
+        assert_eq!(result.receipts[0].status, "dry_run");
+        assert_eq!(result.receipts[0].request_body["content"], "abcde");
+        assert_eq!(result.receipts[5].request_body["content"], "z");
+        assert!(result.receipts[0]
+            .endpoint
+            .ends_with("/channels/room-88/messages"));
+    }
+
+    #[tokio::test]
+    async fn integration_provider_mode_posts_telegram_request() {
+        let server = MockServer::start();
+        let sent = server.mock(|when, then| {
+            when.method(POST).path("/bottest-token/sendMessage");
+            then.status(200)
+                .json_body(json!({"ok": true, "result": {"message_id": 55}}));
+        });
+
+        let dispatcher = MultiChannelOutboundDispatcher::new(MultiChannelOutboundConfig {
+            mode: MultiChannelOutboundMode::Provider,
+            max_chars: 100,
+            telegram_api_base: server.base_url(),
+            telegram_bot_token: Some("test-token".to_string()),
+            ..MultiChannelOutboundConfig::default()
+        })
+        .expect("dispatcher");
+        let result = dispatcher
+            .deliver(
+                &sample_event(MultiChannelTransport::Telegram),
+                "hello telegram",
+            )
+            .await
+            .expect("provider send should succeed");
+        sent.assert_calls(1);
+        assert_eq!(result.chunk_count, 1);
+        assert_eq!(result.receipts[0].status, "sent");
+        assert_eq!(
+            result.receipts[0].provider_message_id.as_deref(),
+            Some("55")
+        );
+    }
+
+    #[tokio::test]
+    async fn regression_provider_mode_returns_stable_reason_for_missing_token() {
+        let dispatcher = MultiChannelOutboundDispatcher::new(MultiChannelOutboundConfig {
+            mode: MultiChannelOutboundMode::Provider,
+            max_chars: 100,
+            telegram_bot_token: None,
+            ..MultiChannelOutboundConfig::default()
+        })
+        .expect("dispatcher");
+        let error = dispatcher
+            .deliver(&sample_event(MultiChannelTransport::Telegram), "hello")
+            .await
+            .expect_err("missing token should fail");
+        assert_eq!(error.reason_code, "delivery_missing_telegram_bot_token");
+        assert!(!error.retryable);
+    }
+}

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -171,6 +171,21 @@ pub(crate) fn validate_multi_channel_contract_runner_cli(cli: &Cli) -> Result<()
     if cli.multi_channel_retry_max_attempts == 0 {
         bail!("--multi-channel-retry-max-attempts must be greater than 0");
     }
+    if cli.multi_channel_outbound_max_chars == 0 {
+        bail!("--multi-channel-outbound-max-chars must be greater than 0");
+    }
+    if cli.multi_channel_outbound_http_timeout_ms == 0 {
+        bail!("--multi-channel-outbound-http-timeout-ms must be greater than 0");
+    }
+    if cli.multi_channel_telegram_api_base.trim().is_empty() {
+        bail!("--multi-channel-telegram-api-base cannot be empty");
+    }
+    if cli.multi_channel_discord_api_base.trim().is_empty() {
+        bail!("--multi-channel-discord-api-base cannot be empty");
+    }
+    if cli.multi_channel_whatsapp_api_base.trim().is_empty() {
+        bail!("--multi-channel-whatsapp-api-base cannot be empty");
+    }
     if !cli.multi_channel_fixture.exists() {
         bail!(
             "--multi-channel-fixture '{}' does not exist",
@@ -218,6 +233,21 @@ pub(crate) fn validate_multi_channel_live_runner_cli(cli: &Cli) -> Result<()> {
     }
     if cli.multi_channel_retry_max_attempts == 0 {
         bail!("--multi-channel-retry-max-attempts must be greater than 0");
+    }
+    if cli.multi_channel_outbound_max_chars == 0 {
+        bail!("--multi-channel-outbound-max-chars must be greater than 0");
+    }
+    if cli.multi_channel_outbound_http_timeout_ms == 0 {
+        bail!("--multi-channel-outbound-http-timeout-ms must be greater than 0");
+    }
+    if cli.multi_channel_telegram_api_base.trim().is_empty() {
+        bail!("--multi-channel-telegram-api-base cannot be empty");
+    }
+    if cli.multi_channel_discord_api_base.trim().is_empty() {
+        bail!("--multi-channel-discord-api-base cannot be empty");
+    }
+    if cli.multi_channel_whatsapp_api_base.trim().is_empty() {
+        bail!("--multi-channel-whatsapp-api-base cannot be empty");
     }
     if !cli.multi_channel_live_ingress_dir.exists() {
         bail!(

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -199,6 +199,48 @@ cargo run -p tau-coding-agent -- \
 Use the same command for `discord` and `whatsapp` payloads by changing
 `--multi-channel-live-ingest-transport` and `--multi-channel-live-ingest-file`.
 
+## Outbound delivery modes
+
+Multi-channel runtime supports outbound modes:
+
+- `channel-store`: log outbound response only (no provider adapter dispatch)
+- `dry-run`: shape provider requests and emit deterministic delivery receipts without network calls
+- `provider`: dispatch outbound responses through provider HTTP adapters
+
+Recommended deterministic CI mode:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-contract-runner \
+  --multi-channel-fixture ./crates/tau-coding-agent/testdata/multi-channel-contract/baseline-three-channel.json \
+  --multi-channel-state-dir .tau/multi-channel \
+  --multi-channel-outbound-mode dry-run \
+  --multi-channel-outbound-max-chars 512
+```
+
+Provider mode example:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --multi-channel-live-runner \
+  --multi-channel-live-ingress-dir .tau/multi-channel/live-ingress \
+  --multi-channel-state-dir .tau/multi-channel \
+  --multi-channel-outbound-mode provider \
+  --multi-channel-outbound-max-chars 1200 \
+  --multi-channel-outbound-http-timeout-ms 5000
+```
+
+Outbound delivery failure reason codes surfaced in channel-store outbound logs:
+
+- `delivery_missing_telegram_bot_token`
+- `delivery_missing_discord_bot_token`
+- `delivery_missing_whatsapp_access_token`
+- `delivery_missing_whatsapp_phone_number_id`
+- `delivery_rate_limited`
+- `delivery_provider_unavailable`
+- `delivery_request_rejected`
+- `delivery_transport_error`
+
 ## Live readiness preflight
 
 Run this gate before enabling `--multi-channel-live-runner`:

--- a/scripts/demo/multi-channel.sh
+++ b/scripts/demo/multi-channel.sh
@@ -36,7 +36,9 @@ tau_demo_common_run_step \
   --multi-channel-queue-limit 64 \
   --multi-channel-processed-event-cap 10000 \
   --multi-channel-retry-max-attempts 4 \
-  --multi-channel-retry-base-delay-ms 0
+  --multi-channel-retry-base-delay-ms 0 \
+  --multi-channel-outbound-mode dry-run \
+  --multi-channel-outbound-max-chars 512
 
 tau_demo_common_run_step \
   "transport-health-inspect-multi-channel" \
@@ -79,7 +81,9 @@ tau_demo_common_run_step \
   --multi-channel-queue-limit 64 \
   --multi-channel-processed-event-cap 10000 \
   --multi-channel-retry-max-attempts 4 \
-  --multi-channel-retry-base-delay-ms 0
+  --multi-channel-retry-base-delay-ms 0 \
+  --multi-channel-outbound-mode dry-run \
+  --multi-channel-outbound-max-chars 512
 
 tau_demo_common_run_step \
   "multi-channel-route-inspect-telegram" \


### PR DESCRIPTION
Closes #844

## Summary of behavior changes
- Added a new multi-channel outbound dispatcher with provider-specific request shaping for Telegram, Discord, and WhatsApp.
- Added outbound mode controls: `channel-store`, `dry-run`, and `provider`.
- Added deterministic outbound chunking with provider-safe limits and configurable chunk size.
- Added outbound delivery receipts to channel-store outbound logs.
- Added stable delivery failure reason codes (`delivery_*`) and surfaced failed attempts in outbound logs.
- Added deterministic retry jitter support for multi-channel runtime retries.
- Added CLI flags for outbound mode, chunking, timeout, provider API bases, and optional provider secrets.
- Wired runtime startup to resolve outbound credentials from CLI/env or credential-store integration ids.
- Updated demo and multi-channel operations docs to cover outbound modes and delivery failure semantics.

## Risks and compatibility notes
- Default outbound mode remains `channel-store`, so existing behavior is preserved unless outbound mode is explicitly enabled.
- `provider` mode now performs real HTTP dispatch and therefore depends on valid provider credentials and endpoints.
- Failure-mode logging volume can increase in `provider` mode when retries are exhausted (intentional for auditability).

## Validation evidence
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent multi_channel_outbound -- --test-threads=1`
- `cargo test -p tau-coding-agent multi_channel_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent multi_channel_ -- --test-threads=1`
- `cargo test --workspace`
- `./scripts/demo/multi-channel.sh`
