### PR TITLE
feat(multi-channel): bridge /tau approvals workflow in-channel

### DIFF
--- a/docs/guides/multi-channel-ops.md
+++ b/docs/guides/multi-channel-ops.md
@@ -443,6 +443,9 @@ Supported commands:
 - `/tau status`
 - `/tau auth status [openai|anthropic|google]`
 - `/tau doctor [--online]`
+- `/tau approvals list [--json] [--status pending|approved|rejected|expired|consumed]`
+- `/tau approvals approve <request_id> [reason]`
+- `/tau approvals reject <request_id> [reason]`
 
 Command responses include a normalized footer:
 
@@ -457,10 +460,12 @@ Command metadata is persisted in outbound channel-store log payloads under:
 
 Operator scope rule:
 
-- `/tau auth status` and `/tau doctor` require allowlisted operator scope
-  (`allow_allowlist` or `allow_allowlist_and_pairing` pairing outcomes).
+- `/tau auth status`, `/tau doctor`, and all `/tau approvals ...` commands require allowlisted
+  operator scope (`allow_allowlist` or `allow_allowlist_and_pairing` pairing outcomes).
 - When scope is insufficient, command execution fails closed with
   `command_rbac_denied`.
+- Approval decisions also persist `decision_actor` from transport actor mapping
+  (`<transport>:<conversation_id>:<actor_id>`) to keep review actions auditable.
 
 ## Outbound delivery modes
 


### PR DESCRIPTION
## Summary
- extend native in-channel `/tau` command parser and execution flow with:
  - `/tau approvals list [--json] [--status pending|approved|rejected|expired|consumed]`
  - `/tau approvals approve <request_id> [reason]`
  - `/tau approvals reject <request_id> [reason]`
- bridge approvals command execution into multi-channel runtime with deterministic reason-code mapping
- persist approval decision actors from transport mapping (`<transport>:<conversation_id>:<actor_id>`) for in-channel approve/reject auditability
- route approvals policy/store paths from runtime state roots for deterministic transport-scoped runs
- add command/parser and runtime behavior tests across unit/functional/integration/regression categories
- update multi-channel ops runbook for the new approvals command surface and actor audit behavior

## Risks and Compatibility
- `/tau approvals ...` now joins operator-scoped command set and requires allowlisted operator scope in-channel
- approval command failures now map to deterministic reason-codes (`command_approvals_*`) in command metadata
- approve/reject flows now stamp `decision_actor` from transport identity when invoked via in-channel command bridge
- additive behavior only; existing `/tau help|status|auth status|doctor` paths remain compatible

## Validation Evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent approvals::tests:: -- --test-threads=1`
- `cargo test -p tau-coding-agent parse_multi_channel_tau_command -- --test-threads=1`
- `cargo test -p tau-coding-agent tau_approvals_ -- --test-threads=1`
- `cargo test -p tau-coding-agent`

Closes #914