### PR TITLE
feat: add multichannel typing/presence/usage telemetry

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -2472,6 +2472,51 @@ pub(crate) struct Cli {
     pub(crate) multi_channel_retry_jitter_ms: u64,
 
     #[arg(
+        long = "multi-channel-telemetry-typing-presence",
+        env = "TAU_MULTI_CHANNEL_TELEMETRY_TYPING_PRESENCE",
+        default_value_t = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Emit typing/presence lifecycle telemetry for long-running multi-channel replies"
+    )]
+    pub(crate) multi_channel_telemetry_typing_presence: bool,
+
+    #[arg(
+        long = "multi-channel-telemetry-usage-summary",
+        env = "TAU_MULTI_CHANNEL_TELEMETRY_USAGE_SUMMARY",
+        default_value_t = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Emit usage summary telemetry records for multi-channel replies"
+    )]
+    pub(crate) multi_channel_telemetry_usage_summary: bool,
+
+    #[arg(
+        long = "multi-channel-telemetry-include-identifiers",
+        env = "TAU_MULTI_CHANNEL_TELEMETRY_INCLUDE_IDENTIFIERS",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Include actor/conversation identifiers in multi-channel telemetry payloads (default is privacy-safe false)"
+    )]
+    pub(crate) multi_channel_telemetry_include_identifiers: bool,
+
+    #[arg(
+        long = "multi-channel-telemetry-min-response-chars",
+        env = "TAU_MULTI_CHANNEL_TELEMETRY_MIN_RESPONSE_CHARS",
+        default_value_t = 120,
+        value_parser = parse_positive_usize,
+        help = "Minimum response length before typing/presence telemetry is emitted"
+    )]
+    pub(crate) multi_channel_telemetry_min_response_chars: usize,
+
+    #[arg(
         long = "multi-channel-outbound-mode",
         env = "TAU_MULTI_CHANNEL_OUTBOUND_MODE",
         value_enum,

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -197,6 +197,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             retry_base_delay_ms: cli.multi_channel_retry_base_delay_ms,
             retry_jitter_ms: cli.multi_channel_retry_jitter_ms,
             outbound: build_multi_channel_outbound_config(cli),
+            telemetry: build_multi_channel_telemetry_config(cli),
         })
         .await?;
         return Ok(true);
@@ -213,6 +214,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             retry_base_delay_ms: cli.multi_channel_retry_base_delay_ms,
             retry_jitter_ms: cli.multi_channel_retry_jitter_ms,
             outbound: build_multi_channel_outbound_config(cli),
+            telemetry: build_multi_channel_telemetry_config(cli),
         })
         .await?;
         return Ok(true);
@@ -419,5 +421,16 @@ fn build_multi_channel_outbound_config(
             cli.multi_channel_whatsapp_phone_number_id.as_deref(),
             "whatsapp-phone-number-id",
         ),
