### PR TITLE
feat(auth): strict subscription fallback guard and diagnostics

### DIFF
--- a/crates/tau-coding-agent/src/auth_commands.rs
+++ b/crates/tau-coding-agent/src/auth_commands.rs
@@ -2389,6 +2389,7 @@ pub(crate) fn execute_auth_status_command(
             "state_filter": state_filter.as_deref().unwrap_or("all"),
             "source_kind_filter": source_kind.as_str(),
             "revoked_filter": revoked.as_str(),
+            "subscription_strict": config.provider_subscription_strict,
             "providers": selected_providers.len(),
             "rows_total": total_rows,
             "rows": rows.len(),
@@ -2416,7 +2417,7 @@ pub(crate) fn execute_auth_status_command(
     }
 
     let mut lines = vec![format!(
-        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} availability_counts={} availability_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
+        "auth status: providers={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} subscription_strict={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} availability_counts={} availability_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         rows.len(),
         mode_supported,
@@ -2430,6 +2431,7 @@ pub(crate) fn execute_auth_status_command(
         state_filter.as_deref().unwrap_or("all"),
         source_kind.as_str(),
         revoked.as_str(),
+        config.provider_subscription_strict,
         total_rows,
         mode_supported_total,
         mode_unsupported_total,
@@ -2615,6 +2617,7 @@ pub(crate) fn execute_auth_matrix_command(
             "state_filter": state_filter.as_deref().unwrap_or("all"),
             "source_kind_filter": source_kind.as_str(),
             "revoked_filter": revoked.as_str(),
+            "subscription_strict": config.provider_subscription_strict,
             "providers": selected_providers.len(),
             "modes": selected_modes.len(),
             "rows_total": total_rows,
@@ -2643,7 +2646,7 @@ pub(crate) fn execute_auth_matrix_command(
     }
 
     let mut lines = vec![format!(
-        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} availability_counts={} availability_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
+        "auth matrix: providers={} modes={} rows={} mode_supported={} mode_unsupported={} available={} unavailable={} provider_filter={} mode_filter={} mode_support_filter={} availability_filter={} state_filter={} source_kind_filter={} revoked_filter={} subscription_strict={} rows_total={} mode_supported_total={} mode_unsupported_total={} mode_counts={} mode_counts_total={} provider_counts={} provider_counts_total={} availability_counts={} availability_counts_total={} state_counts={} state_counts_total={} source_kind_counts={} source_kind_counts_total={} revoked_counts={} revoked_counts_total={}",
         selected_providers.len(),
         selected_modes.len(),
         rows.len(),
@@ -2658,6 +2661,7 @@ pub(crate) fn execute_auth_matrix_command(
         state_filter.as_deref().unwrap_or("all"),
         source_kind.as_str(),
         revoked.as_str(),
+        config.provider_subscription_strict,
         total_rows,
         mode_supported_total,
         mode_unsupported_total,

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -252,6 +252,18 @@ pub(crate) struct Cli {
     pub(crate) google_auth_mode: CliProviderAuthMode,
 
     #[arg(
+        long = "provider-subscription-strict",
+        env = "TAU_PROVIDER_SUBSCRIPTION_STRICT",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        help = "Fail closed for non-api-key auth modes by disabling automatic API-key fallback"
+    )]
+    pub(crate) provider_subscription_strict: bool,
+
+    #[arg(
         long = "google-gemini-backend",
         env = "TAU_GOOGLE_GEMINI_BACKEND",
         default_value_t = true,

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -621,6 +621,7 @@ pub(crate) fn handle_command(
         openai_auth_mode: ProviderAuthMethod::ApiKey,
         anthropic_auth_mode: ProviderAuthMethod::ApiKey,
         google_auth_mode: ProviderAuthMethod::ApiKey,
+        provider_subscription_strict: false,
         openai_codex_backend: true,
         openai_codex_cli: "codex".to_string(),
         anthropic_claude_backend: true,

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -194,6 +194,7 @@ pub(crate) struct AuthCommandConfig {
     pub(crate) openai_auth_mode: ProviderAuthMethod,
     pub(crate) anthropic_auth_mode: ProviderAuthMethod,
     pub(crate) google_auth_mode: ProviderAuthMethod,
+    pub(crate) provider_subscription_strict: bool,
     pub(crate) openai_codex_backend: bool,
     pub(crate) openai_codex_cli: String,
     pub(crate) anthropic_claude_backend: bool,

--- a/crates/tau-coding-agent/src/startup_config.rs
+++ b/crates/tau-coding-agent/src/startup_config.rs
@@ -16,6 +16,7 @@ pub(crate) fn build_auth_command_config(cli: &Cli) -> AuthCommandConfig {
         openai_auth_mode: cli.openai_auth_mode.into(),
         anthropic_auth_mode: cli.anthropic_auth_mode.into(),
         google_auth_mode: cli.google_auth_mode.into(),
+        provider_subscription_strict: cli.provider_subscription_strict,
         openai_codex_backend: cli.openai_codex_backend,
         openai_codex_cli: cli.openai_codex_cli.clone(),
         anthropic_claude_backend: cli.anthropic_claude_backend,

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -50,6 +50,15 @@ cat docs/guides/release-channel-ops.md
 | Anthropic | `--anthropic-auth-mode oauth-token` or `session-token` with Claude backend (`--anthropic-claude-backend=true`) | `--anthropic-auth-mode api-key` with `ANTHROPIC_API_KEY` |
 | Google | `--google-auth-mode oauth-token` (Gemini login) or `--google-auth-mode adc` (Vertex/ADC) with Gemini backend (`--google-gemini-backend=true`) | `--google-auth-mode api-key` with `GEMINI_API_KEY` |
 
+Fail-closed subscription mode (disable automatic API-key fallback for non-API-key auth modes):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --openai-auth-mode oauth-token \
+  --provider-subscription-strict=true
+```
+
 ## First run
 
 Interactive prompt loop:
@@ -79,7 +88,7 @@ OpenAI/Codex:
 
 ```bash
 codex --login
-cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini --openai-auth-mode oauth-token
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini --openai-auth-mode oauth-token --provider-subscription-strict=true
 ```
 
 Anthropic/Claude Code:
@@ -95,6 +104,13 @@ Google/Gemini:
 ```bash
 gemini
 cargo run -p tau-coding-agent -- --model google/gemini-2.5-pro --google-auth-mode oauth-token
+```
+
+Inspect auth diagnostics (includes `subscription_strict` in JSON/text summaries):
+
+```bash
+cargo run -p tau-coding-agent -- --prompt "/auth status --json"
+cargo run -p tau-coding-agent -- --prompt "/auth matrix --json"
 ```
 
 ## Run the TUI demo

--- a/docs/provider-auth/provider-auth-capability-matrix.md
+++ b/docs/provider-auth/provider-auth-capability-matrix.md
@@ -36,6 +36,11 @@ Current recovery order policy:
 - Anthropic: `oauth_token > session_token > api_key`
 - Google: `oauth_token > adc > api_key`
 
+Strict subscription guard:
+- `--provider-subscription-strict=true` (or `TAU_PROVIDER_SUBSCRIPTION_STRICT=true`) disables automatic API-key fallback when configured mode is non-API-key.
+- In strict mode, runtime auth fails closed if subscription/session backend prerequisites are missing.
+- `/auth status` and `/auth matrix` summaries include `subscription_strict=true|false`.
+
 ## Capability Matrix
 | Provider/Channel | Auth Method | Subscription Login Usable for API Calls | Status | Notes |
 |---|---|---|---|---|


### PR DESCRIPTION
## Summary of behavior changes
- add `--provider-subscription-strict` (`TAU_PROVIDER_SUBSCRIPTION_STRICT`) to fail closed for non-API-key auth modes.
- propagate strict subscription policy into runtime auth config.
- block automatic API-key fallback in provider runtime when strict mode is enabled and configured mode is non-API-key.
- include `subscription_strict` in `/auth status` and `/auth matrix` JSON + text summary outputs.
- document strict mode usage and diagnostics behavior in auth docs and quickstart.
- add strict-mode tests for CLI parsing, auth output surfaces, and fallback regression behavior.

## Risks and compatibility notes
- default behavior is unchanged (`subscription_strict=false`).
- strict mode intentionally changes fallback behavior and can surface backend prerequisite errors instead of silently using API keys.
- auth status/matrix JSON schema now includes a new top-level field (`subscription_strict`), which is additive and backward-compatible for consumers that ignore unknown fields.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`

Closes #886
