### PR TITLE
Extract startup daemon preflight handling into tau-onboarding (#999)

### DIFF
--- a/crates/tau-coding-agent/src/daemon_runtime.rs
+++ b/crates/tau-coding-agent/src/daemon_runtime.rs
@@ -1,1 +1,0 @@
-pub use tau_ops::*;

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -15,7 +15,6 @@ mod commands;
 mod credentials;
 mod custom_command_contract;
 mod custom_command_runtime;
-mod daemon_runtime;
 mod dashboard_contract;
 mod dashboard_runtime;
 mod deployment_runtime;
@@ -295,21 +294,20 @@ pub(crate) use tau_cli::validation::validate_gateway_remote_profile_inspect_cli;
 pub(crate) use tau_cli::validation::validate_multi_channel_live_connectors_runner_cli;
 pub(crate) use tau_cli::validation::{
     validate_browser_automation_contract_runner_cli, validate_custom_command_contract_runner_cli,
-    validate_daemon_cli, validate_dashboard_contract_runner_cli,
-    validate_deployment_contract_runner_cli, validate_events_runner_cli,
-    validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
-    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
-    validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
-    validate_multi_channel_live_runner_cli, validate_slack_bridge_cli,
-    validate_voice_contract_runner_cli,
+    validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
+    validate_events_runner_cli, validate_gateway_contract_runner_cli,
+    validate_gateway_openresponses_server_cli, validate_github_issues_bridge_cli,
+    validate_memory_contract_runner_cli, validate_multi_agent_contract_runner_cli,
+    validate_multi_channel_contract_runner_cli, validate_multi_channel_live_runner_cli,
+    validate_slack_bridge_cli, validate_voice_contract_runner_cli,
 };
 #[cfg(test)]
 pub(crate) use tau_cli::validation::{
-    validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
-    validate_event_webhook_ingest_cli, validate_gateway_service_cli,
-    validate_multi_channel_channel_lifecycle_cli, validate_multi_channel_incident_timeline_cli,
-    validate_multi_channel_live_ingest_cli, validate_multi_channel_send_cli,
-    validate_project_index_cli,
+    validate_daemon_cli, validate_deployment_wasm_inspect_cli,
+    validate_deployment_wasm_package_cli, validate_event_webhook_ingest_cli,
+    validate_gateway_service_cli, validate_multi_channel_channel_lifecycle_cli,
+    validate_multi_channel_incident_timeline_cli, validate_multi_channel_live_ingest_cli,
+    validate_multi_channel_send_cli, validate_project_index_cli,
 };
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -150,66 +150,7 @@ impl tau_startup::StartupPreflightActions for TauStartupPreflightActions {
     }
 
     fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool> {
-        if crate::daemon_runtime::tau_daemon_mode_requested(cli) {
-            validate_daemon_cli(cli)?;
-            let config = crate::daemon_runtime::TauDaemonConfig {
-                state_dir: cli.daemon_state_dir.clone(),
-                profile: cli.daemon_profile,
-            };
-
-            if cli.daemon_install {
-                let report = crate::daemon_runtime::install_tau_daemon(&config)?;
-                println!(
-                    "{}",
-                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
-                );
-                return Ok(true);
-            }
-            if cli.daemon_uninstall {
-                let report = crate::daemon_runtime::uninstall_tau_daemon(&config)?;
-                println!(
-                    "{}",
-                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
-                );
-                return Ok(true);
-            }
-            if cli.daemon_start {
-                let report = crate::daemon_runtime::start_tau_daemon(&config)?;
-                println!(
-                    "{}",
-                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
-                );
-                return Ok(true);
-            }
-            if cli.daemon_stop {
-                let report = crate::daemon_runtime::stop_tau_daemon(
-                    &config,
-                    cli.daemon_stop_reason.as_deref(),
-                )?;
-                println!(
-                    "{}",
-                    crate::daemon_runtime::render_tau_daemon_status_report(&report)
-                );
-                return Ok(true);
-            }
-            if cli.daemon_status {
-                let report = crate::daemon_runtime::inspect_tau_daemon(&config)?;
-                if cli.daemon_status_json {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&report)
-                            .context("failed to render daemon status json")?
-                    );
-                } else {
-                    println!(
-                        "{}",
-                        crate::daemon_runtime::render_tau_daemon_status_report(&report)
-                    );
-                }
-                return Ok(true);
-            }
-        }
-        Ok(false)
+        tau_onboarding::startup_daemon_preflight::handle_daemon_commands(cli)
     }
 }
 

