### PR TITLE
feat(github): add /tau auth diagnostics commands for issue bridge

### DIFF
--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -108,6 +108,7 @@ pub(crate) async fn run_transport_mode_if_requested(
             retry_max_attempts: cli.github_retry_max_attempts.max(1),
             retry_base_delay_ms: cli.github_retry_base_delay_ms.max(1),
             artifact_retention_days: cli.github_artifact_retention_days,
+            auth_command_config: build_auth_command_config(cli),
             demo_index_repo_root: None,
             demo_index_script_path: None,
             demo_index_binary_path: None,

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -48,11 +48,16 @@ Bridge control commands in issue comments:
 - `/tau help`
 - `/tau status`
 - `/tau health`
+- `/tau auth <status|matrix> ...`
 - `/tau doctor [--online]`
 - `/tau stop`
 - `/tau chat start|resume|reset|status|summary|replay|show|search|export`
 - `/tau artifacts|artifacts run <run_id>|artifacts show <artifact_id>|artifacts purge`
 - `/tau demo-index list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report`
+
+Auth diagnostics commands:
+- `/tau auth status`: report provider auth posture with strict-subscription context.
+- `/tau auth matrix`: report cross-provider mode/availability matrix and filters.
 
 Doctor diagnostics command:
 - `/tau doctor`: run bounded local diagnostics and post summary plus artifact pointers.


### PR DESCRIPTION
## Summary
- add GitHub issue command support for `/tau auth status ...` and `/tau auth matrix ...`
- restrict issue-side auth commands to diagnostics-only subcommands (no login/logout mutations)
- execute auth diagnostics through existing auth command stack and persist text+JSON artifacts
- include explicit provider auth posture and strict subscription mode status in issue comment output
- update issue command help/docs and RBAC action mapping (`command:/tau-auth-status`, `command:/tau-auth-matrix`)

Closes #905

## Risks and compatibility
- expands GitHub issue command surface with read-only auth diagnostics
- GitHub bridge startup now carries `auth_command_config` for deterministic issue diagnostics
- no behavioral change to existing local `/auth` command semantics

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent unit_parse_tau_issue_command_supports_known_commands`
- `cargo test -p tau-coding-agent regression_parse_tau_issue_command_rejects_slash_like_inputs`
- `cargo test -p tau-coding-agent functional_bridge_auth_status_command_reports_summary_and_artifact_pointers`
- `cargo test -p tau-coding-agent integration_bridge_auth_matrix_command_persists_report_artifacts`
- `cargo test -p tau-coding-agent regression_bridge_auth_status_command_replay_guard_prevents_duplicate_execution`
- `cargo test -p tau-coding-agent`
