### PR TITLE
feat: unified operator control summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Focused guides:
 - Quickstart: [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
 - Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Transports (GitHub/Slack/RPC): [`docs/guides/transports.md`](docs/guides/transports.md)
+- Operator control summary: [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md)
 - Packages and extensions: [`docs/guides/packages.md`](docs/guides/packages.md)
 - Events and scheduler: [`docs/guides/events.md`](docs/guides/events.md)
 

--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -933,6 +933,47 @@ pub(crate) struct Cli {
     pub(crate) github_status_json: bool,
 
     #[arg(
+        long = "operator-control-summary",
+        env = "TAU_OPERATOR_CONTROL_SUMMARY",
+        conflicts_with = "channel_store_inspect",
+        conflicts_with = "channel_store_repair",
+        conflicts_with = "transport_health_inspect",
+        conflicts_with = "github_status_inspect",
+        conflicts_with = "dashboard_status_inspect",
+        conflicts_with = "multi_channel_status_inspect",
+        conflicts_with = "multi_channel_route_inspect_file",
+        conflicts_with = "multi_agent_status_inspect",
+        conflicts_with = "gateway_status_inspect",
+        conflicts_with = "gateway_remote_profile_inspect",
+        conflicts_with = "deployment_status_inspect",
+        conflicts_with = "custom_command_status_inspect",
+        conflicts_with = "voice_status_inspect",
+        conflicts_with = "gateway_service_start",
+        conflicts_with = "gateway_service_stop",
+        conflicts_with = "gateway_service_status",
+        conflicts_with = "daemon_install",
+        conflicts_with = "daemon_uninstall",
+        conflicts_with = "daemon_start",
+        conflicts_with = "daemon_stop",
+        conflicts_with = "daemon_status",
+        help = "Inspect a unified operator control-plane summary (transports, gateway, daemon, release channel, policy posture) and exit"
+    )]
+    pub(crate) operator_control_summary: bool,
+
+    #[arg(
+        long = "operator-control-summary-json",
+        env = "TAU_OPERATOR_CONTROL_SUMMARY_JSON",
+        default_value_t = false,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        requires = "operator_control_summary",
+        help = "Emit --operator-control-summary output as pretty JSON"
+    )]
+    pub(crate) operator_control_summary_json: bool,
+
+    #[arg(
         long = "dashboard-status-inspect",
         env = "TAU_DASHBOARD_STATUS_INSPECT",
         conflicts_with = "channel_store_inspect",

