### PR TITLE
Extract onboarding release-channel helpers into tau-onboarding (#999 stage 2e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "tau-cli",
  "tau-core",
  "tau-provider",
+ "tau-release-channel",
  "tau-skills",
  "tau-tools",
  "tempfile",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -170,9 +170,10 @@ pub(crate) use crate::project_index::execute_project_index_command;
 pub(crate) use crate::qa_loop_commands::{
     execute_qa_loop_cli_command, execute_qa_loop_preflight_command, QA_LOOP_USAGE,
 };
+#[cfg(test)]
+pub(crate) use crate::release_channel_commands::load_release_channel_store;
 pub(crate) use crate::release_channel_commands::{
-    default_release_channel_path, execute_release_channel_command, load_release_channel_store,
-    RELEASE_CHANNEL_USAGE,
+    default_release_channel_path, execute_release_channel_command, RELEASE_CHANNEL_USAGE,
 };
 pub(crate) use crate::rpc_capabilities::execute_rpc_capabilities_command;
 #[cfg(test)]

--- a/crates/tau-coding-agent/src/release_channel_commands.rs
+++ b/crates/tau-coding-agent/src/release_channel_commands.rs
@@ -30,10 +30,11 @@ pub(crate) const RELEASE_CHANNEL_USAGE: &str =
 pub(crate) const RELEASE_UPDATE_STATE_SCHEMA_VERSION: u32 = 1;
 pub(crate) use tau_release_channel::default_release_channel_path;
 pub(crate) use tau_release_channel::ReleaseChannel;
+#[cfg(test)]
+pub(crate) use tau_release_channel::{load_release_channel_store, save_release_channel_store};
 pub(crate) use tau_release_channel::{
-    load_release_channel_store, load_release_channel_store_file, save_release_channel_store,
-    save_release_channel_store_file, ReleaseChannelRollbackMetadata, ReleaseChannelStoreFile,
-    RELEASE_CHANNEL_SCHEMA_VERSION,
+    load_release_channel_store_file, save_release_channel_store_file,
+    ReleaseChannelRollbackMetadata, ReleaseChannelStoreFile, RELEASE_CHANNEL_SCHEMA_VERSION,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -13,6 +13,7 @@ tau-ai = { path = "../tau-ai" }
 tau-cli = { path = "../tau-cli" }
 tau-core = { path = "../tau-core" }
 tau-provider = { path = "../tau-provider" }
+tau-release-channel = { path = "../tau-release-channel" }
 tau-skills = { path = "../tau-skills" }
 tau-tools = { path = "../tau-tools" }
 

--- a/crates/tau-onboarding/src/lib.rs
+++ b/crates/tau-onboarding/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod onboarding_paths;
+pub mod onboarding_release_channel;
 pub mod profile_store;
 pub mod startup_config;
 pub mod startup_dispatch;

--- a/crates/tau-onboarding/src/onboarding_release_channel.rs
+++ b/crates/tau-onboarding/src/onboarding_release_channel.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use std::path::Path;
+use tau_release_channel::{load_release_channel_store, save_release_channel_store, ReleaseChannel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OnboardingReleaseChannelState {
+    pub channel: ReleaseChannel,
+    pub source: &'static str,
+    pub action: &'static str,
+}
+
+fn resolve_onboarding_release_channel_override(
+    raw: Option<&str>,
+) -> Result<Option<ReleaseChannel>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(trimmed.parse::<ReleaseChannel>()?))
+}
+
+pub fn ensure_onboarding_release_channel(
+    release_channel_path: &Path,
+    override_channel_raw: Option<&str>,
+) -> Result<OnboardingReleaseChannelState> {
+    let override_channel = resolve_onboarding_release_channel_override(override_channel_raw)?;
+    let existing = load_release_channel_store(release_channel_path)?;
+
+    match (override_channel, existing) {
+        (Some(channel), Some(existing_channel)) if channel == existing_channel => {
+            Ok(OnboardingReleaseChannelState {
+                channel,
+                source: "override",
+                action: "unchanged",
+            })
+        }
+        (Some(channel), Some(_)) => {
+            save_release_channel_store(release_channel_path, channel)?;
+            Ok(OnboardingReleaseChannelState {
+                channel,
+                source: "override",
+                action: "updated",
+            })
+        }
+        (Some(channel), None) => {
+            save_release_channel_store(release_channel_path, channel)?;
+            Ok(OnboardingReleaseChannelState {
+                channel,
+                source: "override",
+                action: "created",
+            })
+        }
+        (None, Some(channel)) => Ok(OnboardingReleaseChannelState {
+            channel,
+            source: "existing",
+            action: "unchanged",
+        }),
+        (None, None) => {
+            save_release_channel_store(release_channel_path, ReleaseChannel::Stable)?;
+            Ok(OnboardingReleaseChannelState {
+                channel: ReleaseChannel::Stable,
+                source: "default",
+                action: "created",
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_onboarding_release_channel;
+    use tau_release_channel::{load_release_channel_store, ReleaseChannel};
+    use tempfile::tempdir;
+
+    #[test]
+    fn functional_ensure_onboarding_release_channel_defaults_to_stable_when_missing() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join(".tau/release-channel.json");
+        let state =
+            ensure_onboarding_release_channel(&path, None).expect("ensure default release channel");
+        assert_eq!(state.channel, ReleaseChannel::Stable);
+        assert_eq!(state.source, "default");
+        assert_eq!(state.action, "created");
+        let stored = load_release_channel_store(&path)
+            .expect("load stored release channel")
+            .expect("stored channel");
+        assert_eq!(stored, ReleaseChannel::Stable);
+    }
+
+    #[test]
+    fn functional_ensure_onboarding_release_channel_override_updates_existing_value() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join(".tau/release-channel.json");
+        let first =
+            ensure_onboarding_release_channel(&path, Some("beta")).expect("create beta release");
+        assert_eq!(first.channel, ReleaseChannel::Beta);
+        assert_eq!(first.action, "created");
+
+        let second =
+            ensure_onboarding_release_channel(&path, Some("dev")).expect("update to dev release");
+        assert_eq!(second.channel, ReleaseChannel::Dev);
+        assert_eq!(second.source, "override");
+        assert_eq!(second.action, "updated");
+    }
+
+    #[test]
+    fn regression_ensure_onboarding_release_channel_rejects_invalid_override() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join(".tau/release-channel.json");
+        let error = ensure_onboarding_release_channel(&path, Some("nightly"))
+            .expect_err("invalid override should fail");
+        assert!(error.to_string().contains("expected stable|beta|dev"));
+    }
+}


### PR DESCRIPTION
## Summary
- extract onboarding release-channel state/override logic into `tau-onboarding::onboarding_release_channel`
- remove duplicated release-channel onboarding logic from `tau-coding-agent/src/onboarding.rs`
- add onboarding-crate release-channel tests (functional + regression)
- tighten test-only release-channel re-exports in coding-agent to keep clippy clean

## Validation
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

## Tracking
- Part of #999 (startup monolith decomposition stage 2)
