### PR TITLE
feat(github): add /tau doctor diagnostics command for issue bridge

### DIFF
--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -111,6 +111,19 @@ pub(crate) async fn run_transport_mode_if_requested(
             demo_index_repo_root: None,
             demo_index_script_path: None,
             demo_index_binary_path: None,
+            doctor_config: {
+                let fallback_model_refs = Vec::new();
+                let skills_lock_path = default_skills_lock_path(&cli.skills_dir);
+                let mut config = build_doctor_command_config(
+                    cli,
+                    model_ref,
+                    &fallback_model_refs,
+                    &skills_lock_path,
+                );
+                config.skills_dir = cli.skills_dir.clone();
+                config.skills_lock_path = skills_lock_path;
+                config
+            },
         })
         .await?;
         return Ok(true);

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -48,10 +48,15 @@ Bridge control commands in issue comments:
 - `/tau help`
 - `/tau status`
 - `/tau health`
+- `/tau doctor [--online]`
 - `/tau stop`
 - `/tau chat start|resume|reset|status|summary|replay|show|search|export`
 - `/tau artifacts|artifacts run <run_id>|artifacts show <artifact_id>|artifacts purge`
 - `/tau demo-index list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report`
+
+Doctor diagnostics command:
+- `/tau doctor`: run bounded local diagnostics and post summary plus artifact pointers.
+- `/tau doctor --online`: include remote release-update lookup (network dependent).
 
 Demo-index commands for issue-driven demos:
 - `/tau demo-index list`: show allowlisted scenarios and expected markers.


### PR DESCRIPTION
## Summary
- add GitHub issue command support for `/tau doctor` and `/tau doctor --online`
- execute doctor diagnostics from the GitHub bridge runtime using existing doctor checks
- persist detailed diagnostics output as channel-store artifacts and return stable pointers in issue comments
- add replay-safe parser/execution coverage and update transport docs

Closes #904

## Risks and compatibility
- adds a new command surface and RBAC action (`command:/tau-doctor`) for issue-driven operations
- GitHub bridge now requires doctor runtime config wiring at startup; defaults remain bounded/offline unless `--online` is explicitly requested in issue command
- no behavior change for existing `/tau` issue commands

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent unit_parse_tau_issue_command_supports_known_commands`
- `cargo test -p tau-coding-agent functional_bridge_doctor_command_reports_summary_and_artifact_pointers`
- `cargo test -p tau-coding-agent integration_bridge_doctor_command_persists_report_artifacts`
- `cargo test -p tau-coding-agent regression_bridge_doctor_command_replay_guard_prevents_duplicate_execution`
- `cargo test -p tau-coding-agent`