--- a/crates/tau-coding-agent/src/runtime_cli_validation.rs
+++ b/crates/tau-coding-agent/src/runtime_cli_validation.rs
@@ -107,6 +107,7 @@ pub(crate) fn validate_project_index_cli(cli: &Cli) -> Result<()> {
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
         || cli.multi_channel_status_inspect
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect
@@ -563,6 +564,7 @@ pub(crate) fn validate_multi_channel_channel_lifecycle_cli(cli: &Cli) -> Result<
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
         || cli.multi_channel_status_inspect
         || cli.multi_channel_route_inspect_file.is_some()
         || cli.dashboard_status_inspect
@@ -885,6 +887,7 @@ pub(crate) fn validate_daemon_cli(cli: &Cli) -> Result<()> {
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
         || cli.multi_channel_status_inspect
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect
@@ -1012,6 +1015,7 @@ pub(crate) fn validate_gateway_remote_profile_inspect_cli(cli: &Cli) -> Result<(
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
         || cli.multi_channel_status_inspect
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -56,6 +56,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
         || cli.channel_store_repair.is_some()
         || cli.transport_health_inspect.is_some()
         || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
         || cli.multi_channel_status_inspect
         || cli.dashboard_status_inspect
         || cli.multi_agent_status_inspect

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -398,6 +398,8 @@ fn test_cli() -> Cli {
         transport_health_json: false,
         github_status_inspect: None,
         github_status_json: false,
+        operator_control_summary: false,
+        operator_control_summary_json: false,
         dashboard_status_inspect: false,
         dashboard_status_json: false,
         multi_channel_status_inspect: false,
@@ -2811,6 +2813,33 @@ fn functional_cli_github_status_inspect_accepts_json_and_state_dir_override() {
 fn regression_cli_github_status_json_requires_github_status_inspect() {
     let parse = try_parse_cli_with_stack(["tau-rs", "--github-status-json"]);
     let error = parse.expect_err("json output should require inspect flag");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn unit_cli_operator_control_summary_defaults_to_disabled() {
+    let cli = parse_cli_with_stack(["tau-rs"]);
+    assert!(!cli.operator_control_summary);
+    assert!(!cli.operator_control_summary_json);
+}
+
+#[test]
+fn functional_cli_operator_control_summary_accepts_json_mode() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--operator-control-summary",
+        "--operator-control-summary-json",
+    ]);
+    assert!(cli.operator_control_summary);
+    assert!(cli.operator_control_summary_json);
+}
+
+#[test]
+fn regression_cli_operator_control_summary_json_requires_summary_mode() {
+    let parse = try_parse_cli_with_stack(["tau-rs", "--operator-control-summary-json"]);
+    let error = parse.expect_err("json output should require summary flag");
     assert!(error
         .to_string()
         .contains("required arguments were not provided"));
@@ -20992,6 +21021,17 @@ fn functional_execute_startup_preflight_runs_github_status_inspect_mode() {
     .expect("write github state");
 
     let handled = execute_startup_preflight(&cli).expect("github status inspect preflight");
+    assert!(handled);
+}
+
+#[test]
+fn functional_execute_startup_preflight_runs_operator_control_summary_mode() {
+    let temp = tempdir().expect("tempdir");
+    let mut cli = test_cli();
+    set_workspace_tau_paths(&mut cli, temp.path());
+    cli.operator_control_summary = true;
+
+    let handled = execute_startup_preflight(&cli).expect("operator control summary preflight");
     assert!(handled);
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This index maps Tau documentation by audience and task.
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
+| Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |

--- a/docs/guides/operator-control-summary.md
+++ b/docs/guides/operator-control-summary.md
@@ -1,0 +1,61 @@
+# Operator Control Summary
+
+Run from repository root.
+
+## Purpose
+
+`--operator-control-summary` gives one day-2 control-plane view that combines:
+- transport and runtime health for dashboard, multi-channel, multi-agent, gateway, deployment, custom-command, and voice
+- gateway remote-access policy posture
+- daemon lifecycle state
+- release-channel state
+
+## Commands
+
+Text summary:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary
+```
+
+JSON summary:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary \
+  --operator-control-summary-json
+```
+
+## Output shape
+
+Top-level fields:
+- `health_state`: `healthy|degraded|failing`
+- `rollout_gate`: `pass|hold`
+- `reason_codes`: aggregate hold reasons across components
+- `recommendations`: actionable guidance for current hold/degraded/failing conditions
+- `policy_posture`: pairing strictness, gateway auth mode, remote profile posture
+- `daemon`: daemon health and lifecycle posture
+- `release_channel`: release-channel configuration posture
+- `components[]`: per-component health rows with reason/recommendation and queue/failure counters
+
+## Troubleshooting map
+
+Common hold reason codes and actions:
+- `*:state_unavailable`
+  - action: initialize or repair component state (`state.json`) and rerun summary
+- `gateway:service_stopped`
+  - action: start gateway service mode (`--gateway-service-start`) before resuming traffic
+- `daemon:daemon_not_installed`
+  - action: install daemon (`--daemon-install`) if background lifecycle management is required
+- `daemon:daemon_not_running`
+  - action: start daemon (`--daemon-start`) and verify with `--daemon-status --daemon-status-json`
+- `release-channel:release_channel_missing`
+  - action: set release channel with `/release-channel set <stable|beta|dev>`
+- `gateway-remote-profile:*`
+  - action: run `--gateway-remote-profile-inspect` and apply the recommended bind/auth/profile fixes
+
+When `health_state=failing`:
+1. Resolve `reason_codes` in listed order.
+2. Re-run `--operator-control-summary --operator-control-summary-json`.
+3. Confirm `rollout_gate=pass` before promoting runtime changes.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -2,6 +2,16 @@
 
 Run all commands from repository root.
 
+Unified operator control-plane snapshot (all core transport/runtime surfaces):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary \
+  --operator-control-summary-json
+```
+
+Troubleshooting map and field details: `docs/guides/operator-control-summary.md`.
+
 ## GitHub Issues bridge
 
 ```bash


### PR DESCRIPTION
## Summary
- add `--operator-control-summary` and `--operator-control-summary-json` CLI modes in `tau-coding-agent`
- add a unified operator health summary covering dashboard, multi-channel, multi-agent, gateway, deployment, custom commands, voice, daemon, release channel, and policy posture
- add resilient fallback behavior for missing/corrupt state files with explicit recommendations
- add docs and runbook for operator summary output and troubleshooting

## Risks and compatibility
- low runtime risk: functionality is additive and preflight/admin-command scoped
- moderate maintenance risk: summary aggregation includes many sources; mitigated by deterministic rendering and integration/regression tests
- no breaking API changes for existing CLI flags

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent tests::unit_cli_operator_control_summary_defaults_to_disabled -- --exact`
- `cargo test -p tau-coding-agent operator_control_summary -- --nocapture`
- `cargo test -p tau-coding-agent -- --test-threads=1`

Closes #888
