### PR TITLE
Extract startup dispatch skill-path helpers into tau-onboarding (#999 stage 2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ name = "tau-onboarding"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "serde",
  "serde_json",
  "tau-access",
@@ -2959,6 +2960,7 @@ dependencies = [
  "tau-provider",
  "tau-skills",
  "tau-tools",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/tau-coding-agent/src/startup_dispatch.rs
+++ b/crates/tau-coding-agent/src/startup_dispatch.rs
@@ -1,4 +1,7 @@
 use super::*;
+use tau_onboarding::startup_dispatch::{
+    resolve_runtime_skills_dir, resolve_runtime_skills_lock_path,
+};
 
 pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
     if execute_startup_preflight(&cli)? {
@@ -55,27 +58,4 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
         skills_lock_path: &skills_lock_path,
     })
     .await
-}
-
-fn resolve_runtime_skills_dir(cli: &Cli, activation_applied: bool) -> PathBuf {
-    if !activation_applied {
-        return cli.skills_dir.clone();
-    }
-    let activated_skills_dir = cli.package_activate_destination.join("skills");
-    if activated_skills_dir.is_dir() {
-        return activated_skills_dir;
-    }
-    cli.skills_dir.clone()
-}
-
-fn resolve_runtime_skills_lock_path(
-    cli: &Cli,
-    bootstrap_lock_path: &Path,
-    effective_skills_dir: &Path,
-) -> PathBuf {
-    if effective_skills_dir == cli.skills_dir {
-        bootstrap_lock_path.to_path_buf()
-    } else {
-        default_skills_lock_path(effective_skills_dir)
-    }
 }

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -15,3 +15,7 @@ tau-core = { path = "../tau-core" }
 tau-provider = { path = "../tau-provider" }
 tau-skills = { path = "../tau-skills" }
 tau-tools = { path = "../tau-tools" }
+
+[dev-dependencies]
+clap = { workspace = true }
+tempfile = "3"

--- a/crates/tau-onboarding/src/lib.rs
+++ b/crates/tau-onboarding/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod startup_config;
+pub mod startup_dispatch;
 pub mod startup_model_resolution;
 pub mod startup_policy;
 pub mod startup_prompt_composition;

--- a/crates/tau-onboarding/src/startup_dispatch.rs
+++ b/crates/tau-onboarding/src/startup_dispatch.rs
@@ -1,0 +1,100 @@
+use std::path::{Path, PathBuf};
+
+use tau_cli::Cli;
+use tau_skills::default_skills_lock_path;
+
+pub fn resolve_runtime_skills_dir(cli: &Cli, activation_applied: bool) -> PathBuf {
+    if !activation_applied {
+        return cli.skills_dir.clone();
+    }
+    let activated_skills_dir = cli.package_activate_destination.join("skills");
+    if activated_skills_dir.is_dir() {
+        return activated_skills_dir;
+    }
+    cli.skills_dir.clone()
+}
+
+pub fn resolve_runtime_skills_lock_path(
+    cli: &Cli,
+    bootstrap_lock_path: &Path,
+    effective_skills_dir: &Path,
+) -> PathBuf {
+    if effective_skills_dir == cli.skills_dir {
+        bootstrap_lock_path.to_path_buf()
+    } else {
+        default_skills_lock_path(effective_skills_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_runtime_skills_dir, resolve_runtime_skills_lock_path};
+    use clap::Parser;
+    use std::path::PathBuf;
+    use tau_cli::Cli;
+    use tau_skills::default_skills_lock_path;
+    use tempfile::tempdir;
+
+    fn parse_cli_with_stack() -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::parse_from(["tau-rs"]))
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
+    #[test]
+    fn unit_resolve_runtime_skills_lock_path_prefers_bootstrap_lock_for_default_skills_dir() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        let skills_dir = workspace.path().join(".tau/skills");
+        cli.skills_dir = skills_dir.clone();
+
+        let bootstrap_lock_path = workspace.path().join(".tau/skills.lock.json");
+        let resolved = resolve_runtime_skills_lock_path(&cli, &bootstrap_lock_path, &skills_dir);
+        assert_eq!(resolved, bootstrap_lock_path);
+    }
+
+    #[test]
+    fn functional_resolve_runtime_skills_dir_prefers_activated_directory_when_present() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        cli.skills_dir = workspace.path().join(".tau/skills");
+        cli.package_activate_destination = workspace.path().join("packages-active");
+
+        let activated_skills_dir = cli.package_activate_destination.join("skills");
+        std::fs::create_dir_all(&activated_skills_dir).expect("create activated skills dir");
+
+        let resolved = resolve_runtime_skills_dir(&cli, true);
+        assert_eq!(resolved, activated_skills_dir);
+    }
+
+    #[test]
+    fn regression_resolve_runtime_skills_dir_falls_back_when_activation_output_missing() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        let base_skills_dir = workspace.path().join(".tau/skills");
+        cli.skills_dir = base_skills_dir.clone();
+        cli.package_activate_destination = workspace.path().join("packages-active");
+
+        let resolved = resolve_runtime_skills_dir(&cli, true);
+        assert_eq!(resolved, base_skills_dir);
+    }
+
+    #[test]
+    fn regression_resolve_runtime_skills_lock_path_uses_effective_directory_when_switched() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        cli.skills_dir = workspace.path().join(".tau/skills");
+        let bootstrap_lock_path = workspace.path().join(".tau/skills.lock.json");
+
+        let activated_skills_dir = workspace.path().join("packages-active/skills");
+        let resolved =
+            resolve_runtime_skills_lock_path(&cli, &bootstrap_lock_path, &activated_skills_dir);
+
+        assert_eq!(resolved, default_skills_lock_path(&activated_skills_dir));
+        assert_ne!(resolved, PathBuf::from(bootstrap_lock_path));
+    }
+}


### PR DESCRIPTION
## Summary
- extract startup dispatch runtime skills helper functions into `tau-onboarding::startup_dispatch`
- reuse those exported helpers from `tau-coding-agent/src/startup_dispatch.rs`
- add onboarding-crate tests for runtime skills dir/lock path resolution (unit, functional, regression)

## Validation
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

## Tracking
- Part of #999 (startup monolith decomposition stage 2)
