### PR TITLE
Extract tau-core utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,7 @@ dependencies = [
  "shell-words",
  "tau-agent-core",
  "tau-ai",
+ "tau-core",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2656,6 +2657,14 @@ dependencies = [
  "wait-timeout",
  "wasmparser",
  "yrs",
+]
+
+[[package]]
+name = "tau-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/tau-core",
   "crates/tau-ai",
   "crates/tau-agent-core",
   "crates/tau-tui",

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -16,6 +16,7 @@ cron.workspace = true
 ed25519-dalek.workspace = true
 futures-util.workspace = true
 hmac.workspace = true
+tau-core = { path = "../tau-core" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-ai = { path = "../tau-ai" }
 reqwest.workspace = true

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -1,5 +1,4 @@
 mod approvals;
-mod atomic_io;
 mod auth_commands;
 mod auth_types;
 mod bootstrap_helpers;
@@ -92,7 +91,6 @@ mod startup_prompt_composition;
 mod startup_resolution;
 mod startup_skills_bootstrap;
 mod startup_transport_modes;
-mod time_utils;
 mod tool_policy_config;
 mod tools;
 #[cfg(test)]
@@ -126,7 +124,7 @@ pub(crate) use crate::approvals::{
     evaluate_approval_gate, execute_approvals_command, ApprovalAction, ApprovalGateResult,
     APPROVALS_USAGE,
 };
-pub(crate) use crate::atomic_io::write_text_atomic;
+pub(crate) use tau_core::write_text_atomic;
 pub(crate) use crate::auth_commands::execute_auth_command;
 #[cfg(test)]
 pub(crate) use crate::auth_commands::{parse_auth_command, AuthCommand};
@@ -399,9 +397,7 @@ pub(crate) use crate::startup_resolution::{
 };
 pub(crate) use crate::startup_skills_bootstrap::run_startup_skills_bootstrap;
 pub(crate) use crate::startup_transport_modes::run_transport_mode_if_requested;
-pub(crate) use crate::time_utils::{
-    current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix,
-};
+pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
 #[cfg(test)]
 pub(crate) use crate::tool_policy_config::parse_sandbox_command_tokens;
 pub(crate) use crate::tool_policy_config::{build_tool_policy, tool_policy_to_json};

--- a/crates/tau-core/Cargo.toml
+++ b/crates/tau-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tau-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tau-core/src/atomic_io.rs
+++ b/crates/tau-core/src/atomic_io.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 
-use crate::current_unix_timestamp;
+use crate::time_utils::current_unix_timestamp;
 
-pub(crate) fn write_text_atomic(path: &Path, content: &str) -> Result<()> {
+pub fn write_text_atomic(path: &Path, content: &str) -> Result<()> {
     if path.as_os_str().is_empty() {
         bail!("destination path cannot be empty");
     }

--- a/crates/tau-core/src/lib.rs
+++ b/crates/tau-core/src/lib.rs
@@ -1,0 +1,39 @@
+pub mod atomic_io;
+pub mod time_utils;
+
+pub use atomic_io::write_text_atomic;
+pub use time_utils::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
+
+#[cfg(test)]
+mod tests {
+    use std::fs::read_to_string;
+
+    use super::*;
+
+    #[test]
+    fn time_utils_round_trip_bounds() {
+        let now_s = current_unix_timestamp();
+        let now_ms = current_unix_timestamp_ms();
+        let now_ms_s = now_ms / 1_000;
+        assert!(now_ms_s >= now_s);
+        assert!(now_ms_s <= now_s.saturating_add(1));
+    }
+
+    #[test]
+    fn is_expired_unix_respects_none_and_bounds() {
+        let now = current_unix_timestamp();
+        assert!(!is_expired_unix(None, now));
+        assert!(is_expired_unix(Some(now), now));
+        assert!(is_expired_unix(Some(now.saturating_sub(1)), now));
+        assert!(!is_expired_unix(Some(now.saturating_add(1)), now));
+    }
+
+    #[test]
+    fn write_text_atomic_writes_content() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.txt");
+        write_text_atomic(&path, "hello world").expect("write");
+        let contents = read_to_string(&path).expect("read");
+        assert_eq!(contents, "hello world");
+    }
+}

--- a/crates/tau-core/src/time_utils.rs
+++ b/crates/tau-core/src/time_utils.rs
@@ -1,4 +1,4 @@
-pub(crate) fn current_unix_timestamp_ms() -> u64 {
+pub fn current_unix_timestamp_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -7,13 +7,13 @@ pub(crate) fn current_unix_timestamp_ms() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-pub(crate) fn current_unix_timestamp() -> u64 {
+pub fn current_unix_timestamp() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
 }
 
-pub(crate) fn is_expired_unix(expires_unix: Option<u64>, now_unix: u64) -> bool {
+pub fn is_expired_unix(expires_unix: Option<u64>, now_unix: u64) -> bool {
     matches!(expires_unix, Some(value) if value <= now_unix)
 }


### PR DESCRIPTION
## Summary
- add new tau-core crate with time and atomic IO utilities
- wire tau-coding-agent to re-export tau-core utilities
- add unit tests for tau-core utilities

## Risks
- Low; shared utility relocation

## Validation
- cargo test -p tau-core
- cargo test -p tau-coding-agent -- --test-threads=1

Closes #937
