### PR TITLE
Extract session subsystem into tau-session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tau-ai",
+ "tau-core",
  "tempfile",
 ]
 

--- a/crates/tau-coding-agent/src/canvas.rs
+++ b/crates/tau-coding-agent/src/canvas.rs
@@ -1423,7 +1423,7 @@ fn resolve_safe_canvas_path(canvas_dir: &Path, relative_path: &str) -> Result<Pa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::SessionStore;
+    use tau_session::SessionStore;
     use tempfile::tempdir;
 
     fn test_config(root: &Path) -> CanvasCommandConfig {

--- a/crates/tau-coding-agent/src/events.rs
+++ b/crates/tau-coding-agent/src/events.rs
@@ -13,11 +13,12 @@ use tau_events::{
     EventsTemplateConfig, EventsValidateConfig,
 };
 
+use crate::tools::ToolPolicy;
 use crate::{
     channel_store::ChannelLogEntry, current_unix_timestamp_ms, run_prompt_with_cancellation, Cli,
     CliEventTemplateSchedule, PromptRunStatus, RenderOptions, SessionRuntime,
 };
-use crate::{session::SessionStore, tools::ToolPolicy};
+use tau_session::SessionStore;
 
 pub(crate) use tau_events::{
     EventDefinition, EventWebhookIngestConfig, EventsDryRunReport, EventsInspectReport,

--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -34,7 +34,7 @@ use crate::github_transport_helpers::{
     truncate_for_error,
 };
 use crate::runtime_types::{AuthCommandConfig, DoctorCommandConfig};
-use crate::session_commands::{parse_session_search_args, search_session_entries};
+use crate::tools::ToolPolicy;
 use crate::{
     authorize_action_for_principal_with_policy_path, current_unix_timestamp_ms,
     evaluate_pairing_access, execute_canvas_command, github_principal,
@@ -43,7 +43,8 @@ use crate::{
     CanvasEventOrigin, CanvasSessionLinkContext, PairingDecision, PromptRunStatus, RbacDecision,
     RenderOptions, SessionRuntime, TransportHealthSnapshot,
 };
-use crate::{session::SessionStore, tools::ToolPolicy};
+use tau_session::SessionStore;
+use tau_session::{parse_session_search_args, search_session_entries};
 
 const GITHUB_STATE_SCHEMA_VERSION: u32 = 1;
 const GITHUB_COMMENT_MAX_CHARS: usize = 65_000;
@@ -3281,7 +3282,7 @@ impl GithubIssuesBridgeRuntime {
                         }
                         lines.push(format!(
                             "Note: previews truncated to {} chars.",
-                            crate::session_commands::SESSION_SEARCH_PREVIEW_CHARS
+                            tau_session::SESSION_SEARCH_PREVIEW_CHARS
                         ));
                     }
                     lines.join("\n")
@@ -5665,7 +5666,7 @@ fn compact_issue_session(
     session_path: &Path,
     lock_wait_ms: u64,
     lock_stale_ms: u64,
-) -> Result<crate::session::CompactReport> {
+) -> Result<tau_session::CompactReport> {
     if let Some(parent) = session_path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)
@@ -7177,7 +7178,7 @@ printf '%s\n' "${payload}"
             Some(TauIssueCommand::ChatSearch {
                 query: "alpha".to_string(),
                 role: None,
-                limit: crate::session_commands::SESSION_SEARCH_DEFAULT_RESULTS,
+                limit: tau_session::SESSION_SEARCH_DEFAULT_RESULTS,
             })
         );
         assert_eq!(

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -64,11 +64,6 @@ mod runtime_cli_validation;
 mod runtime_loop;
 mod runtime_output;
 mod runtime_types;
-mod session;
-mod session_commands;
-mod session_graph_commands;
-mod session_navigation_commands;
-mod session_runtime_helpers;
 mod skills;
 mod skills_commands;
 mod slack;
@@ -288,40 +283,7 @@ pub(crate) use crate::runtime_types::{
     AuthCommandConfig, CommandExecutionContext, DoctorCommandConfig,
     DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus, ProfileAuthDefaults,
     ProfileDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
-    RenderOptions, SessionRuntime, SkillsSyncCommandConfig,
-};
-use crate::session::{SessionImportMode, SessionStore};
-#[cfg(test)]
-pub(crate) use crate::session_commands::{
-    compute_session_entry_depths, compute_session_stats, execute_session_diff_command,
-    execute_session_search_command, execute_session_stats_command, parse_session_diff_args,
-    parse_session_search_args, parse_session_stats_args, render_session_diff, render_session_stats,
-    render_session_stats_json, search_session_entries, shared_lineage_prefix_depth,
-    SessionDiffEntry, SessionDiffReport, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
-    SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
-};
-pub(crate) use crate::session_commands::{session_message_preview, session_message_role};
-pub(crate) use crate::session_graph_commands::execute_session_graph_export_command;
-#[cfg(test)]
-pub(crate) use crate::session_graph_commands::{
-    escape_graph_label, render_session_graph_dot, render_session_graph_mermaid,
-    resolve_session_graph_format, SessionGraphFormat,
-};
-#[cfg(test)]
-pub(crate) use crate::session_navigation_commands::{
-    branch_alias_path_for_session, load_branch_aliases, load_session_bookmarks,
-    parse_branch_alias_command, parse_session_bookmark_command, save_branch_aliases,
-    save_session_bookmarks, session_bookmark_path_for_session, validate_branch_alias_name,
-    BranchAliasCommand, BranchAliasFile, SessionBookmarkCommand, SessionBookmarkFile,
-    BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
-    SESSION_BOOKMARK_USAGE,
-};
-pub(crate) use crate::session_navigation_commands::{
-    execute_branch_alias_command, execute_session_bookmark_command,
-};
-pub(crate) use crate::session_runtime_helpers::{
-    format_id_list, format_remap_ids, initialize_session, reload_agent_from_active_head,
-    validate_session_file,
+    RenderOptions, SkillsSyncCommandConfig,
 };
 use crate::skills::{
     augment_system_prompt, build_local_skill_lock_hints, build_registry_skill_lock_hints,
@@ -414,6 +376,37 @@ pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_
 use tau_gateway::{run_gateway_contract_runner, GatewayRuntimeConfig};
 #[cfg(test)]
 pub(crate) use tau_orchestrator::parse_numbered_plan_steps;
+pub(crate) use tau_session::execute_session_graph_export_command;
+use tau_session::SessionImportMode;
+#[cfg(test)]
+pub(crate) use tau_session::{
+    branch_alias_path_for_session, load_branch_aliases, load_session_bookmarks,
+    parse_branch_alias_command, parse_session_bookmark_command, save_branch_aliases,
+    save_session_bookmarks, session_bookmark_path_for_session, validate_branch_alias_name,
+    BranchAliasCommand, BranchAliasFile, SessionBookmarkCommand, SessionBookmarkFile,
+    BRANCH_ALIAS_SCHEMA_VERSION, BRANCH_ALIAS_USAGE, SESSION_BOOKMARK_SCHEMA_VERSION,
+    SESSION_BOOKMARK_USAGE,
+};
+#[cfg(test)]
+pub(crate) use tau_session::{
+    compute_session_entry_depths, compute_session_stats, execute_session_diff_command,
+    execute_session_search_command, execute_session_stats_command, parse_session_diff_args,
+    parse_session_search_args, parse_session_stats_args, render_session_diff, render_session_stats,
+    render_session_stats_json, search_session_entries, shared_lineage_prefix_depth,
+    SessionDiffEntry, SessionDiffReport, SessionSearchArgs, SessionStats, SessionStatsOutputFormat,
+    SESSION_SEARCH_DEFAULT_RESULTS, SESSION_SEARCH_PREVIEW_CHARS,
+};
+#[cfg(test)]
+pub(crate) use tau_session::{
+    escape_graph_label, render_session_graph_dot, render_session_graph_mermaid,
+    resolve_session_graph_format, SessionGraphFormat,
+};
+pub(crate) use tau_session::{execute_branch_alias_command, execute_session_bookmark_command};
+pub(crate) use tau_session::{
+    format_id_list, format_remap_ids, initialize_session, session_lineage_messages,
+    validate_session_file, SessionRuntime,
+};
+pub(crate) use tau_session::{session_message_preview, session_message_role};
 use voice_runtime::{run_voice_contract_runner, VoiceRuntimeConfig};
 
 pub(crate) fn normalize_daemon_subcommand_args(args: Vec<String>) -> Vec<String> {

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -4,17 +4,11 @@ use serde::{Deserialize, Serialize};
 use tau_ai::Provider;
 
 use crate::extension_manifest::ExtensionRegisteredCommand;
-use crate::session::{SessionImportMode, SessionStore};
 use crate::{
     default_provider_auth_method, Cli, CredentialStoreEncryptionMode, ModelCatalog,
     ProviderAuthMethod,
 };
-
-#[derive(Debug)]
-pub(crate) struct SessionRuntime {
-    pub(crate) store: SessionStore,
-    pub(crate) active_head: Option<u64>,
-}
+use tau_session::SessionImportMode;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SkillsSyncCommandConfig {

--- a/crates/tau-coding-agent/src/session.rs
+++ b/crates/tau-coding-agent/src/session.rs
@@ -1,1 +1,0 @@
-pub use tau_session::*;

--- a/crates/tau-coding-agent/src/slack.rs
+++ b/crates/tau-coding-agent/src/slack.rs
@@ -21,6 +21,7 @@ use crate::slack_helpers::{
     is_retryable_slack_status, is_retryable_transport_error, parse_retry_after, retry_delay,
     sanitize_for_path, truncate_for_error, truncate_for_slack,
 };
+use crate::tools::ToolPolicy;
 use crate::{
     authorize_action_for_principal_with_policy_path, current_unix_timestamp_ms,
     evaluate_pairing_access, execute_canvas_command, pairing_policy_for_state_dir,
@@ -29,7 +30,7 @@ use crate::{
     PairingDecision, PromptRunStatus, RbacDecision, RenderOptions, SessionRuntime,
     TransportHealthSnapshot,
 };
-use crate::{session::SessionStore, tools::ToolPolicy};
+use tau_session::SessionStore;
 
 const SLACK_STATE_SCHEMA_VERSION: u32 = 1;
 const SLACK_METADATA_MARKER_PREFIX: &str = "<!-- tau-slack-event:";

--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -65,7 +65,17 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     let mut session_runtime = if cli.no_session {
         None
     } else {
-        Some(initialize_session(&mut agent, cli, system_prompt)?)
+        let outcome = initialize_session(
+            &cli.session,
+            cli.session_lock_wait_ms,
+            cli.session_lock_stale_ms,
+            cli.branch_from,
+            system_prompt,
+        )?;
+        if !outcome.lineage.is_empty() {
+            agent.replace_messages(outcome.lineage);
+        }
+        Some(outcome.runtime)
     };
 
     if cli.json_events {

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -84,7 +84,7 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
     }
 
     if cli.session_validate {
-        validate_session_file(cli)?;
+        validate_session_file(&cli.session, cli.no_session)?;
         return Ok(true);
     }
 

--- a/crates/tau-coding-agent/src/tools.rs
+++ b/crates/tau-coding-agent/src/tools.rs
@@ -18,13 +18,12 @@ use crate::extension_manifest::{
 };
 use crate::{
     authorize_tool_for_principal, authorize_tool_for_principal_with_policy_path,
-    evaluate_approval_gate, resolve_local_principal,
-    session::SessionStore,
-    session_commands::{
-        compute_session_entry_depths, search_session_entries, session_message_preview,
-        session_message_role,
-    },
-    ApprovalAction, ApprovalGateResult, RbacDecision,
+    evaluate_approval_gate, resolve_local_principal, ApprovalAction, ApprovalGateResult,
+    RbacDecision,
+};
+use tau_session::{
+    compute_session_entry_depths, search_session_entries, session_message_preview,
+    session_message_role, SessionStore,
 };
 
 const SAFE_BASH_ENV_VARS: &[&str] = &[
@@ -2587,9 +2586,9 @@ mod tests {
         SessionsSearchTool, SessionsSendTool, SessionsStatsTool, ToolExecutionResult, ToolPolicy,
         ToolPolicyPreset, WriteTool,
     };
-    use crate::session::SessionStore;
     use crate::ApprovalAction;
     use tau_ai::Message;
+    use tau_session::{session_message_preview, session_message_role, SessionStore};
 
     fn test_policy(path: &Path) -> Arc<ToolPolicy> {
         Arc::new(ToolPolicy::new(vec![path.to_path_buf()]))
@@ -3228,11 +3227,11 @@ mod tests {
         let persisted = SessionStore::load(&session_path).expect("reload session");
         assert_eq!(persisted.entries().len(), 2);
         assert_eq!(
-            crate::session_commands::session_message_role(&persisted.entries()[1].message),
+            session_message_role(&persisted.entries()[1].message),
             "user"
         );
         assert_eq!(
-            crate::session_commands::session_message_preview(&persisted.entries()[1].message),
+            session_message_preview(&persisted.entries()[1].message),
             "delegate this follow-up"
         );
     }

--- a/crates/tau-session/Cargo.toml
+++ b/crates/tau-session/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tau-ai = { path = "../tau-ai" }
+tau-core = { path = "../tau-core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tau-session/src/lib.rs
+++ b/crates/tau-session/src/lib.rs
@@ -11,6 +11,11 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use tau_ai::Message;
 
+mod session_commands;
+mod session_graph_commands;
+mod session_navigation_commands;
+mod session_runtime_helpers;
+
 const SESSION_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_LOCK_WAIT_MS: u64 = 5_000;
 const DEFAULT_LOCK_STALE_MS: u64 = 30_000;
@@ -88,6 +93,12 @@ pub struct SessionStore {
     next_id: u64,
     lock_wait_ms: u64,
     lock_stale_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct SessionRuntime {
+    pub store: SessionStore,
+    pub active_head: Option<u64>,
 }
 
 impl SessionStore {
@@ -468,6 +479,11 @@ impl SessionStore {
         self.path.with_extension("lock")
     }
 }
+
+pub use session_commands::*;
+pub use session_graph_commands::*;
+pub use session_navigation_commands::*;
+pub use session_runtime_helpers::*;
 
 fn has_cycle(start_id: u64, entries: &HashMap<u64, SessionEntry>) -> bool {
     let mut visited = HashSet::new();

--- a/crates/tau-session/src/session_graph_commands.rs
+++ b/crates/tau-session/src/session_graph_commands.rs
@@ -1,7 +1,11 @@
-use super::*;
+use std::path::{Path, PathBuf};
+
+use tau_core::write_text_atomic;
+
+use crate::{session_message_preview, session_message_role, SessionEntry, SessionRuntime};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SessionGraphFormat {
+pub enum SessionGraphFormat {
     Mermaid,
     Dot,
 }
@@ -15,7 +19,7 @@ impl SessionGraphFormat {
     }
 }
 
-pub(crate) fn resolve_session_graph_format(path: &Path) -> SessionGraphFormat {
+pub fn resolve_session_graph_format(path: &Path) -> SessionGraphFormat {
     let extension = path
         .extension()
         .and_then(|value| value.to_str())
@@ -27,11 +31,11 @@ pub(crate) fn resolve_session_graph_format(path: &Path) -> SessionGraphFormat {
     }
 }
 
-pub(crate) fn escape_graph_label(raw: &str) -> String {
+pub fn escape_graph_label(raw: &str) -> String {
     raw.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-fn session_graph_node_label(entry: &crate::session::SessionEntry) -> String {
+fn session_graph_node_label(entry: &SessionEntry) -> String {
     format!(
         "{}: {} | {}",
         entry.id,
@@ -40,7 +44,7 @@ fn session_graph_node_label(entry: &crate::session::SessionEntry) -> String {
     )
 }
 
-pub(crate) fn render_session_graph_mermaid(entries: &[crate::session::SessionEntry]) -> String {
+pub fn render_session_graph_mermaid(entries: &[SessionEntry]) -> String {
     let mut ordered = entries.iter().collect::<Vec<_>>();
     ordered.sort_by_key(|entry| entry.id);
 
@@ -65,7 +69,7 @@ pub(crate) fn render_session_graph_mermaid(entries: &[crate::session::SessionEnt
     lines.join("\n")
 }
 
-pub(crate) fn render_session_graph_dot(entries: &[crate::session::SessionEntry]) -> String {
+pub fn render_session_graph_dot(entries: &[SessionEntry]) -> String {
     let mut ordered = entries.iter().collect::<Vec<_>>();
     ordered.sort_by_key(|entry| entry.id);
 
@@ -90,17 +94,14 @@ pub(crate) fn render_session_graph_dot(entries: &[crate::session::SessionEntry])
     lines.join("\n")
 }
 
-fn render_session_graph(
-    format: SessionGraphFormat,
-    entries: &[crate::session::SessionEntry],
-) -> String {
+fn render_session_graph(format: SessionGraphFormat, entries: &[SessionEntry]) -> String {
     match format {
         SessionGraphFormat::Mermaid => render_session_graph_mermaid(entries),
         SessionGraphFormat::Dot => render_session_graph_dot(entries),
     }
 }
 
-pub(crate) fn execute_session_graph_export_command(
+pub fn execute_session_graph_export_command(
     runtime: &SessionRuntime,
     command_args: &str,
 ) -> String {


### PR DESCRIPTION
## Summary
- Move session command/navigation/graph/runtime helper modules into `tau-session`.
- Refactor session init/validation helpers to be CLI-agnostic and update call sites.
- Update tau-coding-agent to consume tau-session APIs and navigation outcomes.

## Risks / Compatibility
- Session navigation commands now return outcomes and reload logic is handled by callers; behavior should be equivalent but any missed reload path would surface as stale agent state.
- No expected external API changes; internal module paths changed.

## Validation
- `cargo fmt`
- `cargo test -p tau-session -p tau-coding-agent -- --test-threads=1`
- Clippy: not run

Closes #963
