### PR TITLE
feat: extend WASM packaging for channel automation runtime (#918)

### DIFF
--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -269,12 +269,14 @@ impl From<CliMultiChannelOutboundMode> for MultiChannelOutboundMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum CliDeploymentWasmRuntimeProfile {
     WasmWasi,
+    ChannelAutomationWasi,
 }
 
 impl CliDeploymentWasmRuntimeProfile {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             CliDeploymentWasmRuntimeProfile::WasmWasi => "wasm_wasi",
+            CliDeploymentWasmRuntimeProfile::ChannelAutomationWasi => "channel_automation_wasi",
         }
     }
 }

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -2427,6 +2427,21 @@ fn functional_cli_deployment_wasm_package_flags_accept_explicit_overrides() {
 }
 
 #[test]
+fn functional_cli_deployment_wasm_package_runtime_profile_accepts_channel_automation_wasi() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--deployment-wasm-package-module",
+        "fixtures/edge.wasm",
+        "--deployment-wasm-package-runtime-profile",
+        "channel-automation-wasi",
+    ]);
+    assert_eq!(
+        cli.deployment_wasm_package_runtime_profile,
+        CliDeploymentWasmRuntimeProfile::ChannelAutomationWasi
+    );
+}
+
+#[test]
 fn regression_cli_deployment_wasm_package_json_requires_module_flag() {
     let parse = try_parse_cli_with_stack(["tau-rs", "--deployment-wasm-package-json"]);
     let error = parse.expect_err("package json should require package module");

--- a/docs/guides/deployment-ops.md
+++ b/docs/guides/deployment-ops.md
@@ -66,6 +66,18 @@ cargo run -p tau-coding-agent -- \
   --deployment-wasm-package-json
 ```
 
+Package channel-automation runtime profile artifact:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --deployment-state-dir .tau/deployment \
+  --deployment-wasm-package-module ./crates/tau-coding-agent/testdata/deployment-wasm/edge-runtime.wasm \
+  --deployment-wasm-package-blueprint-id channel-automation-wasm \
+  --deployment-wasm-package-runtime-profile channel-automation-wasi \
+  --deployment-wasm-package-output-dir .tau/deployment/wasm-artifacts \
+  --deployment-wasm-package-json
+```
+
 Manifest guarantees:
 
 - deterministic SHA-256 hash (`artifact_sha256`)
@@ -79,8 +91,9 @@ Manifest guarantees:
 Compatibility matrix:
 
 - Supported `deploy_target`: `wasm`
-- Supported runtime profile(s): `wasm_wasi`
-- Control-plane profile: `control_plane_gateway_v1`
+- Supported runtime profile(s): `wasm_wasi`, `channel_automation_wasi`
+- Runtime constraint profile (`wasm_wasi`): `control_plane_gateway_v1`
+- Runtime constraint profile (`channel_automation_wasi`): `channel_automation_runtime_v1`
 - Required module format: valid WASM binary magic header (`\\0asm`)
 - Unsupported in this path: native/container image packaging, host capability negotiation, and runtime sandbox policy synthesis
 
@@ -97,6 +110,9 @@ cargo run -p tau-coding-agent -- \
 Inspect report fields include:
 
 - `constraint_profile_id`
+- `constraint_target_role`
+- `required_runtime_profile`
+- `required_abi`
 - `compliant`
 - `reason_codes`
 - `observed_import_modules`


### PR DESCRIPTION
Closes #918

## Summary
- added `channel_automation_wasi` as a supported `--deployment-wasm-package-runtime-profile` option
- added deterministic runtime-constraint profile mapping for `wasm_wasi` and `channel_automation_wasi`
- added fail-closed manifest validation against expected profile ID, target role, ABI, feature gates, import module policy, and max artifact size
- added channel-automation capability/feature gate requirement (`channel_event_dispatch_host_capability`) for packaged manifests
- extended inspect report posture with `constraint_target_role`, `required_runtime_profile`, and `required_abi`
- updated deployment runbook with channel-automation packaging guidance and compatibility matrix

## Risks and Compatibility
- backward compatible for existing `wasm_wasi` manifests generated by Tau
- validation is intentionally stricter and now rejects runtime-constraint drift that previously could pass generic checks
- new runtime profile is additive and opt-in via CLI

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent deployment_wasm -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
