### PR TITLE
feat: harden gateway remote-access profile posture checks

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -5,9 +5,10 @@ use clap::{ArgAction, Parser};
 use crate::{
     release_channel_commands::RELEASE_LOOKUP_CACHE_TTL_MS, CliBashProfile, CliCommandFileErrorMode,
     CliCredentialStoreEncryptionMode, CliDaemonProfile, CliDeploymentWasmRuntimeProfile,
-    CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode,
-    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile,
+    CliMultiChannelLiveConnectorMode, CliMultiChannelOutboundMode, CliMultiChannelTransport,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {
@@ -1058,6 +1059,7 @@ pub(crate) struct Cli {
         conflicts_with = "dashboard_status_inspect",
         conflicts_with = "multi_channel_status_inspect",
         conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_remote_profile_inspect",
         conflicts_with = "deployment_status_inspect",
         conflicts_with = "custom_command_status_inspect",
         conflicts_with = "voice_status_inspect",
@@ -1077,6 +1079,36 @@ pub(crate) struct Cli {
         help = "Emit --gateway-status-inspect output as pretty JSON"
     )]
     pub(crate) gateway_status_json: bool,
+
+    #[arg(
+        long = "gateway-remote-profile-inspect",
+        env = "TAU_GATEWAY_REMOTE_PROFILE_INSPECT",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        help = "Inspect gateway remote-access posture and risk reason codes without starting the gateway"
+    )]
+    pub(crate) gateway_remote_profile_inspect: bool,
+
+    #[arg(
+        long = "gateway-remote-profile-json",
+        env = "TAU_GATEWAY_REMOTE_PROFILE_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "gateway_remote_profile_inspect",
+        help = "Emit --gateway-remote-profile-inspect output as pretty JSON"
+    )]
+    pub(crate) gateway_remote_profile_json: bool,
 
     #[arg(
         long = "gateway-service-start",
@@ -3072,6 +3104,15 @@ pub(crate) struct Cli {
         help = "Socket address for --gateway-openresponses-server (host:port)"
     )]
     pub(crate) gateway_openresponses_bind: String,
