### PR TITLE
Extract diagnostics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,12 +2738,14 @@ dependencies = [
  "tau-cli",
  "tau-core",
  "tau-deployment",
+ "tau-diagnostics",
  "tau-events",
  "tau-extensions",
  "tau-gateway",
  "tau-multi-channel",
  "tau-orchestrator",
  "tau-provider",
+ "tau-release-channel",
  "tau-runtime",
  "tau-session",
  "tau-skills",
@@ -2781,6 +2783,22 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasmparser",
+]
+
+[[package]]
+name = "tau-diagnostics"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tau-ai",
+ "tau-cli",
+ "tau-core",
+ "tau-multi-channel",
+ "tau-provider",
+ "tau-release-channel",
+ "tempfile",
 ]
 
 [[package]]
@@ -2888,6 +2906,19 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tau-release-channel"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tau-core",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
   "crates/tau-tui",
   "crates/tau-startup",
   "crates/tau-provider",
+  "crates/tau-release-channel",
+  "crates/tau-diagnostics",
   "crates/tau-coding-agent",
 ]
 resolver = "2"

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -30,6 +30,8 @@ tau-events = { path = "../tau-events" }
 tau-deployment = { path = "../tau-deployment" }
 tau-startup = { path = "../tau-startup" }
 tau-provider = { path = "../tau-provider" }
