### PR TITLE
feat: add gateway auth session end-to-end smoke demo

### DIFF
--- a/.github/scripts/test_gateway_auth_session_demo.py
+++ b/.github/scripts/test_gateway_auth_session_demo.py
@@ -1,0 +1,61 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_SCRIPT = REPO_ROOT / "scripts" / "demo" / "gateway-auth-session.sh"
+RUNBOOK_DOC = REPO_ROOT / "docs" / "guides" / "gateway-auth-session-smoke.md"
+QUICKSTART_DOC = REPO_ROOT / "docs" / "guides" / "quickstart.md"
+
+
+class GatewayAuthSessionDemoTests(unittest.TestCase):
+    def test_unit_gateway_auth_session_script_has_expected_step_labels(self):
+        contents = DEMO_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("wait-for-gateway-startup", contents)
+        self.assertIn("gateway-auth-session-issue-valid-password", contents)
+        self.assertIn("gateway-status-authorized-with-issued-token", contents)
+        self.assertIn("gateway-auth-session-invalid-password-fails-closed", contents)
+        self.assertIn("gateway-status-expired-token-fails-closed", contents)
+        self.assertIn("/gateway/auth/session", contents)
+        self.assertIn("/gateway/status", contents)
+
+    def test_functional_gateway_auth_session_help_prints_usage(self):
+        completed = subprocess.run(
+            [str(DEMO_SCRIPT), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("Usage:", completed.stdout)
+        self.assertIn("gateway-auth-session", completed.stdout)
+
+    def test_integration_gateway_auth_session_runbook_and_quickstart_reference_command(self):
+        runbook = RUNBOOK_DOC.read_text(encoding="utf-8")
+        quickstart = QUICKSTART_DOC.read_text(encoding="utf-8")
+        self.assertIn("./scripts/demo/gateway-auth-session.sh", runbook)
+        self.assertIn("./scripts/demo/gateway-auth-session.sh", quickstart)
+
+    def test_regression_gateway_auth_session_skip_build_requires_binary(self):
+        completed = subprocess.run(
+            [
+                str(DEMO_SCRIPT),
+                "--skip-build",
+                "--repo-root",
+                str(REPO_ROOT),
+                "--binary",
+                "/tmp/tau-missing-binary-for-gateway-auth-session",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("missing tau-coding-agent binary", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Focused guides:
 
 - Quickstart: [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
 - Demo index: [`docs/guides/demo-index.md`](docs/guides/demo-index.md)
+- Gateway auth session smoke: [`docs/guides/gateway-auth-session-smoke.md`](docs/guides/gateway-auth-session-smoke.md)
 - Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Transports (GitHub/Slack/RPC): [`docs/guides/transports.md`](docs/guides/transports.md)
 - Operator control summary: [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md)
@@ -95,6 +96,7 @@ Run deterministic local demos:
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
 ./scripts/demo/gateway-auth.sh
+./scripts/demo/gateway-auth-session.sh
 ./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This index maps Tau documentation by audience and task.
 | Fresh-clone validator / demo operator | [Demo Index Guide](guides/demo-index.md) | Deterministic onboarding, gateway auth, multi-channel live ingest, and deployment WASM demos |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
+| Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |

--- a/docs/guides/gateway-auth-session-smoke.md
+++ b/docs/guides/gateway-auth-session-smoke.md
@@ -1,0 +1,53 @@
+# Gateway Auth Session Smoke
+
+Run all commands from repository root.
+
+This runbook validates gateway password-session auth end-to-end:
+- session issuance via `POST /gateway/auth/session`
+- authorized `GET /gateway/status` with issued bearer token
+- fail-closed invalid password behavior
+- fail-closed expired token behavior
+
+## Command
+
+```bash
+./scripts/demo/gateway-auth-session.sh
+```
+
+Optional timeout per step:
+
+```bash
+./scripts/demo/gateway-auth-session.sh --timeout-seconds 20
+```
+
+## Expected markers
+
+The script must print these PASS markers:
+- `[demo:gateway-auth-session] PASS wait-for-gateway-startup`
+- `[demo:gateway-auth-session] PASS gateway-auth-session-issue-valid-password`
+- `[demo:gateway-auth-session] PASS gateway-status-authorized-with-issued-token`
+- `[demo:gateway-auth-session] PASS gateway-auth-session-invalid-password-fails-closed`
+- `[demo:gateway-auth-session] PASS gateway-status-expired-token-fails-closed`
+- `[demo:gateway-auth-session] summary: total=5 passed=5 failed=0`
+
+## Troubleshooting
+
+- Startup timeout:
+  - confirm localhost port binding is available and no policy blocks loopback listeners.
+  - inspect `.tau/demo-gateway-auth-session/gateway-openresponses.log`.
+
+- Valid password step fails:
+  - verify local process launch arguments include `--gateway-openresponses-auth-mode password-session`.
+  - verify `--gateway-openresponses-auth-password` is non-empty.
+
+- Authorized status step fails:
+  - verify issued token from session endpoint is non-empty.
+  - verify auth header is sent as `Authorization: Bearer <token>`.
+
+- Invalid password step does not fail closed:
+  - verify wrong password payload is being sent.
+  - verify endpoint returns HTTP `401`.
+
+- Expired token step does not fail closed:
+  - verify session TTL remains short in smoke mode and check host clock skew.
+  - verify expired token requests return HTTP `401`.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -153,6 +153,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh
 ./scripts/demo/gateway-auth.sh
+./scripts/demo/gateway-auth-session.sh
 ./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh

--- a/scripts/demo/gateway-auth-session.sh
+++ b/scripts/demo/gateway-auth-session.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "gateway-auth-session" "Run deterministic gateway password-session auth smoke against /gateway/auth/session and /gateway/status." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+tau_demo_common_require_command python3
+tau_demo_common_prepare_binary
+
+demo_state_dir=".tau/demo-gateway-auth-session"
+session_ttl_seconds=1
+gateway_password="demo-gateway-password"
+server_pid=""
+step_total=0
+step_passed=0
+
+mkdir -p "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+server_log_path="${TAU_DEMO_REPO_ROOT}/${demo_state_dir}/gateway-openresponses.log"
+
+cleanup() {
+  if [[ -n "${server_pid}" ]]; then
+    if kill -0 "${server_pid}" >/dev/null 2>&1; then
+      kill "${server_pid}" >/dev/null 2>&1 || true
+      wait "${server_pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+demo_log() {
+  local message="$1"
+  echo "[demo:${TAU_DEMO_NAME}] ${message}"
+}
+
+run_step_command() {
+  if [[ -z "${TAU_DEMO_TIMEOUT_SECONDS}" ]]; then
+    "$@"
+    return $?
+  fi
+
+  python3 - "${TAU_DEMO_TIMEOUT_SECONDS}" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout_seconds = int(sys.argv[1])
+args = sys.argv[2:]
+
+try:
+    completed = subprocess.run(args, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+
+sys.exit(completed.returncode)
+PY
+}
+
+step_begin() {
+  local label="$1"
+  step_total=$((step_total + 1))
+  demo_log "[${step_total}] ${label}"
+}
+
+step_pass() {
+  local label="$1"
+  step_passed=$((step_passed + 1))
+  demo_log "PASS ${label}"
+}
+
+step_fail() {
+  local label="$1"
+  local rc="$2"
+  if [[ "${rc}" -eq 124 && -n "${TAU_DEMO_TIMEOUT_SECONDS}" ]]; then
+    demo_log "TIMEOUT ${label} after ${TAU_DEMO_TIMEOUT_SECONDS}s"
+  else
+    demo_log "FAIL ${label} exit=${rc}"
+  fi
+  return "${rc}"
+}
+
+gateway_bind="$(python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(f"127.0.0.1:{sock.getsockname()[1]}")
+PY
+)"
+gateway_url="http://${gateway_bind}"
+
+demo_log "starting gateway server: ${gateway_url}"
+(
+  cd "${TAU_DEMO_REPO_ROOT}"
+  "${TAU_DEMO_BINARY}" \
+    --model openai/gpt-4o-mini \
+    --gateway-openresponses-server \
+    --gateway-openresponses-bind "${gateway_bind}" \
+    --gateway-openresponses-auth-mode password-session \
+    --gateway-openresponses-auth-password "${gateway_password}" \
+    --gateway-openresponses-session-ttl-seconds "${session_ttl_seconds}" \
+    --gateway-state-dir "${demo_state_dir}" \
+    >"${server_log_path}" 2>&1
+) &
+server_pid=$!
+
+step_begin "wait-for-gateway-startup"
+if run_step_command python3 - "${gateway_bind}" <<'PY'
+import socket
+import sys
+import time
+
+host, raw_port = sys.argv[1].split(":", 1)
+port = int(raw_port)
+deadline = time.time() + 10.0
+
+while time.time() < deadline:
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            raise SystemExit(0)
+    except OSError:
+        time.sleep(0.1)
+
+print(f"gateway server did not start within timeout: {host}:{port}", file=sys.stderr)
+raise SystemExit(1)
+PY
+then
+  step_pass "wait-for-gateway-startup"
+else
+  rc=$?
+  step_fail "wait-for-gateway-startup" "${rc}"
+fi
+
+step_begin "gateway-auth-session-issue-valid-password"
+if session_token="$(run_step_command python3 - "${gateway_url}" "${gateway_password}" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+gateway_url = sys.argv[1]
+password = sys.argv[2]
+url = f"{gateway_url}/gateway/auth/session"
+body = json.dumps({"password": password}).encode("utf-8")
+request = urllib.request.Request(
+    url,
+    data=body,
+    method="POST",
+    headers={"content-type": "application/json"},
+)
+
+try:
+    with urllib.request.urlopen(request, timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+except urllib.error.HTTPError as error:
+    print(f"unexpected HTTP status for valid password: {error.code}", file=sys.stderr)
+    raise SystemExit(1)
+
+token = payload.get("access_token")
+if not isinstance(token, str) or not token:
+    print("missing access_token in auth session response", file=sys.stderr)
+    raise SystemExit(1)
+
+print(token)
+PY
+)"; then
+  step_pass "gateway-auth-session-issue-valid-password"
+else
+  rc=$?
+  step_fail "gateway-auth-session-issue-valid-password" "${rc}"
+fi
+
+step_begin "gateway-status-authorized-with-issued-token"
+if run_step_command python3 - "${gateway_url}" "${session_token}" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+gateway_url = sys.argv[1]
+token = sys.argv[2]
+request = urllib.request.Request(
+    f"{gateway_url}/gateway/status",
+    method="GET",
+    headers={"authorization": f"Bearer {token}"},
+)
+
+try:
+    with urllib.request.urlopen(request, timeout=5) as response:
+        if response.status != 200:
+            print(f"unexpected status code: {response.status}", file=sys.stderr)
+            raise SystemExit(1)
+        payload = json.loads(response.read().decode("utf-8"))
+except urllib.error.HTTPError as error:
+    print(f"unexpected HTTP status for authorized status call: {error.code}", file=sys.stderr)
+    raise SystemExit(1)
+
+if not isinstance(payload, dict):
+    print("gateway status response payload is not an object", file=sys.stderr)
+    raise SystemExit(1)
+if "auth" not in payload:
+    print("gateway status response missing auth section", file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  step_pass "gateway-status-authorized-with-issued-token"
+else
+  rc=$?
+  step_fail "gateway-status-authorized-with-issued-token" "${rc}"
+fi
+
+step_begin "gateway-auth-session-invalid-password-fails-closed"
+if run_step_command python3 - "${gateway_url}" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+gateway_url = sys.argv[1]
+url = f"{gateway_url}/gateway/auth/session"
+body = json.dumps({"password": "wrong-password"}).encode("utf-8")
+request = urllib.request.Request(
+    url,
+    data=body,
+    method="POST",
+    headers={"content-type": "application/json"},
+)
+
+try:
+    urllib.request.urlopen(request, timeout=5)
+except urllib.error.HTTPError as error:
+    if error.code == 401:
+        raise SystemExit(0)
+    print(f"unexpected HTTP status for invalid password: {error.code}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("invalid password unexpectedly accepted", file=sys.stderr)
+raise SystemExit(1)
+PY
+then
+  step_pass "gateway-auth-session-invalid-password-fails-closed"
+else
+  rc=$?
+  step_fail "gateway-auth-session-invalid-password-fails-closed" "${rc}"
+fi
+
+step_begin "gateway-status-expired-token-fails-closed"
+if run_step_command python3 - "${gateway_url}" "${session_token}" <<'PY'
+import sys
+import time
+import urllib.error
+import urllib.request
+
+gateway_url = sys.argv[1]
+token = sys.argv[2]
+time.sleep(2.2)
+request = urllib.request.Request(
+    f"{gateway_url}/gateway/status",
+    method="GET",
+    headers={"authorization": f"Bearer {token}"},
+)
+
+try:
+    urllib.request.urlopen(request, timeout=5)
+except urllib.error.HTTPError as error:
+    if error.code == 401:
+        raise SystemExit(0)
+    print(f"unexpected HTTP status for expired token: {error.code}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("expired token unexpectedly accepted", file=sys.stderr)
+raise SystemExit(1)
+PY
+then
+  step_pass "gateway-status-expired-token-fails-closed"
+else
+  rc=$?
+  step_fail "gateway-status-expired-token-fails-closed" "${rc}"
+fi
+
+failed=$((step_total - step_passed))
+demo_log "summary: total=${step_total} passed=${step_passed} failed=${failed}"
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add deterministic auth-session smoke wrapper `scripts/demo/gateway-auth-session.sh`
- validate end-to-end password-session flow:
  - issue token via `POST /gateway/auth/session`
  - call protected `GET /gateway/status` with issued bearer token
  - verify invalid-password fail-closed (`401`)
  - verify expired-token fail-closed (`401`)
- add runbook `docs/guides/gateway-auth-session-smoke.md`
- link new runbook/command in docs index, quickstart, and root README
- add helper tests in `.github/scripts/test_gateway_auth_session_demo.py`

## Risks and compatibility
- low runtime risk: changes are additive and isolated to a new demo wrapper + docs/tests
- no API behavior changes in gateway runtime; this story exercises existing auth endpoints in a deterministic smoke path
- low CI cost impact: helper tests are lightweight; no default CI lane expansion required

## Validation
- `./scripts/demo/gateway-auth-session.sh --timeout-seconds 30`
- `python3 -m unittest discover -s .github/scripts -p "test_gateway_auth_session_demo.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `cargo test -p tau-coding-agent gateway_auth_session`
- `cargo test -p tau-coding-agent password_session_token_expires_and_fails_closed`
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`

Closes #897
