### PR TITLE
feat: add runnable operator demo index and gateway auth scenario

### DIFF
--- a/.github/demo-smoke-manifest.json
+++ b/.github/demo-smoke-manifest.json
@@ -58,6 +58,13 @@
       ]
     },
     {
+      "name": "onboard-non-interactive",
+      "args": [
+        "--onboard",
+        "--onboard-non-interactive"
+      ]
+    },
+    {
       "name": "multi-channel-live-ingest-telegram",
       "args": [
         "--multi-channel-live-ingest-file",
@@ -155,6 +162,24 @@
       ]
     },
     {
+      "name": "gateway-remote-profile-token-auth",
+      "args": [
+        "--gateway-remote-profile-inspect",
+        "--gateway-remote-profile-json",
+        "--gateway-remote-profile",
+        "proxy-remote",
+        "--gateway-openresponses-server",
+        "--gateway-openresponses-auth-mode",
+        "token",
+        "--gateway-openresponses-auth-token",
+        "ci-smoke-token",
+        "--gateway-openresponses-bind",
+        "127.0.0.1:8787",
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-auth"
+      ]
+    },
+    {
       "name": "gateway-service-start",
       "args": [
         "--gateway-state-dir",
@@ -179,6 +204,29 @@
         "--gateway-service-stop",
         "--gateway-service-stop-reason",
         "ci_smoke_complete"
+      ]
+    },
+    {
+      "name": "deployment-wasm-package",
+      "args": [
+        "--deployment-state-dir",
+        ".tau/ci-smoke/deployment",
+        "--deployment-wasm-package-module",
+        "./crates/tau-coding-agent/testdata/deployment-wasm/edge-runtime.wasm",
+        "--deployment-wasm-package-blueprint-id",
+        "edge-wasm",
+        "--deployment-wasm-package-output-dir",
+        ".tau/ci-smoke/deployment/wasm-artifacts",
+        "--deployment-wasm-package-json"
+      ]
+    },
+    {
+      "name": "deployment-channel-store-inspect-edge-wasm",
+      "args": [
+        "--channel-store-root",
+        ".tau/ci-smoke/deployment/channel-store",
+        "--channel-store-inspect",
+        "deployment/edge-wasm"
       ]
     }
   ]

--- a/.github/scripts/test_demo_index.py
+++ b/.github/scripts/test_demo_index.py
@@ -1,0 +1,117 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+DEMO_INDEX_SCRIPT = REPO_ROOT / "scripts" / "demo" / "index.sh"
+DEMO_ALL_SCRIPT = REPO_ROOT / "scripts" / "demo" / "all.sh"
+DEMO_SMOKE_MANIFEST = REPO_ROOT / ".github" / "demo-smoke-manifest.json"
+
+
+def run_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class DemoIndexTests(unittest.TestCase):
+    def test_unit_demo_index_list_json_has_expected_scenarios(self):
+        result = run_command(["bash", str(DEMO_INDEX_SCRIPT), "--list", "--json"])
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        scenario_ids = [entry["id"] for entry in payload["scenarios"]]
+        self.assertEqual(
+            scenario_ids,
+            ["onboarding", "gateway-auth", "multi-channel-live", "deployment-wasm"],
+        )
+        wrappers = {entry["id"]: entry["wrapper"] for entry in payload["scenarios"]}
+        self.assertEqual(wrappers["onboarding"], "local.sh")
+        self.assertEqual(wrappers["gateway-auth"], "gateway-auth.sh")
+        self.assertEqual(wrappers["multi-channel-live"], "multi-channel.sh")
+        self.assertEqual(wrappers["deployment-wasm"], "deployment.sh")
+
+    def test_functional_demo_index_list_text_contains_markers_and_hints(self):
+        result = run_command(["bash", str(DEMO_INDEX_SCRIPT), "--list"])
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("onboarding", result.stdout)
+        self.assertIn("gateway-auth", result.stdout)
+        self.assertIn("multi-channel-live", result.stdout)
+        self.assertIn("deployment-wasm", result.stdout)
+        self.assertIn("expected_marker:", result.stdout)
+        self.assertIn("troubleshooting:", result.stdout)
+
+    def test_integration_demo_index_report_file_matches_json_payload(self):
+        with tempfile.TemporaryDirectory(prefix="tau-demo-index-test-") as temp_dir:
+            report_file = Path(temp_dir) / "report.json"
+            result = run_command(
+                [
+                    "bash",
+                    str(DEMO_INDEX_SCRIPT),
+                    "--list",
+                    "--json",
+                    "--report-file",
+                    str(report_file),
+                ]
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertTrue(report_file.exists())
+            stdout_payload = json.loads(result.stdout)
+            file_payload = json.loads(report_file.read_text(encoding="utf-8"))
+            self.assertEqual(stdout_payload, file_payload)
+
+            all_list_result = run_command(
+                [
+                    "bash",
+                    str(DEMO_ALL_SCRIPT),
+                    "--list",
+                    "--only",
+                    "gateway-auth",
+                ]
+            )
+            self.assertEqual(all_list_result.returncode, 0, msg=all_list_result.stderr)
+            self.assertIn("gateway-auth.sh", all_list_result.stdout)
+
+    def test_regression_demo_index_alias_filter_and_unknown_filter_handling(self):
+        alias_result = run_command(
+            [
+                "bash",
+                str(DEMO_INDEX_SCRIPT),
+                "--list",
+                "--json",
+                "--only",
+                "local,gatewayauth,multi-channel,deployment",
+            ]
+        )
+        self.assertEqual(alias_result.returncode, 0, msg=alias_result.stderr)
+        alias_payload = json.loads(alias_result.stdout)
+        alias_ids = [entry["id"] for entry in alias_payload["scenarios"]]
+        self.assertEqual(
+            alias_ids,
+            ["onboarding", "gateway-auth", "multi-channel-live", "deployment-wasm"],
+        )
+
+        unknown_result = run_command(
+            ["bash", str(DEMO_INDEX_SCRIPT), "--list", "--only", "unknown-scenario"]
+        )
+        self.assertNotEqual(unknown_result.returncode, 0)
+        self.assertIn("unknown scenario names", unknown_result.stderr)
+
+    def test_regression_demo_smoke_manifest_includes_story_889_core_commands(self):
+        manifest = json.loads(DEMO_SMOKE_MANIFEST.read_text(encoding="utf-8"))
+        command_names = [entry["name"] for entry in manifest["commands"]]
+        self.assertIn("onboard-non-interactive", command_names)
+        self.assertIn("gateway-remote-profile-token-auth", command_names)
+        self.assertIn("deployment-wasm-package", command_names)
+        self.assertIn("deployment-channel-store-inspect-edge-wasm", command_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -151,9 +151,11 @@ class DemoScriptsTests(unittest.TestCase):
                 "package.sh",
                 "multi-channel.sh",
                 "multi-agent.sh",
+                "browser-automation.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "gateway-auth.sh",
                 "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
@@ -215,9 +217,11 @@ class DemoScriptsTests(unittest.TestCase):
                 "package.sh",
                 "multi-channel.sh",
                 "multi-agent.sh",
+                "browser-automation.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "gateway-auth.sh",
                 "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
@@ -288,7 +292,7 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=12 passed=12 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=14 passed=14 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 30)
@@ -340,11 +344,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=12 passed=12 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=14 passed=14 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 12, "passed": 12, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 14, "passed": 14, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -354,9 +358,11 @@ class DemoScriptsTests(unittest.TestCase):
                     "package.sh",
                     "multi-channel.sh",
                     "multi-agent.sh",
+                    "browser-automation.sh",
                     "memory.sh",
                     "dashboard.sh",
                     "gateway.sh",
+                    "gateway-auth.sh",
                     "deployment.sh",
                     "custom-command.sh",
                     "voice.sh",
@@ -433,12 +439,14 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [4] package.sh", completed.stdout)
             self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
             self.assertIn("[demo:all] [6] multi-agent.sh", completed.stdout)
-            self.assertIn("[demo:all] [7] memory.sh", completed.stdout)
-            self.assertIn("[demo:all] [8] dashboard.sh", completed.stdout)
-            self.assertIn("[demo:all] [9] gateway.sh", completed.stdout)
-            self.assertIn("[demo:all] [10] deployment.sh", completed.stdout)
-            self.assertIn("[demo:all] [11] custom-command.sh", completed.stdout)
-            self.assertIn("[demo:all] [12] voice.sh", completed.stdout)
+            self.assertIn("[demo:all] [7] browser-automation.sh", completed.stdout)
+            self.assertIn("[demo:all] [8] memory.sh", completed.stdout)
+            self.assertIn("[demo:all] [9] dashboard.sh", completed.stdout)
+            self.assertIn("[demo:all] [10] gateway.sh", completed.stdout)
+            self.assertIn("[demo:all] [11] gateway-auth.sh", completed.stdout)
+            self.assertIn("[demo:all] [12] deployment.sh", completed.stdout)
+            self.assertIn("[demo:all] [13] custom-command.sh", completed.stdout)
+            self.assertIn("[demo:all] [14] voice.sh", completed.stdout)
 
     def test_integration_multi_channel_demo_includes_live_mode_diagnostics_steps(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -522,9 +530,11 @@ class DemoScriptsTests(unittest.TestCase):
                 "package.sh",
                 "multi-channel.sh",
                 "multi-agent.sh",
+                "browser-automation.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
+                "gateway-auth.sh",
                 "deployment.sh",
                 "custom-command.sh",
                 "voice.sh",
@@ -674,8 +684,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 12)
-            self.assertEqual(payload["summary"]["failed"], 12)
+            self.assertEqual(payload["summary"]["total"], 14)
+            self.assertEqual(payload["summary"]["failed"], 14)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Start with the docs index: [`docs/README.md`](docs/README.md)
 Focused guides:
 
 - Quickstart: [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
+- Demo index: [`docs/guides/demo-index.md`](docs/guides/demo-index.md)
 - Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Transports (GitHub/Slack/RPC): [`docs/guides/transports.md`](docs/guides/transports.md)
 - Operator control summary: [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md)
@@ -66,6 +67,12 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 Run deterministic local demos:
 
 ```bash
+# operator-focused fresh-clone validation path
+./scripts/demo/index.sh
+./scripts/demo/index.sh --list
+./scripts/demo/index.sh --only onboarding,gateway-auth --fail-fast
+./scripts/demo/index.sh --json --report-file .tau/reports/demo-index-summary.json
+
 # all.sh prepares the binary once, then reuses it across selected wrappers.
 ./scripts/demo/all.sh
 ./scripts/demo/all.sh --list
@@ -87,6 +94,7 @@ Run deterministic local demos:
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/gateway-auth.sh
 ./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This index maps Tau documentation by audience and task.
 | Audience | Start Here | Scope |
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
+| Fresh-clone validator / demo operator | [Demo Index Guide](guides/demo-index.md) | Deterministic onboarding, gateway auth, multi-channel live ingest, and deployment WASM demos |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -1,0 +1,81 @@
+# Demo Index Guide
+
+Run all commands from repository root.
+
+This guide provides a compact, reproducible demo suite for fresh-clone validation of
+core Tau operator workflows.
+
+## Quick start
+
+```bash
+./scripts/demo/index.sh
+```
+
+List available scenarios without execution:
+
+```bash
+./scripts/demo/index.sh --list
+./scripts/demo/index.sh --list --json
+```
+
+Run only selected scenarios:
+
+```bash
+./scripts/demo/index.sh --only onboarding,gateway-auth --fail-fast
+```
+
+Write deterministic JSON summary:
+
+```bash
+./scripts/demo/index.sh --json --report-file .tau/reports/demo-index-summary.json
+```
+
+## Scenario matrix
+
+### onboarding
+- Wrapper: `./scripts/demo/local.sh`
+- Purpose: bootstrap first-run local Tau operator state and baseline commands.
+- Expected markers:
+  - `[demo:local] PASS onboard-non-interactive`
+  - `[demo:local] summary: total=`
+- Troubleshooting checkpoint:
+  - confirm `.tau` is writable, then rerun `./scripts/demo/local.sh --fail-fast`.
+
+### gateway-auth
+- Wrapper: `./scripts/demo/gateway-auth.sh`
+- Purpose: validate gateway auth posture for token and password-session remote profiles.
+- Expected markers:
+  - `[demo:gateway-auth] PASS gateway-remote-profile-token-mode`
+  - `[demo:gateway-auth] PASS gateway-remote-profile-password-session-mode`
+- Troubleshooting checkpoint:
+  - verify `--gateway-openresponses-auth-mode` and required token/password flags.
+
+### multi-channel-live
+- Wrapper: `./scripts/demo/multi-channel.sh`
+- Purpose: ingest live fixtures and verify transport health for Telegram, Discord, and WhatsApp.
+- Expected markers:
+  - `[demo:multi-channel] PASS multi-channel-live-ingest-telegram`
+  - `[demo:multi-channel] PASS multi-channel-live-ingest-discord`
+  - `[demo:multi-channel] PASS multi-channel-live-ingest-whatsapp`
+- Troubleshooting checkpoint:
+  - verify fixture files in `crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw`.
+
+### deployment-wasm
+- Wrapper: `./scripts/demo/deployment.sh`
+- Purpose: package WASM deployment artifact and verify inspect/status outputs.
+- Expected markers:
+  - `[demo:deployment] PASS deployment-wasm-package`
+  - `[demo:deployment] PASS channel-store-inspect-deployment-edge-wasm`
+- Troubleshooting checkpoint:
+  - verify deployment fixture paths and WASM module file in `testdata/deployment-wasm`.
+
+## CI-light smoke notes
+
+The repository smoke manifest (`.github/demo-smoke-manifest.json`) includes lightweight
+commands that cover the same workflow classes:
+- onboarding bootstrap
+- gateway auth posture inspect
+- multi-channel live ingress (Telegram/Discord/WhatsApp)
+- deployment WASM package and inspect
+
+This keeps smoke runs deterministic while avoiding external-service dependencies.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -122,6 +122,12 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ## Run deterministic local demos
 
 ```bash
+# operator-focused fresh-clone validation path
+./scripts/demo/index.sh
+./scripts/demo/index.sh --list
+./scripts/demo/index.sh --only onboarding,gateway-auth --fail-fast
+./scripts/demo/index.sh --json --report-file .tau/reports/demo-index-summary.json
+
 # all.sh prepares the binary once, then reuses it across selected wrappers.
 ./scripts/demo/all.sh
 ./scripts/demo/all.sh --list
@@ -146,6 +152,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
+./scripts/demo/gateway-auth.sh
 ./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -23,6 +23,7 @@ demo_scripts=(
   "memory.sh"
   "dashboard.sh"
   "gateway.sh"
+  "gateway-auth.sh"
   "deployment.sh"
   "custom-command.sh"
   "voice.sh"
@@ -101,6 +102,10 @@ normalize_demo_name() {
       ;;
     gateway|gateway.sh)
       echo "gateway.sh"
+      return 0
+      ;;
+    gateway-auth|gatewayauth|gateway-auth.sh|gatewayauth.sh)
+      echo "gateway-auth.sh"
       return 0
       ;;
     deployment|deployment.sh)
@@ -225,14 +230,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/memory/dashboard/gateway/deployment/custom-command/voice) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/memory/dashboard/gateway/gateway-auth/deployment/custom-command/voice) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,memory,dashboard,gateway,deployment,custom-command,voice)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,memory,dashboard,gateway,gateway-auth,deployment,custom-command,voice)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/gateway-auth.sh
+++ b/scripts/demo/gateway-auth.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "gateway-auth" "Run deterministic gateway auth posture demo commands without starting external services." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+demo_state_dir=".tau/demo-gateway-auth"
+
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "gateway-remote-profile-token-mode" \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile proxy-remote \
+  --gateway-openresponses-server \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-openresponses-auth-mode token \
+  --gateway-openresponses-auth-token demo-gateway-token \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-remote-profile-json
+
+tau_demo_common_run_step \
+  "gateway-remote-profile-password-session-mode" \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile password-remote \
+  --gateway-openresponses-server \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-openresponses-auth-mode password-session \
+  --gateway-openresponses-auth-password demo-gateway-password \
+  --gateway-openresponses-session-ttl-seconds 900 \
+  --gateway-state-dir "${demo_state_dir}" \
+  --gateway-remote-profile-json
+
+tau_demo_common_finish