+
+    #[arg(
+        long = "gateway-remote-profile",
+        env = "TAU_GATEWAY_REMOTE_PROFILE",
+        value_enum,
+        default_value_t = CliGatewayRemoteProfile::LocalOnly,
+        help = "Gateway remote-access posture: local-only, password-remote, or proxy-remote"
+    )]
+    pub(crate) gateway_remote_profile: CliGatewayRemoteProfile,
 
     #[arg(
         long = "gateway-openresponses-auth-mode",

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -140,6 +140,23 @@ impl CliGatewayOpenResponsesAuthMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliGatewayRemoteProfile {
+    LocalOnly,
+    PasswordRemote,
+    ProxyRemote,
+}
+
+impl CliGatewayRemoteProfile {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CliGatewayRemoteProfile::LocalOnly => "local-only",
+            CliGatewayRemoteProfile::PasswordRemote => "password-remote",
+            CliGatewayRemoteProfile::ProxyRemote => "proxy-remote",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum CliDaemonProfile {
     Auto,
     Launchd,

--- a/crates/tau-coding-agent/src/gateway_remote_profile.rs
+++ b/crates/tau-coding-agent/src/gateway_remote_profile.rs
@@ -1,0 +1,358 @@
+use super::*;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct GatewayRemoteProfileReport {
+    pub(crate) profile: String,
+    pub(crate) posture: String,
+    pub(crate) gate: String,
+    pub(crate) risk_level: String,
+    pub(crate) server_enabled: bool,
+    pub(crate) bind: String,
+    pub(crate) bind_ip: String,
+    pub(crate) loopback_bind: bool,
+    pub(crate) auth_mode: String,
+    pub(crate) auth_token_configured: bool,
+    pub(crate) auth_password_configured: bool,
+    pub(crate) remote_enabled: bool,
+    pub(crate) reason_codes: Vec<String>,
+    pub(crate) recommendations: Vec<String>,
+}
+
+fn has_non_empty(value: Option<&str>) -> bool {
+    value
+        .map(str::trim)
+        .map(|candidate| !candidate.is_empty())
+        .unwrap_or(false)
+}
+
+fn push_unique(list: &mut Vec<String>, value: &str) {
+    if list.iter().any(|existing| existing == value) {
+        return;
+    }
+    list.push(value.to_string());
+}
+
+fn mark_hold(
+    gate: &mut &'static str,
+    reason_codes: &mut Vec<String>,
+    recommendations: &mut Vec<String>,
+    reason_code: &str,
+    recommendation: &str,
+) {
+    *gate = "hold";
+    push_unique(reason_codes, reason_code);
+    push_unique(recommendations, recommendation);
+}
+
+pub(crate) fn evaluate_gateway_remote_profile(cli: &Cli) -> Result<GatewayRemoteProfileReport> {
+    let bind_addr = crate::gateway_openresponses::validate_gateway_openresponses_bind(
+        &cli.gateway_openresponses_bind,
+    )
+    .with_context(|| {
+        format!(
+            "failed to evaluate gateway remote profile bind '{}'",
+            cli.gateway_openresponses_bind
+        )
+    })?;
+    let loopback_bind = bind_addr.ip().is_loopback();
+    let auth_mode = cli.gateway_openresponses_auth_mode.as_str();
+    let profile = cli.gateway_remote_profile.as_str();
+    let auth_token_configured = has_non_empty(cli.gateway_openresponses_auth_token.as_deref());
+    let auth_password_configured =
+        has_non_empty(cli.gateway_openresponses_auth_password.as_deref());
+
+    let mut gate = "pass";
+    let mut reason_codes = Vec::new();
+    let mut recommendations = Vec::new();
+    let remote_enabled = !matches!(
+        cli.gateway_remote_profile,
+        CliGatewayRemoteProfile::LocalOnly
+    );
+
+    push_unique(
+        &mut reason_codes,
+        &format!("profile_{}", profile.replace('-', "_")),
+    );
+    if cli.gateway_openresponses_server {
+        push_unique(&mut reason_codes, "server_enabled");
+    } else {
+        push_unique(&mut reason_codes, "server_disabled_inspect_only");
+    }
+
+    match cli.gateway_remote_profile {
+        CliGatewayRemoteProfile::LocalOnly => {
+            if loopback_bind {
+                push_unique(&mut reason_codes, "local_only_loopback_bind");
+            } else {
+                mark_hold(
+                    &mut gate,
+                    &mut reason_codes,
+                    &mut recommendations,
+                    "local_only_non_loopback_bind",
+                    "set --gateway-openresponses-bind to a loopback address for local-only profile",
+                );
+            }
+            push_unique(
+                &mut reason_codes,
+                &format!("local_only_auth_{}", auth_mode.replace('-', "_")),
+            );
+        }
+        CliGatewayRemoteProfile::PasswordRemote => {
+            if cli.gateway_openresponses_auth_mode
+                != CliGatewayOpenResponsesAuthMode::PasswordSession
+            {
+                mark_hold(
+                    &mut gate,
+                    &mut reason_codes,
+                    &mut recommendations,
+                    "password_remote_auth_mode_mismatch",
+                    "set --gateway-openresponses-auth-mode password-session",
+                );
+            } else {
+                push_unique(&mut reason_codes, "password_remote_password_session_auth");
+            }
+            if auth_password_configured {
+                push_unique(&mut reason_codes, "password_remote_password_configured");
+            } else {
+                mark_hold(
+                    &mut gate,
+                    &mut reason_codes,
+                    &mut recommendations,
+                    "password_remote_missing_password",
+                    "set --gateway-openresponses-auth-password to a non-empty value",
+                );
+            }
+            if loopback_bind {
+                push_unique(&mut reason_codes, "password_remote_loopback_bind");
+                push_unique(
+                    &mut recommendations,
+                    "publish loopback bind through a trusted tunnel or reverse proxy for remote operators",
+                );
+            } else {
+                push_unique(&mut reason_codes, "password_remote_non_loopback_bind");
+            }
+        }
+        CliGatewayRemoteProfile::ProxyRemote => {
+            if cli.gateway_openresponses_auth_mode != CliGatewayOpenResponsesAuthMode::Token {
+                mark_hold(
+                    &mut gate,
+                    &mut reason_codes,
+                    &mut recommendations,
+                    "proxy_remote_auth_mode_mismatch",
+                    "set --gateway-openresponses-auth-mode token",
+                );
+            } else {
+                push_unique(&mut reason_codes, "proxy_remote_token_auth");
+            }
+            if auth_token_configured {
+                push_unique(&mut reason_codes, "proxy_remote_token_configured");
+            } else {
+                mark_hold(
+                    &mut gate,
+                    &mut reason_codes,
+                    &mut recommendations,
+                    "proxy_remote_missing_token",
+                    "set --gateway-openresponses-auth-token to a non-empty bearer token",
+                );
+            }
+            if loopback_bind {
+                push_unique(&mut reason_codes, "proxy_remote_loopback_bind");
+                push_unique(
+                    &mut recommendations,
+                    "keep loopback bind and expose access through a trusted reverse proxy/tunnel",
+                );
+            } else {
+                push_unique(&mut reason_codes, "proxy_remote_non_loopback_bind");
+            }
+        }
+    }
+
+    let posture = if remote_enabled {
+        "remote-enabled"
+    } else {
+        "local-only"
+    }
+    .to_string();
+    let risk_level = if gate == "hold" {
+        "high"
+    } else if remote_enabled && !loopback_bind {
+        "elevated"
+    } else if remote_enabled {
+        "moderate"
+    } else {
+        "low"
+    }
+    .to_string();
+
+    Ok(GatewayRemoteProfileReport {
+        profile: profile.to_string(),
+        posture,
+        gate: gate.to_string(),
+        risk_level,
+        server_enabled: cli.gateway_openresponses_server,
+        bind: cli.gateway_openresponses_bind.clone(),
+        bind_ip: bind_addr.ip().to_string(),
+        loopback_bind,
+        auth_mode: auth_mode.to_string(),
+        auth_token_configured,
+        auth_password_configured,
+        remote_enabled,
+        reason_codes,
+        recommendations,
+    })
+}
+
+pub(crate) fn render_gateway_remote_profile_report(report: &GatewayRemoteProfileReport) -> String {
+    let reason_codes = if report.reason_codes.is_empty() {
+        "none".to_string()
+    } else {
+        report.reason_codes.join(",")
+    };
+    let recommendations = if report.recommendations.is_empty() {
+        "none".to_string()
+    } else {
+        report.recommendations.join(" | ")
+    };
+    format!(
+        "gateway remote profile inspect: profile={} posture={} gate={} risk_level={} server_enabled={} remote_enabled={} bind={} bind_ip={} loopback_bind={} auth_mode={} auth_token_configured={} auth_password_configured={} reason_codes={} recommendations={}",
+        report.profile,
+        report.posture,
+        report.gate,
+        report.risk_level,
+        report.server_enabled,
+        report.remote_enabled,
+        report.bind,
+        report.bind_ip,
+        report.loopback_bind,
+        report.auth_mode,
+        report.auth_token_configured,
+        report.auth_password_configured,
+        reason_codes,
+        recommendations
+    )
+}
+
+pub(crate) fn execute_gateway_remote_profile_inspect_command(cli: &Cli) -> Result<()> {
+    let report = evaluate_gateway_remote_profile(cli)?;
+    if cli.gateway_remote_profile_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to render gateway remote profile inspect json")?
+        );
+    } else {
+        println!("{}", render_gateway_remote_profile_report(&report));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_gateway_remote_profile_for_openresponses(cli: &Cli) -> Result<()> {
+    if !cli.gateway_openresponses_server {
+        return Ok(());
+    }
+    let report = evaluate_gateway_remote_profile(cli)?;
+    if report.gate == "pass" {
+        return Ok(());
+    }
+    let reason_codes = if report.reason_codes.is_empty() {
+        "unknown".to_string()
+    } else {
+        report.reason_codes.join(",")
+    };
+    bail!(
+        "gateway remote profile rejected: profile={} gate={} reason_codes={} (run --gateway-remote-profile-inspect for full posture details)",
+        report.profile,
+        report.gate,
+        reason_codes
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        evaluate_gateway_remote_profile, validate_gateway_remote_profile_for_openresponses,
+    };
+    use crate::Cli;
+    use clap::Parser;
+
+    fn parse_cli_with_stack(args: &[&str]) -> Cli {
+        let owned_args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || Cli::parse_from(owned_args))
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
+    #[test]
+    fn unit_evaluate_gateway_remote_profile_default_is_local_only_pass() {
+        let cli = parse_cli_with_stack(&["tau-rs"]);
+        let report = evaluate_gateway_remote_profile(&cli).expect("evaluate");
+        assert_eq!(report.profile, "local-only");
+        assert_eq!(report.posture, "local-only");
+        assert_eq!(report.gate, "pass");
+        assert!(report.loopback_bind);
+        assert!(!report.remote_enabled);
+        assert!(report
+            .reason_codes
+            .contains(&"local_only_loopback_bind".to_string()));
+    }
+
+    #[test]
+    fn unit_evaluate_gateway_remote_profile_password_remote_requires_password_session() {
+        let cli = parse_cli_with_stack(&["tau-rs", "--gateway-remote-profile", "password-remote"]);
+        let report = evaluate_gateway_remote_profile(&cli).expect("evaluate");
+        assert_eq!(report.profile, "password-remote");
+        assert_eq!(report.gate, "hold");
+        assert!(report
+            .reason_codes
+            .contains(&"password_remote_auth_mode_mismatch".to_string()));
+    }
+
+    #[test]
+    fn functional_evaluate_gateway_remote_profile_proxy_remote_accepts_loopback_token_profile() {
+        let cli = parse_cli_with_stack(&[
+            "tau-rs",
+            "--gateway-openresponses-server",
+            "--gateway-remote-profile",
+            "proxy-remote",
+            "--gateway-openresponses-auth-mode",
+            "token",
+            "--gateway-openresponses-auth-token",
+            "edge-proxy-token",
+        ]);
+        let report = evaluate_gateway_remote_profile(&cli).expect("evaluate");
+        assert_eq!(report.profile, "proxy-remote");
+        assert_eq!(report.posture, "remote-enabled");
+        assert_eq!(report.gate, "pass");
+        assert_eq!(report.auth_mode, "token");
+        assert!(report.auth_token_configured);
+        assert!(report
+            .reason_codes
+            .contains(&"proxy_remote_token_configured".to_string()));
+    }
+
+    #[test]
+    fn regression_validate_gateway_remote_profile_for_openresponses_rejects_unsafe_combo() {
+        let cli = parse_cli_with_stack(&[
+            "tau-rs",
+            "--gateway-openresponses-server",
+            "--gateway-openresponses-bind",
+            "0.0.0.0:8787",
+            "--gateway-openresponses-auth-mode",
+            "token",
+            "--gateway-openresponses-auth-token",
+            "token-value",
+            "--gateway-remote-profile",
+            "local-only",
+        ]);
+        let error = validate_gateway_remote_profile_for_openresponses(&cli)
+            .expect_err("unsafe local-only non-loopback bind should fail");
+        assert!(error
+            .to_string()
+            .contains("gateway remote profile rejected"));
+        assert!(error.to_string().contains("local_only_non_loopback_bind"));
+    }
+}

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -28,6 +28,7 @@ mod events;
 mod extension_manifest;
 mod gateway_contract;
 mod gateway_openresponses;
+mod gateway_remote_profile;
 mod gateway_runtime;
 mod gateway_ws_protocol;
 mod gemini_cli_client;
@@ -140,9 +141,9 @@ pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliDaemonProfile,
     CliDeploymentWasmRuntimeProfile, CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode,
-    CliMultiChannelLiveConnectorMode, CliMultiChannelOutboundMode, CliMultiChannelTransport,
-    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
-    CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
+    CliGatewayRemoteProfile, CliMultiChannelLiveConnectorMode, CliMultiChannelOutboundMode,
+    CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
+    CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
@@ -279,6 +280,8 @@ pub(crate) use crate::rpc_protocol::{
     execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
     execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
 };
+#[cfg(test)]
+pub(crate) use crate::runtime_cli_validation::validate_gateway_remote_profile_inspect_cli;
 #[cfg(test)]
 pub(crate) use crate::runtime_cli_validation::validate_multi_channel_live_connectors_runner_cli;
 pub(crate) use crate::runtime_cli_validation::{

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -68,6 +68,12 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         return Ok(true);
     }
 
+    if cli.gateway_remote_profile_inspect {
+        crate::runtime_cli_validation::validate_gateway_remote_profile_inspect_cli(cli)?;
+        crate::gateway_remote_profile::execute_gateway_remote_profile_inspect_command(cli)?;
+        return Ok(true);
+    }
+
     if crate::daemon_runtime::tau_daemon_mode_requested(cli) {
         validate_daemon_cli(cli)?;
         let config = crate::daemon_runtime::TauDaemonConfig {

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -85,35 +85,35 @@ use super::{
     validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
     validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
-    validate_gateway_service_cli, validate_github_issues_bridge_cli, validate_macro_command_entry,
-    validate_macro_name, validate_memory_contract_runner_cli,
-    validate_multi_agent_contract_runner_cli, validate_multi_channel_channel_lifecycle_cli,
-    validate_multi_channel_contract_runner_cli, validate_multi_channel_live_connectors_runner_cli,
-    validate_multi_channel_live_ingest_cli, validate_multi_channel_live_runner_cli,
-    validate_profile_name, validate_project_index_cli, validate_rpc_frame_file,
-    validate_session_file, validate_skills_prune_file_name, validate_slack_bridge_cli,
-    validate_voice_contract_runner_cli, AuthCommand, AuthCommandConfig, BranchAliasCommand,
-    BranchAliasFile, Cli, CliBashProfile, CliCommandFileErrorMode,
+    validate_gateway_remote_profile_inspect_cli, validate_gateway_service_cli,
+    validate_github_issues_bridge_cli, validate_macro_command_entry, validate_macro_name,
+    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
+    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_contract_runner_cli,
+    validate_multi_channel_live_connectors_runner_cli, validate_multi_channel_live_ingest_cli,
+    validate_multi_channel_live_runner_cli, validate_profile_name, validate_project_index_cli,
+    validate_rpc_frame_file, validate_session_file, validate_skills_prune_file_name,
+    validate_slack_bridge_cli, validate_voice_contract_runner_cli, AuthCommand, AuthCommandConfig,
+    BranchAliasCommand, BranchAliasFile, Cli, CliBashProfile, CliCommandFileErrorMode,
     CliCredentialStoreEncryptionMode, CliDaemonProfile, CliDeploymentWasmRuntimeProfile,
-    CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode,
-    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOrchestratorMode, CliOsSandboxMode,
-    CliProviderAuthMode, CliSessionImportMode, CliToolPolicyPreset, CliWebhookSignatureAlgorithm,
-    ClientRoute, CommandAction, CommandExecutionContext, CommandFileEntry, CommandFileReport,
-    CredentialStoreData, CredentialStoreEncryptionMode, DoctorCheckOptions, DoctorCheckResult,
-    DoctorCommandArgs, DoctorCommandConfig, DoctorCommandOutputFormat,
-    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus, DoctorStatus,
-    FallbackRoutingClient, IntegrationAuthCommand, IntegrationCredentialStoreRecord, MacroCommand,
-    MacroFile, MultiAgentRouteTable, ProfileCommand, ProfileDefaults, ProfileStoreFile,
-    PromptRunStatus, PromptTelemetryLogger, ProviderAuthMethod, ProviderCredentialStoreRecord,
-    RenderOptions, RuntimeExtensionHooksConfig, SessionBookmarkCommand, SessionBookmarkFile,
-    SessionDiffEntry, SessionDiffReport, SessionGraphFormat, SessionRuntime, SessionSearchArgs,
-    SessionStats, SessionStatsOutputFormat, SkillsPruneMode, SkillsSyncCommandConfig,
-    SkillsVerifyEntry, SkillsVerifyReport, SkillsVerifyStatus, SkillsVerifySummary,
-    SkillsVerifyTrustSummary, ToolAuditLogger, TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION,
-    BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION, MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE,
-    SESSION_BOOKMARK_SCHEMA_VERSION, SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS,
-    SESSION_SEARCH_PREVIEW_CHARS, SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE,
-    SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
+    CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile,
+    CliMultiChannelLiveConnectorMode, CliMultiChannelOutboundMode, CliMultiChannelTransport,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode, CliSessionImportMode,
+    CliToolPolicyPreset, CliWebhookSignatureAlgorithm, ClientRoute, CommandAction,
+    CommandExecutionContext, CommandFileEntry, CommandFileReport, CredentialStoreData,
+    CredentialStoreEncryptionMode, DoctorCheckOptions, DoctorCheckResult, DoctorCommandArgs,
+    DoctorCommandConfig, DoctorCommandOutputFormat, DoctorMultiChannelReadinessConfig,
+    DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient, IntegrationAuthCommand,
+    IntegrationCredentialStoreRecord, MacroCommand, MacroFile, MultiAgentRouteTable,
+    ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
+    ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions, RuntimeExtensionHooksConfig,
+    SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry, SessionDiffReport,
+    SessionGraphFormat, SessionRuntime, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
+    SkillsPruneMode, SkillsSyncCommandConfig, SkillsVerifyEntry, SkillsVerifyReport,
+    SkillsVerifyStatus, SkillsVerifySummary, SkillsVerifyTrustSummary, ToolAuditLogger,
+    TrustedRootRecord, BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, MACRO_SCHEMA_VERSION,
+    MACRO_USAGE, PROFILE_SCHEMA_VERSION, PROFILE_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
+    SESSION_BOOKMARK_USAGE, SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
+    SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE, SKILLS_VERIFY_USAGE,
 };
 use crate::auth_commands::{
     auth_availability_counts, auth_mode_counts, auth_provider_counts, auth_revoked_counts,
@@ -408,6 +408,8 @@ fn test_cli() -> Cli {
         multi_agent_status_json: false,
         gateway_status_inspect: false,
         gateway_status_json: false,
+        gateway_remote_profile_inspect: false,
+        gateway_remote_profile_json: false,
         gateway_service_start: false,
         gateway_service_stop: false,
         gateway_service_stop_reason: None,
@@ -612,6 +614,7 @@ fn test_cli() -> Cli {
         dashboard_retry_base_delay_ms: 0,
         gateway_openresponses_server: false,
         gateway_openresponses_bind: "127.0.0.1:8787".to_string(),
+        gateway_remote_profile: CliGatewayRemoteProfile::LocalOnly,
         gateway_openresponses_auth_mode: CliGatewayOpenResponsesAuthMode::Token,
         gateway_openresponses_auth_token: None,
         gateway_openresponses_auth_password: None,
@@ -2973,6 +2976,51 @@ fn functional_cli_gateway_status_inspect_accepts_json_and_state_dir_override() {
 #[test]
 fn regression_cli_gateway_status_json_requires_gateway_status_inspect() {
     let parse = try_parse_cli_with_stack(["tau-rs", "--gateway-status-json"]);
+    let error = parse.expect_err("json output should require inspect flag");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn unit_cli_gateway_remote_profile_flags_default_to_local_only() {
+    let cli = parse_cli_with_stack(["tau-rs"]);
+    assert!(!cli.gateway_remote_profile_inspect);
+    assert!(!cli.gateway_remote_profile_json);
+    assert_eq!(
+        cli.gateway_remote_profile,
+        CliGatewayRemoteProfile::LocalOnly
+    );
+}
+
+#[test]
+fn functional_cli_gateway_remote_profile_inspect_accepts_json_and_profile_override() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--gateway-remote-profile-inspect",
+        "--gateway-remote-profile-json",
+        "--gateway-openresponses-server",
+        "--gateway-remote-profile",
+        "proxy-remote",
+        "--gateway-openresponses-auth-mode",
+        "token",
+        "--gateway-openresponses-auth-token",
+        "edge-token",
+        "--gateway-openresponses-bind",
+        "127.0.0.1:8787",
+    ]);
+    assert!(cli.gateway_remote_profile_inspect);
+    assert!(cli.gateway_remote_profile_json);
+    assert_eq!(
+        cli.gateway_remote_profile,
+        CliGatewayRemoteProfile::ProxyRemote
+    );
+    assert!(cli.gateway_openresponses_server);
+}
+
+#[test]
+fn regression_cli_gateway_remote_profile_json_requires_inspect() {
+    let parse = try_parse_cli_with_stack(["tau-rs", "--gateway-remote-profile-json"]);
     let error = parse.expect_err("json output should require inspect flag");
     assert!(error
         .to_string()
@@ -15372,6 +15420,28 @@ fn regression_validate_daemon_cli_rejects_whitespace_stop_reason() {
 }
 
 #[test]
+fn unit_validate_gateway_remote_profile_inspect_cli_accepts_minimum_configuration() {
+    let mut cli = test_cli();
+    cli.gateway_remote_profile_inspect = true;
+
+    validate_gateway_remote_profile_inspect_cli(&cli)
+        .expect("gateway remote profile inspect config should validate");
+}
+
+#[test]
+fn functional_validate_gateway_remote_profile_inspect_cli_rejects_prompt_conflicts() {
+    let mut cli = test_cli();
+    cli.gateway_remote_profile_inspect = true;
+    cli.prompt = Some("conflict".to_string());
+
+    let error =
+        validate_gateway_remote_profile_inspect_cli(&cli).expect_err("prompt conflict should fail");
+    assert!(error
+        .to_string()
+        .contains("--gateway-remote-profile-inspect cannot be combined"));
+}
+
+#[test]
 fn unit_validate_gateway_openresponses_server_cli_accepts_minimum_configuration() {
     let mut cli = test_cli();
     cli.gateway_openresponses_server = true;
@@ -15477,6 +15547,23 @@ fn regression_validate_gateway_openresponses_server_cli_rejects_non_loopback_loc
     assert!(error.to_string().contains(
         "--gateway-openresponses-auth-mode=localhost-dev requires loopback bind address"
     ));
+}
+
+#[test]
+fn integration_validate_gateway_openresponses_server_cli_rejects_unsafe_local_only_remote_combo() {
+    let mut cli = test_cli();
+    cli.gateway_openresponses_server = true;
+    cli.gateway_remote_profile = CliGatewayRemoteProfile::LocalOnly;
+    cli.gateway_openresponses_auth_mode = CliGatewayOpenResponsesAuthMode::Token;
+    cli.gateway_openresponses_auth_token = Some("secret-token".to_string());
+    cli.gateway_openresponses_bind = "0.0.0.0:8787".to_string();
+
+    let error = validate_gateway_openresponses_server_cli(&cli)
+        .expect_err("non-loopback local-only profile should fail");
+    assert!(error
+        .to_string()
+        .contains("gateway remote profile rejected"));
+    assert!(error.to_string().contains("local_only_non_loopback_bind"));
 }
 
 #[test]
@@ -20942,6 +21029,37 @@ fn functional_execute_startup_preflight_runs_gateway_status_inspect_mode() {
 
     let handled = execute_startup_preflight(&cli).expect("gateway status inspect preflight");
     assert!(handled);
+}
+
+#[test]
+fn functional_execute_startup_preflight_runs_gateway_remote_profile_inspect_mode() {
+    let mut cli = test_cli();
+    cli.gateway_remote_profile_inspect = true;
+    cli.gateway_remote_profile_json = true;
+    cli.gateway_openresponses_server = true;
+    cli.gateway_remote_profile = CliGatewayRemoteProfile::ProxyRemote;
+    cli.gateway_openresponses_auth_mode = CliGatewayOpenResponsesAuthMode::Token;
+    cli.gateway_openresponses_auth_token = Some("edge-token".to_string());
+    cli.gateway_openresponses_bind = "127.0.0.1:8787".to_string();
+
+    let handled =
+        execute_startup_preflight(&cli).expect("gateway remote profile inspect preflight");
+    assert!(handled);
+}
+
+#[test]
+fn regression_execute_startup_preflight_gateway_remote_profile_inspect_fails_closed() {
+    let mut cli = test_cli();
+    cli.gateway_remote_profile_inspect = true;
+    cli.gateway_openresponses_server = true;
+    cli.gateway_remote_profile = CliGatewayRemoteProfile::LocalOnly;
+    cli.gateway_openresponses_auth_mode = CliGatewayOpenResponsesAuthMode::Token;
+    cli.gateway_openresponses_auth_token = Some("edge-token".to_string());
+    cli.gateway_openresponses_bind = "0.0.0.0:8787".to_string();
+
+    let error = execute_startup_preflight(&cli)
+        .expect_err("unsafe local-only remote profile should fail closed");
+    assert!(error.to_string().contains("local_only_non_loopback_bind"));
 }
 
 #[test]

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -54,6 +54,26 @@ cargo run -p tau-coding-agent -- \
   --gateway-openresponses-max-input-chars 32000
 ```
 
+Remote-access profile posture:
+
+- `--gateway-remote-profile local-only` (default)
+- `--gateway-remote-profile password-remote`
+- `--gateway-remote-profile proxy-remote`
+
+Inspect remote-access posture without starting the gateway:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile-json
+```
+
+Detailed setup and rollback guidance:
+
+```bash
+cat docs/guides/gateway-remote-access.md
+```
+
 Auth mode summary:
 
 - `token` (default): bearer token required on `/v1/responses` and `/gateway/status`.

--- a/docs/guides/gateway-remote-access.md
+++ b/docs/guides/gateway-remote-access.md
@@ -1,0 +1,76 @@
+# Gateway Remote Access Runbook
+
+Run all commands from repository root.
+
+## Scope
+
+This runbook covers safe remote-access posture checks for the OpenResponses gateway.
+
+Profiles:
+- `local-only`
+- `password-remote`
+- `proxy-remote`
+
+## Inspect posture without starting the gateway
+
+Default local-only posture:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-profile-inspect
+```
+
+JSON posture report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile-json
+```
+
+Inspect a proxy-remote plan before rollout:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-profile-inspect \
+  --gateway-openresponses-server \
+  --gateway-remote-profile proxy-remote \
+  --gateway-openresponses-auth-mode token \
+  --gateway-openresponses-auth-token edge-token \
+  --gateway-openresponses-bind 127.0.0.1:8787
+```
+
+## Profile guidance
+
+`local-only`:
+- intended for workstation/local service usage.
+- keep loopback bind (`127.0.0.1` or `::1`).
+
+`password-remote`:
+- intended for controlled remote operator access with session-token exchange.
+- requires `--gateway-openresponses-auth-mode password-session`.
+- requires non-empty `--gateway-openresponses-auth-password`.
+
+`proxy-remote`:
+- intended for exposure behind a trusted reverse proxy or tunnel.
+- requires `--gateway-openresponses-auth-mode token`.
+- requires non-empty `--gateway-openresponses-auth-token`.
+
+## Security recommendations
+
+- Prefer loopback bind with external tunnel/proxy termination over direct public binds.
+- Keep bearer/password secrets out of shell history; use environment variables or secret stores.
+- Rotate gateway auth credentials on operator changes.
+- Keep transport health and gateway status checks in rollout gates:
+  - `--transport-health-inspect gateway --transport-health-json`
+  - `--gateway-status-inspect --gateway-status-json`
+
+## Rollback steps
+
+1. Stop gateway service mode:
+   `--gateway-service-stop --gateway-service-stop-reason remote_access_rollback`
+2. Revert to local-only profile and loopback bind in launch configs:
+   - `--gateway-remote-profile local-only`
+   - `--gateway-openresponses-bind 127.0.0.1:8787`
+3. Re-run remote profile inspect and verify `gate=pass`.
+4. Rotate affected auth token/password values before re-enabling remote exposure.


### PR DESCRIPTION
## Summary of behavior changes
- adds a gateway remote-access posture evaluator with explicit profiles: `local-only`, `password-remote`, and `proxy-remote`
- adds new CLI controls:
  - `--gateway-remote-profile`
  - `--gateway-remote-profile-inspect`
  - `--gateway-remote-profile-json`
- wires gateway remote-profile inspect into startup preflight command dispatch
- enforces fail-closed validation for unsafe remote-profile combinations when gateway server mode is enabled
- extends docs with a dedicated remote-access runbook and updates gateway ops guidance

## Risks and compatibility notes
- **stricter validation:** startup preflight now rejects unsafe gateway profile/bind/auth combinations that previously could pass inspection mode
- **CLI surface expansion:** new flags are additive and backward-compatible, but scripts using unsafe combos may now fail fast
- **runtime safety impact:** intended behavior change is deliberate fail-closed posture for remote-access hardening

## Validation evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -- --test-threads=1`

Closes #887
