### PR TITLE
Gateway auth hardening: modes, sessions, and rate limits (#861)

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -5,8 +5,9 @@ use clap::{ArgAction, Parser};
 use crate::{
     release_channel_commands::RELEASE_LOOKUP_CACHE_TTL_MS, CliBashProfile, CliCommandFileErrorMode,
     CliCredentialStoreEncryptionMode, CliDeploymentWasmRuntimeProfile, CliEventTemplateSchedule,
-    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliGatewayOpenResponsesAuthMode, CliMultiChannelOutboundMode, CliMultiChannelTransport,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {
@@ -2512,12 +2513,60 @@ pub(crate) struct Cli {
     pub(crate) gateway_openresponses_bind: String,
 
     #[arg(
+        long = "gateway-openresponses-auth-mode",
+        env = "TAU_GATEWAY_OPENRESPONSES_AUTH_MODE",
+        value_enum,
+        default_value_t = CliGatewayOpenResponsesAuthMode::Token,
+        requires = "gateway_openresponses_server",
+        help = "Gateway auth mode: token, password-session, or localhost-dev"
+    )]
+    pub(crate) gateway_openresponses_auth_mode: CliGatewayOpenResponsesAuthMode,
+
+    #[arg(
         long = "gateway-openresponses-auth-token",
         env = "TAU_GATEWAY_OPENRESPONSES_AUTH_TOKEN",
         requires = "gateway_openresponses_server",
-        help = "Bearer token required by --gateway-openresponses-server"
+        help = "Bearer token used when --gateway-openresponses-auth-mode=token"
     )]
     pub(crate) gateway_openresponses_auth_token: Option<String>,
+
+    #[arg(
+        long = "gateway-openresponses-auth-password",
+        env = "TAU_GATEWAY_OPENRESPONSES_AUTH_PASSWORD",
+        requires = "gateway_openresponses_server",
+        help = "Password used by /gateway/auth/session when --gateway-openresponses-auth-mode=password-session"
+    )]
+    pub(crate) gateway_openresponses_auth_password: Option<String>,
+
+    #[arg(
+        long = "gateway-openresponses-session-ttl-seconds",
+        env = "TAU_GATEWAY_OPENRESPONSES_SESSION_TTL_SECONDS",
+        default_value_t = 3600,
+        value_parser = parse_positive_u64,
+        requires = "gateway_openresponses_server",
+        help = "Session token TTL in seconds for password-session auth mode"
+    )]
+    pub(crate) gateway_openresponses_session_ttl_seconds: u64,
+
+    #[arg(
+        long = "gateway-openresponses-rate-limit-window-seconds",
+        env = "TAU_GATEWAY_OPENRESPONSES_RATE_LIMIT_WINDOW_SECONDS",
+        default_value_t = 60,
+        value_parser = parse_positive_u64,
+        requires = "gateway_openresponses_server",
+        help = "Rate-limit window size in seconds"
+    )]
+    pub(crate) gateway_openresponses_rate_limit_window_seconds: u64,
+
+    #[arg(
+        long = "gateway-openresponses-rate-limit-max-requests",
+        env = "TAU_GATEWAY_OPENRESPONSES_RATE_LIMIT_MAX_REQUESTS",
+        default_value_t = 120,
+        value_parser = parse_positive_usize,
+        requires = "gateway_openresponses_server",
+        help = "Maximum accepted requests per auth principal within one rate-limit window"
+    )]
+    pub(crate) gateway_openresponses_rate_limit_max_requests: usize,
 
     #[arg(
         long = "gateway-openresponses-max-input-chars",

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -123,6 +123,23 @@ impl From<CliProviderAuthMode> for ProviderAuthMethod {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliGatewayOpenResponsesAuthMode {
+    Token,
+    PasswordSession,
+    LocalhostDev,
+}
+
+impl CliGatewayOpenResponsesAuthMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CliGatewayOpenResponsesAuthMode::Token => "token",
+            CliGatewayOpenResponsesAuthMode::PasswordSession => "password-session",
+            CliGatewayOpenResponsesAuthMode::LocalhostDev => "localhost-dev",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum CliCredentialStoreEncryptionMode {
     Auto,
     None,

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -132,9 +132,9 @@ pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
 pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode,
-    CliDeploymentWasmRuntimeProfile, CliEventTemplateSchedule, CliMultiChannelOutboundMode,
-    CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
-    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliDeploymentWasmRuntimeProfile, CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode,
+    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
+    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -28,12 +28,13 @@ pub(crate) async fn run_transport_mode_if_requested(
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                anyhow!(
-                    "--gateway-openresponses-auth-token is required when --gateway-openresponses-server is set"
-                )
-            })?
-            .to_string();
+            .map(str::to_string);
+        let auth_password = cli
+            .gateway_openresponses_auth_password
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
         crate::gateway_openresponses::run_gateway_openresponses_server(
             crate::gateway_openresponses::GatewayOpenResponsesServerConfig {
                 client: client.clone(),
@@ -46,7 +47,12 @@ pub(crate) async fn run_transport_mode_if_requested(
                 session_lock_stale_ms: cli.session_lock_stale_ms,
                 state_dir: cli.gateway_state_dir.clone(),
                 bind: cli.gateway_openresponses_bind.clone(),
+                auth_mode: cli.gateway_openresponses_auth_mode,
                 auth_token,
+                auth_password,
+                session_ttl_seconds: cli.gateway_openresponses_session_ttl_seconds,
+                rate_limit_window_seconds: cli.gateway_openresponses_rate_limit_window_seconds,
+                rate_limit_max_requests: cli.gateway_openresponses_rate_limit_max_requests,
                 max_input_chars: cli.gateway_openresponses_max_input_chars,
             },
         )

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -91,7 +91,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
-- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway-served webchat/status endpoints.
+- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway auth/session (`/gateway/auth/session`) and webchat/status endpoints.
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
 - `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).
 - `deployment_wasm.rs`: WASM artifact packaging, manifest verification, and deployment state deliverable tracking.


### PR DESCRIPTION
Closes #861

## Summary of behavior changes
- Added `--gateway-openresponses-auth-mode` with three supported modes:
  - `token` (default bearer token auth)
  - `password-session` (password exchange endpoint + short-lived bearer sessions)
  - `localhost-dev` (loopback-only dev mode without bearer header)
- Added `POST /gateway/auth/session` for password-session login and bearer issuance.
- Added gateway request limiting with deterministic `429` `rate_limited` errors.
- Added auth telemetry into `/gateway/status` output (`mode`, session totals, auth failures, rate-limit counters).
- Added mode-aware CLI validation (required token/password and loopback constraint for localhost-dev).
- Updated gateway operations docs and code map.

## Risks and compatibility notes
- Gateway auth defaults remain backward-compatible (`token` mode).
- `password-session` and `localhost-dev` add new auth behavior; operators must set matching flags.
- Rate limiting is now enforced on gateway status/responses/auth session issuance; aggressive limits can reject legitimate bursts.

## Validation evidence
- `cargo fmt --all --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent gateway_openresponses -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
- `scripts/demo/gateway.sh --timeout-seconds 30`
