### PR TITLE
refactor: extract gateway run branch into onboarding helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,7 @@ dependencies = [
  "tau-skills",
  "tau-tools",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -5,9 +5,9 @@ use crate::channel_adapters::{
 use crate::validate_multi_channel_live_connectors_runner_cli;
 use std::sync::Arc;
 use tau_onboarding::startup_transport_modes::{
-    build_gateway_openresponses_server_config, build_multi_channel_media_config,
-    build_multi_channel_outbound_config, build_multi_channel_telemetry_config,
-    resolve_multi_channel_outbound_secret,
+    build_multi_channel_media_config, build_multi_channel_outbound_config,
+    build_multi_channel_telemetry_config, resolve_multi_channel_outbound_secret,
+    run_gateway_openresponses_server_if_requested,
 };
 
 pub(crate) async fn run_transport_mode_if_requested(
@@ -34,15 +34,15 @@ pub(crate) async fn run_transport_mode_if_requested(
     validate_custom_command_contract_runner_cli(cli)?;
     validate_voice_contract_runner_cli(cli)?;
 
-    if cli.gateway_openresponses_server {
-        let config = build_gateway_openresponses_server_config(
-            cli,
-            client.clone(),
-            model_ref,
-            system_prompt,
-            tool_policy,
-        );
-        tau_gateway::run_gateway_openresponses_server(config).await?;
+    if run_gateway_openresponses_server_if_requested(
+        cli,
+        client.clone(),
+        model_ref,
+        system_prompt,
+        tool_policy,
+    )
+    .await?
+    {
         return Ok(true);
     }
 

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -24,4 +24,5 @@ tau-ops = { path = "../tau-ops" }
 [dev-dependencies]
 async-trait = { workspace = true }
 clap = { workspace = true }
+tokio = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add `run_gateway_openresponses_server_if_requested` to onboarding transport module
- move gateway run branch orchestration out of coding-agent transport runtime into onboarding helper
- keep gateway config building centralized in onboarding helpers
- add async onboarding test verifying disabled-path behavior for gateway run helper

## Testing
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings
