### PR TITLE
feat: add deterministic project index build/query/inspect workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Start with the docs index: [`docs/README.md`](docs/README.md)
 Focused guides:
 
 - Quickstart: [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
+- Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Transports (GitHub/Slack/RPC): [`docs/guides/transports.md`](docs/guides/transports.md)
 - Packages and extensions: [`docs/guides/packages.md`](docs/guides/packages.md)
 - Events and scheduler: [`docs/guides/events.md`](docs/guides/events.md)
@@ -116,6 +117,7 @@ Implemented now:
 - OAuth/session login backend routing for Codex, Claude Code, and Gemini CLI flows
 - Interactive prompt mode, one-shot mode, and plan-first orchestration mode
 - Persistent JSONL sessions with branch/resume/repair/export/import tooling
+- Deterministic project index build/query/inspect workflow for local code search
 - Built-in filesystem and shell tools
 - Transport bridges for GitHub Issues and Slack Socket Mode
 - RPC capabilities/dispatch/serve NDJSON protocol surfaces

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -724,6 +724,76 @@ pub(crate) struct Cli {
     pub(crate) doctor_release_cache_ttl_ms: u64,
 
     #[arg(
+        long = "project-index-build",
+        env = "TAU_PROJECT_INDEX_BUILD",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        conflicts_with = "project_index_query",
+        conflicts_with = "project_index_inspect",
+        help = "Build or refresh the local project index under --project-index-state-dir and exit"
+    )]
+    pub(crate) project_index_build: bool,
+
+    #[arg(
+        long = "project-index-query",
+        env = "TAU_PROJECT_INDEX_QUERY",
+        conflicts_with = "project_index_build",
+        conflicts_with = "project_index_inspect",
+        value_name = "query",
+        help = "Query the local project index for symbol/path/token matches and exit"
+    )]
+    pub(crate) project_index_query: Option<String>,
+
+    #[arg(
+        long = "project-index-inspect",
+        env = "TAU_PROJECT_INDEX_INSPECT",
+        conflicts_with = "project_index_build",
+        conflicts_with = "project_index_query",
+        help = "Inspect local project index metadata and exit"
+    )]
+    pub(crate) project_index_inspect: bool,
+
+    #[arg(
+        long = "project-index-json",
+        env = "TAU_PROJECT_INDEX_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Emit project index build/query/inspect output as pretty JSON"
+    )]
+    pub(crate) project_index_json: bool,
+
+    #[arg(
+        long = "project-index-root",
+        env = "TAU_PROJECT_INDEX_ROOT",
+        default_value = ".",
+        help = "Workspace root directory scanned by --project-index-build and resolved by query/inspect operations"
+    )]
+    pub(crate) project_index_root: PathBuf,
+
+    #[arg(
+        long = "project-index-state-dir",
+        env = "TAU_PROJECT_INDEX_STATE_DIR",
+        default_value = ".tau/index",
+        help = "Directory containing project index state artifacts"
+    )]
+    pub(crate) project_index_state_dir: PathBuf,
+
+    #[arg(
+        long = "project-index-limit",
+        env = "TAU_PROJECT_INDEX_LIMIT",
+        default_value_t = 25,
+        value_parser = parse_positive_usize,
+        help = "Maximum number of query results returned by --project-index-query"
+    )]
+    pub(crate) project_index_limit: usize,
+
+    #[arg(
         long = "channel-store-root",
         env = "TAU_CHANNEL_STORE_ROOT",
         default_value = ".tau/channel-store",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -51,6 +51,7 @@ mod onboarding;
 mod orchestrator;
 mod package_manifest;
 mod pairing;
+mod project_index;
 mod provider_auth;
 mod provider_client;
 mod provider_credentials;
@@ -232,6 +233,7 @@ pub(crate) use crate::pairing::{
     evaluate_pairing_access, execute_pair_command, execute_unpair_command,
     pairing_policy_for_state_dir, PairingDecision,
 };
