### PR TITLE
Extract startup preflight into tau-startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "tau-runtime",
  "tau-session",
  "tau-skills",
+ "tau-startup",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2909,6 +2910,21 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "tau-startup"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "tau-access",
+ "tau-cli",
+ "tau-core",
+ "tau-events",
+ "tau-gateway",
+ "tau-multi-channel",
+ "tau-session",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/tau-events",
   "crates/tau-deployment",
   "crates/tau-tui",
+  "crates/tau-startup",
   "crates/tau-coding-agent",
 ]
 resolver = "2"

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -28,6 +28,7 @@ tau-orchestrator = { path = "../tau-orchestrator" }
 tau-runtime = { path = "../tau-runtime" }
 tau-events = { path = "../tau-events" }
 tau-deployment = { path = "../tau-deployment" }
+tau-startup = { path = "../tau-startup" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-ai = { path = "../tau-ai" }
 reqwest.workspace = true

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -22,17 +22,6 @@ impl From<CliOsSandboxMode> for OsSandboxMode {
     }
 }
 
-pub(crate) fn map_webhook_signature_algorithm(
-    value: CliWebhookSignatureAlgorithm,
-) -> crate::events::WebhookSignatureAlgorithm {
-    match value {
-        CliWebhookSignatureAlgorithm::GithubSha256 => {
-            crate::events::WebhookSignatureAlgorithm::GithubSha256
-        }
-        CliWebhookSignatureAlgorithm::SlackV0 => crate::events::WebhookSignatureAlgorithm::SlackV0,
-    }
-}
-
 impl From<CliToolPolicyPreset> for ToolPolicyPreset {
     fn from(value: CliToolPolicyPreset) -> Self {
         match value {

--- a/crates/tau-coding-agent/src/events.rs
+++ b/crates/tau-coding-agent/src/events.rs
@@ -5,8 +5,7 @@ use async_trait::async_trait;
 use tau_agent_core::{Agent, AgentConfig, AgentEvent};
 use tau_ai::{LlmClient, Message, MessageRole};
 use tau_events::{
-    dry_run_events, enforce_events_dry_run_gate,
-    ingest_webhook_immediate_event as ingest_webhook_immediate_event_core, inspect_events,
+    dry_run_events, enforce_events_dry_run_gate, inspect_events,
     run_event_scheduler as run_core_event_scheduler, simulate_events, validate_events_definitions,
     EventRunner, EventSchedulerConfig as CoreEventSchedulerConfig, EventTemplateSchedule,
     EventsDryRunConfig, EventsDryRunGateConfig, EventsInspectConfig, EventsSimulateConfig,
@@ -21,8 +20,8 @@ use crate::{
 use tau_session::SessionStore;
 
 pub(crate) use tau_events::{
-    EventDefinition, EventWebhookIngestConfig, EventsDryRunReport, EventsInspectReport,
-    EventsSimulateReport, EventsValidateReport, WebhookSignatureAlgorithm,
+    EventDefinition, EventsDryRunReport, EventsInspectReport, EventsSimulateReport,
+    EventsValidateReport,
 };
 
 #[derive(Clone)]
@@ -232,10 +231,6 @@ pub(crate) async fn run_event_scheduler(config: EventSchedulerConfig) -> Result<
         stale_immediate_max_age_seconds: config.stale_immediate_max_age_seconds,
     };
     run_core_event_scheduler(core).await
-}
-
-pub(crate) fn ingest_webhook_immediate_event(config: &EventWebhookIngestConfig) -> Result<()> {
-    ingest_webhook_immediate_event_core(config)
 }
 
 #[derive(Clone)]

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -160,8 +160,7 @@ pub(crate) use crate::diagnostics_commands::{
 use crate::events::{
     execute_events_dry_run_command, execute_events_inspect_command,
     execute_events_simulate_command, execute_events_template_write_command,
-    execute_events_validate_command, ingest_webhook_immediate_event, run_event_scheduler,
-    EventSchedulerConfig, EventWebhookIngestConfig,
+    execute_events_validate_command, run_event_scheduler, EventSchedulerConfig,
 };
 pub(crate) use crate::extension_manifest::{
     apply_extension_message_transforms, dispatch_extension_runtime_hook,
@@ -333,26 +332,33 @@ pub(crate) use tau_access::trust_roots::{
     apply_trust_root_mutation_specs, load_trust_root_records, parse_trust_rotation_spec,
     parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
 };
+#[cfg(test)]
 pub(crate) use tau_cli::validation::validate_gateway_remote_profile_inspect_cli;
 pub(crate) use tau_cli::validation::validate_multi_channel_live_connectors_runner_cli;
 pub(crate) use tau_cli::validation::{
-    validate_browser_automation_contract_runner_cli, validate_browser_automation_preflight_cli,
-    validate_custom_command_contract_runner_cli, validate_daemon_cli,
-    validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
-    validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
-    validate_event_webhook_ingest_cli, validate_events_runner_cli,
+    validate_browser_automation_contract_runner_cli, validate_custom_command_contract_runner_cli,
+    validate_daemon_cli, validate_dashboard_contract_runner_cli,
+    validate_deployment_contract_runner_cli, validate_events_runner_cli,
     validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
-    validate_gateway_service_cli, validate_github_issues_bridge_cli,
-    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
-    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_contract_runner_cli,
-    validate_multi_channel_incident_timeline_cli, validate_multi_channel_live_ingest_cli,
-    validate_multi_channel_live_runner_cli, validate_multi_channel_send_cli,
-    validate_project_index_cli, validate_slack_bridge_cli, validate_voice_contract_runner_cli,
+    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
+    validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
+    validate_multi_channel_live_runner_cli, validate_slack_bridge_cli,
+    validate_voice_contract_runner_cli,
+};
+#[cfg(test)]
+pub(crate) use tau_cli::validation::{
+    validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
+    validate_event_webhook_ingest_cli, validate_gateway_service_cli,
+    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_incident_timeline_cli,
+    validate_multi_channel_live_ingest_cli, validate_multi_channel_send_cli,
+    validate_project_index_cli,
 };
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
 use tau_gateway::{run_gateway_contract_runner, GatewayRuntimeConfig};
+#[cfg(test)]
 pub(crate) use tau_multi_channel::build_multi_channel_incident_timeline_report;
+#[cfg(test)]
 pub(crate) use tau_multi_channel::build_multi_channel_route_inspect_report;
 use tau_multi_channel::{
     run_multi_channel_contract_runner, run_multi_channel_live_runner,
@@ -364,6 +370,8 @@ use tau_orchestrator::multi_agent_runtime::{
 #[cfg(test)]
 pub(crate) use tau_orchestrator::parse_numbered_plan_steps;
 pub(crate) use tau_session::execute_session_graph_export_command;
+#[cfg(test)]
+pub(crate) use tau_session::validate_session_file;
 use tau_session::SessionImportMode;
 #[cfg(test)]
 pub(crate) use tau_session::{
@@ -390,8 +398,7 @@ pub(crate) use tau_session::{
 };
 pub(crate) use tau_session::{execute_branch_alias_command, execute_session_bookmark_command};
 pub(crate) use tau_session::{
-    format_id_list, format_remap_ids, initialize_session, session_lineage_messages,
-    validate_session_file, SessionRuntime,
+    format_id_list, format_remap_ids, initialize_session, session_lineage_messages, SessionRuntime,
 };
 pub(crate) use tau_session::{session_message_preview, session_message_role};
 use voice_runtime::{run_voice_contract_runner, VoiceRuntimeConfig};

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -1,518 +1,218 @@
 use super::*;
 
-pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
-    if cli.onboard {
-        execute_onboarding_command(cli)?;
-        return Ok(true);
+struct TauStartupPreflightActions;
+
+impl tau_startup::StartupPreflightActions for TauStartupPreflightActions {
+    fn execute_onboarding_command(&self, cli: &Cli) -> Result<()> {
+        execute_onboarding_command(cli)
     }
 
-    if let Some(inspect_file) = cli.multi_channel_route_inspect_file.as_ref() {
-        let report = build_multi_channel_route_inspect_report(
-            &tau_multi_channel::MultiChannelRouteInspectConfig {
-                inspect_file: inspect_file.clone(),
-                state_dir: cli.multi_channel_state_dir.clone(),
-                orchestrator_route_table_path: cli.orchestrator_route_table.clone(),
-            },
-        )?;
-        if cli.multi_channel_route_inspect_json {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&report)
-                    .context("failed to render multi-channel route inspect json")?
-            );
-        } else {
-            println!(
-                "{}",
-                tau_multi_channel::render_multi_channel_route_inspect_report(&report)
-            );
-        }
-        return Ok(true);
+    fn execute_multi_channel_send_command(&self, cli: &Cli) -> Result<()> {
+        crate::channel_send::execute_multi_channel_send_command(cli)
     }
 
-    if cli.multi_channel_incident_timeline {
-        validate_multi_channel_incident_timeline_cli(cli)?;
-        let report = build_multi_channel_incident_timeline_report(
-            &tau_multi_channel::MultiChannelIncidentTimelineQuery {
-                state_dir: cli.multi_channel_state_dir.clone(),
-                window_start_unix_ms: cli.multi_channel_incident_start_unix_ms,
-                window_end_unix_ms: cli.multi_channel_incident_end_unix_ms,
-                event_limit: cli.multi_channel_incident_event_limit.unwrap_or(200),
-                replay_export_path: cli.multi_channel_incident_replay_export.clone(),
-            },
-        )?;
-        if cli.multi_channel_incident_timeline_json {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&report)
-                    .context("failed to render multi-channel incident timeline json")?
-            );
-        } else {
-            println!(
-                "{}",
-                tau_multi_channel::render_multi_channel_incident_timeline_report(&report)
-            );
-        }
-        return Ok(true);
+    fn execute_multi_channel_channel_lifecycle_command(&self, cli: &Cli) -> Result<()> {
+        crate::channel_lifecycle::execute_multi_channel_channel_lifecycle_command(cli)
     }
 
-    if cli.multi_channel_send.is_some() {
-        validate_multi_channel_send_cli(cli)?;
-        crate::channel_send::execute_multi_channel_send_command(cli)?;
-        return Ok(true);
+    fn execute_deployment_wasm_package_command(&self, cli: &Cli) -> Result<()> {
+        crate::deployment_wasm::execute_deployment_wasm_package_command(cli)
     }
 
-    if cli.multi_channel_channel_status.is_some()
-        || cli.multi_channel_channel_login.is_some()
-        || cli.multi_channel_channel_logout.is_some()
-        || cli.multi_channel_channel_probe.is_some()
-    {
-        validate_multi_channel_channel_lifecycle_cli(cli)?;
-        crate::channel_lifecycle::execute_multi_channel_channel_lifecycle_command(cli)?;
-        return Ok(true);
+    fn execute_deployment_wasm_inspect_command(&self, cli: &Cli) -> Result<()> {
+        crate::deployment_wasm::execute_deployment_wasm_inspect_command(cli)
     }
 
-    if cli.deployment_wasm_package_module.is_some() {
-        validate_deployment_wasm_package_cli(cli)?;
-        crate::deployment_wasm::execute_deployment_wasm_package_command(cli)?;
-        return Ok(true);
+    fn execute_project_index_command(&self, cli: &Cli) -> Result<()> {
+        execute_project_index_command(cli)
     }
 
-    if cli.deployment_wasm_inspect_manifest.is_some() {
-        validate_deployment_wasm_inspect_cli(cli)?;
-        crate::deployment_wasm::execute_deployment_wasm_inspect_command(cli)?;
-        return Ok(true);
+    fn execute_channel_store_admin_command(&self, cli: &Cli) -> Result<()> {
+        execute_channel_store_admin_command(cli)
     }
 
-    if cli.session_validate {
-        validate_session_file(&cli.session, cli.no_session)?;
-        return Ok(true);
+    fn execute_multi_channel_live_readiness_preflight_command(&self, cli: &Cli) -> Result<()> {
+        execute_multi_channel_live_readiness_preflight_command(cli)
     }
 
-    if cli.project_index_build
-        || cli.project_index_query.is_some()
-        || cli.project_index_inspect
-        || cli.project_index_json
-    {
-        validate_project_index_cli(cli)?;
-        execute_project_index_command(cli)?;
-        return Ok(true);
+    fn execute_browser_automation_preflight_command(&self, cli: &Cli) -> Result<()> {
+        execute_browser_automation_preflight_command(cli)
     }
 
-    if crate::daemon_runtime::tau_daemon_mode_requested(cli) {
-        validate_daemon_cli(cli)?;
+    fn execute_extension_exec_command(&self, cli: &Cli) -> Result<()> {
+        execute_extension_exec_command(cli)
     }
 
-    if cli.channel_store_inspect.is_some()
-        || cli.channel_store_repair.is_some()
-        || cli.transport_health_inspect.is_some()
-        || cli.github_status_inspect.is_some()
-        || cli.operator_control_summary
-        || cli.multi_channel_status_inspect
-        || cli.dashboard_status_inspect
-        || cli.multi_agent_status_inspect
-        || cli.gateway_status_inspect
-        || cli.deployment_status_inspect
-        || cli.custom_command_status_inspect
-        || cli.voice_status_inspect
-    {
-        execute_channel_store_admin_command(cli)?;
-        return Ok(true);
+    fn execute_extension_list_command(&self, cli: &Cli) -> Result<()> {
+        execute_extension_list_command(cli)
     }
 
-    if cli.gateway_remote_profile_inspect {
-        crate::validate_gateway_remote_profile_inspect_cli(cli)?;
-        tau_cli::gateway_remote_profile::execute_gateway_remote_profile_inspect_command(cli)?;
-        return Ok(true);
+    fn execute_extension_show_command(&self, cli: &Cli) -> Result<()> {
+        execute_extension_show_command(cli)
     }
 
-    if crate::daemon_runtime::tau_daemon_mode_requested(cli) {
-        validate_daemon_cli(cli)?;
-        let config = crate::daemon_runtime::TauDaemonConfig {
-            state_dir: cli.daemon_state_dir.clone(),
-            profile: cli.daemon_profile,
-        };
+    fn execute_extension_validate_command(&self, cli: &Cli) -> Result<()> {
+        execute_extension_validate_command(cli)
+    }
 
-        if cli.daemon_install {
-            let report = crate::daemon_runtime::install_tau_daemon(&config)?;
-            println!(
-                "{}",
-                crate::daemon_runtime::render_tau_daemon_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.daemon_uninstall {
-            let report = crate::daemon_runtime::uninstall_tau_daemon(&config)?;
-            println!(
-                "{}",
-                crate::daemon_runtime::render_tau_daemon_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.daemon_start {
-            let report = crate::daemon_runtime::start_tau_daemon(&config)?;
-            println!(
-                "{}",
-                crate::daemon_runtime::render_tau_daemon_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.daemon_stop {
-            let report =
-                crate::daemon_runtime::stop_tau_daemon(&config, cli.daemon_stop_reason.as_deref())?;
-            println!(
-                "{}",
-                crate::daemon_runtime::render_tau_daemon_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.daemon_status {
-            let report = crate::daemon_runtime::inspect_tau_daemon(&config)?;
-            if cli.daemon_status_json {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&report)
-                        .context("failed to render daemon status json")?
-                );
-            } else {
+    fn execute_package_validate_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_validate_command(cli)
+    }
+
+    fn execute_package_show_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_show_command(cli)
+    }
+
+    fn execute_package_install_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_install_command(cli)
+    }
+
+    fn execute_package_update_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_update_command(cli)
+    }
+
+    fn execute_package_list_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_list_command(cli)
+    }
+
+    fn execute_package_remove_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_remove_command(cli)
+    }
+
+    fn execute_package_rollback_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_rollback_command(cli)
+    }
+
+    fn execute_package_conflicts_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_conflicts_command(cli)
+    }
+
+    fn execute_package_activate_command(&self, cli: &Cli) -> Result<()> {
+        execute_package_activate_command(cli)
+    }
+
+    fn execute_qa_loop_preflight_command(&self, cli: &Cli) -> Result<()> {
+        execute_qa_loop_preflight_command(cli)
+    }
+
+    fn execute_mcp_server_command(&self, cli: &Cli) -> Result<()> {
+        execute_mcp_server_command(cli)
+    }
+
+    fn execute_rpc_capabilities_command(&self, cli: &Cli) -> Result<()> {
+        execute_rpc_capabilities_command(cli)
+    }
+
+    fn execute_rpc_validate_frame_command(&self, cli: &Cli) -> Result<()> {
+        execute_rpc_validate_frame_command(cli)
+    }
+
+    fn execute_rpc_dispatch_frame_command(&self, cli: &Cli) -> Result<()> {
+        execute_rpc_dispatch_frame_command(cli)
+    }
+
+    fn execute_rpc_dispatch_ndjson_command(&self, cli: &Cli) -> Result<()> {
+        execute_rpc_dispatch_ndjson_command(cli)
+    }
+
+    fn execute_rpc_serve_ndjson_command(&self, cli: &Cli) -> Result<()> {
+        execute_rpc_serve_ndjson_command(cli)
+    }
+
+    fn execute_events_inspect_command(&self, cli: &Cli) -> Result<()> {
+        execute_events_inspect_command(cli)
+    }
+
+    fn execute_events_validate_command(&self, cli: &Cli) -> Result<()> {
+        execute_events_validate_command(cli)
+    }
+
+    fn execute_events_simulate_command(&self, cli: &Cli) -> Result<()> {
+        execute_events_simulate_command(cli)
+    }
+
+    fn execute_events_dry_run_command(&self, cli: &Cli) -> Result<()> {
+        execute_events_dry_run_command(cli)
+    }
+
+    fn execute_events_template_write_command(&self, cli: &Cli) -> Result<()> {
+        execute_events_template_write_command(cli)
+    }
+
+    fn resolve_secret_from_cli_or_store_id(
+        &self,
+        cli: &Cli,
+        direct_secret: Option<&str>,
+        secret_id: Option<&str>,
+        secret_id_flag: &str,
+    ) -> Result<Option<String>> {
+        resolve_secret_from_cli_or_store_id(cli, direct_secret, secret_id, secret_id_flag)
+    }
+
+    fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool> {
+        if crate::daemon_runtime::tau_daemon_mode_requested(cli) {
+            validate_daemon_cli(cli)?;
+            let config = crate::daemon_runtime::TauDaemonConfig {
+                state_dir: cli.daemon_state_dir.clone(),
+                profile: cli.daemon_profile,
+            };
+
+            if cli.daemon_install {
+                let report = crate::daemon_runtime::install_tau_daemon(&config)?;
                 println!(
                     "{}",
                     crate::daemon_runtime::render_tau_daemon_status_report(&report)
                 );
+                return Ok(true);
             }
-            return Ok(true);
-        }
-    }
-
-    if cli.gateway_service_start || cli.gateway_service_stop || cli.gateway_service_status {
-        validate_gateway_service_cli(cli)?;
-        if cli.gateway_service_start {
-            let report = tau_gateway::start_gateway_service_mode(&cli.gateway_state_dir)?;
-            println!(
-                "{}",
-                tau_gateway::render_gateway_service_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.gateway_service_stop {
-            let report = tau_gateway::stop_gateway_service_mode(
-                &cli.gateway_state_dir,
-                cli.gateway_service_stop_reason.as_deref(),
-            )?;
-            println!(
-                "{}",
-                tau_gateway::render_gateway_service_status_report(&report)
-            );
-            return Ok(true);
-        }
-        if cli.gateway_service_status {
-            let report = tau_gateway::inspect_gateway_service_mode(&cli.gateway_state_dir)?;
-            if cli.gateway_service_status_json {
+            if cli.daemon_uninstall {
+                let report = crate::daemon_runtime::uninstall_tau_daemon(&config)?;
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&report)
-                        .context("failed to render gateway service status json")?
+                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
                 );
-            } else {
+                return Ok(true);
+            }
+            if cli.daemon_start {
+                let report = crate::daemon_runtime::start_tau_daemon(&config)?;
                 println!(
                     "{}",
-                    tau_gateway::render_gateway_service_status_report(&report)
+                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
                 );
+                return Ok(true);
             }
-            return Ok(true);
-        }
-    }
-
-    if cli.multi_channel_live_ingest_file.is_some() {
-        validate_multi_channel_live_ingest_cli(cli)?;
-        let payload_file = cli
-            .multi_channel_live_ingest_file
-            .clone()
-            .ok_or_else(|| anyhow!("--multi-channel-live-ingest-file is required"))?;
-        let transport: tau_multi_channel::MultiChannelTransport = cli
-            .multi_channel_live_ingest_transport
-            .ok_or_else(|| anyhow!("--multi-channel-live-ingest-transport is required"))?
-            .into();
-        let report = tau_multi_channel::ingest_multi_channel_live_raw_payload(
-            &tau_multi_channel::MultiChannelLivePayloadIngestConfig {
-                ingress_dir: cli.multi_channel_live_ingest_dir.clone(),
-                payload_file,
-                transport,
-                provider: cli.multi_channel_live_ingest_provider.clone(),
-            },
-        )?;
-        println!(
-            "multi-channel live ingest queued: transport={} provider={} event_id={} conversation_id={} ingress_file={}",
-            report.transport.as_str(),
-            report.provider,
-            report.event_id,
-            report.conversation_id,
-            report.ingress_path.display()
-        );
-        return Ok(true);
-    }
-
-    if cli.multi_channel_live_readiness_preflight {
-        execute_multi_channel_live_readiness_preflight_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.browser_automation_preflight {
-        validate_browser_automation_preflight_cli(cli)?;
-        execute_browser_automation_preflight_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.multi_channel_live_connectors_status {
-        let report = tau_multi_channel::load_multi_channel_live_connectors_status_report(
-            &cli.multi_channel_live_connectors_state_path,
-        )?;
-        if cli.multi_channel_live_connectors_status_json {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&report)
-                    .context("failed to render live connector status json")?
-            );
-        } else {
-            let mut channel_lines = Vec::new();
-            for (channel, status) in &report.channels {
-                let operator_guidance = if status.breaker_state == "open" {
-                    format!(
-                        "wait_for_breaker_recovery_until:{}",
-                        status.breaker_open_until_unix_ms
-                    )
-                } else if status.liveness == "degraded" {
-                    "inspect_provider_errors_and_credentials".to_string()
-                } else {
-                    "none".to_string()
-                };
-                channel_lines.push(format!(
-                    "{}:mode={} liveness={} breaker_state={} retry_budget_remaining={} breaker_open_until_unix_ms={} breaker_last_open_reason={} ingested={} duplicates={} retries={} auth_failures={} parse_failures={} provider_failures={} last_error_code={} guidance={}",
-                    channel,
-                    if status.mode.is_empty() { "unknown" } else { status.mode.as_str() },
-                    if status.liveness.is_empty() { "unknown" } else { status.liveness.as_str() },
-                    if status.breaker_state.is_empty() {
-                        "unknown"
-                    } else {
-                        status.breaker_state.as_str()
-                    },
-                    status.retry_budget_remaining,
-                    status.breaker_open_until_unix_ms,
-                    if status.breaker_last_open_reason.is_empty() {
-                        "none"
-                    } else {
-                        status.breaker_last_open_reason.as_str()
-                    },
-                    status.events_ingested,
-                    status.duplicates_skipped,
-                    status.retry_attempts,
-                    status.auth_failures,
-                    status.parse_failures,
-                    status.provider_failures,
-                    if status.last_error_code.is_empty() {
-                        "none"
-                    } else {
-                        status.last_error_code.as_str()
-                    },
-                    operator_guidance
-                ));
+            if cli.daemon_stop {
+                let report = crate::daemon_runtime::stop_tau_daemon(
+                    &config,
+                    cli.daemon_stop_reason.as_deref(),
+                )?;
+                println!(
+                    "{}",
+                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
+                );
+                return Ok(true);
             }
-            channel_lines.sort();
-            println!(
-                "multi-channel live connectors status: state_path={} state_present={} schema_version={} processed_event_count={} channels={}",
-                report.state_path,
-                report.state_present,
-                report.schema_version,
-                report.processed_event_count,
-                if channel_lines.is_empty() {
-                    "none".to_string()
+            if cli.daemon_status {
+                let report = crate::daemon_runtime::inspect_tau_daemon(&config)?;
+                if cli.daemon_status_json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&report)
+                            .context("failed to render daemon status json")?
+                    );
                 } else {
-                    channel_lines.join(" | ")
+                    println!(
+                        "{}",
+                        crate::daemon_runtime::render_tau_daemon_status_report(&report)
+                    );
                 }
-            );
+                return Ok(true);
+            }
         }
-        return Ok(true);
+        Ok(false)
     }
+}
 
-    if cli.extension_exec_manifest.is_some() {
-        execute_extension_exec_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.extension_list {
-        execute_extension_list_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.extension_show.is_some() {
-        execute_extension_show_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.extension_validate.is_some() {
-        execute_extension_validate_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_validate.is_some() {
-        execute_package_validate_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_show.is_some() {
-        execute_package_show_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_install.is_some() {
-        execute_package_install_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_update.is_some() {
-        execute_package_update_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_list {
-        execute_package_list_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_remove.is_some() {
-        execute_package_remove_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_rollback.is_some() {
-        execute_package_rollback_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_conflicts {
-        execute_package_conflicts_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.package_activate {
-        execute_package_activate_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.qa_loop {
-        execute_qa_loop_preflight_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.mcp_server {
-        execute_mcp_server_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.rpc_capabilities {
-        execute_rpc_capabilities_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.rpc_validate_frame_file.is_some() {
-        execute_rpc_validate_frame_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.rpc_dispatch_frame_file.is_some() {
-        execute_rpc_dispatch_frame_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.rpc_dispatch_ndjson_file.is_some() {
-        execute_rpc_dispatch_ndjson_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.rpc_serve_ndjson {
-        execute_rpc_serve_ndjson_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.events_inspect {
-        execute_events_inspect_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.events_validate {
-        execute_events_validate_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.events_simulate {
-        execute_events_simulate_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.events_dry_run {
-        execute_events_dry_run_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.events_template_write.is_some() {
-        execute_events_template_write_command(cli)?;
-        return Ok(true);
-    }
-
-    if cli.event_webhook_ingest_file.is_some() {
-        validate_event_webhook_ingest_cli(cli)?;
-        let payload_file = cli
-            .event_webhook_ingest_file
-            .clone()
-            .ok_or_else(|| anyhow!("--event-webhook-ingest-file is required"))?;
-        let channel_ref = cli
-            .event_webhook_channel
-            .clone()
-            .ok_or_else(|| anyhow!("--event-webhook-channel is required"))?;
-        let pairing_policy = pairing_policy_for_state_dir(&cli.channel_store_root);
-        let actor_id = cli.event_webhook_actor_id.clone().unwrap_or_default();
-        let pairing_decision = evaluate_pairing_access(
-            &pairing_policy,
-            &channel_ref,
-            &actor_id,
-            current_unix_timestamp_ms(),
-        )?;
-        if let PairingDecision::Deny { reason_code } = pairing_decision {
-            println!(
-                "webhook ingest denied: channel={} actor_id={} reason_code={}",
-                channel_ref,
-                if actor_id.is_empty() {
-                    "(missing)"
-                } else {
-                    actor_id.as_str()
-                },
-                reason_code
-            );
-            return Ok(true);
-        }
-        let event_webhook_secret = resolve_secret_from_cli_or_store_id(
-            cli,
-            cli.event_webhook_secret.as_deref(),
-            cli.event_webhook_secret_id.as_deref(),
-            "--event-webhook-secret-id",
-        )?;
-        ingest_webhook_immediate_event(&EventWebhookIngestConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            channel_ref,
-            payload_file,
-            prompt_prefix: cli.event_webhook_prompt_prefix.clone(),
-            debounce_key: cli.event_webhook_debounce_key.clone(),
-            debounce_window_seconds: cli.event_webhook_debounce_window_seconds,
-            signature: cli.event_webhook_signature.clone(),
-            timestamp: cli.event_webhook_timestamp.clone(),
-            secret: event_webhook_secret,
-            signature_algorithm: cli
-                .event_webhook_signature_algorithm
-                .map(crate::cli_types::map_webhook_signature_algorithm),
-            signature_max_skew_seconds: cli.event_webhook_signature_max_skew_seconds,
-        })?;
-        return Ok(true);
-    }
-
-    Ok(false)
+pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
+    tau_startup::execute_startup_preflight(cli, &TauStartupPreflightActions)
 }

--- a/crates/tau-startup/Cargo.toml
+++ b/crates/tau-startup/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tau-startup"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+serde_json = "1"
+
+[dependencies.tau-access]
+path = "../tau-access"
+
+[dependencies.tau-cli]
+path = "../tau-cli"
+
+[dependencies.tau-core]
+path = "../tau-core"
+
+[dependencies.tau-events]
+path = "../tau-events"
+
+[dependencies.tau-gateway]
+path = "../tau-gateway"
+
+[dependencies.tau-multi-channel]
+path = "../tau-multi-channel"
+
+[dependencies.tau-session]
+path = "../tau-session"

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -1,0 +1,526 @@
+use anyhow::{anyhow, Context, Result};
+use tau_access::pairing::{evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision};
+use tau_cli::validation::{
+    validate_browser_automation_preflight_cli, validate_deployment_wasm_inspect_cli,
+    validate_deployment_wasm_package_cli, validate_event_webhook_ingest_cli,
+    validate_gateway_remote_profile_inspect_cli, validate_gateway_service_cli,
+    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_incident_timeline_cli,
+    validate_multi_channel_live_ingest_cli, validate_multi_channel_send_cli,
+    validate_project_index_cli,
+};
+use tau_cli::Cli;
+use tau_core::current_unix_timestamp_ms;
+use tau_events::{
+    ingest_webhook_immediate_event, EventWebhookIngestConfig, WebhookSignatureAlgorithm,
+};
+use tau_gateway::{
+    inspect_gateway_service_mode, render_gateway_service_status_report, start_gateway_service_mode,
+    stop_gateway_service_mode,
+};
+use tau_session::validate_session_file;
+
+pub trait StartupPreflightActions {
+    fn execute_onboarding_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_multi_channel_send_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_multi_channel_channel_lifecycle_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_deployment_wasm_package_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_deployment_wasm_inspect_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_project_index_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_channel_store_admin_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_multi_channel_live_readiness_preflight_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_browser_automation_preflight_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_extension_exec_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_extension_list_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_extension_show_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_extension_validate_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_validate_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_show_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_install_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_update_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_list_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_remove_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_rollback_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_conflicts_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_package_activate_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_qa_loop_preflight_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_mcp_server_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_rpc_capabilities_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_rpc_validate_frame_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_rpc_dispatch_frame_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_rpc_dispatch_ndjson_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_rpc_serve_ndjson_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_events_inspect_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_events_validate_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_events_simulate_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_events_dry_run_command(&self, cli: &Cli) -> Result<()>;
+    fn execute_events_template_write_command(&self, cli: &Cli) -> Result<()>;
+    fn resolve_secret_from_cli_or_store_id(
+        &self,
+        cli: &Cli,
+        direct_secret: Option<&str>,
+        secret_id: Option<&str>,
+        secret_id_flag: &str,
+    ) -> Result<Option<String>>;
+    fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool>;
+}
+
+pub fn execute_startup_preflight(cli: &Cli, actions: &dyn StartupPreflightActions) -> Result<bool> {
+    if cli.onboard {
+        actions.execute_onboarding_command(cli)?;
+        return Ok(true);
+    }
+
+    if let Some(inspect_file) = cli.multi_channel_route_inspect_file.as_ref() {
+        let report = tau_multi_channel::build_multi_channel_route_inspect_report(
+            &tau_multi_channel::MultiChannelRouteInspectConfig {
+                inspect_file: inspect_file.clone(),
+                state_dir: cli.multi_channel_state_dir.clone(),
+                orchestrator_route_table_path: cli.orchestrator_route_table.clone(),
+            },
+        )?;
+        if cli.multi_channel_route_inspect_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render multi-channel route inspect json")?
+            );
+        } else {
+            println!(
+                "{}",
+                tau_multi_channel::render_multi_channel_route_inspect_report(&report)
+            );
+        }
+        return Ok(true);
+    }
+
+    if cli.multi_channel_incident_timeline {
+        validate_multi_channel_incident_timeline_cli(cli)?;
+        let report = tau_multi_channel::build_multi_channel_incident_timeline_report(
+            &tau_multi_channel::MultiChannelIncidentTimelineQuery {
+                state_dir: cli.multi_channel_state_dir.clone(),
+                window_start_unix_ms: cli.multi_channel_incident_start_unix_ms,
+                window_end_unix_ms: cli.multi_channel_incident_end_unix_ms,
+                event_limit: cli.multi_channel_incident_event_limit.unwrap_or(200),
+                replay_export_path: cli.multi_channel_incident_replay_export.clone(),
+            },
+        )?;
+        if cli.multi_channel_incident_timeline_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render multi-channel incident timeline json")?
+            );
+        } else {
+            println!(
+                "{}",
+                tau_multi_channel::render_multi_channel_incident_timeline_report(&report)
+            );
+        }
+        return Ok(true);
+    }
+
+    if cli.multi_channel_send.is_some() {
+        validate_multi_channel_send_cli(cli)?;
+        actions.execute_multi_channel_send_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.multi_channel_channel_status.is_some()
+        || cli.multi_channel_channel_login.is_some()
+        || cli.multi_channel_channel_logout.is_some()
+        || cli.multi_channel_channel_probe.is_some()
+    {
+        validate_multi_channel_channel_lifecycle_cli(cli)?;
+        actions.execute_multi_channel_channel_lifecycle_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.deployment_wasm_package_module.is_some() {
+        validate_deployment_wasm_package_cli(cli)?;
+        actions.execute_deployment_wasm_package_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.deployment_wasm_inspect_manifest.is_some() {
+        validate_deployment_wasm_inspect_cli(cli)?;
+        actions.execute_deployment_wasm_inspect_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.session_validate {
+        validate_session_file(&cli.session, cli.no_session)?;
+        return Ok(true);
+    }
+
+    if cli.project_index_build
+        || cli.project_index_query.is_some()
+        || cli.project_index_inspect
+        || cli.project_index_json
+    {
+        validate_project_index_cli(cli)?;
+        actions.execute_project_index_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.channel_store_inspect.is_some()
+        || cli.channel_store_repair.is_some()
+        || cli.transport_health_inspect.is_some()
+        || cli.github_status_inspect.is_some()
+        || cli.operator_control_summary
+        || cli.multi_channel_status_inspect
+        || cli.dashboard_status_inspect
+        || cli.multi_agent_status_inspect
+        || cli.gateway_status_inspect
+        || cli.deployment_status_inspect
+        || cli.custom_command_status_inspect
+        || cli.voice_status_inspect
+    {
+        actions.execute_channel_store_admin_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.gateway_remote_profile_inspect {
+        validate_gateway_remote_profile_inspect_cli(cli)?;
+        tau_cli::gateway_remote_profile::execute_gateway_remote_profile_inspect_command(cli)?;
+        return Ok(true);
+    }
+
+    if actions.handle_daemon_commands(cli)? {
+        return Ok(true);
+    }
+
+    if cli.gateway_service_start || cli.gateway_service_stop || cli.gateway_service_status {
+        validate_gateway_service_cli(cli)?;
+        if cli.gateway_service_start {
+            let report = start_gateway_service_mode(&cli.gateway_state_dir)?;
+            println!("{}", render_gateway_service_status_report(&report));
+            return Ok(true);
+        }
+        if cli.gateway_service_stop {
+            let report = stop_gateway_service_mode(
+                &cli.gateway_state_dir,
+                cli.gateway_service_stop_reason.as_deref(),
+            )?;
+            println!("{}", render_gateway_service_status_report(&report));
+            return Ok(true);
+        }
+        if cli.gateway_service_status {
+            let report = inspect_gateway_service_mode(&cli.gateway_state_dir)?;
+            if cli.gateway_service_status_json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .context("failed to render gateway service status json")?
+                );
+            } else {
+                println!("{}", render_gateway_service_status_report(&report));
+            }
+            return Ok(true);
+        }
+    }
+
+    if cli.multi_channel_live_ingest_file.is_some() {
+        validate_multi_channel_live_ingest_cli(cli)?;
+        let payload_file = cli
+            .multi_channel_live_ingest_file
+            .clone()
+            .ok_or_else(|| anyhow!("--multi-channel-live-ingest-file is required"))?;
+        let transport: tau_multi_channel::MultiChannelTransport = cli
+            .multi_channel_live_ingest_transport
+            .ok_or_else(|| anyhow!("--multi-channel-live-ingest-transport is required"))?
+            .into();
+        let report = tau_multi_channel::ingest_multi_channel_live_raw_payload(
+            &tau_multi_channel::MultiChannelLivePayloadIngestConfig {
+                ingress_dir: cli.multi_channel_live_ingest_dir.clone(),
+                payload_file,
+                transport,
+                provider: cli.multi_channel_live_ingest_provider.clone(),
+            },
+        )?;
+        println!(
+            "multi-channel live ingest queued: transport={} provider={} event_id={} conversation_id={} ingress_file={}",
+            report.transport.as_str(),
+            report.provider,
+            report.event_id,
+            report.conversation_id,
+            report.ingress_path.display()
+        );
+        return Ok(true);
+    }
+
+    if cli.multi_channel_live_readiness_preflight {
+        actions.execute_multi_channel_live_readiness_preflight_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.browser_automation_preflight {
+        validate_browser_automation_preflight_cli(cli)?;
+        actions.execute_browser_automation_preflight_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.multi_channel_live_connectors_status {
+        let report = tau_multi_channel::load_multi_channel_live_connectors_status_report(
+            &cli.multi_channel_live_connectors_state_path,
+        )?;
+        if cli.multi_channel_live_connectors_status_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render live connector status json")?
+            );
+        } else {
+            let mut channel_lines = Vec::new();
+            for (channel, status) in &report.channels {
+                let operator_guidance = if status.breaker_state == "open" {
+                    format!(
+                        "wait_for_breaker_recovery_until:{}",
+                        status.breaker_open_until_unix_ms
+                    )
+                } else if status.liveness == "degraded" {
+                    "inspect_provider_errors_and_credentials".to_string()
+                } else {
+                    "none".to_string()
+                };
+                channel_lines.push(format!(
+                    "{}:mode={} liveness={} breaker_state={} retry_budget_remaining={} breaker_open_until_unix_ms={} breaker_last_open_reason={} ingested={} duplicates={} retries={} auth_failures={} parse_failures={} provider_failures={} last_error_code={} guidance={}",
+                    channel,
+                    if status.mode.is_empty() { "unknown" } else { status.mode.as_str() },
+                    if status.liveness.is_empty() { "unknown" } else { status.liveness.as_str() },
+                    if status.breaker_state.is_empty() {
+                        "unknown"
+                    } else {
+                        status.breaker_state.as_str()
+                    },
+                    status.retry_budget_remaining,
+                    status.breaker_open_until_unix_ms,
+                    if status.breaker_last_open_reason.is_empty() {
+                        "none"
+                    } else {
+                        status.breaker_last_open_reason.as_str()
+                    },
+                    status.events_ingested,
+                    status.duplicates_skipped,
+                    status.retry_attempts,
+                    status.auth_failures,
+                    status.parse_failures,
+                    status.provider_failures,
+                    if status.last_error_code.is_empty() {
+                        "none"
+                    } else {
+                        status.last_error_code.as_str()
+                    },
+                    operator_guidance
+                ));
+            }
+            channel_lines.sort();
+            println!(
+                "multi-channel live connectors status: state_path={} state_present={} schema_version={} processed_event_count={} channels={}",
+                report.state_path,
+                report.state_present,
+                report.schema_version,
+                report.processed_event_count,
+                if channel_lines.is_empty() {
+                    "none".to_string()
+                } else {
+                    channel_lines.join(" | ")
+                }
+            );
+        }
+        return Ok(true);
+    }
+
+    if cli.extension_exec_manifest.is_some() {
+        actions.execute_extension_exec_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.extension_list {
+        actions.execute_extension_list_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.extension_show.is_some() {
+        actions.execute_extension_show_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.extension_validate.is_some() {
+        actions.execute_extension_validate_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_validate.is_some() {
+        actions.execute_package_validate_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_show.is_some() {
+        actions.execute_package_show_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_install.is_some() {
+        actions.execute_package_install_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_update.is_some() {
+        actions.execute_package_update_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_list {
+        actions.execute_package_list_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_remove.is_some() {
+        actions.execute_package_remove_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_rollback.is_some() {
+        actions.execute_package_rollback_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_conflicts {
+        actions.execute_package_conflicts_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.package_activate {
+        actions.execute_package_activate_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.qa_loop {
+        actions.execute_qa_loop_preflight_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.mcp_server {
+        actions.execute_mcp_server_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.rpc_capabilities {
+        actions.execute_rpc_capabilities_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.rpc_validate_frame_file.is_some() {
+        actions.execute_rpc_validate_frame_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.rpc_dispatch_frame_file.is_some() {
+        actions.execute_rpc_dispatch_frame_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.rpc_dispatch_ndjson_file.is_some() {
+        actions.execute_rpc_dispatch_ndjson_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.rpc_serve_ndjson {
+        actions.execute_rpc_serve_ndjson_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.events_inspect {
+        actions.execute_events_inspect_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.events_validate {
+        actions.execute_events_validate_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.events_simulate {
+        actions.execute_events_simulate_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.events_dry_run {
+        actions.execute_events_dry_run_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.events_template_write.is_some() {
+        actions.execute_events_template_write_command(cli)?;
+        return Ok(true);
+    }
+
+    if cli.event_webhook_ingest_file.is_some() {
+        validate_event_webhook_ingest_cli(cli)?;
+        let payload_file = cli
+            .event_webhook_ingest_file
+            .clone()
+            .ok_or_else(|| anyhow!("--event-webhook-ingest-file is required"))?;
+        let channel_ref = cli
+            .event_webhook_channel
+            .clone()
+            .ok_or_else(|| anyhow!("--event-webhook-channel is required"))?;
+        let pairing_policy = pairing_policy_for_state_dir(&cli.channel_store_root);
+        let actor_id = cli.event_webhook_actor_id.clone().unwrap_or_default();
+        let pairing_decision = evaluate_pairing_access(
+            &pairing_policy,
+            &channel_ref,
+            &actor_id,
+            current_unix_timestamp_ms(),
+        )?;
+        if let PairingDecision::Deny { reason_code } = pairing_decision {
+            println!(
+                "webhook ingest denied: channel={} actor_id={} reason_code={}",
+                channel_ref,
+                if actor_id.is_empty() {
+                    "(missing)"
+                } else {
+                    actor_id.as_str()
+                },
+                reason_code
+            );
+            return Ok(true);
+        }
+        let event_webhook_secret = actions.resolve_secret_from_cli_or_store_id(
+            cli,
+            cli.event_webhook_secret.as_deref(),
+            cli.event_webhook_secret_id.as_deref(),
+            "--event-webhook-secret-id",
+        )?;
+        ingest_webhook_immediate_event(&EventWebhookIngestConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            channel_ref,
+            payload_file,
+            prompt_prefix: cli.event_webhook_prompt_prefix.clone(),
+            debounce_key: cli.event_webhook_debounce_key.clone(),
+            debounce_window_seconds: cli.event_webhook_debounce_window_seconds,
+            signature: cli.event_webhook_signature.clone(),
+            timestamp: cli.event_webhook_timestamp.clone(),
+            secret: event_webhook_secret,
+            signature_algorithm: map_webhook_signature_algorithm(
+                cli.event_webhook_signature_algorithm,
+            ),
+            signature_max_skew_seconds: cli.event_webhook_signature_max_skew_seconds,
+        })?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn map_webhook_signature_algorithm(
+    algorithm: Option<tau_cli::CliWebhookSignatureAlgorithm>,
+) -> Option<WebhookSignatureAlgorithm> {
+    algorithm.map(|value| match value {
+        tau_cli::CliWebhookSignatureAlgorithm::GithubSha256 => {
+            WebhookSignatureAlgorithm::GithubSha256
+        }
+        tau_cli::CliWebhookSignatureAlgorithm::SlackV0 => WebhookSignatureAlgorithm::SlackV0,
+    })
+}


### PR DESCRIPTION
## Summary
- move startup preflight flow into new `tau-startup` crate
- keep `tau-coding-agent` as thin adapter for preflight actions
- remove unused helper shims after extraction

## Risks
- low: code moved across crates; behavior preserved, but any missing re-exports could surface in edge paths

## Validation
- `cargo fmt`
- `cargo test -p tau-startup -p tau-coding-agent -- --test-threads=1`

Closes #982
