### PR TITLE
refactor: extract startup gateway auth helpers into tau-onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "tau-ai",
  "tau-cli",
  "tau-core",
+ "tau-gateway",
  "tau-multi-channel",
  "tau-ops",
  "tau-provider",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -95,12 +95,11 @@ pub(crate) use crate::cli_types::CliProviderAuthMode;
 #[cfg(test)]
 pub(crate) use crate::cli_types::{
     CliBashProfile, CliCredentialStoreEncryptionMode, CliDeploymentWasmRuntimeProfile,
-    CliMultiChannelLiveConnectorMode, CliMultiChannelTransport, CliOsSandboxMode,
-    CliSessionImportMode, CliToolPolicyPreset,
+    CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode, CliMultiChannelTransport,
+    CliOsSandboxMode, CliSessionImportMode, CliToolPolicyPreset,
 };
 pub(crate) use crate::cli_types::{
-    CliCommandFileErrorMode, CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode,
-    CliOrchestratorMode,
+    CliCommandFileErrorMode, CliEventTemplateSchedule, CliOrchestratorMode,
 };
 #[cfg(test)]
 pub(crate) use crate::cli_types::{CliDaemonProfile, CliGatewayRemoteProfile};

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -13,6 +13,7 @@ tau-ai = { path = "../tau-ai" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-cli = { path = "../tau-cli" }
 tau-core = { path = "../tau-core" }
+tau-gateway = { path = "../tau-gateway" }
 tau-multi-channel = { path = "../tau-multi-channel" }
 tau-provider = { path = "../tau-provider" }
 tau-release-channel = { path = "../tau-release-channel" }


### PR DESCRIPTION
## Summary
- extract gateway OpenResponses auth helpers into `tau-onboarding` transport module:
  - `map_gateway_openresponses_auth_mode`
  - `resolve_gateway_openresponses_auth`
- update coding-agent transport runtime to consume onboarding helpers for gateway auth-mode mapping and normalized auth credentials
- add onboarding tests for gateway auth helper coverage (unit, functional, regression)
- keep coding-agent test compatibility by scoping `CliGatewayOpenResponsesAuthMode` re-export to `#[cfg(test)]`

## Testing
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings
