### PR TITLE
feat(multi-channel): native /tau command surface with RBAC and metadata

### DIFF
--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -205,6 +205,8 @@ pub(crate) async fn run_transport_mode_if_requested(
     }
 
     if cli.multi_channel_contract_runner {
+        let fallback_model_refs = Vec::new();
+        let skills_lock_path = default_skills_lock_path(&cli.skills_dir);
         run_multi_channel_contract_runner(MultiChannelRuntimeConfig {
             fixture_path: cli.multi_channel_fixture.clone(),
             state_dir: cli.multi_channel_state_dir.clone(),
@@ -217,12 +219,21 @@ pub(crate) async fn run_transport_mode_if_requested(
             outbound: build_multi_channel_outbound_config(cli),
             telemetry: build_multi_channel_telemetry_config(cli),
             media: build_multi_channel_media_config(cli),
+            auth_command_config: build_auth_command_config(cli),
+            doctor_config: build_doctor_command_config(
+                cli,
+                model_ref,
+                &fallback_model_refs,
+                &skills_lock_path,
+            ),
         })
         .await?;
         return Ok(true);
     }
 
     if cli.multi_channel_live_runner {
+        let fallback_model_refs = Vec::new();
+        let skills_lock_path = default_skills_lock_path(&cli.skills_dir);
         run_multi_channel_live_runner(MultiChannelLiveRuntimeConfig {
             ingress_dir: cli.multi_channel_live_ingress_dir.clone(),
             state_dir: cli.multi_channel_state_dir.clone(),
@@ -235,6 +246,13 @@ pub(crate) async fn run_transport_mode_if_requested(
             outbound: build_multi_channel_outbound_config(cli),
             telemetry: build_multi_channel_telemetry_config(cli),
             media: build_multi_channel_media_config(cli),
+            auth_command_config: build_auth_command_config(cli),
+            doctor_config: build_doctor_command_config(
+                cli,
+                model_ref,
+                &fallback_model_refs,
+                &skills_lock_path,
+            ),
         })
         .await?;
         return Ok(true);

--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -353,6 +353,36 @@ Lifecycle reason codes include:
 - `credential_store_unreadable`
 - `logout_requested`
 
+## Native `/tau` commands in channel messages
+
+Multi-channel runtime now intercepts `/tau ...` messages and executes a bounded operator command
+surface directly from inbound Telegram/Discord/WhatsApp events.
+
+Supported commands:
+
+- `/tau help`
+- `/tau status`
+- `/tau auth status [openai|anthropic|google]`
+- `/tau doctor [--online]`
+
+Command responses include a normalized footer:
+
+- `Tau command /tau <command> | status <reported|failed> | reason_code <...>`
+
+Command metadata is persisted in outbound channel-store log payloads under:
+
+- `command.schema` = `multi_channel_tau_command_v1`
+- `command.command`
+- `command.status`
+- `command.reason_code`
+
+Operator scope rule:
+
+- `/tau auth status` and `/tau doctor` require allowlisted operator scope
+  (`allow_allowlist` or `allow_allowlist_and_pairing` pairing outcomes).
+- When scope is insufficient, command execution fails closed with
+  `command_rbac_denied`.
+
 ## Outbound delivery modes
 
 Multi-channel runtime supports outbound modes:


### PR DESCRIPTION
## Summary
- add native `/tau` command parsing and execution for multi-channel ingress events
- implement initial command set: `/tau help`, `/tau status`, `/tau auth status [provider]`, `/tau doctor [--online]`
- enforce operator scope for sensitive commands and fail closed with deterministic reason codes
- persist normalized command metadata (`command`, `status`, `reason_code`, `schema`) in outbound payloads
- wire auth/doctor command config into multi-channel runtime startup paths
- document command behavior and metadata contract in multi-channel ops guide

## Risks and Compatibility
- extends inbound message handling by intercepting slash commands prefixed with `/tau`; non-command message routing remains unchanged
- sensitive commands now require allowlisted operator scope in multi-channel runtime; unauthorized callers receive explicit denial reason code
- outbound payloads now include optional `command` metadata object for command responses; consumers expecting strict payload shape should tolerate additive fields

## Validation Evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent`

Closes #911
