### PR TITLE
feat: add gateway webchat UI and status endpoint

### DIFF
--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -9,6 +9,7 @@ This runbook covers:
 - fixture-driven gateway runtime (`--gateway-contract-runner`)
 - gateway service lifecycle control (`--gateway-service-start|stop|status`)
 - OpenResponses-compatible HTTP gateway (`--gateway-openresponses-server`)
+- gateway-served webchat/control endpoints (`/webchat`, `/gateway/status`)
 
 ## Service lifecycle commands
 
@@ -85,6 +86,19 @@ Current compatibility notes:
 - Session continuity derives from `metadata.session_id`, then `conversation`, then `previous_response_id`.
 - Unknown request fields are ignored safely and surfaced in `ignored_fields` on the response.
 - `model` in request payload is accepted but ignored; runtime uses CLI-selected model.
+
+Webchat/control surface:
+
+- Open browser at `http://127.0.0.1:8787/webchat`.
+- Paste the same bearer token used for `/v1/responses` (`local-dev-token` in this example).
+- Use the status refresh control to inspect `/gateway/status` from the same page.
+
+Direct status endpoint check:
+
+```bash
+curl -sS http://127.0.0.1:8787/gateway/status \
+  -H "Authorization: Bearer local-dev-token"
+```
 
 ## Health and observability signals
 

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -91,6 +91,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
+- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway-served webchat/status endpoints.
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
 - `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).
 - `deployment_wasm.rs`: WASM artifact packaging, manifest verification, and deployment state deliverable tracking.


### PR DESCRIPTION
Closes #860

## Summary of behavior changes
- Adds a gateway-served webchat UI route at `/webchat` for operator chat against the existing OpenResponses runtime.
- Adds authenticated gateway status endpoint at `/gateway/status` (same bearer token policy as `/v1/responses`).
- Webchat supports session key selection, stream vs non-stream mode, persisted token/session browser state, and live status refresh.
- Updates gateway operations runbook and code map with webchat/status endpoint usage.

## Risks and compatibility notes
- `/webchat` is a new unauthenticated static page; protected operations still require bearer token via `/v1/responses` and `/gateway/status`.
- `/gateway/status` adds a new authenticated read surface over existing gateway state; no mutation path was introduced.
- Existing `/v1/responses` behavior and request compatibility remain unchanged.

## Validation evidence
- `cargo fmt --all --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent gateway_openresponses -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
- `scripts/demo/gateway.sh --timeout-seconds 30`
