### PR TITLE
feat: add release-channel update planning and apply workflow

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -88,7 +88,7 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
         usage: RELEASE_CHANNEL_USAGE,
         description: "Show or persist release track selection",
         details:
-            "Supports stable/beta/dev release tracks, online checks, and cache show/clear/refresh/prune operations in project-local .tau metadata.",
+            "Supports stable/beta/dev release tracks, update plan/apply with dry-run guardrails, and cache show/clear/refresh/prune operations in project-local .tau metadata.",
         example: "/release-channel set beta",
     },
     CommandSpec {

--- a/crates/tau-coding-agent/src/release_channel_commands/update_state.rs
+++ b/crates/tau-coding-agent/src/release_channel_commands/update_state.rs
@@ -1,0 +1,71 @@
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::write_text_atomic;
+
+use super::{ReleaseChannel, RELEASE_UPDATE_STATE_SCHEMA_VERSION};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ReleaseUpdateStateFile {
+    pub(super) schema_version: u32,
+    pub(super) channel: ReleaseChannel,
+    pub(super) current_version: String,
+    pub(super) target_version: String,
+    pub(super) action: String,
+    pub(super) dry_run: bool,
+    pub(super) lookup_source: String,
+    pub(super) guard_code: String,
+    pub(super) guard_reason: String,
+    pub(super) planned_at_unix_ms: u64,
+    pub(super) apply_attempts: u64,
+    pub(super) last_apply_unix_ms: Option<u64>,
+    pub(super) last_apply_status: Option<String>,
+    pub(super) last_apply_target: Option<String>,
+    pub(super) rollback_channel: Option<ReleaseChannel>,
+    pub(super) rollback_version: Option<String>,
+}
+
+pub(super) fn load_release_update_state_file(
+    path: &Path,
+) -> Result<Option<ReleaseUpdateStateFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read release update state {}", path.display()))?;
+    let parsed = serde_json::from_str::<ReleaseUpdateStateFile>(&raw)
+        .with_context(|| format!("failed to parse release update state {}", path.display()))?;
+    if parsed.schema_version != RELEASE_UPDATE_STATE_SCHEMA_VERSION {
+        bail!(
+            "unsupported release update state schema_version {} in {} (expected {})",
+            parsed.schema_version,
+            path.display(),
+            RELEASE_UPDATE_STATE_SCHEMA_VERSION
+        );
+    }
+    Ok(Some(parsed))
+}
+
+pub(super) fn save_release_update_state_file(
+    path: &Path,
+    state: &ReleaseUpdateStateFile,
+) -> Result<()> {
+    let mut encoded =
+        serde_json::to_string_pretty(state).context("failed to encode release update state")?;
+    encoded.push('\n');
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "release update state path {} does not have a parent directory",
+            path.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create release update state directory {}",
+            parent.display()
+        )
+    })?;
+    write_text_atomic(path, &encoded)
+}

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -12051,7 +12051,7 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/session-diff [<left-id> <right-id>]"));
     assert!(help.contains("/doctor"));
     assert!(help.contains(
-        "/release-channel [show|set <stable|beta|dev>|check|cache <show|clear|refresh|prune>]"
+        "/release-channel [show|set <stable|beta|dev>|check|plan [--target <version>] [--dry-run]|apply [--target <version>] [--dry-run]|cache <show|clear|refresh|prune>]"
     ));
     assert!(help.contains("/session-graph-export <path>"));
     assert!(help.contains("/session-export <path>"));
@@ -12190,7 +12190,7 @@ fn functional_render_command_help_supports_release_channel_topic_without_slash()
     let help = render_command_help("release-channel").expect("render help");
     assert!(help.contains("command: /release-channel"));
     assert!(help.contains(
-        "usage: /release-channel [show|set <stable|beta|dev>|check|cache <show|clear|refresh|prune>]"
+        "usage: /release-channel [show|set <stable|beta|dev>|check|plan [--target <version>] [--dry-run]|apply [--target <version>] [--dry-run]|cache <show|clear|refresh|prune>]"
     ));
     assert!(help.contains("example: /release-channel set beta"));
 }

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -24,6 +24,12 @@ Interactive onboarding mode:
 cargo run -p tau-coding-agent -- --onboard --onboard-profile default
 ```
 
+Release channel planning/apply workflow runbook:
+
+```bash
+cat docs/guides/release-channel-ops.md
+```
+
 ## Auth modes
 
 | Provider | Local/dev recommended | CI/automation recommended |

--- a/docs/guides/release-channel-ops.md
+++ b/docs/guides/release-channel-ops.md
@@ -1,0 +1,77 @@
+# Release Channel Ops
+
+Run commands from repository root.
+
+## Inspect channel and rollback metadata
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel show
+/quit
+EOF
+```
+
+The output includes persisted rollback metadata fields:
+- `rollback_channel`
+- `rollback_version`
+- `rollback_reason`
+- `rollback_reference_unix_ms`
+
+## Switch channel policy
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel set stable
+/release-channel set beta
+/release-channel set dev
+/quit
+EOF
+```
+
+Channel changes persist rollback hints automatically.
+
+## Plan an update
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel plan
+/release-channel plan --target v0.1.5 --dry-run
+/quit
+EOF
+```
+
+Planning writes `.tau/release-update-state.json` with:
+- target version
+- guard decision and reason code
+- action (`upgrade|noop|blocked`)
+- dry-run mode and lookup source
+
+## Apply an update plan
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel apply
+/release-channel apply --target v0.1.5 --dry-run
+/quit
+EOF
+```
+
+`apply` enforces fail-closed guards:
+- malformed version fields
+- prerelease target blocked on `stable`
+- unsafe major-version jumps
+
+Current implementation records deterministic apply metadata and rollback hints.
+Binary replacement remains an operator-managed step.
+
+## Cache maintenance
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel cache show
+/release-channel cache refresh
+/release-channel cache prune
+/release-channel cache clear
+/quit
+EOF
+```

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -41,6 +41,7 @@ Use this area when adding or changing flags, defaults, and typed CLI input behav
 - `auth_commands.rs`: provider auth command handling.
 - `release_channel_commands.rs`: `/release-channel` command parsing/rendering and dispatch.
 - `release_channel_commands/cache.rs`: release lookup cache load/save/prune helpers.
+- `release_channel_commands/update_state.rs`: release update plan/apply lifecycle state persistence.
 - `diagnostics_commands.rs`: doctor/audit/policy diagnostics commands.
 - `macro_profile_commands.rs`: macro/profile command workflows.
 


### PR DESCRIPTION
## Summary
- extend `/release-channel` with update lifecycle commands: `plan` and `apply` (supporting `--target` and `--dry-run`)
- add persisted rollback metadata to release-channel store and keep compatibility with legacy schema v1 payloads
- add persisted update lifecycle state at `.tau/release-update-state.json` for cross-run plan/apply continuity
- enforce compatibility guards for malformed versions, stable prerelease restrictions, and major-version jump risk
- add runbook docs for update/rollback operations and wire usage/help updates

Closes #875

## Risks and compatibility notes
- `apply` currently performs deterministic metadata/state application (`status=applied_metadata`) and guard enforcement; binary replacement remains an operator step
- release-channel store schema now writes v2 while continuing to read legacy v1 payloads
- release plan/apply fails closed on malformed update state payloads

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent release_channel_commands -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