+    }
+}
+
+fn build_multi_channel_telemetry_config(
+    cli: &Cli,
+) -> crate::multi_channel_runtime::MultiChannelTelemetryConfig {
+    crate::multi_channel_runtime::MultiChannelTelemetryConfig {
+        typing_presence_enabled: cli.multi_channel_telemetry_typing_presence,
+        usage_summary_enabled: cli.multi_channel_telemetry_usage_summary,
+        include_identifiers: cli.multi_channel_telemetry_include_identifiers,
+        typing_presence_min_response_chars: cli.multi_channel_telemetry_min_response_chars.max(1),
     }
 }

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -537,6 +537,10 @@ fn test_cli() -> Cli {
         multi_channel_retry_max_attempts: 4,
         multi_channel_retry_base_delay_ms: 0,
         multi_channel_retry_jitter_ms: 0,
+        multi_channel_telemetry_typing_presence: true,
+        multi_channel_telemetry_usage_summary: true,
+        multi_channel_telemetry_include_identifiers: false,
+        multi_channel_telemetry_min_response_chars: 120,
         multi_channel_outbound_mode: CliMultiChannelOutboundMode::ChannelStore,
         multi_channel_outbound_max_chars: 1200,
         multi_channel_outbound_http_timeout_ms: 5000,
@@ -1507,6 +1511,10 @@ fn unit_cli_multi_channel_runner_flags_default_to_disabled() {
     assert_eq!(cli.multi_channel_retry_max_attempts, 4);
     assert_eq!(cli.multi_channel_retry_base_delay_ms, 0);
     assert_eq!(cli.multi_channel_retry_jitter_ms, 0);
+    assert!(cli.multi_channel_telemetry_typing_presence);
+    assert!(cli.multi_channel_telemetry_usage_summary);
+    assert!(!cli.multi_channel_telemetry_include_identifiers);
+    assert_eq!(cli.multi_channel_telemetry_min_response_chars, 120);
     assert_eq!(
         cli.multi_channel_outbound_mode,
         CliMultiChannelOutboundMode::ChannelStore
@@ -1619,6 +1627,11 @@ fn functional_cli_multi_channel_runner_flags_accept_explicit_overrides() {
         "25",
         "--multi-channel-retry-jitter-ms",
         "9",
+        "--multi-channel-telemetry-typing-presence=false",
+        "--multi-channel-telemetry-usage-summary=false",
+        "--multi-channel-telemetry-include-identifiers=true",
+        "--multi-channel-telemetry-min-response-chars",
+        "80",
         "--multi-channel-outbound-mode",
         "dry-run",
         "--multi-channel-outbound-max-chars",
@@ -1646,6 +1659,10 @@ fn functional_cli_multi_channel_runner_flags_accept_explicit_overrides() {
     assert_eq!(cli.multi_channel_retry_max_attempts, 7);
     assert_eq!(cli.multi_channel_retry_base_delay_ms, 25);
     assert_eq!(cli.multi_channel_retry_jitter_ms, 9);
+    assert!(!cli.multi_channel_telemetry_typing_presence);
+    assert!(!cli.multi_channel_telemetry_usage_summary);
+    assert!(cli.multi_channel_telemetry_include_identifiers);
+    assert_eq!(cli.multi_channel_telemetry_min_response_chars, 80);
     assert_eq!(
         cli.multi_channel_outbound_mode,
         CliMultiChannelOutboundMode::DryRun
@@ -1695,6 +1712,18 @@ fn functional_cli_multi_channel_live_runner_flags_accept_explicit_overrides() {
     assert_eq!(cli.multi_channel_queue_limit, 40);
     assert_eq!(cli.multi_channel_processed_event_cap, 512);
     assert_eq!(cli.multi_channel_retry_max_attempts, 5);
+}
+
+#[test]
+fn regression_cli_multi_channel_telemetry_min_response_chars_rejects_zero() {
+    let parse = try_parse_cli_with_stack([
+        "tau-rs",
+        "--multi-channel-contract-runner",
+        "--multi-channel-telemetry-min-response-chars",
+        "0",
+    ]);
+    let error = parse.expect_err("zero threshold should be rejected");
+    assert!(error.to_string().contains("invalid value"));
 }
 
 #[test]

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -40,6 +40,19 @@ Primary state files:
 - `.tau/multi-channel/security/multi-channel-route-bindings.json`
 - `.tau/multi-channel/channel-store/<transport>/<channel>/...`
 
+Telemetry controls (runtime flags, privacy-safe defaults):
+
+- `--multi-channel-telemetry-typing-presence=true|false`
+- `--multi-channel-telemetry-usage-summary=true|false`
+- `--multi-channel-telemetry-include-identifiers=true|false` (default `false`)
+- `--multi-channel-telemetry-min-response-chars=<N>` (default `120`)
+
+`--multi-channel-status-inspect` now includes telemetry counters and policy snapshot:
+
+- lifecycle counters: typing + presence totals/per-transport
+- usage counters: records/chars/chunks/cost totals/per-transport
+- active telemetry policy toggles and threshold
+
 `runtime-events.jsonl` reason codes:
 
 - `healthy_cycle`
@@ -51,6 +64,8 @@ Primary state files:
 - `pairing_policy_permissive`
 - `pairing_policy_enforced`
 - `pairing_policy_denied_events`
+- `telemetry_lifecycle_emitted`
+- `telemetry_usage_summary_emitted`
 
 ## Pairing and allowlist policy
 


### PR DESCRIPTION
## Summary
- adds multi-channel telemetry policy controls for Telegram/Discord/WhatsApp runtime paths
- emits deterministic typing/presence lifecycle telemetry for long replies
- captures per-event usage summaries and persists telemetry counters into multi-channel runtime state
- surfaces telemetry totals/per-transport rollups and policy snapshot in `--multi-channel-status-inspect`
- updates the multi-channel operations runbook with telemetry controls and reason codes

Closes #871

## Behavior Changes
- new CLI flags:
  - `--multi-channel-telemetry-typing-presence`
  - `--multi-channel-telemetry-usage-summary`
  - `--multi-channel-telemetry-include-identifiers`
  - `--multi-channel-telemetry-min-response-chars`
- runtime state now persists telemetry counters/policy snapshot in `.tau/multi-channel/state.json`
- status inspect output now includes telemetry summary and policy details

## Risks and Compatibility
- state format adds optional telemetry fields; missing fields default safely for backward compatibility
- default privacy posture is preserved (`include-identifiers=false`)
- telemetry adds additional outbound lifecycle records only for long-reply paths (threshold configurable)

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`
