### PR TITLE
feat: add operator control summary snapshot compare and drift diff

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -974,6 +974,24 @@ pub(crate) struct Cli {
     pub(crate) operator_control_summary_json: bool,
 
     #[arg(
+        long = "operator-control-summary-snapshot-out",
+        env = "TAU_OPERATOR_CONTROL_SUMMARY_SNAPSHOT_OUT",
+        value_name = "PATH",
+        requires = "operator_control_summary",
+        help = "Write current --operator-control-summary report as JSON snapshot to PATH"
+    )]
+    pub(crate) operator_control_summary_snapshot_out: Option<PathBuf>,
+
+    #[arg(
+        long = "operator-control-summary-compare",
+        env = "TAU_OPERATOR_CONTROL_SUMMARY_COMPARE",
+        value_name = "PATH",
+        requires = "operator_control_summary",
+        help = "Compare current --operator-control-summary report against a baseline snapshot JSON at PATH"
+    )]
+    pub(crate) operator_control_summary_compare: Option<PathBuf>,
+
+    #[arg(
         long = "dashboard-status-inspect",
         env = "TAU_DASHBOARD_STATUS_INSPECT",
         conflicts_with = "channel_store_inspect",

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -400,6 +400,8 @@ fn test_cli() -> Cli {
         github_status_json: false,
         operator_control_summary: false,
         operator_control_summary_json: false,
+        operator_control_summary_snapshot_out: None,
+        operator_control_summary_compare: None,
         dashboard_status_inspect: false,
         dashboard_status_json: false,
         multi_channel_status_inspect: false,
@@ -2837,9 +2839,56 @@ fn functional_cli_operator_control_summary_accepts_json_mode() {
 }
 
 #[test]
+fn functional_cli_operator_control_summary_accepts_snapshot_and_compare_paths() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--operator-control-summary",
+        "--operator-control-summary-compare",
+        ".tau/operator-control-baseline.json",
+        "--operator-control-summary-snapshot-out",
+        ".tau/operator-control-current.json",
+    ]);
+    assert!(cli.operator_control_summary);
+    assert_eq!(
+        cli.operator_control_summary_compare,
+        Some(PathBuf::from(".tau/operator-control-baseline.json"))
+    );
+    assert_eq!(
+        cli.operator_control_summary_snapshot_out,
+        Some(PathBuf::from(".tau/operator-control-current.json"))
+    );
+}
+
+#[test]
 fn regression_cli_operator_control_summary_json_requires_summary_mode() {
     let parse = try_parse_cli_with_stack(["tau-rs", "--operator-control-summary-json"]);
     let error = parse.expect_err("json output should require summary flag");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn regression_cli_operator_control_summary_compare_requires_summary_mode() {
+    let parse = try_parse_cli_with_stack([
+        "tau-rs",
+        "--operator-control-summary-compare",
+        ".tau/operator-control-baseline.json",
+    ]);
+    let error = parse.expect_err("compare path should require summary flag");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn regression_cli_operator_control_summary_snapshot_out_requires_summary_mode() {
+    let parse = try_parse_cli_with_stack([
+        "tau-rs",
+        "--operator-control-summary-snapshot-out",
+        ".tau/operator-control-current.json",
+    ]);
+    let error = parse.expect_err("snapshot path should require summary flag");
     assert!(error
         .to_string()
         .contains("required arguments were not provided"));

--- a/docs/guides/operator-control-summary.md
+++ b/docs/guides/operator-control-summary.md
@@ -27,6 +27,31 @@ cargo run -p tau-coding-agent -- \
   --operator-control-summary-json
 ```
 
+Capture baseline snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary \
+  --operator-control-summary-snapshot-out .tau/reports/operator-control-baseline.json
+```
+
+Compare current state against baseline snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary \
+  --operator-control-summary-compare .tau/reports/operator-control-baseline.json
+```
+
+Compare in JSON mode:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --operator-control-summary \
+  --operator-control-summary-json \
+  --operator-control-summary-compare .tau/reports/operator-control-baseline.json
+```
+
 ## Output shape
 
 Top-level fields:
@@ -38,6 +63,14 @@ Top-level fields:
 - `daemon`: daemon health and lifecycle posture
 - `release_channel`: release-channel configuration posture
 - `components[]`: per-component health rows with reason/recommendation and queue/failure counters
+
+When `--operator-control-summary-compare` is used:
+- `drift_state`: `stable|changed|improved|regressed`
+- `risk_level`: `low|moderate|high`
+- `reason_codes_added|reason_codes_removed`: aggregate reason-code deltas
+- `recommendations_added|recommendations_removed`: recommendation deltas
+- `changed_components[]`: per-component drift rows (`severity`, before/after state, queue/failure counters)
+- `unchanged_component_count`: stable component count
 
 ## Troubleshooting map
 


### PR DESCRIPTION
## Summary
- add operator control summary snapshot and compare CLI flags:
  - `--operator-control-summary-snapshot-out <PATH>`
  - `--operator-control-summary-compare <PATH>`
- add snapshot persistence/load flow for operator control summaries
- add deterministic drift diff report generation with:
  - drift classification (`stable|changed|improved|regressed`)
  - risk classification (`low|moderate|high`)
  - top-level reason/recommendation deltas
  - per-component before/after drift rows (state, reason, recommendation, queue/failure counters)
- add text and JSON diff rendering for compare mode
- add docs for baseline capture + compare workflows in `docs/guides/operator-control-summary.md`
- add tests for CLI parsing and diff/snapshot internals across unit/functional/integration/regression categories

## Risks and compatibility
- low-to-moderate runtime risk: feature is additive and only active when operator summary compare/snapshot flags are used
- existing `--operator-control-summary` behavior is unchanged when compare/snapshot flags are not supplied
- compare mode fails closed on missing/invalid snapshot files with explicit error contexts

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent operator_control_summary`
- `cargo run -p tau-coding-agent -- --operator-control-summary --operator-control-summary-snapshot-out /tmp/tau-operator-control-baseline.json`
- `cargo run -p tau-coding-agent -- --operator-control-summary --operator-control-summary-compare /tmp/tau-operator-control-baseline.json`
- `cargo run -p tau-coding-agent -- --operator-control-summary --operator-control-summary-json --operator-control-summary-compare /tmp/tau-operator-control-baseline.json`
- missing baseline regression: compare against a non-existent snapshot returns explicit read failure

Closes #897