+tau-diagnostics = { path = "../tau-diagnostics" }
+tau-release-channel = { path = "../tau-release-channel" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-ai = { path = "../tau-ai" }
 reqwest.workspace = true

--- a/crates/tau-coding-agent/src/channel_adapters.rs
+++ b/crates/tau-coding-agent/src/channel_adapters.rs
@@ -4,15 +4,15 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::auth_commands::execute_auth_command;
-use crate::diagnostics_commands::{
-    execute_doctor_command, execute_doctor_command_with_options, DoctorCheckOptions,
-    DoctorCommandOutputFormat,
-};
 use crate::runtime_types::{AuthCommandConfig, DoctorCommandConfig};
 use tau_access::approvals::{
     approval_paths_for_state_dir, execute_approvals_command_with_paths_and_actor,
 };
 use tau_access::pairing::{evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision};
+use tau_diagnostics::{
+    execute_doctor_command, execute_doctor_command_with_options, DoctorCheckOptions,
+    DoctorCommandOutputFormat,
+};
 use tau_multi_channel::{
     MultiChannelApprovalsCommandExecutor, MultiChannelAuthCommandExecutor,
     MultiChannelCommandHandlers, MultiChannelDoctorCommandExecutor, MultiChannelPairingDecision,

--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -21,10 +21,6 @@ use crate::auth_commands::{
 use crate::channel_store::{
     ChannelArtifactRecord, ChannelAttachmentRecord, ChannelLogEntry, ChannelStore,
 };
-use crate::diagnostics_commands::{
-    render_doctor_report, render_doctor_report_json, run_doctor_checks_with_options,
-    DoctorCheckOptions, DoctorStatus,
-};
 use crate::github_issues_helpers::{
     attachment_filename_from_url, chunk_text_by_chars, evaluate_attachment_content_type_policy,
     evaluate_attachment_url_policy, extract_attachment_urls, split_at_char_index,
@@ -42,6 +38,10 @@ use crate::{
     session_message_preview, session_message_role, write_text_atomic, CanvasCommandConfig,
     CanvasEventOrigin, CanvasSessionLinkContext, PairingDecision, PromptRunStatus, RbacDecision,
     RenderOptions, SessionRuntime, TransportHealthSnapshot,
+};
+use tau_diagnostics::{
+    render_doctor_report, render_doctor_report_json, run_doctor_checks_with_options,
+    DoctorCheckOptions, DoctorStatus,
 };
 use tau_session::SessionStore;
 use tau_session::{parse_session_search_args, search_session_entries};

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -20,7 +20,6 @@ mod dashboard_contract;
 mod dashboard_runtime;
 mod deployment_runtime;
 mod deployment_wasm;
-mod diagnostics_commands;
 mod events;
 mod extension_manifest;
 mod github_issues;
@@ -123,22 +122,6 @@ pub(crate) use crate::credentials::{
 };
 #[cfg(test)]
 pub(crate) use crate::credentials::{parse_integration_auth_command, IntegrationAuthCommand};
-pub(crate) use crate::diagnostics_commands::{
-    build_doctor_command_config, execute_audit_summary_command,
-    execute_browser_automation_preflight_command, execute_doctor_cli_command,
-    execute_multi_channel_live_readiness_preflight_command, execute_policy_command,
-};
-#[cfg(test)]
-pub(crate) use crate::diagnostics_commands::{
-    evaluate_multi_channel_live_readiness, parse_doctor_command_args, percentile_duration_ms,
-    render_audit_summary, render_doctor_report, render_doctor_report_json, run_doctor_checks,
-    run_doctor_checks_with_lookup, summarize_audit_file, DoctorCheckOptions, DoctorCheckResult,
-    DoctorCommandArgs, DoctorCommandOutputFormat, DoctorStatus,
-};
-#[cfg(test)]
-pub(crate) use crate::diagnostics_commands::{
-    execute_doctor_command, execute_doctor_command_with_options,
-};
 use crate::events::{
     execute_events_dry_run_command, execute_events_inspect_command,
     execute_events_simulate_command, execute_events_template_write_command,
@@ -211,10 +194,13 @@ pub(crate) use crate::runtime_output::{
     event_to_json, persist_messages, print_assistant_messages, summarize_message,
 };
 pub(crate) use crate::runtime_types::{
-    AuthCommandConfig, CommandExecutionContext, DoctorCommandConfig,
-    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus, ProfileAuthDefaults,
-    ProfileDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
-    RenderOptions, SkillsSyncCommandConfig,
+    AuthCommandConfig, CommandExecutionContext, ProfileAuthDefaults, ProfileDefaults,
+    ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults, RenderOptions,
+    SkillsSyncCommandConfig,
+};
+#[cfg(test)]
+pub(crate) use crate::runtime_types::{
+    DoctorCommandConfig, DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus,
 };
 use crate::skills::{
     augment_system_prompt, build_local_skill_lock_hints, build_registry_skill_lock_hints,
@@ -320,6 +306,20 @@ pub(crate) use tau_cli::validation::{
 };
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
+pub(crate) use tau_diagnostics::{
+    build_doctor_command_config, execute_audit_summary_command,
+    execute_browser_automation_preflight_command, execute_doctor_cli_command,
+    execute_multi_channel_live_readiness_preflight_command, execute_policy_command,
+};
+#[cfg(test)]
+pub(crate) use tau_diagnostics::{
+    evaluate_multi_channel_live_readiness, parse_doctor_command_args, percentile_duration_ms,
+    render_audit_summary, render_doctor_report, render_doctor_report_json, run_doctor_checks,
+    run_doctor_checks_with_lookup, summarize_audit_file, DoctorCheckOptions, DoctorCheckResult,
+    DoctorCommandArgs, DoctorCommandOutputFormat, DoctorStatus,
+};
+#[cfg(test)]
+pub(crate) use tau_diagnostics::{execute_doctor_command, execute_doctor_command_with_options};
 use tau_gateway::{run_gateway_contract_runner, GatewayRuntimeConfig};
 #[cfg(test)]
 pub(crate) use tau_multi_channel::build_multi_channel_incident_timeline_report;
@@ -338,10 +338,15 @@ pub(crate) use tau_orchestrator::parse_numbered_plan_steps;
 pub(crate) use tau_provider::provider_auth_snapshot_for_status;
 #[cfg(test)]
 pub(crate) use tau_provider::refresh_provider_access_token;
+#[cfg(test)]
+pub(crate) use tau_provider::resolve_api_key;
+#[cfg(test)]
+pub(crate) use tau_provider::CredentialStoreEncryptionMode;
+pub(crate) use tau_provider::ProviderAuthMethod;
 pub(crate) use tau_provider::{
-    build_client_with_fallbacks, configured_provider_auth_method,
-    configured_provider_auth_method_from_config, missing_provider_api_key_message,
-    provider_auth_capability, provider_auth_mode_flag, resolve_api_key, resolve_fallback_models,
+    build_client_with_fallbacks, configured_provider_auth_method_from_config,
+    missing_provider_api_key_message, provider_auth_capability, provider_auth_mode_flag,
+    resolve_fallback_models,
 };
 #[cfg(test)]
 pub(crate) use tau_provider::{build_provider_client, provider_api_key_candidates_with_inputs};
@@ -360,7 +365,6 @@ pub(crate) use tau_provider::{
     resolve_non_empty_secret_with_source, save_credential_store, CredentialStoreData,
     ProviderCredentialStoreRecord,
 };
-pub(crate) use tau_provider::{CredentialStoreEncryptionMode, ProviderAuthMethod};
 pub(crate) use tau_session::execute_session_graph_export_command;
 #[cfg(test)]
 pub(crate) use tau_session::validate_session_file;

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -1,13 +1,11 @@
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
-use tau_ai::Provider;
-
 use crate::extension_manifest::ExtensionRegisteredCommand;
-use crate::{
-    default_provider_auth_method, Cli, CredentialStoreEncryptionMode, ModelCatalog,
-    ProviderAuthMethod,
-};
+use crate::{default_provider_auth_method, Cli, ModelCatalog, ProviderAuthMethod};
+use serde::{Deserialize, Serialize};
+pub(crate) use tau_diagnostics::DoctorCommandConfig;
+#[cfg(test)]
+pub(crate) use tau_diagnostics::{DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus};
 pub(crate) use tau_provider::AuthCommandConfig;
 use tau_session::SessionImportMode;
 
@@ -17,62 +15,6 @@ pub(crate) struct SkillsSyncCommandConfig {
     pub(crate) default_lock_path: PathBuf,
     pub(crate) default_trust_root_path: Option<PathBuf>,
     pub(crate) doctor_config: DoctorCommandConfig,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DoctorProviderKeyStatus {
-    pub(crate) provider_kind: Provider,
-    pub(crate) provider: String,
-    pub(crate) key_env_var: String,
-    pub(crate) present: bool,
-    pub(crate) auth_mode: ProviderAuthMethod,
-    pub(crate) mode_supported: bool,
-    pub(crate) login_backend_enabled: bool,
-    pub(crate) login_backend_executable: Option<String>,
-    pub(crate) login_backend_available: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DoctorMultiChannelReadinessConfig {
-    pub(crate) ingress_dir: PathBuf,
-    pub(crate) credential_store_path: PathBuf,
-    pub(crate) credential_store_encryption: CredentialStoreEncryptionMode,
-    pub(crate) credential_store_key: Option<String>,
-    pub(crate) telegram_bot_token: Option<String>,
-    pub(crate) discord_bot_token: Option<String>,
-    pub(crate) whatsapp_access_token: Option<String>,
-    pub(crate) whatsapp_phone_number_id: Option<String>,
-}
-
-impl Default for DoctorMultiChannelReadinessConfig {
-    fn default() -> Self {
-        Self {
-            ingress_dir: PathBuf::from(".tau/multi-channel/live-ingress"),
-            credential_store_path: PathBuf::from(".tau/credentials.json"),
-            credential_store_encryption: CredentialStoreEncryptionMode::None,
-            credential_store_key: None,
-            telegram_bot_token: None,
-            discord_bot_token: None,
-            whatsapp_access_token: None,
-            whatsapp_phone_number_id: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DoctorCommandConfig {
-    pub(crate) model: String,
-    pub(crate) provider_keys: Vec<DoctorProviderKeyStatus>,
-    pub(crate) release_channel_path: PathBuf,
-    pub(crate) release_lookup_cache_path: PathBuf,
-    pub(crate) release_lookup_cache_ttl_ms: u64,
-    pub(crate) browser_automation_playwright_cli: String,
-    pub(crate) session_enabled: bool,
-    pub(crate) session_path: PathBuf,
-    pub(crate) skills_dir: PathBuf,
-    pub(crate) skills_lock_path: PathBuf,
-    pub(crate) trust_root_path: Option<PathBuf>,
-    pub(crate) multi_channel_live_readiness: DoctorMultiChannelReadinessConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/tau-diagnostics/Cargo.toml
+++ b/crates/tau-diagnostics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tau-diagnostics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tau-ai = { path = "../tau-ai" }
+tau-cli = { path = "../tau-cli" }
+tau-core = { path = "../tau-core" }
+tau-provider = { path = "../tau-provider" }
+tau-release-channel = { path = "../tau-release-channel" }
+tau-multi-channel = { path = "../tau-multi-channel" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tau-release-channel/Cargo.toml
+++ b/crates/tau-release-channel/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tau-release-channel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tau-core = { path = "../tau-core" }
+tokio.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tau-release-channel/src/lib.rs
+++ b/crates/tau-release-channel/src/lib.rs
@@ -1,0 +1,364 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tau_core::write_text_atomic;
+
+pub mod cache;
+
+pub const RELEASE_LOOKUP_CACHE_SCHEMA_VERSION: u32 = 1;
+pub const RELEASE_LOOKUP_CACHE_TTL_MS: u64 = 15 * 60 * 1_000;
+pub const RELEASE_CHANNEL_SCHEMA_VERSION: u32 = 2;
+pub const RELEASE_LOOKUP_URL: &str = "https://api.github.com/repos/njfio/Tau/releases?per_page=30";
+pub const RELEASE_LOOKUP_USER_AGENT: &str = "tau-coding-agent/release-channel-check";
+pub const RELEASE_LOOKUP_TIMEOUT_MS: u64 = 8_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReleaseChannel {
+    Stable,
+    Beta,
+    Dev,
+}
+
+impl ReleaseChannel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReleaseChannel::Stable => "stable",
+            ReleaseChannel::Beta => "beta",
+            ReleaseChannel::Dev => "dev",
+        }
+    }
+}
+
+impl std::fmt::Display for ReleaseChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ReleaseChannel {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "stable" => Ok(Self::Stable),
+            "beta" => Ok(Self::Beta),
+            "dev" => Ok(Self::Dev),
+            _ => bail!(
+                "invalid release channel '{}'; expected stable|beta|dev",
+                value
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ReleaseChannelRollbackMetadata {
+    #[serde(default)]
+    pub previous_channel: Option<ReleaseChannel>,
+    #[serde(default)]
+    pub previous_version: Option<String>,
+    #[serde(default)]
+    pub reference_unix_ms: Option<u64>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseChannelStoreFile {
+    pub schema_version: u32,
+    pub release_channel: ReleaseChannel,
+    #[serde(default)]
+    pub rollback: ReleaseChannelRollbackMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct LegacyReleaseChannelStoreFile {
+    schema_version: u32,
+    release_channel: ReleaseChannel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitHubReleaseRecord {
+    pub tag_name: String,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub draft: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseLookupSource {
+    Live,
+    CacheFresh,
+    CacheStaleFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LatestChannelReleaseResolution {
+    pub latest: Option<String>,
+    pub source: ReleaseLookupSource,
+}
+
+pub fn release_lookup_url() -> &'static str {
+    RELEASE_LOOKUP_URL
+}
+
+pub fn default_release_channel_path() -> Result<PathBuf> {
+    Ok(std::env::current_dir()
+        .context("failed to resolve current working directory")?
+        .join(".tau")
+        .join("release-channel.json"))
+}
+
+pub fn load_release_channel_store(path: &Path) -> Result<Option<ReleaseChannel>> {
+    Ok(load_release_channel_store_file(path)?.map(|store| store.release_channel))
+}
+
+pub fn load_release_channel_store_file(path: &Path) -> Result<Option<ReleaseChannelStoreFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read release channel file {}", path.display()))?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw)
+        .with_context(|| format!("failed to parse release channel file {}", path.display()))?;
+    let schema_version = value
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            anyhow!(
+                "release channel file {} is missing schema_version",
+                path.display()
+            )
+        })?;
+
+    match schema_version {
+        1 => {
+            let legacy = serde_json::from_value::<LegacyReleaseChannelStoreFile>(value)
+                .with_context(|| {
+                    format!("failed to parse release channel file {}", path.display())
+                })?;
+            Ok(Some(ReleaseChannelStoreFile {
+                schema_version: RELEASE_CHANNEL_SCHEMA_VERSION,
+                release_channel: legacy.release_channel,
+                rollback: ReleaseChannelRollbackMetadata::default(),
+            }))
+        }
+        version if version == RELEASE_CHANNEL_SCHEMA_VERSION as u64 => {
+            let parsed =
+                serde_json::from_value::<ReleaseChannelStoreFile>(value).with_context(|| {
+                    format!("failed to parse release channel file {}", path.display())
+                })?;
+            Ok(Some(parsed))
+        }
+        other => bail!(
+            "unsupported release channel schema_version {} in {} (expected {} or 1)",
+            other,
+            path.display(),
+            RELEASE_CHANNEL_SCHEMA_VERSION
+        ),
+    }
+}
+
+pub fn save_release_channel_store_file(
+    path: &Path,
+    payload: &ReleaseChannelStoreFile,
+) -> Result<()> {
+    let mut encoded =
+        serde_json::to_string_pretty(payload).context("failed to encode release channel store")?;
+    encoded.push('\n');
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "release channel path {} does not have a parent directory",
+            path.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create release channel directory {}",
+            parent.display()
+        )
+    })?;
+    write_text_atomic(path, &encoded)
+}
+
+pub fn save_release_channel_store(path: &Path, channel: ReleaseChannel) -> Result<()> {
+    let existing = load_release_channel_store_file(path)?;
+    let payload = ReleaseChannelStoreFile {
+        schema_version: RELEASE_CHANNEL_SCHEMA_VERSION,
+        release_channel: channel,
+        rollback: existing.map(|store| store.rollback).unwrap_or_default(),
+    };
+    save_release_channel_store_file(path, &payload)
+}
+
+pub fn compare_versions(current: &str, latest: &str) -> Option<std::cmp::Ordering> {
+    let current_segments = parse_version_segments(current)?;
+    let latest_segments = parse_version_segments(latest)?;
+    let max_len = current_segments.len().max(latest_segments.len());
+    for index in 0..max_len {
+        let current_value = *current_segments.get(index).unwrap_or(&0);
+        let latest_value = *latest_segments.get(index).unwrap_or(&0);
+        match current_value.cmp(&latest_value) {
+            std::cmp::Ordering::Less => return Some(std::cmp::Ordering::Less),
+            std::cmp::Ordering::Greater => return Some(std::cmp::Ordering::Greater),
+            std::cmp::Ordering::Equal => {}
+        }
+    }
+    Some(std::cmp::Ordering::Equal)
+}
+
+pub fn resolve_latest_channel_release(
+    channel: ReleaseChannel,
+    url: &str,
+) -> Result<Option<String>> {
+    let releases = fetch_release_records(url)?;
+    Ok(select_latest_channel_release(channel, &releases))
+}
+
+pub fn resolve_latest_channel_release_cached(
+    channel: ReleaseChannel,
+    url: &str,
+    cache_path: &Path,
+    cache_ttl_ms: u64,
+) -> Result<LatestChannelReleaseResolution> {
+    let now_ms = current_unix_timestamp_ms();
+    let mut stale_cache_releases: Option<Vec<GitHubReleaseRecord>> = None;
+
+    if let Ok(Some(cache)) = cache::load_release_lookup_cache(cache_path, url) {
+        let age_ms = now_ms.saturating_sub(cache.fetched_at_unix_ms);
+        if age_ms <= cache_ttl_ms {
+            return Ok(LatestChannelReleaseResolution {
+                latest: select_latest_channel_release(channel, &cache.releases),
+                source: ReleaseLookupSource::CacheFresh,
+            });
+        }
+        stale_cache_releases = Some(cache.releases);
+    }
+
+    match fetch_release_records(url) {
+        Ok(releases) => {
+            let _ = cache::save_release_lookup_cache(cache_path, url, now_ms, &releases);
+            Ok(LatestChannelReleaseResolution {
+                latest: select_latest_channel_release(channel, &releases),
+                source: ReleaseLookupSource::Live,
+            })
+        }
+        Err(error) => {
+            if let Some(releases) = stale_cache_releases {
+                return Ok(LatestChannelReleaseResolution {
+                    latest: select_latest_channel_release(channel, &releases),
+                    source: ReleaseLookupSource::CacheStaleFallback,
+                });
+            }
+            Err(error)
+        }
+    }
+}
+
+pub fn select_latest_channel_release(
+    channel: ReleaseChannel,
+    releases: &[GitHubReleaseRecord],
+) -> Option<String> {
+    let stable = releases
+        .iter()
+        .find(|item| !item.draft && !item.prerelease)
+        .map(|item| item.tag_name.trim().to_string())
+        .filter(|tag| !tag.is_empty());
+    let prerelease = releases
+        .iter()
+        .find(|item| !item.draft && item.prerelease)
+        .map(|item| item.tag_name.trim().to_string())
+        .filter(|tag| !tag.is_empty());
+
+    match channel {
+        ReleaseChannel::Stable => stable,
+        ReleaseChannel::Beta | ReleaseChannel::Dev => prerelease.or(stable),
+    }
+}
+
+fn parse_version_segments(raw: &str) -> Option<Vec<u64>> {
+    let trimmed = raw.trim().trim_start_matches('v').trim_start_matches('V');
+    let core = trimmed
+        .split_once('-')
+        .map(|(left, _)| left)
+        .unwrap_or(trimmed);
+    if core.is_empty() {
+        return None;
+    }
+    let mut segments = Vec::new();
+    for token in core.split('.') {
+        segments.push(token.parse::<u64>().ok()?);
+    }
+    if segments.is_empty() {
+        return None;
+    }
+    Some(segments)
+}
+
+pub fn fetch_release_records(url: &str) -> Result<Vec<GitHubReleaseRecord>> {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| handle.block_on(fetch_release_records_async(url)))
+    } else {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to create runtime for release-channel check")?;
+        runtime.block_on(fetch_release_records_async(url))
+    }
+}
+
+fn current_unix_timestamp_ms() -> u64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis().min(u64::MAX as u128) as u64,
+        Err(_) => 0,
+    }
+}
+
+async fn fetch_release_records_async(url: &str) -> Result<Vec<GitHubReleaseRecord>> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(RELEASE_LOOKUP_TIMEOUT_MS))
+        .build()
+        .context("failed to construct HTTP client for release-channel check")?;
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, RELEASE_LOOKUP_USER_AGENT)
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch release metadata from '{}'", url))?;
+    if !response.status().is_success() {
+        bail!(
+            "release lookup request to '{}' returned status {}",
+            url,
+            response.status()
+        );
+    }
+    response
+        .json::<Vec<GitHubReleaseRecord>>()
+        .await
+        .with_context(|| format!("failed to parse release lookup response from '{}'", url))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_compare_versions_handles_prefix_suffix_and_invalid_input() {
+        assert_eq!(
+            compare_versions("0.1.0", "0.1.1"),
+            Some(std::cmp::Ordering::Less)
+        );
+        assert_eq!(
+            compare_versions("v1.2.3-beta.1", "1.2.3"),
+            Some(std::cmp::Ordering::Equal)
+        );
+        assert_eq!(
+            compare_versions("1.2.3", "1.2.2"),
+            Some(std::cmp::Ordering::Greater)
+        );
+        assert_eq!(compare_versions("abc", "1.0.0"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- extract diagnostics/doctor/audit/policy commands into new `tau-diagnostics` crate
- add `tau-release-channel` shared crate for release lookup/cache and store helpers
- update tau-coding-agent wiring and test imports to use new crates

## Risks
- release-channel and diagnostics boundaries changed; miswired imports could affect status output
- cache/store schema handling could drift if wiring is wrong

## Validation
- cargo fmt
- cargo clippy -p tau-diagnostics -p tau-coding-agent -- -D warnings
- cargo test -p tau-diagnostics -p tau-coding-agent -- --test-threads=1

Closes #984
