### PR TITLE
Move CLI validation into tau-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,7 +2700,10 @@ dependencies = [
 name = "tau-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "serde_json",
+ "tau-gateway",
  "tau-multi-channel",
  "tau-session",
 ]

--- a/crates/tau-cli/Cargo.toml
+++ b/crates/tau-cli/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+serde_json = "1"
 tau-session = { path = "../tau-session" }
+tau-gateway = { path = "../tau-gateway" }
 
 [dependencies.tau-multi-channel]
 path = "../tau-multi-channel"

--- a/crates/tau-cli/src/gateway_remote_profile.rs
+++ b/crates/tau-cli/src/gateway_remote_profile.rs
@@ -34,7 +34,7 @@ fn has_non_empty(value: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
-pub(crate) fn evaluate_gateway_remote_profile(cli: &Cli) -> Result<GatewayRemoteProfileReport> {
+pub fn evaluate_gateway_remote_profile(cli: &Cli) -> Result<GatewayRemoteProfileReport> {
     let config = GatewayRemoteProfileConfig {
         bind: cli.gateway_openresponses_bind.clone(),
         auth_mode: map_auth_mode(cli.gateway_openresponses_auth_mode),
@@ -46,7 +46,7 @@ pub(crate) fn evaluate_gateway_remote_profile(cli: &Cli) -> Result<GatewayRemote
     evaluate_gateway_remote_profile_config(&config)
 }
 
-pub(crate) fn render_gateway_remote_profile_report(report: &GatewayRemoteProfileReport) -> String {
+pub fn render_gateway_remote_profile_report(report: &GatewayRemoteProfileReport) -> String {
     let reason_codes = if report.reason_codes.is_empty() {
         "none".to_string()
     } else {
@@ -76,7 +76,7 @@ pub(crate) fn render_gateway_remote_profile_report(report: &GatewayRemoteProfile
     )
 }
 
-pub(crate) fn execute_gateway_remote_profile_inspect_command(cli: &Cli) -> Result<()> {
+pub fn execute_gateway_remote_profile_inspect_command(cli: &Cli) -> Result<()> {
     let report = evaluate_gateway_remote_profile(cli)?;
     if cli.gateway_remote_profile_json {
         println!(
@@ -90,7 +90,7 @@ pub(crate) fn execute_gateway_remote_profile_inspect_command(cli: &Cli) -> Resul
     Ok(())
 }
 
-pub(crate) fn validate_gateway_remote_profile_for_openresponses(cli: &Cli) -> Result<()> {
+pub fn validate_gateway_remote_profile_for_openresponses(cli: &Cli) -> Result<()> {
     if !cli.gateway_openresponses_server {
         return Ok(());
     }

--- a/crates/tau-cli/src/lib.rs
+++ b/crates/tau-cli/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod cli_args;
 pub mod cli_types;
+pub mod gateway_remote_profile;
+pub mod validation;
 
 pub use cli_args::Cli;
 pub use cli_types::*;
+pub use gateway_remote_profile::*;
+pub use validation::*;

--- a/crates/tau-cli/src/validation.rs
+++ b/crates/tau-cli/src/validation.rs
@@ -1,4 +1,15 @@
-use super::*;
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::{
+    Cli, CliGatewayOpenResponsesAuthMode, CliMultiChannelOutboundMode, CliWebhookSignatureAlgorithm,
+};
+
+fn resolve_non_empty_cli_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
 
 fn has_prompt_or_command_input(cli: &Cli) -> bool {
     cli.prompt.is_some()
@@ -47,7 +58,7 @@ fn project_index_mode_requested(cli: &Cli) -> bool {
     cli.project_index_build || cli.project_index_query.is_some() || cli.project_index_inspect
 }
 
-pub(crate) fn validate_project_index_cli(cli: &Cli) -> Result<()> {
+pub fn validate_project_index_cli(cli: &Cli) -> Result<()> {
     let mode_requested = project_index_mode_requested(cli);
     if !mode_requested && !cli.project_index_json {
         return Ok(());
@@ -135,7 +146,7 @@ pub(crate) fn validate_project_index_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
+pub fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
     if !cli.github_issues_bridge {
         return Ok(());
     }
@@ -189,7 +200,7 @@ pub(crate) fn validate_github_issues_bridge_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_slack_bridge_cli(cli: &Cli) -> Result<()> {
+pub fn validate_slack_bridge_cli(cli: &Cli) -> Result<()> {
     if !cli.slack_bridge {
         return Ok(());
     }
@@ -234,7 +245,7 @@ pub(crate) fn validate_slack_bridge_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_events_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_events_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.events_runner {
         return Ok(());
     }
@@ -259,7 +270,7 @@ pub(crate) fn validate_events_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.multi_channel_contract_runner {
         return Ok(());
     }
@@ -328,7 +339,7 @@ pub(crate) fn validate_multi_channel_contract_runner_cli(cli: &Cli) -> Result<()
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_live_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_live_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.multi_channel_live_runner {
         return Ok(());
     }
@@ -397,7 +408,7 @@ pub(crate) fn validate_multi_channel_live_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_live_connectors_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_live_connectors_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.multi_channel_live_connectors_runner {
         return Ok(());
     }
@@ -487,7 +498,7 @@ pub(crate) fn validate_multi_channel_live_connectors_runner_cli(cli: &Cli) -> Re
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_live_ingest_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_live_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.multi_channel_live_ingest_file.is_none() {
         return Ok(());
     }
@@ -548,7 +559,7 @@ pub(crate) fn validate_multi_channel_live_ingest_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_incident_timeline_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_incident_timeline_cli(cli: &Cli) -> Result<()> {
     if !multi_channel_incident_timeline_mode_requested(cli) {
         return Ok(());
     }
@@ -634,7 +645,7 @@ pub(crate) fn validate_multi_channel_incident_timeline_cli(cli: &Cli) -> Result<
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_channel_lifecycle_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_channel_lifecycle_cli(cli: &Cli) -> Result<()> {
     if !multi_channel_channel_lifecycle_mode_requested(cli) {
         return Ok(());
     }
@@ -729,7 +740,7 @@ pub(crate) fn validate_multi_channel_channel_lifecycle_cli(cli: &Cli) -> Result<
     Ok(())
 }
 
-pub(crate) fn validate_multi_channel_send_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_channel_send_cli(cli: &Cli) -> Result<()> {
     if !multi_channel_send_mode_requested(cli) {
         if cli.multi_channel_send_json
             || cli.multi_channel_send_target.is_some()
@@ -841,7 +852,7 @@ pub(crate) fn validate_multi_channel_send_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_multi_agent_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_multi_agent_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.multi_agent_contract_runner {
         return Ok(());
     }
@@ -887,7 +898,7 @@ pub(crate) fn validate_multi_agent_contract_runner_cli(cli: &Cli) -> Result<()> 
     Ok(())
 }
 
-pub(crate) fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.browser_automation_contract_runner {
         return Ok(());
     }
@@ -946,7 +957,7 @@ pub(crate) fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Resu
     Ok(())
 }
 
-pub(crate) fn validate_browser_automation_preflight_cli(cli: &Cli) -> Result<()> {
+pub fn validate_browser_automation_preflight_cli(cli: &Cli) -> Result<()> {
     if !cli.browser_automation_preflight {
         return Ok(());
     }
@@ -979,7 +990,7 @@ pub(crate) fn validate_browser_automation_preflight_cli(cli: &Cli) -> Result<()>
     Ok(())
 }
 
-pub(crate) fn validate_memory_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_memory_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.memory_contract_runner {
         return Ok(());
     }
@@ -1023,7 +1034,7 @@ pub(crate) fn validate_memory_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_dashboard_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_dashboard_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.dashboard_contract_runner {
         return Ok(());
     }
@@ -1068,7 +1079,7 @@ pub(crate) fn validate_dashboard_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_daemon_cli(cli: &Cli) -> Result<()> {
+pub fn validate_daemon_cli(cli: &Cli) -> Result<()> {
     if !daemon_mode_requested(cli) {
         return Ok(());
     }
@@ -1149,7 +1160,7 @@ pub(crate) fn validate_daemon_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_gateway_service_cli(cli: &Cli) -> Result<()> {
+pub fn validate_gateway_service_cli(cli: &Cli) -> Result<()> {
     if !gateway_service_mode_requested(cli) {
         return Ok(());
     }
@@ -1208,7 +1219,7 @@ pub(crate) fn validate_gateway_service_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_gateway_remote_profile_inspect_cli(cli: &Cli) -> Result<()> {
+pub fn validate_gateway_remote_profile_inspect_cli(cli: &Cli) -> Result<()> {
     if !gateway_remote_profile_inspect_mode_requested(cli) {
         if cli.gateway_remote_profile_json {
             bail!("--gateway-remote-profile-json requires --gateway-remote-profile-inspect");
@@ -1274,7 +1285,7 @@ pub(crate) fn validate_gateway_remote_profile_inspect_cli(cli: &Cli) -> Result<(
     Ok(())
 }
 
-pub(crate) fn validate_gateway_openresponses_server_cli(cli: &Cli) -> Result<()> {
+pub fn validate_gateway_openresponses_server_cli(cli: &Cli) -> Result<()> {
     if !gateway_openresponses_mode_requested(cli) {
         return Ok(());
     }
@@ -1359,7 +1370,7 @@ pub(crate) fn validate_gateway_openresponses_server_cli(cli: &Cli) -> Result<()>
     Ok(())
 }
 
-pub(crate) fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.gateway_contract_runner {
         return Ok(());
     }
@@ -1403,7 +1414,7 @@ pub(crate) fn validate_gateway_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_deployment_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_deployment_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.deployment_contract_runner {
         return Ok(());
     }
@@ -1453,7 +1464,7 @@ pub(crate) fn validate_deployment_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_deployment_wasm_package_cli(cli: &Cli) -> Result<()> {
+pub fn validate_deployment_wasm_package_cli(cli: &Cli) -> Result<()> {
     if cli.deployment_wasm_package_module.is_none() {
         return Ok(());
     }
@@ -1517,7 +1528,7 @@ pub(crate) fn validate_deployment_wasm_package_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_deployment_wasm_inspect_cli(cli: &Cli) -> Result<()> {
+pub fn validate_deployment_wasm_inspect_cli(cli: &Cli) -> Result<()> {
     if cli.deployment_wasm_inspect_manifest.is_none() {
         return Ok(());
     }
@@ -1567,7 +1578,7 @@ pub(crate) fn validate_deployment_wasm_inspect_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.custom_command_contract_runner {
         return Ok(());
     }
@@ -1615,7 +1626,7 @@ pub(crate) fn validate_custom_command_contract_runner_cli(cli: &Cli) -> Result<(
     Ok(())
 }
 
-pub(crate) fn validate_voice_contract_runner_cli(cli: &Cli) -> Result<()> {
+pub fn validate_voice_contract_runner_cli(cli: &Cli) -> Result<()> {
     if !cli.voice_contract_runner {
         return Ok(());
     }
@@ -1664,7 +1675,7 @@ pub(crate) fn validate_voice_contract_runner_cli(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
+pub fn validate_event_webhook_ingest_cli(cli: &Cli) -> Result<()> {
     if cli.event_webhook_ingest_file.is_none() {
         return Ok(());
     }

--- a/crates/tau-coding-agent/src/channel_store_admin.rs
+++ b/crates/tau-coding-agent/src/channel_store_admin.rs
@@ -2660,9 +2660,10 @@ fn collect_operator_policy_posture(cli: &Cli) -> OperatorControlPolicyPosture {
     let pairing_strict_effective =
         pairing_policy.strict_mode || pairing_allowlist_strict || pairing_rules_configured;
 
-    let remote_profile = match crate::gateway_remote_profile::evaluate_gateway_remote_profile(cli) {
+    let remote_profile = match tau_cli::gateway_remote_profile::evaluate_gateway_remote_profile(cli)
+    {
         Ok(report) => report,
-        Err(_) => crate::gateway_remote_profile::GatewayRemoteProfileReport {
+        Err(_) => tau_cli::gateway_remote_profile::GatewayRemoteProfileReport {
             profile: cli.gateway_remote_profile.as_str().to_string(),
             posture: "unknown".to_string(),
             gate: "hold".to_string(),

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -26,7 +26,6 @@ mod deployment_wasm;
 mod diagnostics_commands;
 mod events;
 mod extension_manifest;
-mod gateway_remote_profile;
 mod gemini_cli_client;
 mod github_issues;
 mod github_issues_helpers;
@@ -50,7 +49,6 @@ mod qa_loop_commands;
 mod release_channel_commands;
 mod rpc_capabilities;
 mod rpc_protocol;
-mod runtime_cli_validation;
 mod runtime_loop;
 mod runtime_output;
 mod runtime_types;
@@ -112,14 +110,15 @@ pub(crate) use crate::cli_args::Cli;
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliDaemonProfile,
     CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile,
-    CliMultiChannelOutboundMode, CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
-    CliWebhookSignatureAlgorithm,
+    CliOrchestratorMode, CliOsSandboxMode, CliProviderAuthMode,
 };
 #[cfg(test)]
 pub(crate) use crate::cli_types::{
     CliDeploymentWasmRuntimeProfile, CliMultiChannelLiveConnectorMode, CliMultiChannelTransport,
     CliSessionImportMode, CliToolPolicyPreset,
 };
+#[cfg(test)]
+pub(crate) use crate::cli_types::{CliMultiChannelOutboundMode, CliWebhookSignatureAlgorithm};
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
 pub(crate) use crate::commands::{
@@ -237,24 +236,6 @@ pub(crate) use crate::rpc_protocol::{
     execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
     execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
 };
-#[cfg(test)]
-pub(crate) use crate::runtime_cli_validation::validate_gateway_remote_profile_inspect_cli;
-#[cfg(test)]
-pub(crate) use crate::runtime_cli_validation::validate_multi_channel_live_connectors_runner_cli;
-pub(crate) use crate::runtime_cli_validation::{
-    validate_browser_automation_contract_runner_cli, validate_browser_automation_preflight_cli,
-    validate_custom_command_contract_runner_cli, validate_daemon_cli,
-    validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
-    validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
-    validate_event_webhook_ingest_cli, validate_events_runner_cli,
-    validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
-    validate_gateway_service_cli, validate_github_issues_bridge_cli,
-    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
-    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_contract_runner_cli,
-    validate_multi_channel_incident_timeline_cli, validate_multi_channel_live_ingest_cli,
-    validate_multi_channel_live_runner_cli, validate_multi_channel_send_cli,
-    validate_project_index_cli, validate_slack_bridge_cli, validate_voice_contract_runner_cli,
-};
 pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
     run_prompt_with_cancellation, InteractiveRuntimeConfig, PromptRunStatus,
@@ -351,6 +332,22 @@ pub(crate) use tau_access::rbac::{
 pub(crate) use tau_access::trust_roots::{
     apply_trust_root_mutation_specs, load_trust_root_records, parse_trust_rotation_spec,
     parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
+};
+pub(crate) use tau_cli::validation::validate_gateway_remote_profile_inspect_cli;
+pub(crate) use tau_cli::validation::validate_multi_channel_live_connectors_runner_cli;
+pub(crate) use tau_cli::validation::{
+    validate_browser_automation_contract_runner_cli, validate_browser_automation_preflight_cli,
+    validate_custom_command_contract_runner_cli, validate_daemon_cli,
+    validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
+    validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
+    validate_event_webhook_ingest_cli, validate_events_runner_cli,
+    validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
+    validate_gateway_service_cli, validate_github_issues_bridge_cli,
+    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
+    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_contract_runner_cli,
+    validate_multi_channel_incident_timeline_cli, validate_multi_channel_live_ingest_cli,
+    validate_multi_channel_live_runner_cli, validate_multi_channel_send_cli,
+    validate_project_index_cli, validate_slack_bridge_cli, validate_voice_contract_runner_cli,
 };
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -120,8 +120,8 @@ pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
     }
 
     if cli.gateway_remote_profile_inspect {
-        crate::runtime_cli_validation::validate_gateway_remote_profile_inspect_cli(cli)?;
-        crate::gateway_remote_profile::execute_gateway_remote_profile_inspect_command(cli)?;
+        crate::validate_gateway_remote_profile_inspect_cli(cli)?;
+        tau_cli::gateway_remote_profile::execute_gateway_remote_profile_inspect_command(cli)?;
         return Ok(true);
     }
 

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::channel_adapters::{
     build_multi_channel_command_handlers, build_multi_channel_pairing_evaluator,
 };
-use crate::runtime_cli_validation::validate_multi_channel_live_connectors_runner_cli;
+use crate::validate_multi_channel_live_connectors_runner_cli;
 use std::sync::Arc;
 use tau_gateway::{GatewayOpenResponsesAuthMode, GatewayToolRegistrar};
 


### PR DESCRIPTION
## Summary
- move runtime CLI validation and gateway remote profile helpers into tau-cli
- add tau-cli dependencies needed for validation (anyhow, serde_json, tau-gateway)
- update tau-coding-agent call sites to use tau-cli validation and gateway remote profile

## Risks
- tau-cli now owns validation and gateway remote profile behavior; ensure compatibility with existing CLI flags

## Validation
- cargo fmt
- cargo test -p tau-cli -p tau-coding-agent -- --test-threads=1

Closes #981