### PR TITLE
feat: onboarding daemon bootstrap readiness workflow

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -707,6 +707,25 @@ pub(crate) struct Cli {
     pub(crate) onboard_release_channel: Option<String>,
 
     #[arg(
+        long = "onboard-install-daemon",
+        env = "TAU_ONBOARD_INSTALL_DAEMON",
+        default_value_t = false,
+        requires = "onboard",
+        help = "Install Tau daemon profile files during onboarding using --daemon-profile and --daemon-state-dir"
+    )]
+    pub(crate) onboard_install_daemon: bool,
+
+    #[arg(
+        long = "onboard-start-daemon",
+        env = "TAU_ONBOARD_START_DAEMON",
+        default_value_t = false,
+        requires = "onboard",
+        requires = "onboard_install_daemon",
+        help = "Start Tau daemon lifecycle state after onboarding daemon install"
+    )]
+    pub(crate) onboard_start_daemon: bool,
+
+    #[arg(
         long = "doctor-release-cache-file",
         env = "TAU_DOCTOR_RELEASE_CACHE_FILE",
         default_value = ".tau/release-lookup-cache.json",

--- a/docs/guides/daemon-ops.md
+++ b/docs/guides/daemon-ops.md
@@ -7,6 +7,21 @@ This runbook covers Tau daemon lifecycle operations and profile troubleshooting.
 - Lifecycle commands: install, uninstall, start, stop, status.
 - Profile targets: launchd (macOS) and systemd user-mode (Linux).
 - State root: `--daemon-state-dir` (default `.tau/daemon`).
+- Onboarding bootstrap flags: `--onboard-install-daemon`, `--onboard-start-daemon`.
+
+## Onboarding bootstrap
+
+Non-interactive onboarding with daemon install/start:
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive --onboard-install-daemon --onboard-start-daemon
+```
+
+Interactive onboarding with daemon install only:
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-profile default --onboard-install-daemon
+```
 
 ## Lifecycle commands
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,10 +18,22 @@ Initialize `.tau` directories, profile store, and release-channel metadata:
 cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive
 ```
 
+Initialize onboarding and bootstrap daemon install/start in one pass:
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive --onboard-install-daemon --onboard-start-daemon
+```
+
 Interactive onboarding mode:
 
 ```bash
 cargo run -p tau-coding-agent -- --onboard --onboard-profile default
+```
+
+Interactive onboarding with daemon install only:
+
+```bash
+cargo run -p tau-coding-agent -- --onboard --onboard-profile default --onboard-install-daemon
 ```
 
 Release channel planning/apply workflow runbook:

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -26,7 +26,7 @@ If a preflight or transport mode completes, runtime startup exits early.
 
 - `cli_args.rs`: all CLI flags and clap definitions.
 - `cli_types.rs`: clap-facing enums and value types.
-- `onboarding.rs`: first-run onboarding wizard and bootstrap report flow.
+- `onboarding.rs`: first-run onboarding wizard, daemon bootstrap options, and readiness report flow.
 - `runtime_types.rs`: shared runtime/config structs used across modules.
 
 Use this area when adding or changing flags, defaults, and typed CLI input behavior.


### PR DESCRIPTION
## Summary
- add onboarding daemon bootstrap flags: `--onboard-install-daemon` and `--onboard-start-daemon`
- execute daemon install/start/inspect during onboarding when requested and fail closed with remediation contexts
- extend onboarding report to schema v2 with `daemon_bootstrap` readiness/status payload
- include daemon bootstrap and readiness reason codes in onboarding summary output
- update quickstart + daemon runbook docs with runnable onboarding daemon examples

## Risks and compatibility
- onboarding report schema changed from v1 to v2 (new `daemon_bootstrap` object)
- `--onboard-start-daemon` now requires `--onboard-install-daemon`, which tightens CLI guardrails
- onboarding with daemon bootstrap now performs daemon lifecycle writes in `--daemon-state-dir`; misconfigured paths fail closed
- default onboarding behavior is unchanged when daemon flags are omitted

## Validation
- cargo fmt --all
- cargo clippy -p tau-coding-agent --all-targets -- -D warnings
- cargo test -p tau-coding-agent -- --test-threads=1

Closes #885
