### PR TITLE
feat: harden GitHub Issues chat workflow diagnostics

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -796,6 +796,41 @@ pub(crate) struct Cli {
     pub(crate) transport_health_json: bool,
 
     #[arg(
+        long = "github-status-inspect",
+        env = "TAU_GITHUB_STATUS_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_channel_route_inspect_file",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        conflicts_with = "gateway_service_start",
+        conflicts_with = "gateway_service_stop",
+        conflicts_with = "gateway_service_status",
+        value_name = "owner/repo",
+        help = "Inspect GitHub issues bridge state and event logs for one repository and exit"
+    )]
+    pub(crate) github_status_inspect: Option<String>,
+
+    #[arg(
+        long = "github-status-json",
+        env = "TAU_GITHUB_STATUS_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "github_status_inspect",
+        help = "Emit --github-status-inspect output as pretty JSON"
+    )]
+    pub(crate) github_status_json: bool,
+
+    #[arg(
         long = "dashboard-status-inspect",
         env = "TAU_DASHBOARD_STATUS_INSPECT",
         conflicts_with = "channel_store_inspect",
@@ -3041,7 +3076,6 @@ pub(crate) struct Cli {
         long = "github-state-dir",
         env = "TAU_GITHUB_STATE_DIR",
         default_value = ".tau/github-issues",
-        requires = "github_issues_bridge",
         help = "Directory for github bridge state/session/event logs"
     )]
     pub(crate) github_state_dir: PathBuf,

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -448,6 +448,7 @@ pub(crate) fn validate_multi_channel_channel_lifecycle_cli(cli: &Cli) -> Result<
     if cli.channel_store_inspect.is_some()
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
+        || cli.github_status_inspect.is_some()
         || cli.multi_channel_status_inspect
         || cli.multi_channel_route_inspect_file.is_some()
         || cli.dashboard_status_inspect

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -35,6 +35,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
     if cli.channel_store_inspect.is_some()
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
+        || cli.github_status_inspect.is_some()
         || cli.multi_channel_status_inspect
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -39,8 +39,17 @@ Bridge control commands in issue comments:
 - `/tau status`
 - `/tau health`
 - `/tau stop`
-- `/tau chat start|resume|reset|status|show|search|export`
+- `/tau chat start|resume|reset|status|summary|replay|show|search|export`
 - `/tau artifacts|artifacts run <run_id>|artifacts show <artifact_id>|artifacts purge`
+
+Inspect deterministic GitHub bridge state/report output:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --github-status-inspect owner/repo \
+  --github-state-dir .tau/github-issues \
+  --github-status-json
+```
 
 ## Slack Socket Mode bridge
 


### PR DESCRIPTION
## Summary
- add `/tau chat summary` and `/tau chat replay` command support in the GitHub Issues bridge
- expand per-issue chat session diagnostics with run/event counters, actor/kind metadata, and reason-code visibility
- add deterministic `--github-status-inspect owner/repo` report mode with optional `--github-status-json` output
- wire inspect mode through startup preflight + runtime CLI validation and update runbook docs

## Risks and compatibility
- state schema expands `issue_sessions` fields in GitHub bridge `state.json`; serde defaults preserve backward compatibility for legacy files
- inspect command is additive and does not alter bridge runtime behavior when not invoked
- chat reset semantics were guarded to avoid accidental session recreation during outcome logging

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`

## Test matrix coverage
- Unit: command parsing, footer/render helpers, inspect report formatting
- Functional: bridge command handling and status report collection
- Integration: issue event processing to response diagnostics and startup preflight inspect flow
- Regression: duplicate events/idempotency, missing log fallback paths, chat reset continuity

Closes #863
