### PR TITLE
refactor: extract gateway contract transport helper into onboarding

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -324,7 +324,6 @@ pub(crate) use tau_diagnostics::{
 };
 #[cfg(test)]
 pub(crate) use tau_diagnostics::{execute_doctor_command, execute_doctor_command_with_options};
-use tau_gateway::{run_gateway_contract_runner, GatewayRuntimeConfig};
 #[cfg(test)]
 pub(crate) use tau_multi_channel::build_multi_channel_incident_timeline_report;
 #[cfg(test)]

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -6,8 +6,8 @@ use crate::validate_multi_channel_live_connectors_runner_cli;
 use std::sync::Arc;
 use tau_onboarding::startup_transport_modes::{
     build_multi_channel_media_config, build_multi_channel_outbound_config,
-    build_multi_channel_telemetry_config, run_gateway_openresponses_server_if_requested,
-    run_multi_channel_live_connectors_if_requested,
+    build_multi_channel_telemetry_config, run_gateway_contract_runner_if_requested,
+    run_gateway_openresponses_server_if_requested, run_multi_channel_live_connectors_if_requested,
 };
 
 pub(crate) async fn run_transport_mode_if_requested(
@@ -296,22 +296,7 @@ pub(crate) async fn run_transport_mode_if_requested(
         return Ok(true);
     }
 
-    if cli.gateway_contract_runner {
-        run_gateway_contract_runner(GatewayRuntimeConfig {
-            fixture_path: cli.gateway_fixture.clone(),
-            state_dir: cli.gateway_state_dir.clone(),
-            queue_limit: 64,
-            processed_case_cap: 10_000,
-            retry_max_attempts: 4,
-            retry_base_delay_ms: 0,
-            guardrail_failure_streak_threshold: cli
-                .gateway_guardrail_failure_streak_threshold
-                .max(1),
-            guardrail_retryable_failures_threshold: cli
-                .gateway_guardrail_retryable_failures_threshold
-                .max(1),
-        })
-        .await?;
+    if run_gateway_contract_runner_if_requested(cli).await? {
         return Ok(true);
     }
 


### PR DESCRIPTION
## Summary
- add onboarding helper `build_gateway_contract_runner_config` for gateway contract runtime config mapping
- add onboarding helper `run_gateway_contract_runner_if_requested` for disabled-gate + runtime invocation
- rewire `tau-coding-agent` startup transport gateway contract branch to call onboarding helper
- remove stale `tau_gateway` imports from `tau-coding-agent/src/main.rs`
- add onboarding unit/integration/regression tests for gateway contract runner config behavior

## Testing
- `cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1`
- `cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings`
