### PR TITLE
feat: add Tailscale gateway remote profiles (#928)

### DIFF
--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -144,6 +144,8 @@ pub(crate) enum CliGatewayRemoteProfile {
     LocalOnly,
     PasswordRemote,
     ProxyRemote,
+    TailscaleServe,
+    TailscaleFunnel,
 }
 
 impl CliGatewayRemoteProfile {
@@ -152,6 +154,8 @@ impl CliGatewayRemoteProfile {
             CliGatewayRemoteProfile::LocalOnly => "local-only",
             CliGatewayRemoteProfile::PasswordRemote => "password-remote",
             CliGatewayRemoteProfile::ProxyRemote => "proxy-remote",
+            CliGatewayRemoteProfile::TailscaleServe => "tailscale-serve",
+            CliGatewayRemoteProfile::TailscaleFunnel => "tailscale-funnel",
         }
     }
 }

--- a/docs/guides/gateway-remote-access.md
+++ b/docs/guides/gateway-remote-access.md
@@ -10,6 +10,8 @@ Profiles:
 - `local-only`
 - `password-remote`
 - `proxy-remote`
+- `tailscale-serve`
+- `tailscale-funnel`
 
 ## Inspect posture without starting the gateway
 
@@ -40,6 +42,18 @@ cargo run -p tau-coding-agent -- \
   --gateway-openresponses-bind 127.0.0.1:8787
 ```
 
+Inspect a tailscale-funnel plan before rollout:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-profile-inspect \
+  --gateway-openresponses-server \
+  --gateway-remote-profile tailscale-funnel \
+  --gateway-openresponses-auth-mode password-session \
+  --gateway-openresponses-auth-password edge-password \
+  --gateway-openresponses-bind 127.0.0.1:8787
+```
+
 ## Profile guidance
 
 `local-only`:
@@ -55,6 +69,18 @@ cargo run -p tau-coding-agent -- \
 - intended for exposure behind a trusted reverse proxy or tunnel.
 - requires `--gateway-openresponses-auth-mode token`.
 - requires non-empty `--gateway-openresponses-auth-token`.
+
+`tailscale-serve`:
+- intended for tailnet-only exposure while preserving loopback bind on host.
+- requires loopback bind (`127.0.0.1` or `::1`).
+- requires auth mode `token` or `password-session` (localhost-dev is rejected).
+- requires corresponding non-empty auth secret.
+
+`tailscale-funnel`:
+- intended for public exposure through Tailscale Funnel.
+- requires loopback bind (`127.0.0.1` or `::1`).
+- requires `--gateway-openresponses-auth-mode password-session`.
+- requires non-empty `--gateway-openresponses-auth-password`.
 
 ## Security recommendations
 


### PR DESCRIPTION
Closes #928

## Summary
- added new gateway remote profiles `tailscale-serve` and `tailscale-funnel`
- enforced deterministic inspect posture + reason codes + recommendations for Tailscale exposure patterns
- added fail-closed gate validation for non-compliant profile/auth/bind combinations
- updated remote access runbook with Tailscale profile guidance
- added unit/functional/integration/regression coverage for new profile behaviors

## Risks and Compatibility
- backward compatible for existing profiles (`local-only`, `password-remote`, `proxy-remote`)
- stricter gating may reject previously accepted but unsafe Tailscale exposure configurations (intentional)

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent gateway_remote_profile -- --test-threads=1`
- `cargo test -p tau-coding-agent -- --test-threads=1`
