### PR TITLE
Gateway websocket control protocol bootstrap (issue #873)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -214,8 +215,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2628,7 +2631,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "tracing-subscriber",
  "wait-timeout",
@@ -2809,8 +2812,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.24.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -2957,6 +2972,23 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-axum = { version = "0.8", features = ["json", "http1", "tokio"] }
+axum = { version = "0.8", features = ["json", "http1", "tokio", "ws"] }
 anyhow = "1"
 async-trait = "0.1"
 base64 = "0.22"

--- a/crates/tau-coding-agent/src/gateway_ws_protocol.rs
+++ b/crates/tau-coding-agent/src/gateway_ws_protocol.rs
@@ -1,0 +1,607 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub(crate) const GATEWAY_WS_REQUEST_SCHEMA_VERSION: u32 = 1;
+pub(crate) const GATEWAY_WS_RESPONSE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const GATEWAY_WS_PROTOCOL_VERSION: &str = "0.1.0";
+pub(crate) const GATEWAY_WS_HEARTBEAT_INTERVAL_SECONDS: u64 = 15;
+
+const GATEWAY_WS_COMPATIBLE_REQUEST_SCHEMA_VERSIONS: [u32; 2] =
+    [0, GATEWAY_WS_REQUEST_SCHEMA_VERSION];
+
+pub(crate) const GATEWAY_WS_ERROR_CODE_INVALID_JSON: &str = "invalid_json";
+pub(crate) const GATEWAY_WS_ERROR_CODE_UNSUPPORTED_SCHEMA: &str = "unsupported_schema";
+pub(crate) const GATEWAY_WS_ERROR_CODE_UNSUPPORTED_KIND: &str = "unsupported_kind";
+pub(crate) const GATEWAY_WS_ERROR_CODE_INVALID_REQUEST_ID: &str = "invalid_request_id";
+pub(crate) const GATEWAY_WS_ERROR_CODE_INVALID_PAYLOAD: &str = "invalid_payload";
+pub(crate) const GATEWAY_WS_ERROR_CODE_UNAUTHORIZED: &str = "unauthorized";
+pub(crate) const GATEWAY_WS_ERROR_CODE_RATE_LIMITED: &str = "rate_limited";
+pub(crate) const GATEWAY_WS_ERROR_CODE_INTERNAL_ERROR: &str = "internal_error";
+
+const GATEWAY_WS_REQUEST_KINDS: &[&str] = &[
+    "capabilities.request",
+    "gateway.status.request",
+    "session.status.request",
+    "session.reset.request",
+    "run.lifecycle.status.request",
+];
+
+const GATEWAY_WS_RESPONSE_KINDS: &[&str] = &[
+    "capabilities.response",
+    "gateway.status.response",
+    "session.status.response",
+    "session.reset.response",
+    "run.lifecycle.status.response",
+    "gateway.heartbeat",
+    "error",
+];
+
+const GATEWAY_WS_RUN_LIFECYCLE_EVENT_KINDS: &[&str] = &[
+    "run.lifecycle.accepted",
+    "run.lifecycle.cancelled",
+    "run.lifecycle.completed",
+    "run.lifecycle.failed",
+    "run.lifecycle.timed_out",
+    "run.lifecycle.status",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GatewayWsRequestKind {
+    Capabilities,
+    GatewayStatus,
+    SessionStatus,
+    SessionReset,
+    RunLifecycleStatus,
+}
+
+impl FromStr for GatewayWsRequestKind {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "capabilities.request" => Ok(Self::Capabilities),
+            "gateway.status.request" => Ok(Self::GatewayStatus),
+            "session.status.request" => Ok(Self::SessionStatus),
+            "session.reset.request" => Ok(Self::SessionReset),
+            "run.lifecycle.status.request" => Ok(Self::RunLifecycleStatus),
+            other => bail!(
+                "unsupported gateway websocket frame kind '{}'; supported kinds are capabilities.request, gateway.status.request, session.status.request, session.reset.request, run.lifecycle.status.request",
+                other
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GatewayWsRequestFrame {
+    pub request_id: String,
+    pub kind: GatewayWsRequestKind,
+    pub payload: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct GatewayWsResponseFrame {
+    pub schema_version: u32,
+    pub request_id: String,
+    pub kind: String,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawGatewayWsRequestFrame {
+    schema_version: u32,
+    request_id: String,
+    kind: String,
+    payload: Value,
+}
+
+pub(crate) fn parse_gateway_ws_request_frame(raw: &str) -> Result<GatewayWsRequestFrame> {
+    let frame = serde_json::from_str::<RawGatewayWsRequestFrame>(raw)
+        .context("failed to parse gateway websocket frame JSON")?;
+    if !GATEWAY_WS_COMPATIBLE_REQUEST_SCHEMA_VERSIONS.contains(&frame.schema_version) {
+        let supported = GATEWAY_WS_COMPATIBLE_REQUEST_SCHEMA_VERSIONS
+            .iter()
+            .map(|version| version.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "unsupported gateway websocket frame schema: supported request schema versions are [{}], found {}",
+            supported,
+            frame.schema_version
+        );
+    }
+    let request_id = frame.request_id.trim();
+    if request_id.is_empty() {
+        bail!("gateway websocket frame request_id must be non-empty");
+    }
+    let kind = GatewayWsRequestKind::from_str(frame.kind.trim())?;
+    let payload = frame
+        .payload
+        .as_object()
+        .ok_or_else(|| anyhow!("gateway websocket frame payload must be a JSON object"))?
+        .clone();
+
+    Ok(GatewayWsRequestFrame {
+        request_id: request_id.to_string(),
+        kind,
+        payload,
+    })
+}
+
+pub(crate) fn best_effort_gateway_ws_request_id(raw: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(raw).ok()?;
+    let request_id = value
+        .as_object()
+        .and_then(|object| object.get("request_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(request_id.to_string())
+}
+
+pub(crate) fn classify_gateway_ws_parse_error(message: &str) -> &'static str {
+    if message.contains("failed to parse gateway websocket frame JSON") {
+        GATEWAY_WS_ERROR_CODE_INVALID_JSON
+    } else if message.contains("unsupported gateway websocket frame schema") {
+        GATEWAY_WS_ERROR_CODE_UNSUPPORTED_SCHEMA
+    } else if message.contains("unsupported gateway websocket frame kind") {
+        GATEWAY_WS_ERROR_CODE_UNSUPPORTED_KIND
+    } else if message.contains("gateway websocket frame request_id must be non-empty") {
+        GATEWAY_WS_ERROR_CODE_INVALID_REQUEST_ID
+    } else if message.contains("gateway websocket frame payload must be a JSON object")
+        || message.contains("optional payload field 'session_key'")
+    {
+        GATEWAY_WS_ERROR_CODE_INVALID_PAYLOAD
+    } else {
+        GATEWAY_WS_ERROR_CODE_INTERNAL_ERROR
+    }
+}
+
+pub(crate) fn build_gateway_ws_response_frame(
+    request_id: &str,
+    kind: &str,
+    payload: Value,
+) -> GatewayWsResponseFrame {
+    GatewayWsResponseFrame {
+        schema_version: GATEWAY_WS_RESPONSE_SCHEMA_VERSION,
+        request_id: request_id.to_string(),
+        kind: kind.to_string(),
+        payload,
+    }
+}
+
+pub(crate) fn build_gateway_ws_error_frame(
+    request_id: &str,
+    code: &str,
+    message: &str,
+) -> GatewayWsResponseFrame {
+    build_gateway_ws_response_frame(
+        request_id,
+        "error",
+        json!({
+            "code": code,
+            "message": message,
+        }),
+    )
+}
+
+pub(crate) fn parse_optional_session_key(
+    payload: &serde_json::Map<String, Value>,
+) -> Result<Option<String>> {
+    let Some(value) = payload.get("session_key") else {
+        return Ok(None);
+    };
+
+    let raw = value
+        .as_str()
+        .ok_or_else(|| anyhow!("optional payload field 'session_key' must be a string"))?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("optional payload field 'session_key' must be non-empty when provided");
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+pub(crate) fn gateway_ws_capabilities_payload() -> Value {
+    json!({
+        "schema_version": GATEWAY_WS_RESPONSE_SCHEMA_VERSION,
+        "protocol_version": GATEWAY_WS_PROTOCOL_VERSION,
+        "response_schema_version": GATEWAY_WS_RESPONSE_SCHEMA_VERSION,
+        "supported_request_schema_versions": GATEWAY_WS_COMPATIBLE_REQUEST_SCHEMA_VERSIONS,
+        "request_kinds": GATEWAY_WS_REQUEST_KINDS,
+        "response_kinds": GATEWAY_WS_RESPONSE_KINDS,
+        "contracts": {
+            "heartbeat": {
+                "interval_seconds": GATEWAY_WS_HEARTBEAT_INTERVAL_SECONDS,
+                "transport_events": ["ws.ping", "gateway.heartbeat"],
+            },
+            "session": {
+                "session_key_field": "session_key",
+                "defaults_to": "default",
+                "status_response_kind": "session.status.response",
+                "reset_response_kind": "session.reset.response",
+            },
+            "run_lifecycle": {
+                "event_kinds": GATEWAY_WS_RUN_LIFECYCLE_EVENT_KINDS,
+                "status_request_kind": "run.lifecycle.status.request",
+                "status_response_kind": "run.lifecycle.status.response",
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
+
+    use anyhow::{bail, Context, Result};
+    use serde::Deserialize;
+    use serde_json::Value;
+
+    use super::{
+        best_effort_gateway_ws_request_id, build_gateway_ws_error_frame,
+        build_gateway_ws_response_frame, classify_gateway_ws_parse_error,
+        gateway_ws_capabilities_payload, parse_gateway_ws_request_frame,
+        parse_optional_session_key, GatewayWsRequestKind, GatewayWsResponseFrame,
+        GATEWAY_WS_ERROR_CODE_INVALID_JSON, GATEWAY_WS_ERROR_CODE_INVALID_PAYLOAD,
+        GATEWAY_WS_ERROR_CODE_UNSUPPORTED_SCHEMA, GATEWAY_WS_RESPONSE_SCHEMA_VERSION,
+    };
+
+    const GATEWAY_WS_SCHEMA_COMPAT_FIXTURE_SCHEMA_VERSION: u32 = 1;
+
+    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    enum GatewayWsCompatMode {
+        Dispatch,
+    }
+
+    #[derive(Debug, Clone, Deserialize, PartialEq)]
+    struct GatewayWsSchemaCompatFixture {
+        schema_version: u32,
+        name: String,
+        mode: GatewayWsCompatMode,
+        input_frames: Vec<String>,
+        expected_processed_frames: usize,
+        expected_error_count: usize,
+        expected_responses: Vec<Value>,
+    }
+
+    #[derive(Debug, Default)]
+    struct FixtureControlRuntime {
+        sessions: BTreeMap<String, bool>,
+    }
+
+    impl FixtureControlRuntime {
+        fn new() -> Self {
+            let mut sessions = BTreeMap::new();
+            sessions.insert("default".to_string(), true);
+            Self { sessions }
+        }
+    }
+
+    fn gateway_ws_schema_compat_fixture_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("gateway-ws-protocol")
+            .join(name)
+    }
+
+    fn parse_gateway_ws_schema_compat_fixture(raw: &str) -> Result<GatewayWsSchemaCompatFixture> {
+        let fixture = serde_json::from_str::<GatewayWsSchemaCompatFixture>(raw)
+            .context("failed to parse gateway websocket schema compatibility fixture")?;
+        validate_gateway_ws_schema_compat_fixture(&fixture)?;
+        Ok(fixture)
+    }
+
+    fn load_gateway_ws_schema_compat_fixture(name: &str) -> GatewayWsSchemaCompatFixture {
+        let path = gateway_ws_schema_compat_fixture_path(name);
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        parse_gateway_ws_schema_compat_fixture(&raw)
+            .unwrap_or_else(|error| panic!("invalid fixture {}: {error}", path.display()))
+    }
+
+    fn validate_gateway_ws_schema_compat_fixture(
+        fixture: &GatewayWsSchemaCompatFixture,
+    ) -> Result<()> {
+        if fixture.schema_version != GATEWAY_WS_SCHEMA_COMPAT_FIXTURE_SCHEMA_VERSION {
+            bail!(
+                "unsupported gateway websocket schema compatibility fixture schema_version {} (expected {})",
+                fixture.schema_version,
+                GATEWAY_WS_SCHEMA_COMPAT_FIXTURE_SCHEMA_VERSION
+            );
+        }
+        if fixture.name.trim().is_empty() {
+            bail!("gateway websocket schema compatibility fixture name cannot be empty");
+        }
+        if fixture.input_frames.is_empty() {
+            bail!(
+                "gateway websocket schema compatibility fixture '{}' must include at least one input frame",
+                fixture.name
+            );
+        }
+        if fixture.expected_responses.is_empty() {
+            bail!(
+                "gateway websocket schema compatibility fixture '{}' must include at least one expected response",
+                fixture.name
+            );
+        }
+        Ok(())
+    }
+
+    fn dispatch_gateway_ws_fixture_frame(
+        runtime: &mut FixtureControlRuntime,
+        raw: &str,
+    ) -> GatewayWsResponseFrame {
+        let frame = match parse_gateway_ws_request_frame(raw) {
+            Ok(frame) => frame,
+            Err(error) => {
+                let request_id = best_effort_gateway_ws_request_id(raw)
+                    .unwrap_or_else(|| "unknown-request".to_string());
+                let code = classify_gateway_ws_parse_error(error.to_string().as_str());
+                return build_gateway_ws_error_frame(&request_id, code, error.to_string().as_str());
+            }
+        };
+
+        match frame.kind {
+            GatewayWsRequestKind::Capabilities => build_gateway_ws_response_frame(
+                &frame.request_id,
+                "capabilities.response",
+                gateway_ws_capabilities_payload(),
+            ),
+            GatewayWsRequestKind::GatewayStatus => build_gateway_ws_response_frame(
+                &frame.request_id,
+                "gateway.status.response",
+                serde_json::json!({
+                    "service_status": "running",
+                    "transport": "websocket",
+                    "authenticated": true,
+                }),
+            ),
+            GatewayWsRequestKind::SessionStatus => {
+                let session_key = parse_optional_session_key(&frame.payload)
+                    .unwrap_or_else(|error| {
+                        panic!("invalid fixture session.status payload: {error}")
+                    })
+                    .unwrap_or_else(|| "default".to_string());
+                let exists = runtime.sessions.get(&session_key).copied().unwrap_or(false);
+                build_gateway_ws_response_frame(
+                    &frame.request_id,
+                    "session.status.response",
+                    serde_json::json!({
+                        "session_key": session_key,
+                        "exists": exists,
+                        "message_count": if exists { 2 } else { 0 },
+                    }),
+                )
+            }
+            GatewayWsRequestKind::SessionReset => {
+                let session_key = parse_optional_session_key(&frame.payload)
+                    .unwrap_or_else(|error| {
+                        panic!("invalid fixture session.reset payload: {error}")
+                    })
+                    .unwrap_or_else(|| "default".to_string());
+                let existed = runtime.sessions.remove(&session_key).unwrap_or(false);
+                build_gateway_ws_response_frame(
+                    &frame.request_id,
+                    "session.reset.response",
+                    serde_json::json!({
+                        "session_key": session_key,
+                        "reset": existed,
+                    }),
+                )
+            }
+            GatewayWsRequestKind::RunLifecycleStatus => build_gateway_ws_response_frame(
+                &frame.request_id,
+                "run.lifecycle.status.response",
+                serde_json::json!({
+                    "active_runs": [],
+                    "recent_events": [],
+                }),
+            ),
+        }
+    }
+
+    fn replay_gateway_ws_schema_compat_fixture(
+        fixture: &GatewayWsSchemaCompatFixture,
+    ) -> (usize, usize, Vec<Value>) {
+        let mut runtime = FixtureControlRuntime::new();
+        let mut responses = Vec::new();
+        let mut error_count = 0usize;
+
+        match fixture.mode {
+            GatewayWsCompatMode::Dispatch => {
+                for raw in &fixture.input_frames {
+                    let response = dispatch_gateway_ws_fixture_frame(&mut runtime, raw);
+                    if response.kind == "error" {
+                        error_count = error_count.saturating_add(1);
+                    }
+                    responses.push(
+                        serde_json::to_value(response)
+                            .expect("gateway websocket response frame should serialize"),
+                    );
+                }
+            }
+        }
+
+        (fixture.input_frames.len(), error_count, responses)
+    }
+
+    #[test]
+    fn unit_parse_gateway_ws_request_frame_accepts_supported_schema_versions() {
+        let frame = parse_gateway_ws_request_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-status",
+  "kind": "gateway.status.request",
+  "payload": {}
+}"#,
+        )
+        .expect("parse frame");
+        assert_eq!(frame.request_id, "req-status");
+        assert_eq!(frame.kind, GatewayWsRequestKind::GatewayStatus);
+
+        let legacy = parse_gateway_ws_request_frame(
+            r#"{
+  "schema_version": 0,
+  "request_id": "req-cap",
+  "kind": "capabilities.request",
+  "payload": {}
+}"#,
+        )
+        .expect("parse legacy frame");
+        assert_eq!(legacy.kind, GatewayWsRequestKind::Capabilities);
+    }
+
+    #[test]
+    fn unit_parse_gateway_ws_request_frame_rejects_invalid_session_key_payload() {
+        let frame = parse_gateway_ws_request_frame(
+            r#"{
+  "schema_version": 1,
+  "request_id": "req-session",
+  "kind": "session.status.request",
+  "payload": {"session_key": ""}
+}"#,
+        )
+        .expect("parse frame");
+        let error = parse_optional_session_key(&frame.payload)
+            .expect_err("empty session key should fail validation");
+        assert!(error
+            .to_string()
+            .contains("optional payload field 'session_key' must be non-empty"));
+    }
+
+    #[test]
+    fn functional_gateway_ws_capabilities_payload_is_deterministic() {
+        let payload = gateway_ws_capabilities_payload();
+        assert_eq!(
+            payload["schema_version"].as_u64(),
+            Some(GATEWAY_WS_RESPONSE_SCHEMA_VERSION as u64)
+        );
+        assert_eq!(
+            payload["request_kinds"].as_array().map(|kinds| kinds.len()),
+            Some(5)
+        );
+        assert_eq!(
+            payload["response_kinds"]
+                .as_array()
+                .map(|kinds| kinds.len()),
+            Some(7)
+        );
+        assert_eq!(
+            payload["contracts"]["heartbeat"]["interval_seconds"].as_u64(),
+            Some(15)
+        );
+        assert_eq!(
+            payload["contracts"]["run_lifecycle"]["event_kinds"]
+                .as_array()
+                .map(|kinds| kinds.len()),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn unit_parse_gateway_ws_schema_compat_fixture_rejects_unsupported_fixture_schema() {
+        let raw = r#"{
+  "schema_version": 99,
+  "name": "invalid",
+  "mode": "dispatch",
+  "input_frames": [
+    "{\"schema_version\":1,\"request_id\":\"req\",\"kind\":\"capabilities.request\",\"payload\":{}}"
+  ],
+  "expected_processed_frames": 1,
+  "expected_error_count": 0,
+  "expected_responses": [
+    {"schema_version":1,"request_id":"req","kind":"capabilities.response","payload":{}}
+  ]
+}"#;
+
+        let error = parse_gateway_ws_schema_compat_fixture(raw).expect_err("schema should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported gateway websocket schema compatibility fixture schema_version"));
+    }
+
+    #[test]
+    fn functional_gateway_ws_schema_compat_fixture_replays_supported_controls() {
+        let fixture = load_gateway_ws_schema_compat_fixture("dispatch-supported-controls.json");
+        let (processed, errors, responses) = replay_gateway_ws_schema_compat_fixture(&fixture);
+        assert_eq!(processed, fixture.expected_processed_frames);
+        assert_eq!(errors, fixture.expected_error_count);
+        assert_eq!(responses, fixture.expected_responses);
+    }
+
+    #[test]
+    fn integration_gateway_ws_schema_compat_fixture_replay_is_deterministic() {
+        for name in [
+            "dispatch-supported-controls.json",
+            "dispatch-unsupported-schema-continues.json",
+            "dispatch-unknown-kind-continues.json",
+        ] {
+            let fixture = load_gateway_ws_schema_compat_fixture(name);
+            let first = replay_gateway_ws_schema_compat_fixture(&fixture);
+            let second = replay_gateway_ws_schema_compat_fixture(&fixture);
+            assert_eq!(first, second);
+            assert_eq!(first.0, fixture.expected_processed_frames);
+            assert_eq!(first.1, fixture.expected_error_count);
+            assert_eq!(first.2, fixture.expected_responses);
+        }
+    }
+
+    #[test]
+    fn regression_gateway_ws_schema_compat_fixture_preserves_error_contracts() {
+        let unsupported =
+            load_gateway_ws_schema_compat_fixture("dispatch-unsupported-schema-continues.json");
+        let (_, unsupported_errors, unsupported_responses) =
+            replay_gateway_ws_schema_compat_fixture(&unsupported);
+        assert_eq!(unsupported_errors, 1);
+        assert_eq!(unsupported_responses, unsupported.expected_responses);
+        assert_eq!(unsupported_responses[0]["kind"], "error");
+        assert_eq!(
+            unsupported_responses[0]["payload"]["code"],
+            GATEWAY_WS_ERROR_CODE_UNSUPPORTED_SCHEMA
+        );
+
+        let unknown = load_gateway_ws_schema_compat_fixture("dispatch-unknown-kind-continues.json");
+        let (_, unknown_errors, unknown_responses) =
+            replay_gateway_ws_schema_compat_fixture(&unknown);
+        assert_eq!(unknown_errors, 1);
+        assert_eq!(unknown_responses[0]["kind"], "error");
+    }
+
+    #[test]
+    fn regression_gateway_ws_error_helpers_keep_request_id_for_malformed_json() {
+        let missing_request_id = build_gateway_ws_error_frame(
+            "unknown-request",
+            GATEWAY_WS_ERROR_CODE_INVALID_JSON,
+            "failed to parse gateway websocket frame JSON: expected value at line 1 column 1",
+        );
+        assert_eq!(missing_request_id.request_id, "unknown-request");
+        assert_eq!(missing_request_id.kind, "error");
+        assert_eq!(
+            missing_request_id.payload["code"],
+            GATEWAY_WS_ERROR_CODE_INVALID_JSON
+        );
+
+        let raw = "not-json";
+        assert_eq!(best_effort_gateway_ws_request_id(raw), None);
+        assert_eq!(
+            classify_gateway_ws_parse_error(
+                "failed to parse gateway websocket frame JSON: expected value at line 1 column 1"
+            ),
+            GATEWAY_WS_ERROR_CODE_INVALID_JSON
+        );
+        assert_eq!(
+            classify_gateway_ws_parse_error(
+                "optional payload field 'session_key' must be non-empty when provided"
+            ),
+            GATEWAY_WS_ERROR_CODE_INVALID_PAYLOAD
+        );
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -28,6 +28,7 @@ mod extension_manifest;
 mod gateway_contract;
 mod gateway_openresponses;
 mod gateway_runtime;
+mod gateway_ws_protocol;
 mod gemini_cli_client;
 mod github_issues;
 mod github_issues_helpers;

--- a/crates/tau-coding-agent/testdata/gateway-ws-protocol/README.md
+++ b/crates/tau-coding-agent/testdata/gateway-ws-protocol/README.md
@@ -1,0 +1,9 @@
+# Gateway Websocket Protocol Compatibility Fixtures
+
+This fixture corpus locks deterministic websocket control-frame behavior for Tau gateway schema compatibility and fail-closed handling.
+
+- `dispatch-supported-controls.json`: supported control methods for capabilities, gateway status, session status/reset, and run lifecycle status.
+- `dispatch-unsupported-schema-continues.json`: unsupported request schema regression while processing continues for later valid frames.
+- `dispatch-unknown-kind-continues.json`: unsupported method regression while processing continues for later valid frames.
+
+Each fixture includes ordered input frames, expected processed/error counts, and exact response envelopes.

--- a/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-supported-controls.json
+++ b/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-supported-controls.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "name": "dispatch-supported-controls",
+  "mode": "dispatch",
+  "input_frames": [
+    "{\"schema_version\":1,\"request_id\":\"req-cap\",\"kind\":\"capabilities.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-status\",\"kind\":\"gateway.status.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-session-before\",\"kind\":\"session.status.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-session-reset\",\"kind\":\"session.reset.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-session-after\",\"kind\":\"session.status.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-run\",\"kind\":\"run.lifecycle.status.request\",\"payload\":{}}"
+  ],
+  "expected_processed_frames": 6,
+  "expected_error_count": 0,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-cap",
+      "kind": "capabilities.response",
+      "payload": {
+        "schema_version": 1,
+        "protocol_version": "0.1.0",
+        "response_schema_version": 1,
+        "supported_request_schema_versions": [0, 1],
+        "request_kinds": [
+          "capabilities.request",
+          "gateway.status.request",
+          "session.status.request",
+          "session.reset.request",
+          "run.lifecycle.status.request"
+        ],
+        "response_kinds": [
+          "capabilities.response",
+          "gateway.status.response",
+          "session.status.response",
+          "session.reset.response",
+          "run.lifecycle.status.response",
+          "gateway.heartbeat",
+          "error"
+        ],
+        "contracts": {
+          "heartbeat": {
+            "interval_seconds": 15,
+            "transport_events": ["ws.ping", "gateway.heartbeat"]
+          },
+          "session": {
+            "session_key_field": "session_key",
+            "defaults_to": "default",
+            "status_response_kind": "session.status.response",
+            "reset_response_kind": "session.reset.response"
+          },
+          "run_lifecycle": {
+            "event_kinds": [
+              "run.lifecycle.accepted",
+              "run.lifecycle.cancelled",
+              "run.lifecycle.completed",
+              "run.lifecycle.failed",
+              "run.lifecycle.timed_out",
+              "run.lifecycle.status"
+            ],
+            "status_request_kind": "run.lifecycle.status.request",
+            "status_response_kind": "run.lifecycle.status.response"
+          }
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-status",
+      "kind": "gateway.status.response",
+      "payload": {
+        "service_status": "running",
+        "transport": "websocket",
+        "authenticated": true
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-session-before",
+      "kind": "session.status.response",
+      "payload": {
+        "session_key": "default",
+        "exists": true,
+        "message_count": 2
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-session-reset",
+      "kind": "session.reset.response",
+      "payload": {
+        "session_key": "default",
+        "reset": true
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-session-after",
+      "kind": "session.status.response",
+      "payload": {
+        "session_key": "default",
+        "exists": false,
+        "message_count": 0
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-run",
+      "kind": "run.lifecycle.status.response",
+      "payload": {
+        "active_runs": [],
+        "recent_events": []
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-unknown-kind-continues.json
+++ b/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-unknown-kind-continues.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "name": "dispatch-unknown-kind-continues",
+  "mode": "dispatch",
+  "input_frames": [
+    "{\"schema_version\":1,\"request_id\":\"req-bad-kind\",\"kind\":\"session.delete.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-good\",\"kind\":\"run.lifecycle.status.request\",\"payload\":{}}"
+  ],
+  "expected_processed_frames": 2,
+  "expected_error_count": 1,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-bad-kind",
+      "kind": "error",
+      "payload": {
+        "code": "unsupported_kind",
+        "message": "unsupported gateway websocket frame kind 'session.delete.request'; supported kinds are capabilities.request, gateway.status.request, session.status.request, session.reset.request, run.lifecycle.status.request"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-good",
+      "kind": "run.lifecycle.status.response",
+      "payload": {
+        "active_runs": [],
+        "recent_events": []
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-unsupported-schema-continues.json
+++ b/crates/tau-coding-agent/testdata/gateway-ws-protocol/dispatch-unsupported-schema-continues.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "name": "dispatch-unsupported-schema-continues",
+  "mode": "dispatch",
+  "input_frames": [
+    "{\"schema_version\":99,\"request_id\":\"req-bad-schema\",\"kind\":\"session.status.request\",\"payload\":{}}",
+    "{\"schema_version\":1,\"request_id\":\"req-good\",\"kind\":\"session.status.request\",\"payload\":{}}"
+  ],
+  "expected_processed_frames": 2,
+  "expected_error_count": 1,
+  "expected_responses": [
+    {
+      "schema_version": 1,
+      "request_id": "req-bad-schema",
+      "kind": "error",
+      "payload": {
+        "code": "unsupported_schema",
+        "message": "unsupported gateway websocket frame schema: supported request schema versions are [0, 1], found 99"
+      }
+    },
+    {
+      "schema_version": 1,
+      "request_id": "req-good",
+      "kind": "session.status.response",
+      "payload": {
+        "session_key": "default",
+        "exists": true,
+        "message_count": 2
+      }
+    }
+  ]
+}

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -91,7 +91,8 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `events.rs`: scheduler runner and webhook immediate-event ingestion.
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
-- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway auth/session (`/gateway/auth/session`) and webchat/status endpoints.
+- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway auth/session (`/gateway/auth/session`), gateway status (`/gateway/status`), websocket control (`/gateway/ws`), and webchat endpoint.
+- `gateway_ws_protocol.rs`: websocket control-plane frame schema, version compatibility, parse/error contracts, and fixture replay compatibility tests.
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
 - `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).
 - `deployment_wasm.rs`: WASM artifact packaging, manifest verification, and deployment state deliverable tracking.


### PR DESCRIPTION
Closes #873

## Summary
- add authenticated websocket control endpoint at `GET /gateway/ws` to the OpenResponses gateway server
- introduce versioned websocket protocol schema and compatibility parser in `crates/tau-coding-agent/src/gateway_ws_protocol.rs`
- implement deterministic control methods:
  - `capabilities.request`
  - `gateway.status.request`
  - `session.status.request`
  - `session.reset.request`
  - `run.lifecycle.status.request`
- add heartbeat behavior (`ws.ping` + `gateway.heartbeat`) and fail-closed error envelopes for malformed/unsupported frames
- add protocol compatibility fixture corpus under `crates/tau-coding-agent/testdata/gateway-ws-protocol`
- expand gateway tests with websocket functional/integration/regression coverage and update docs/code-map

## Risks and compatibility notes
- workspace `axum` features now include `ws`; this introduces websocket support at dependency level
- websocket protocol currently accepts request schema versions `0` and `1`; response schema is version `1`
- websocket session reset removes persisted session file + lock file for the resolved session key
- gateway websocket endpoint reuses existing auth and rate-limit guardrails from HTTP gateway paths

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent gateway_ws_protocol -- --test-threads=1`
- `cargo test -p tau-coding-agent gateway_openresponses -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
