### PR TITLE
feat: add GitHub issue demo-index list/run/report commands

### DIFF
--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -108,6 +108,9 @@ pub(crate) async fn run_transport_mode_if_requested(
             retry_max_attempts: cli.github_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.github_retry_base_delay_ms.max(1),
             artifact_retention_days: cli.github_artifact_retention_days,
+            demo_index_repo_root: None,
+            demo_index_script_path: None,
+            demo_index_binary_path: None,
         })
         .await?;
         return Ok(true);

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -51,6 +51,12 @@ Bridge control commands in issue comments:
 - `/tau stop`
 - `/tau chat start|resume|reset|status|summary|replay|show|search|export`
 - `/tau artifacts|artifacts run <run_id>|artifacts show <artifact_id>|artifacts purge`
+- `/tau demo-index list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report`
+
+Demo-index commands for issue-driven demos:
+- `/tau demo-index list`: show allowlisted scenarios and expected markers.
+- `/tau demo-index run onboarding,gateway-auth --timeout-seconds 120`: execute bounded demo scenarios from the issue thread and persist report/log artifacts.
+- `/tau demo-index report`: show latest demo-index report artifact pointers for the issue channel.
 
 Inspect deterministic GitHub bridge state/report output:
 


### PR DESCRIPTION
Closes #899

## Summary
- add new GitHub issue bridge commands:
  - `/tau demo-index list`
  - `/tau demo-index run [scenario[,scenario...]] [--timeout-seconds <n>]`
  - `/tau demo-index report`
- enforce bounded, allowlisted demo-index execution for issue-driven workflows using the existing `scripts/demo/index.sh` path
- persist demo-index report/log artifacts in issue channel-store and surface artifact pointers in issue comments
- extend command parser/help text, RBAC action mapping (`command:/tau-demo-index`), and transport docs for operator usage

## Risks and Compatibility
- no breaking CLI flag changes; behavior is additive to GitHub issue bridge command handling
- demo-index run command now depends on `scripts/demo/index.sh` availability in the runtime environment; failures are surfaced as command failure comments
- added runtime config fields for demo-index path overrides (used for testability); startup path keeps defaults (no user-facing flag changes)

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent demo_index`
- `cargo test -p tau-coding-agent github_issues::tests::unit_parse_tau_issue_command_supports_known_commands`
- `cargo test -p tau-coding-agent`