+pub(crate) use crate::project_index::execute_project_index_command;
 pub(crate) use crate::provider_auth::{
     configured_provider_auth_method, configured_provider_auth_method_from_config,
     missing_provider_api_key_message, provider_api_key_candidates,
@@ -282,7 +284,7 @@ pub(crate) use crate::runtime_cli_validation::{
     validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
     validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_contract_runner_cli,
     validate_multi_channel_live_ingest_cli, validate_multi_channel_live_runner_cli,
-    validate_slack_bridge_cli, validate_voice_contract_runner_cli,
+    validate_project_index_cli, validate_slack_bridge_cli, validate_voice_contract_runner_cli,
 };
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,

--- a/crates/tau-coding-agent/src/project_index.rs
+++ b/crates/tau-coding-agent/src/project_index.rs
@@ -1,0 +1,809 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use super::*;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const PROJECT_INDEX_SCHEMA_VERSION: u32 = 1;
+const PROJECT_INDEX_FILE_NAME: &str = "project-index.json";
+const MAX_INDEX_FILE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_TOKENS_PER_FILE: usize = 512;
+const MAX_SYMBOLS_PER_FILE: usize = 128;
+const MAX_TOKENIZED_CHARS: usize = 200_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectIndexState {
+    schema_version: u32,
+    generated_unix_ms: u64,
+    root: String,
+    files: Vec<ProjectIndexEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectIndexEntry {
+    path: String,
+    sha256: String,
+    bytes: u64,
+    lines: u64,
+    token_count: usize,
+    tokens: Vec<String>,
+    symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ProjectIndexBuildReport {
+    root: String,
+    index_path: String,
+    schema_version: u32,
+    generated_unix_ms: u64,
+    files_discovered: usize,
+    files_indexed: usize,
+    files_reused: usize,
+    files_updated: usize,
+    files_removed: usize,
+    skipped_non_utf8: usize,
+    skipped_large: usize,
+    recovered_from_corrupt_state: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ProjectIndexInspectReport {
+    root: String,
+    index_path: String,
+    schema_version: u32,
+    generated_unix_ms: u64,
+    files_indexed: usize,
+    total_bytes: u64,
+    total_lines: u64,
+    total_tokens: usize,
+    extension_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ProjectIndexQueryResult {
+    path: String,
+    score: u64,
+    bytes: u64,
+    lines: u64,
+    token_count: usize,
+    matched_symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ProjectIndexQueryReport {
+    root: String,
+    index_path: String,
+    query: String,
+    query_tokens: Vec<String>,
+    limit: usize,
+    total_matches: usize,
+    results: Vec<ProjectIndexQueryResult>,
+}
+
+pub(crate) fn execute_project_index_command(cli: &Cli) -> Result<()> {
+    let root = resolve_project_index_root(&cli.project_index_root)?;
+    let index_path = project_index_file_path(&cli.project_index_state_dir);
+    if cli.project_index_build {
+        let report = build_project_index(&root, &cli.project_index_state_dir)?;
+        if cli.project_index_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render project index build report as json")?
+            );
+        } else {
+            println!("{}", render_project_index_build_report(&report));
+        }
+        return Ok(());
+    }
+
+    if let Some(query) = cli.project_index_query.as_deref() {
+        let report = query_project_index(&root, &index_path, query, cli.project_index_limit)?;
+        if cli.project_index_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render project index query report as json")?
+            );
+        } else {
+            println!("{}", render_project_index_query_report(&report));
+        }
+        return Ok(());
+    }
+
+    if cli.project_index_inspect {
+        let report = inspect_project_index(&root, &index_path)?;
+        if cli.project_index_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render project index inspect report as json")?
+            );
+        } else {
+            println!("{}", render_project_index_inspect_report(&report));
+        }
+        return Ok(());
+    }
+
+    bail!("no project index action selected");
+}
+
+fn resolve_project_index_root(root: &Path) -> Result<PathBuf> {
+    if !root.exists() {
+        bail!("--project-index-root '{}' does not exist", root.display());
+    }
+    if !root.is_dir() {
+        bail!(
+            "--project-index-root '{}' must point to a directory",
+            root.display()
+        );
+    }
+    Ok(fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()))
+}
+
+fn project_index_file_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(PROJECT_INDEX_FILE_NAME)
+}
+
+fn should_skip_directory(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | ".tau"
+            | "target"
+            | "node_modules"
+            | "dist"
+            | "build"
+            | ".venv"
+            | "venv"
+            | ".idea"
+            | ".vscode"
+    )
+}
+
+fn should_index_file(path: &Path) -> bool {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    matches!(
+        extension.as_str(),
+        "rs" | "md"
+            | "toml"
+            | "json"
+            | "yaml"
+            | "yml"
+            | "txt"
+            | "py"
+            | "go"
+            | "java"
+            | "kt"
+            | "swift"
+            | "js"
+            | "jsx"
+            | "ts"
+            | "tsx"
+            | "sql"
+            | "sh"
+            | "bash"
+            | "zsh"
+            | "html"
+            | "css"
+            | "scss"
+            | "c"
+            | "cc"
+            | "cpp"
+            | "h"
+            | "hpp"
+    )
+}
+
+fn collect_index_candidate_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_index_candidate_files_recursive(root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_index_candidate_files_recursive(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries = fs::read_dir(dir)
+        .with_context(|| format!("failed to read directory '{}'", dir.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to list directory entries for '{}'", dir.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to inspect '{}'", path.display()))?;
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if should_skip_directory(&name) {
+                continue;
+            }
+            collect_index_candidate_files_recursive(&path, files)?;
+            continue;
+        }
+        if file_type.is_file() && should_index_file(&path) {
+            files.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("{digest:x}")
+}
+
+fn normalize_relative_path(root: &Path, path: &Path) -> Result<String> {
+    let relative = path.strip_prefix(root).with_context(|| {
+        format!(
+            "failed to compute path relative to root '{}'",
+            root.display()
+        )
+    })?;
+    let normalized = relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+        .collect::<Vec<_>>()
+        .join("/");
+    Ok(normalized)
+}
+
+fn extract_tokens(text: &str) -> Vec<String> {
+    let mut tokens = BTreeSet::new();
+    let mut current = String::new();
+
+    for character in text.chars().take(MAX_TOKENIZED_CHARS) {
+        if character.is_ascii_alphanumeric() || character == '_' {
+            current.push(character.to_ascii_lowercase());
+            continue;
+        }
+        if !current.is_empty() {
+            if current.len() >= 2 && !is_stopword(&current) {
+                tokens.insert(current.clone());
+                if tokens.len() >= MAX_TOKENS_PER_FILE {
+                    break;
+                }
+            }
+            current.clear();
+        }
+    }
+    if !current.is_empty() && current.len() >= 2 && !is_stopword(&current) {
+        tokens.insert(current);
+    }
+
+    tokens.into_iter().take(MAX_TOKENS_PER_FILE).collect()
+}
+
+fn is_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "the"
+            | "and"
+            | "for"
+            | "with"
+            | "that"
+            | "this"
+            | "from"
+            | "into"
+            | "true"
+            | "false"
+            | "none"
+            | "null"
+            | "let"
+            | "pub"
+            | "use"
+    )
+}
+
+fn extract_symbols(text: &str) -> Vec<String> {
+    let prefixes = [
+        "pub fn ",
+        "fn ",
+        "pub struct ",
+        "struct ",
+        "pub enum ",
+        "enum ",
+        "pub trait ",
+        "trait ",
+        "pub mod ",
+        "mod ",
+        "class ",
+        "interface ",
+        "type ",
+        "impl ",
+    ];
+    let mut symbols = BTreeSet::new();
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        for prefix in prefixes {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                let name = parse_identifier(rest);
+                if !name.is_empty() {
+                    symbols.insert(name.to_string());
+                    if symbols.len() >= MAX_SYMBOLS_PER_FILE {
+                        return symbols.into_iter().collect();
+                    }
+                }
+                break;
+            }
+        }
+    }
+    symbols.into_iter().collect()
+}
+
+fn parse_identifier(raw: &str) -> &str {
+    let trimmed = raw.trim_start();
+    let mut end = 0usize;
+    for (index, character) in trimmed.char_indices() {
+        if character.is_ascii_alphanumeric() || character == '_' || character == ':' {
+            end = index + character.len_utf8();
+        } else {
+            break;
+        }
+    }
+    trimmed.get(..end).unwrap_or_default()
+}
+
+fn load_project_index_state(index_path: &Path) -> Result<ProjectIndexState> {
+    let raw = fs::read_to_string(index_path)
+        .with_context(|| format!("failed reading '{}'", index_path.display()))?;
+    let state: ProjectIndexState = serde_json::from_str(&raw)
+        .with_context(|| format!("failed parsing '{}'", index_path.display()))?;
+    if state.schema_version != PROJECT_INDEX_SCHEMA_VERSION {
+        bail!(
+            "project index schema mismatch in '{}': expected {}, got {}",
+            index_path.display(),
+            PROJECT_INDEX_SCHEMA_VERSION,
+            state.schema_version
+        );
+    }
+    Ok(state)
+}
+
+fn build_project_index(root: &Path, state_dir: &Path) -> Result<ProjectIndexBuildReport> {
+    fs::create_dir_all(state_dir).with_context(|| {
+        format!(
+            "failed creating project index state directory '{}'",
+            state_dir.display()
+        )
+    })?;
+    let index_path = project_index_file_path(state_dir);
+
+    let mut recovered_from_corrupt_state = false;
+    let existing = if index_path.exists() {
+        match load_project_index_state(&index_path) {
+            Ok(state) => Some(state),
+            Err(_) => {
+                recovered_from_corrupt_state = true;
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let existing_entries = existing
+        .map(|state| {
+            state
+                .files
+                .into_iter()
+                .map(|entry| (entry.path.clone(), entry))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    let candidate_files = collect_index_candidate_files(root)?;
+    let files_discovered = candidate_files.len();
+    let mut files_reused = 0usize;
+    let mut files_updated = 0usize;
+    let mut skipped_non_utf8 = 0usize;
+    let mut skipped_large = 0usize;
+    let mut indexed_entries = Vec::new();
+    let mut indexed_paths = BTreeSet::new();
+
+    for file_path in candidate_files {
+        let relative_path = normalize_relative_path(root, &file_path)?;
+        let bytes = fs::read(&file_path)
+            .with_context(|| format!("failed reading '{}'", file_path.display()))?;
+        if bytes.len() > MAX_INDEX_FILE_BYTES {
+            skipped_large = skipped_large.saturating_add(1);
+            continue;
+        }
+
+        let text = match String::from_utf8(bytes.clone()) {
+            Ok(value) => value,
+            Err(_) => {
+                skipped_non_utf8 = skipped_non_utf8.saturating_add(1);
+                continue;
+            }
+        };
+
+        let sha = sha256_hex(&bytes);
+        if let Some(existing_entry) = existing_entries.get(&relative_path) {
+            if existing_entry.sha256 == sha {
+                files_reused = files_reused.saturating_add(1);
+                indexed_paths.insert(relative_path);
+                indexed_entries.push(existing_entry.clone());
+                continue;
+            }
+        }
+
+        files_updated = files_updated.saturating_add(1);
+        indexed_paths.insert(relative_path.clone());
+        let tokens = extract_tokens(&text);
+        let symbols = extract_symbols(&text);
+        indexed_entries.push(ProjectIndexEntry {
+            path: relative_path,
+            sha256: sha,
+            bytes: bytes.len() as u64,
+            lines: text.lines().count() as u64,
+            token_count: tokens.len(),
+            tokens,
+            symbols,
+        });
+    }
+
+    indexed_entries.sort_by(|left, right| left.path.cmp(&right.path));
+    let files_removed = existing_entries
+        .keys()
+        .filter(|path| !indexed_paths.contains(*path))
+        .count();
+    let generated_unix_ms = current_unix_timestamp_ms();
+    let state = ProjectIndexState {
+        schema_version: PROJECT_INDEX_SCHEMA_VERSION,
+        generated_unix_ms,
+        root: root.display().to_string(),
+        files: indexed_entries.clone(),
+    };
+    write_text_atomic(
+        &index_path,
+        &serde_json::to_string_pretty(&state)
+            .context("failed to serialize project index state payload")?,
+    )
+    .with_context(|| format!("failed writing '{}'", index_path.display()))?;
+
+    Ok(ProjectIndexBuildReport {
+        root: root.display().to_string(),
+        index_path: index_path.display().to_string(),
+        schema_version: PROJECT_INDEX_SCHEMA_VERSION,
+        generated_unix_ms,
+        files_discovered,
+        files_indexed: indexed_entries.len(),
+        files_reused,
+        files_updated,
+        files_removed,
+        skipped_non_utf8,
+        skipped_large,
+        recovered_from_corrupt_state,
+    })
+}
+
+fn inspect_project_index(root: &Path, index_path: &Path) -> Result<ProjectIndexInspectReport> {
+    let state = load_project_index_state(index_path).with_context(|| {
+        format!(
+            "failed loading project index from '{}'; run --project-index-build to regenerate",
+            index_path.display()
+        )
+    })?;
+    let mut extension_counts = BTreeMap::new();
+    let mut total_bytes = 0u64;
+    let mut total_lines = 0u64;
+    let mut total_tokens = 0usize;
+    for entry in &state.files {
+        let extension = Path::new(&entry.path)
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or("(none)")
+            .to_ascii_lowercase();
+        *extension_counts.entry(extension).or_insert(0usize) += 1;
+        total_bytes = total_bytes.saturating_add(entry.bytes);
+        total_lines = total_lines.saturating_add(entry.lines);
+        total_tokens = total_tokens.saturating_add(entry.token_count);
+    }
+    Ok(ProjectIndexInspectReport {
+        root: root.display().to_string(),
+        index_path: index_path.display().to_string(),
+        schema_version: state.schema_version,
+        generated_unix_ms: state.generated_unix_ms,
+        files_indexed: state.files.len(),
+        total_bytes,
+        total_lines,
+        total_tokens,
+        extension_counts,
+    })
+}
+
+fn query_project_index(
+    root: &Path,
+    index_path: &Path,
+    query: &str,
+    limit: usize,
+) -> Result<ProjectIndexQueryReport> {
+    let state = load_project_index_state(index_path).with_context(|| {
+        format!(
+            "failed loading project index from '{}'; run --project-index-build to regenerate",
+            index_path.display()
+        )
+    })?;
+    let query_trimmed = query.trim();
+    if query_trimmed.is_empty() {
+        bail!("--project-index-query cannot be empty");
+    }
+    let query_lower = query_trimmed.to_ascii_lowercase();
+    let mut query_tokens = extract_tokens(query_trimmed);
+    if query_tokens.is_empty() {
+        query_tokens.push(query_lower.clone());
+    }
+
+    let mut results = state
+        .files
+        .iter()
+        .filter_map(|entry| score_project_index_entry(entry, &query_lower, &query_tokens))
+        .collect::<Vec<_>>();
+    results.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let total_matches = results.len();
+    results.truncate(limit);
+
+    Ok(ProjectIndexQueryReport {
+        root: root.display().to_string(),
+        index_path: index_path.display().to_string(),
+        query: query_trimmed.to_string(),
+        query_tokens,
+        limit,
+        total_matches,
+        results,
+    })
+}
+
+fn score_project_index_entry(
+    entry: &ProjectIndexEntry,
+    query_lower: &str,
+    query_tokens: &[String],
+) -> Option<ProjectIndexQueryResult> {
+    let path_lower = entry.path.to_ascii_lowercase();
+    let symbol_rows = entry
+        .symbols
+        .iter()
+        .map(|symbol| symbol.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+
+    let mut score = 0u64;
+    if path_lower.contains(query_lower) {
+        score = score.saturating_add(120);
+    }
+    for token in query_tokens {
+        if path_lower.contains(token) {
+            score = score.saturating_add(40);
+        }
+        if symbol_rows.iter().any(|symbol| symbol.contains(token)) {
+            score = score.saturating_add(30);
+        }
+        if entry.tokens.binary_search(token).is_ok() {
+            score = score.saturating_add(10);
+        }
+    }
+    if score == 0 {
+        return None;
+    }
+
+    let matched_symbols = entry
+        .symbols
+        .iter()
+        .filter(|symbol| {
+            let lower = symbol.to_ascii_lowercase();
+            lower.contains(query_lower) || query_tokens.iter().any(|token| lower.contains(token))
+        })
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Some(ProjectIndexQueryResult {
+        path: entry.path.clone(),
+        score,
+        bytes: entry.bytes,
+        lines: entry.lines,
+        token_count: entry.token_count,
+        matched_symbols,
+    })
+}
+
+fn render_project_index_build_report(report: &ProjectIndexBuildReport) -> String {
+    format!(
+        "project index build: root={} index_path={} schema_version={} generated_unix_ms={} discovered={} indexed={} reused={} updated={} removed={} skipped_non_utf8={} skipped_large={} recovered_from_corrupt_state={}",
+        report.root,
+        report.index_path,
+        report.schema_version,
+        report.generated_unix_ms,
+        report.files_discovered,
+        report.files_indexed,
+        report.files_reused,
+        report.files_updated,
+        report.files_removed,
+        report.skipped_non_utf8,
+        report.skipped_large,
+        report.recovered_from_corrupt_state
+    )
+}
+
+fn render_project_index_inspect_report(report: &ProjectIndexInspectReport) -> String {
+    let extension_summary = if report.extension_counts.is_empty() {
+        "none".to_string()
+    } else {
+        report
+            .extension_counts
+            .iter()
+            .map(|(extension, count)| format!("{extension}:{count}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!(
+        "project index inspect: root={} index_path={} schema_version={} generated_unix_ms={} files={} total_bytes={} total_lines={} total_tokens={} extensions={}",
+        report.root,
+        report.index_path,
+        report.schema_version,
+        report.generated_unix_ms,
+        report.files_indexed,
+        report.total_bytes,
+        report.total_lines,
+        report.total_tokens,
+        extension_summary
+    )
+}
+
+fn render_project_index_query_report(report: &ProjectIndexQueryReport) -> String {
+    let mut lines = vec![format!(
+        "project index query: root={} query={} matches={} limit={}",
+        report.root, report.query, report.total_matches, report.limit
+    )];
+    for result in &report.results {
+        let symbols = if result.matched_symbols.is_empty() {
+            "none".to_string()
+        } else {
+            result.matched_symbols.join("|")
+        };
+        lines.push(format!(
+            "score={} path={} bytes={} lines={} token_count={} symbols={}",
+            result.score, result.path, result.bytes, result.lines, result.token_count, symbols
+        ));
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn unit_extract_tokens_and_symbols_are_deterministic() {
+        let text = r#"
+            pub struct IndexReport { value: usize }
+            pub fn build_index() {}
+            fn private_helper() {}
+        "#;
+        let first_tokens = extract_tokens(text);
+        let second_tokens = extract_tokens(text);
+        assert_eq!(first_tokens, second_tokens);
+        assert!(first_tokens.iter().any(|token| token == "indexreport"));
+        assert!(first_tokens.iter().any(|token| token == "build_index"));
+
+        let symbols = extract_symbols(text);
+        assert_eq!(
+            symbols,
+            vec![
+                "IndexReport".to_string(),
+                "build_index".to_string(),
+                "private_helper".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn functional_build_project_index_writes_state_and_counts_files() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let state_dir = temp.path().join("state");
+        fs::create_dir_all(root.join("src")).expect("create src");
+        fs::write(
+            root.join("src").join("lib.rs"),
+            "pub fn parse_value() -> usize { 1 }\n",
+        )
+        .expect("write rust file");
+        fs::write(root.join("README.md"), "Tau project index demo\n").expect("write readme");
+
+        let report = build_project_index(&root, &state_dir).expect("build should succeed");
+        assert_eq!(report.files_discovered, 2);
+        assert_eq!(report.files_indexed, 2);
+        assert_eq!(report.files_updated, 2);
+        assert_eq!(report.files_reused, 0);
+        assert!(
+            project_index_file_path(&state_dir).exists(),
+            "index file should exist after build"
+        );
+
+        let inspect = inspect_project_index(&root, &project_index_file_path(&state_dir))
+            .expect("inspect should succeed");
+        assert_eq!(inspect.files_indexed, 2);
+        assert_eq!(inspect.extension_counts.get("rs"), Some(&1usize));
+        assert_eq!(inspect.extension_counts.get("md"), Some(&1usize));
+    }
+
+    #[test]
+    fn integration_build_then_query_reuses_unchanged_entries_and_ranks_matches() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let state_dir = temp.path().join("state");
+        fs::create_dir_all(root.join("src")).expect("create src");
+        fs::write(
+            root.join("src").join("alpha.rs"),
+            "pub fn alpha_runner() {}\n",
+        )
+        .expect("write alpha");
+        fs::write(
+            root.join("src").join("beta.rs"),
+            "pub fn beta_runner() {}\n",
+        )
+        .expect("write beta");
+
+        let first = build_project_index(&root, &state_dir).expect("first build should succeed");
+        assert_eq!(first.files_updated, 2);
+        assert_eq!(first.files_reused, 0);
+
+        fs::write(
+            root.join("src").join("beta.rs"),
+            "pub fn beta_runner_v2() {}\n",
+        )
+        .expect("update beta");
+
+        let second = build_project_index(&root, &state_dir).expect("second build should succeed");
+        assert_eq!(second.files_updated, 1);
+        assert_eq!(second.files_reused, 1);
+
+        let query = query_project_index(
+            &root,
+            &project_index_file_path(&state_dir),
+            "beta_runner_v2",
+            5,
+        )
+        .expect("query should succeed");
+        assert_eq!(query.total_matches, 1);
+        assert_eq!(query.results[0].path, "src/beta.rs");
+        assert!(query.results[0].score > 0);
+    }
+
+    #[test]
+    fn regression_query_fails_on_corrupt_state_with_repair_guidance() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let state_dir = temp.path().join("state");
+        fs::create_dir_all(&root).expect("create root");
+        fs::create_dir_all(&state_dir).expect("create state");
+        fs::write(project_index_file_path(&state_dir), "{invalid json").expect("write corrupt");
+
+        let error = query_project_index(&root, &project_index_file_path(&state_dir), "alpha", 5)
+            .expect_err("query should fail on corrupt state");
+        let message = error.to_string();
+        assert!(message.contains("run --project-index-build to regenerate"));
+
+        let report = build_project_index(&root, &state_dir).expect("build should recover");
+        assert!(report.recovered_from_corrupt_state);
+    }
+}

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -32,6 +32,16 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.project_index_build
+        || cli.project_index_query.is_some()
+        || cli.project_index_inspect
+        || cli.project_index_json
+    {
+        validate_project_index_cli(cli)?;
+        execute_project_index_command(cli)?;
+        return Ok(true);
+    }
+
     if cli.channel_store_inspect.is_some()
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This index maps Tau documentation by audience and task.
 | Audience | Start Here | Scope |
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
+| Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |

--- a/docs/guides/project-index.md
+++ b/docs/guides/project-index.md
@@ -1,0 +1,57 @@
+# Project Index Guide
+
+Tau provides a local, deterministic project index workflow for fast path/symbol/token lookup.
+
+## Commands
+
+Build or refresh index artifacts:
+
+```bash
+cargo run -p tau-coding-agent -- --project-index-build
+```
+
+Build from a specific root/state path:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --project-index-build \
+  --project-index-root /path/to/workspace \
+  --project-index-state-dir /path/to/workspace/.tau/index
+```
+
+Query the index:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --project-index-query "gateway status" \
+  --project-index-limit 20
+```
+
+Inspect metadata and inventory counters:
+
+```bash
+cargo run -p tau-coding-agent -- --project-index-inspect
+```
+
+Use JSON output for automation:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --project-index-query "route table" \
+  --project-index-json
+```
+
+## Behavior
+
+- Index state is stored at `--project-index-state-dir/project-index.json`.
+- Builds are deterministic and reuse unchanged file entries by content hash.
+- Query ranking favors path and symbol hits, then token matches.
+- On corrupt index state, query/inspect fail closed with guidance to rebuild.
+
+## Demo Path
+
+```bash
+cargo run -p tau-coding-agent -- --project-index-build
+cargo run -p tau-coding-agent -- --project-index-query "main loop"
+cargo run -p tau-coding-agent -- --project-index-inspect --project-index-json
+```


### PR DESCRIPTION
## Summary
- add a new project index runtime module with deterministic build/query/inspect flows
- add CLI surfaces for project indexing:
  - --project-index-build
  - --project-index-query
  - --project-index-inspect
  - --project-index-json
  - --project-index-root / --project-index-state-dir / --project-index-limit
- wire project index mode through startup preflight and runtime CLI validation
- add regression-safe index state handling (corrupt state recovery on build, fail-closed guidance for query/inspect)
- add operator docs and demo workflow in `docs/guides/project-index.md`

## Risks and compatibility
- additive CLI surface only; existing prompt/runtime paths are unchanged unless project-index flags are used
- project index files are isolated to `--project-index-state-dir/project-index.json`
- validation now rejects mixing project-index mode with active runtime/transport preflight modes

## Validation
- cargo fmt --all
- cargo clippy -p tau-coding-agent --all-targets -- -D warnings
- cargo test -p tau-coding-agent project_index -- --test-threads=1
- cargo test -p tau-coding-agent -- --test-threads=1

## Test matrix coverage
- Unit: tokenization/symbol extraction determinism, CLI defaults/validation
- Functional: build/write/inspect/report and startup preflight build dispatch
- Integration: rebuild reuse behavior + ranked query flow across file changes
- Regression: corrupt index recovery on build and fail-closed query validation

Closes #869