--- a/scripts/demo/index.sh
+++ b/scripts/demo/index.sh
@@ -1,0 +1,553 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+binary="${repo_root}/target/debug/tau-coding-agent"
+skip_build="false"
+list_only="false"
+json_output="false"
+has_only_filter="false"
+report_file=""
+fail_fast="false"
+timeout_seconds=""
+
+scenario_ids=(
+  "onboarding"
+  "gateway-auth"
+  "multi-channel-live"
+  "deployment-wasm"
+)
+
+declare -A selected_scenario_lookup=()
+declare -a unknown_scenario_names=()
+
+run_scenario_names=()
+run_scenario_statuses=()
+run_scenario_exit_codes=()
+run_scenario_durations_ms=()
+
+log_info() {
+  local message="$1"
+  if [[ "${json_output}" == "true" ]]; then
+    echo "${message}" >&2
+  else
+    echo "${message}"
+  fi
+}
+
+log_error() {
+  local message="$1"
+  echo "${message}" >&2
+}
+
+require_command() {
+  local executable="$1"
+  if ! command -v "${executable}" >/dev/null 2>&1; then
+    log_error "missing required executable: ${executable}"
+    return 1
+  fi
+}
+
+trim_spaces() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  echo "${value}"
+}
+
+current_time_ms() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+    return 0
+  fi
+
+  date +%s | awk '{ print $1 * 1000 }'
+}
+
+write_report_file() {
+  local payload="$1"
+  local destination="$2"
+  local destination_parent
+  destination_parent="$(dirname "${destination}")"
+  mkdir -p "${destination_parent}"
+  printf '%s\n' "${payload}" > "${destination}"
+}
+
+scenario_wrapper() {
+  local scenario_id="$1"
+  case "${scenario_id}" in
+    onboarding)
+      echo "local.sh"
+      ;;
+    gateway-auth)
+      echo "gateway-auth.sh"
+      ;;
+    multi-channel-live)
+      echo "multi-channel.sh"
+      ;;
+    deployment-wasm)
+      echo "deployment.sh"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+scenario_description() {
+  local scenario_id="$1"
+  case "${scenario_id}" in
+    onboarding)
+      echo "Bootstrap local Tau state and verify first-run operator commands."
+      ;;
+    gateway-auth)
+      echo "Validate gateway remote profile auth posture for token and password-session modes."
+      ;;
+    multi-channel-live)
+      echo "Exercise Telegram/Discord/WhatsApp fixture ingest and multi-channel routing health."
+      ;;
+    deployment-wasm)
+      echo "Package and inspect deployment WASM artifacts with deterministic status checks."
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+scenario_expected_markers() {
+  local scenario_id="$1"
+  case "${scenario_id}" in
+    onboarding)
+      echo "[demo:local] PASS onboard-non-interactive"
+      echo "[demo:local] summary: total="
+      ;;
+    gateway-auth)
+      echo "[demo:gateway-auth] PASS gateway-remote-profile-token-mode"
+      echo "[demo:gateway-auth] PASS gateway-remote-profile-password-session-mode"
+      ;;
+    multi-channel-live)
+      echo "[demo:multi-channel] PASS multi-channel-live-ingest-telegram"
+      echo "[demo:multi-channel] PASS multi-channel-live-ingest-discord"
+      echo "[demo:multi-channel] PASS multi-channel-live-ingest-whatsapp"
+      ;;
+    deployment-wasm)
+      echo "[demo:deployment] PASS deployment-wasm-package"
+      echo "[demo:deployment] PASS channel-store-inspect-deployment-edge-wasm"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+scenario_troubleshooting_hint() {
+  local scenario_id="$1"
+  case "${scenario_id}" in
+    onboarding)
+      echo "Verify writable .tau state and rerun ./scripts/demo/local.sh --fail-fast to isolate first failing step."
+      ;;
+    gateway-auth)
+      echo "Check gateway auth flags (--gateway-openresponses-auth-mode/token/password) and rerun ./scripts/demo/gateway-auth.sh."
+      ;;
+    multi-channel-live)
+      echo "Confirm Telegram/Discord/WhatsApp fixture files exist and rerun ./scripts/demo/multi-channel.sh --fail-fast."
+      ;;
+    deployment-wasm)
+      echo "Confirm deployment fixture/module paths exist and rerun ./scripts/demo/deployment.sh --fail-fast."
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+normalize_scenario_name() {
+  local candidate="$1"
+  case "${candidate}" in
+    onboarding|local|onboarding.sh|local.sh)
+      echo "onboarding"
+      return 0
+      ;;
+    gateway-auth|gatewayauth|gateway-auth.sh|gatewayauth.sh)
+      echo "gateway-auth"
+      return 0
+      ;;
+    multi-channel-live|multichannel-live|multi-channel|multi-channel-live.sh|multi-channel.sh)
+      echo "multi-channel-live"
+      return 0
+      ;;
+    deployment-wasm|deploymentwasm|deployment|deployment-wasm.sh|deployment.sh)
+      echo "deployment-wasm"
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+print_scenario_list_text() {
+  local selected=("$@")
+  local scenario_id
+  local wrapper
+  local command_path
+  local description
+  local hint
+  local marker
+  local first_marker
+  for scenario_id in "${selected[@]}"; do
+    wrapper="$(scenario_wrapper "${scenario_id}")"
+    command_path="./scripts/demo/${wrapper}"
+    description="$(scenario_description "${scenario_id}")"
+    hint="$(scenario_troubleshooting_hint "${scenario_id}")"
+    echo "${scenario_id}"
+    echo "  wrapper: ${wrapper}"
+    echo "  command: ${command_path}"
+    echo "  description: ${description}"
+    first_marker="true"
+    while IFS= read -r marker; do
+      if [[ "${first_marker}" == "true" ]]; then
+        echo "  expected_marker: ${marker}"
+        first_marker="false"
+      else
+        echo "  expected_marker_continued: ${marker}"
+      fi
+    done < <(scenario_expected_markers "${scenario_id}")
+    echo "  troubleshooting: ${hint}"
+  done
+}
+
+print_scenario_list_json() {
+  local selected=("$@")
+  local idx
+  local marker
+  local marker_idx
+  local wrapper
+  local description
+  local hint
+  local marker_list
+  echo "{"
+  echo "  \"schema_version\": 1,"
+  echo "  \"scenarios\": ["
+  for idx in "${!selected[@]}"; do
+    scenario_id="${selected[$idx]}"
+    wrapper="$(scenario_wrapper "${scenario_id}")"
+    description="$(scenario_description "${scenario_id}")"
+    hint="$(scenario_troubleshooting_hint "${scenario_id}")"
+    marker_list=()
+    while IFS= read -r marker; do
+      marker_list+=("${marker}")
+    done < <(scenario_expected_markers "${scenario_id}")
+    echo "    {"
+    echo "      \"id\": \"${scenario_id}\","
+    echo "      \"wrapper\": \"${wrapper}\","
+    echo "      \"command\": \"./scripts/demo/${wrapper}\","
+    echo "      \"description\": \"${description}\","
+    echo "      \"expected_markers\": ["
+    if [[ ${#marker_list[@]} -gt 0 ]]; then
+      for marker_idx in "${!marker_list[@]}"; do
+        suffix=","
+        if [[ "${marker_idx}" -eq $(( ${#marker_list[@]} - 1 )) ]]; then
+          suffix=""
+        fi
+        echo "        \"${marker_list[$marker_idx]}\"${suffix}"
+      done
+    fi
+    echo "      ],"
+    echo "      \"troubleshooting\": \"${hint}\""
+    suffix=","
+    if [[ "${idx}" -eq $(( ${#selected[@]} - 1 )) ]]; then
+      suffix=""
+    fi
+    echo "    }${suffix}"
+  done
+  echo "  ]"
+  echo "}"
+}
+
+prepare_binary_once() {
+  if [[ "${skip_build}" == "true" ]]; then
+    if [[ ! -f "${binary}" ]]; then
+      log_error "missing tau-coding-agent binary (use --binary or remove --skip-build): ${binary}"
+      return 1
+    fi
+    return 0
+  fi
+
+  require_command cargo || return 1
+  log_info "[demo:index] building tau-coding-agent"
+  (
+    cd "${repo_root}"
+    cargo build -p tau-coding-agent >/dev/null
+  ) || return $?
+
+  if [[ ! -f "${binary}" ]]; then
+    log_error "missing tau-coding-agent binary after build: ${binary}"
+    return 1
+  fi
+}
+
+print_summary_json() {
+  local total_count="$1"
+  local passed_count="$2"
+  local failed_count="$3"
+  local idx
+  local last_index
+
+  echo "{"
+  echo "  \"schema_version\": 1,"
+  echo "  \"scenarios\": ["
+  if [[ ${#run_scenario_names[@]} -gt 0 ]]; then
+    last_index=$(( ${#run_scenario_names[@]} - 1 ))
+    for idx in "${!run_scenario_names[@]}"; do
+      comma=","
+      if [[ "${idx}" -eq "${last_index}" ]]; then
+        comma=""
+      fi
+      printf '    {"id":"%s","status":"%s","exit_code":%s,"duration_ms":%s}%s\n' \
+        "${run_scenario_names[$idx]}" \
+        "${run_scenario_statuses[$idx]}" \
+        "${run_scenario_exit_codes[$idx]}" \
+        "${run_scenario_durations_ms[$idx]}" \
+        "${comma}"
+    done
+  fi
+  echo "  ],"
+  printf '  "summary":{"total":%s,"passed":%s,"failed":%s}\n' "${total_count}" "${passed_count}" "${failed_count}"
+  echo "}"
+}
+
+print_usage() {
+  cat <<EOF
+Usage: index.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only SCENARIOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
+
+Run the operator-focused demo index for fresh-clone validation:
+- onboarding
+- gateway-auth
+- multi-channel-live (Telegram/Discord/WhatsApp)
+- deployment-wasm
+
+Options:
+  --repo-root PATH   Repository root (defaults to caller-derived root)
+  --binary PATH      tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
+  --skip-build       Skip cargo build and require --binary to exist
+  --list             Print selected scenarios and exit without execution
+  --only SCENARIOS   Comma-separated subset (names: onboarding,gateway-auth,multi-channel-live,deployment-wasm)
+  --json             Emit deterministic JSON output for list/summary modes
+  --report-file      Write deterministic JSON report artifact to path
+  --fail-fast        Stop after first failed scenario
+  --timeout-seconds  Positive integer timeout for each scenario wrapper
+  --help             Show this usage message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        log_error "missing value for --repo-root"
+        print_usage >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --binary)
+      if [[ $# -lt 2 ]]; then
+        log_error "missing value for --binary"
+        print_usage >&2
+        exit 2
+      fi
+      binary="$2"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build="true"
+      shift
+      ;;
+    --list)
+      list_only="true"
+      shift
+      ;;
+    --only)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        log_error "missing value for --only"
+        print_usage >&2
+        exit 2
+      fi
+      has_only_filter="true"
+      IFS=',' read -r -a requested_scenario_names <<< "$2"
+      for requested_scenario_name in "${requested_scenario_names[@]}"; do
+        trimmed_requested_scenario_name="$(trim_spaces "${requested_scenario_name}")"
+        if [[ -z "${trimmed_requested_scenario_name}" ]]; then
+          continue
+        fi
+        if normalized_scenario_name="$(normalize_scenario_name "${trimmed_requested_scenario_name}")"; then
+          selected_scenario_lookup["${normalized_scenario_name}"]=1
+        else
+          unknown_scenario_names+=("${trimmed_requested_scenario_name}")
+        fi
+      done
+      shift 2
+      ;;
+    --json)
+      json_output="true"
+      shift
+      ;;
+    --report-file)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        log_error "missing value for --report-file"
+        print_usage >&2
+        exit 2
+      fi
+      report_file="$2"
+      shift 2
+      ;;
+    --fail-fast)
+      fail_fast="true"
+      shift
+      ;;
+    --timeout-seconds)
+      if [[ $# -lt 2 ]]; then
+        log_error "missing value for --timeout-seconds"
+        print_usage >&2
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+        log_error "invalid value for --timeout-seconds (expected positive integer): $2"
+        print_usage >&2
+        exit 2
+      fi
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "${repo_root}" ]]; then
+  log_error "invalid --repo-root path (directory not found): ${repo_root}"
+  exit 2
+fi
+repo_root="$(cd "${repo_root}" && pwd)"
+
+if [[ "${binary}" != /* ]]; then
+  binary="${repo_root}/${binary}"
+fi
+
+if [[ ${#unknown_scenario_names[@]} -gt 0 ]]; then
+  log_error "unknown scenario names in --only: ${unknown_scenario_names[*]}"
+  exit 2
+fi
+
+selected_scenarios=("${scenario_ids[@]}")
+if [[ "${has_only_filter}" == "true" ]]; then
+  selected_scenarios=()
+  for scenario_id in "${scenario_ids[@]}"; do
+    if [[ -n "${selected_scenario_lookup[${scenario_id}]:-}" ]]; then
+      selected_scenarios+=("${scenario_id}")
+    fi
+  done
+  if [[ ${#selected_scenarios[@]} -eq 0 ]]; then
+    log_error "no scenarios selected by --only filter"
+    exit 2
+  fi
+fi
+
+if [[ "${list_only}" == "true" ]]; then
+  list_json_payload="$(print_scenario_list_json "${selected_scenarios[@]}")"
+  if [[ -n "${report_file}" ]]; then
+    write_report_file "${list_json_payload}" "${report_file}"
+  fi
+  if [[ "${json_output}" == "true" ]]; then
+    echo "${list_json_payload}"
+  else
+    print_scenario_list_text "${selected_scenarios[@]}"
+  fi
+  exit 0
+fi
+
+prepare_binary_once || exit $?
+
+total=0
+passed=0
+failed=0
+
+for scenario_id in "${selected_scenarios[@]}"; do
+  total=$((total + 1))
+  wrapper_script="$(scenario_wrapper "${scenario_id}")"
+  log_info "[demo:index] [${total}] ${scenario_id} (${wrapper_script})"
+  args=("${script_dir}/${wrapper_script}" "--repo-root" "${repo_root}" "--binary" "${binary}" "--skip-build")
+  if [[ -n "${timeout_seconds}" ]]; then
+    args+=("--timeout-seconds" "${timeout_seconds}")
+  fi
+
+  started_ms="$(current_time_ms)"
+  if [[ "${json_output}" == "true" ]]; then
+    if "${args[@]}" >&2; then
+      scenario_exit_code=0
+      scenario_status="passed"
+    else
+      scenario_exit_code=$?
+      scenario_status="failed"
+    fi
+  elif "${args[@]}"; then
+    scenario_exit_code=0
+    scenario_status="passed"
+  else
+    scenario_exit_code=$?
+    scenario_status="failed"
+  fi
+  ended_ms="$(current_time_ms)"
+  scenario_duration_ms=$((ended_ms - started_ms))
+  if [[ "${scenario_duration_ms}" -lt 0 ]]; then
+    scenario_duration_ms=0
+  fi
+
+  run_scenario_names+=("${scenario_id}")
+  run_scenario_statuses+=("${scenario_status}")
+  run_scenario_exit_codes+=("${scenario_exit_code}")
+  run_scenario_durations_ms+=("${scenario_duration_ms}")
+
+  if [[ "${scenario_status}" == "passed" ]]; then
+    passed=$((passed + 1))
+    log_info "[demo:index] PASS ${scenario_id}"
+  else
+    failed=$((failed + 1))
+    hint="$(scenario_troubleshooting_hint "${scenario_id}")"
+    log_error "[demo:index] FAIL ${scenario_id} exit=${scenario_exit_code}"
+    log_error "[demo:index] remediation: ${hint}"
+    if [[ "${fail_fast}" == "true" ]]; then
+      log_error "[demo:index] fail-fast triggered; stopping after ${scenario_id}"
+      break
+    fi
+  fi
+done
+
+summary_json_payload="$(print_summary_json "${total}" "${passed}" "${failed}")"
+if [[ -n "${report_file}" ]]; then
+  write_report_file "${summary_json_payload}" "${report_file}"
+fi
+
+if [[ "${json_output}" == "true" ]]; then
+  echo "${summary_json_payload}"
+else
+  echo "[demo:index] summary: total=${total} passed=${passed} failed=${failed}"
+fi
+
+if [[ ${failed} -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/demo/index.sh` as the fresh-clone operator demo index with deterministic scenario orchestration, list/json/report modes, fail-fast behavior, and remediation hints
- add `scripts/demo/gateway-auth.sh` for deterministic gateway auth posture validation (token + password-session)
- extend `scripts/demo/all.sh` inventory and aliases to include `gateway-auth`
- add runbook `docs/guides/demo-index.md` and update docs/readme/quickstart links and commands
- extend CI-light smoke manifest with onboarding, gateway auth posture inspect, and deployment wasm package/inspect commands
- add helper coverage in `.github/scripts/test_demo_index.py` and update `.github/scripts/test_demo_scripts.py` for the expanded 14-wrapper inventory

## Risks and compatibility
- low runtime risk: demo index and wrapper additions are additive; existing wrapper behavior is unchanged
- low CI risk: smoke manifest adds deterministic local commands only; no external network/service dependency introduced
- compatibility note: `scripts/demo/all.sh` list order/count changed from 12 to 14 wrappers due `browser-automation` (already present) and new `gateway-auth` inclusion

## Validation
- `./scripts/demo/index.sh --only onboarding,gateway-auth,multi-channel-live,deployment-wasm --fail-fast --report-file .tau/reports/demo-index-run.json`
- `./scripts/demo-smoke.sh`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`

Closes #889
