### PR TITLE
refactor: extract startup gateway server config builder into tau-onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ name = "tau-onboarding"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "serde",
  "serde_json",

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -22,5 +22,6 @@ tau-tools = { path = "../tau-tools" }
 tau-ops = { path = "../tau-ops" }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 clap = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary
- extract gateway OpenResponses server config construction into `tau-onboarding` transport module:
  - `build_gateway_openresponses_server_config`
- move gateway tool registrar wiring into onboarding using `GatewayToolRegistrarFn` + `tau_tools::register_builtin_tools`
- update coding-agent transport runtime to call onboarding config builder
- add onboarding integration coverage for gateway server config construction

## Testing
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings
