### PR TITLE
Move multi-agent runtime into tau-orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tau-core",
+ "tau-runtime",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -34,7 +34,6 @@ mod memory_contract;
 mod memory_runtime;
 mod model_catalog;
 mod multi_agent_router;
-mod multi_agent_runtime;
 mod multi_channel_adapters;
 mod multi_channel_contract;
 mod multi_channel_lifecycle;
@@ -382,7 +381,6 @@ use dashboard_runtime::{run_dashboard_contract_runner, DashboardRuntimeConfig};
 use deployment_runtime::{run_deployment_contract_runner, DeploymentRuntimeConfig};
 use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use memory_runtime::{run_memory_contract_runner, MemoryRuntimeConfig};
-use multi_agent_runtime::{run_multi_agent_contract_runner, MultiAgentRuntimeConfig};
 use multi_channel_runtime::{
     run_multi_channel_contract_runner, run_multi_channel_live_runner,
     MultiChannelLiveRuntimeConfig, MultiChannelRuntimeConfig,
@@ -409,6 +407,9 @@ pub(crate) use tau_access::trust_roots::{
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
 use tau_gateway::{run_gateway_contract_runner, GatewayRuntimeConfig};
+use tau_orchestrator::multi_agent_runtime::{
+    run_multi_agent_contract_runner, MultiAgentRuntimeConfig,
+};
 #[cfg(test)]
 pub(crate) use tau_orchestrator::parse_numbered_plan_steps;
 use voice_runtime::{run_voice_contract_runner, VoiceRuntimeConfig};

--- a/crates/tau-orchestrator/Cargo.toml
+++ b/crates/tau-orchestrator/Cargo.toml
@@ -9,7 +9,10 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tau-core = { path = "../tau-core" }
+tau-runtime = { path = "../tau-runtime" }
+tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/tau-orchestrator/src/lib.rs
+++ b/crates/tau-orchestrator/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod multi_agent_contract;
 pub mod multi_agent_router;
+pub mod multi_agent_runtime;
 pub mod orchestrator;
 
 pub use multi_agent_contract::*;
 pub use multi_agent_router::*;
+pub use multi_agent_runtime::*;
 pub use orchestrator::*;


### PR DESCRIPTION
## Summary\n- move multi-agent runtime/runner into tau-orchestrator\n- update tau-coding-agent to use orchestrator runtime API\n- add tau-runtime/tau-core/tokio deps for runtime state + health\n\n## Risks\n- runtime state/health persistence now comes from tau-runtime/tau-core; path or serialization changes could affect downstream tooling\n- contract runner wiring now routes through tau-orchestrator\n\n## Validation\n- cargo test -p tau-orchestrator\n- cargo test -p tau-coding-agent -- --test-threads=1\n\nCloses #975