--- a/crates/tau-onboarding/src/lib.rs
+++ b/crates/tau-onboarding/src/lib.rs
@@ -5,6 +5,7 @@ pub mod onboarding_release_channel;
 pub mod onboarding_report;
 pub mod profile_store;
 pub mod startup_config;
+pub mod startup_daemon_preflight;
 pub mod startup_dispatch;
 pub mod startup_model_resolution;
 pub mod startup_policy;

--- a/crates/tau-onboarding/src/startup_daemon_preflight.rs
+++ b/crates/tau-onboarding/src/startup_daemon_preflight.rs
@@ -1,0 +1,101 @@
+use anyhow::{Context, Result};
+use tau_cli::{validate_daemon_cli, Cli};
+use tau_ops::{
+    inspect_tau_daemon, install_tau_daemon, render_tau_daemon_status_report, start_tau_daemon,
+    stop_tau_daemon, tau_daemon_mode_requested, uninstall_tau_daemon, TauDaemonConfig,
+};
+
+pub fn handle_daemon_commands(cli: &Cli) -> Result<bool> {
+    if !tau_daemon_mode_requested(cli) {
+        return Ok(false);
+    }
+
+    validate_daemon_cli(cli)?;
+    let config = TauDaemonConfig {
+        state_dir: cli.daemon_state_dir.clone(),
+        profile: cli.daemon_profile,
+    };
+
+    if cli.daemon_install {
+        let report = install_tau_daemon(&config)?;
+        println!("{}", render_tau_daemon_status_report(&report));
+        return Ok(true);
+    }
+    if cli.daemon_uninstall {
+        let report = uninstall_tau_daemon(&config)?;
+        println!("{}", render_tau_daemon_status_report(&report));
+        return Ok(true);
+    }
+    if cli.daemon_start {
+        let report = start_tau_daemon(&config)?;
+        println!("{}", render_tau_daemon_status_report(&report));
+        return Ok(true);
+    }
+    if cli.daemon_stop {
+        let report = stop_tau_daemon(&config, cli.daemon_stop_reason.as_deref())?;
+        println!("{}", render_tau_daemon_status_report(&report));
+        return Ok(true);
+    }
+    if cli.daemon_status {
+        let report = inspect_tau_daemon(&config)?;
+        if cli.daemon_status_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to render daemon status json")?
+            );
+        } else {
+            println!("{}", render_tau_daemon_status_report(&report));
+        }
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::handle_daemon_commands;
+    use clap::Parser;
+    use tau_cli::Cli;
+    use tempfile::tempdir;
+
+    fn parse_cli_with_stack(args: &[&str]) -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn({
+                let args = args
+                    .iter()
+                    .copied()
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>();
+                move || Cli::parse_from(args)
+            })
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
+    #[test]
+    fn functional_handle_daemon_commands_runs_status_mode() {
+        let temp = tempdir().expect("tempdir");
+        let mut cli = parse_cli_with_stack(&["tau-rs", "--daemon-status"]);
+        cli.daemon_state_dir = temp.path().join(".tau/daemon");
+        let handled = handle_daemon_commands(&cli).expect("daemon status should succeed");
+        assert!(handled);
+    }
+
+    #[test]
+    fn integration_handle_daemon_commands_returns_false_when_not_requested() {
+        let cli = parse_cli_with_stack(&["tau-rs"]);
+        let handled = handle_daemon_commands(&cli).expect("daemon noop should succeed");
+        assert!(!handled);
+    }
+
+    #[test]
+    fn regression_handle_daemon_commands_fails_closed_on_prompt_conflict() {
+        let cli = parse_cli_with_stack(&["tau-rs", "--daemon-status", "--prompt", "conflict"]);
+        let error = handle_daemon_commands(&cli).expect_err("prompt conflict should fail");
+        assert!(error.to_string().contains("--prompt"));
+    }
+}


### PR DESCRIPTION
## Summary
- extract startup daemon preflight handling into `tau-onboarding::startup_daemon_preflight::handle_daemon_commands`
- replace inlined daemon preflight branch in `tau-coding-agent/src/startup_preflight.rs` with the onboarding helper
- remove now-unused `tau-coding-agent/src/daemon_runtime.rs` re-export shim
- align daemon validation re-export scope in `main.rs` (test-only where appropriate)
- add startup daemon preflight tests in tau-onboarding (functional, integration, regression)

## Validation
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

## Tracking
- Part of #999 (startup monolith decomposition stage 2)
