### PR TITLE
refactor: extract multi-agent transport helper into onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,6 +2962,7 @@ dependencies = [
  "tau-gateway",
  "tau-multi-channel",
  "tau-ops",
+ "tau-orchestrator",
  "tau-provider",
  "tau-release-channel",
  "tau-skills",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -332,9 +332,6 @@ use tau_multi_channel::{
     run_multi_channel_contract_runner, run_multi_channel_live_runner,
     MultiChannelLiveRuntimeConfig, MultiChannelRuntimeConfig,
 };
-use tau_orchestrator::multi_agent_runtime::{
-    run_multi_agent_contract_runner, MultiAgentRuntimeConfig,
-};
 #[cfg(test)]
 pub(crate) use tau_orchestrator::parse_numbered_plan_steps;
 #[cfg(test)]

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use tau_onboarding::startup_transport_modes::{
     build_multi_channel_media_config, build_multi_channel_outbound_config,
     build_multi_channel_telemetry_config, run_gateway_contract_runner_if_requested,
-    run_gateway_openresponses_server_if_requested, run_multi_channel_live_connectors_if_requested,
+    run_gateway_openresponses_server_if_requested, run_multi_agent_contract_runner_if_requested,
+    run_multi_channel_live_connectors_if_requested,
 };
 
 pub(crate) async fn run_transport_mode_if_requested(
@@ -241,16 +242,7 @@ pub(crate) async fn run_transport_mode_if_requested(
         return Ok(true);
     }
 
-    if cli.multi_agent_contract_runner {
-        run_multi_agent_contract_runner(MultiAgentRuntimeConfig {
-            fixture_path: cli.multi_agent_fixture.clone(),
-            state_dir: cli.multi_agent_state_dir.clone(),
-            queue_limit: cli.multi_agent_queue_limit.max(1),
-            processed_case_cap: cli.multi_agent_processed_case_cap.max(1),
-            retry_max_attempts: cli.multi_agent_retry_max_attempts.max(1),
-            retry_base_delay_ms: cli.multi_agent_retry_base_delay_ms,
-        })
-        .await?;
+    if run_multi_agent_contract_runner_if_requested(cli).await? {
         return Ok(true);
     }
 

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -20,6 +20,7 @@ tau-release-channel = { path = "../tau-release-channel" }
 tau-skills = { path = "../tau-skills" }
 tau-tools = { path = "../tau-tools" }
 tau-ops = { path = "../tau-ops" }
+tau-orchestrator = { path = "../tau-orchestrator" }
 
 [dev-dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
## Summary
- add onboarding helper `build_multi_agent_contract_runner_config` for multi-agent runtime config mapping
- add onboarding helper `run_multi_agent_contract_runner_if_requested` to own disabled-gate + runner invocation
- rewire `tau-coding-agent` startup transport dispatcher to call onboarding helper instead of inlining multi-agent config assembly
- add onboarding unit/integration/regression tests for multi-agent config minimums and field mapping
- add `tau-orchestrator` dependency to `tau-onboarding` for multi-agent runtime config/runner wiring

## Testing
- `cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1`
- `cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings`
