### PR TITLE
Story #906: GitHub issue command UX hardening

### DIFF
--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -55,6 +55,17 @@ Bridge control commands in issue comments:
 - `/tau artifacts|artifacts run <run_id>|artifacts show <artifact_id>|artifacts purge`
 - `/tau demo-index list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report`
 
+Issue command response schema (normalized):
+- Footer format: ``Tau command `<command>` | status `<status>` | reason_code `<reason_code>` ``.
+- Status taxonomy:
+- `acknowledged`: command accepted (for example stop/cancel acknowledgement).
+- `reported`: command completed and returned diagnostics/control output.
+- `failed`: command execution failed.
+- Artifact pointers: `label: id=\`...\` path=\`...\` bytes=\`...\``.
+- Oversized command output is truncated deterministically and spilled to a channel-store artifact:
+- `output_truncated: true`
+- `overflow_artifact: id=\`...\` path=\`...\` bytes=\`...\``
+
 Auth diagnostics commands:
 - `/tau auth status`: report provider auth posture with strict-subscription context.
 - `/tau auth matrix`: report cross-provider mode/availability matrix and filters.


### PR DESCRIPTION
Closes #906

## Summary of behavior changes
- Normalized issue-command footer schema to include stable `status` and `reason_code` fields.
- Standardized artifact pointer rendering for issue command outputs.
- Added deterministic oversized-output truncation with artifact spillover (`github-issue-command-overflow`).
- Added outbound log records that include normalized `status`, `reason_code`, and overflow artifact metadata.
- Updated transport guide with response schema/operator interpretation.

## Risks and compatibility notes
- Footer format changed to include `reason_code`; consumers parsing old footer format must tolerate/accept this added field.
- Oversized issue command responses now spill to artifact records and include `output_truncated: true` metadata.
- Status values are normalized (`acknowledged|reported|failed`) to improve machine-scannability.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent`
- Targeted tests for schema normalization, outbound log reason-codes, and overflow spillover behavior.
