### PR TITLE
Extract startup local runtime hook subscriber into tau-onboarding

### DIFF
--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::extension_manifest::{
     discover_extension_runtime_registrations, ExtensionRuntimeRegistrationSummary,
 };
-use tau_onboarding::startup_local_runtime::extension_tool_hook_dispatch;
+use tau_onboarding::startup_local_runtime::register_runtime_extension_tool_hook_subscriber as register_onboarding_runtime_extension_tool_hook_subscriber;
 
 pub(crate) struct LocalRuntimeConfig<'a> {
     pub(crate) cli: &'a Cli,
@@ -211,19 +211,10 @@ pub(crate) fn register_runtime_extension_tool_hook_subscriber(
     agent: &mut Agent,
     extension_runtime_hooks: &RuntimeExtensionHooksConfig,
 ) {
-    if !extension_runtime_hooks.enabled {
-        return;
-    }
-
-    let root = extension_runtime_hooks.root.clone();
-    agent.subscribe(move |event| {
-        let dispatch = extension_tool_hook_dispatch(event);
-        let Some((hook, payload)) = dispatch else {
-            return;
-        };
-        let summary = dispatch_extension_runtime_hook(&root, hook, &payload);
-        for diagnostic in summary.diagnostics {
-            eprintln!("{diagnostic}");
-        }
-    });
+    register_onboarding_runtime_extension_tool_hook_subscriber(
+        agent,
+        extension_runtime_hooks.enabled,
+        extension_runtime_hooks.root.clone(),
+        |root, hook, payload| dispatch_extension_runtime_hook(root, hook, payload).diagnostics,
+    );
 }

--- a/crates/tau-onboarding/src/startup_local_runtime.rs
+++ b/crates/tau-onboarding/src/startup_local_runtime.rs
@@ -1,5 +1,7 @@
+use std::path::{Path, PathBuf};
+
 use serde_json::Value;
-use tau_agent_core::AgentEvent;
+use tau_agent_core::{Agent, AgentEvent};
 use tau_core::current_unix_timestamp_ms;
 
 const EXTENSION_TOOL_HOOK_PAYLOAD_SCHEMA_VERSION: u32 = 1;
@@ -43,6 +45,40 @@ pub fn extension_tool_hook_dispatch(event: &AgentEvent) -> Option<(&'static str,
     }
 }
 
+pub fn extension_tool_hook_diagnostics<F>(
+    event: &AgentEvent,
+    root: &Path,
+    dispatch_hook: &F,
+) -> Vec<String>
+where
+    F: Fn(&Path, &'static str, &Value) -> Vec<String>,
+{
+    let Some((hook, payload)) = extension_tool_hook_dispatch(event) else {
+        return Vec::new();
+    };
+    dispatch_hook(root, hook, &payload)
+}
+
+pub fn register_runtime_extension_tool_hook_subscriber<F>(
+    agent: &mut Agent,
+    enabled: bool,
+    root: PathBuf,
+    dispatch_hook: F,
+) where
+    F: Fn(&Path, &'static str, &Value) -> Vec<String> + Send + Sync + 'static,
+{
+    if !enabled {
+        return;
+    }
+
+    agent.subscribe(move |event| {
+        let diagnostics = extension_tool_hook_diagnostics(event, &root, &dispatch_hook);
+        for diagnostic in diagnostics {
+            eprintln!("{diagnostic}");
+        }
+    });
+}
+
 fn extension_tool_hook_payload(hook: &str, data: Value) -> Value {
     let mut payload = serde_json::Map::new();
     payload.insert(
@@ -68,8 +104,86 @@ fn extension_tool_hook_payload(hook: &str, data: Value) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::extension_tool_hook_dispatch;
-    use tau_agent_core::{AgentEvent, ToolExecutionResult};
+    use super::{
+        extension_tool_hook_diagnostics, extension_tool_hook_dispatch,
+        register_runtime_extension_tool_hook_subscriber,
+    };
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::collections::VecDeque;
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+    use tau_agent_core::{Agent, AgentConfig, AgentEvent, AgentTool, ToolExecutionResult};
+    use tau_ai::{
+        ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, TauAiError,
+        ToolDefinition,
+    };
+    use tokio::sync::Mutex as AsyncMutex;
+
+    struct QueueClient {
+        responses: AsyncMutex<VecDeque<ChatResponse>>,
+    }
+
+    #[async_trait]
+    impl LlmClient for QueueClient {
+        async fn complete(&self, _request: ChatRequest) -> Result<ChatResponse, TauAiError> {
+            let mut responses = self.responses.lock().await;
+            responses.pop_front().ok_or_else(|| {
+                TauAiError::InvalidResponse("queue client has no responses".to_string())
+            })
+        }
+    }
+
+    struct EchoTool;
+
+    #[async_trait]
+    impl AgentTool for EchoTool {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: "echo".to_string(),
+                description: "echo tool for tests".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"}
+                    },
+                    "required": ["text"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+            ToolExecutionResult::ok(serde_json::json!({ "echo": arguments["text"] }))
+        }
+    }
+
+    fn build_tool_loop_agent() -> Agent {
+        let responses = VecDeque::from(vec![
+            ChatResponse {
+                message: Message::assistant_blocks(vec![ContentBlock::ToolCall {
+                    id: "call-1".to_string(),
+                    name: "echo".to_string(),
+                    arguments: serde_json::json!({ "text": "hello" }),
+                }]),
+                finish_reason: Some("tool_calls".to_string()),
+                usage: ChatUsage::default(),
+            },
+            ChatResponse {
+                message: Message::assistant_text("done"),
+                finish_reason: Some("stop".to_string()),
+                usage: ChatUsage::default(),
+            },
+        ]);
+        let mut agent = Agent::new(
+            Arc::new(QueueClient {
+                responses: AsyncMutex::new(responses),
+            }),
+            AgentConfig::default(),
+        );
+        agent.register_tool(EchoTool);
+        agent
+    }
 
     #[test]
     fn unit_extension_tool_hook_dispatch_maps_start_event_payload() {
@@ -110,5 +224,78 @@ mod tests {
     fn regression_extension_tool_hook_dispatch_ignores_non_tool_events() {
         let event = AgentEvent::AgentStart;
         assert!(extension_tool_hook_dispatch(&event).is_none());
+    }
+
+    #[test]
+    fn functional_extension_tool_hook_diagnostics_routes_dispatch_payload() {
+        let event = AgentEvent::ToolExecutionStart {
+            tool_call_id: "call-1".to_string(),
+            tool_name: "read".to_string(),
+            arguments: serde_json::json!({"path":"README.md"}),
+        };
+
+        let diagnostics = extension_tool_hook_diagnostics(
+            &event,
+            Path::new("/tmp/extensions"),
+            &|root, hook, payload| {
+                assert_eq!(root, Path::new("/tmp/extensions"));
+                assert_eq!(hook, "pre-tool-call");
+                assert_eq!(payload["tool_name"], "read");
+                vec!["ok".to_string()]
+            },
+        );
+
+        assert_eq!(diagnostics, vec!["ok".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn integration_register_runtime_extension_tool_hook_subscriber_dispatches_hooks() {
+        let mut agent = build_tool_loop_agent();
+        let extension_root = Path::new("/tmp/extensions").to_path_buf();
+        let captured = Arc::new(Mutex::new(Vec::<(String, String, Value)>::new()));
+        let sink = Arc::clone(&captured);
+
+        register_runtime_extension_tool_hook_subscriber(
+            &mut agent,
+            true,
+            extension_root,
+            move |root, hook, payload| {
+                sink.lock().expect("capture lock").push((
+                    root.display().to_string(),
+                    hook.to_string(),
+                    payload.clone(),
+                ));
+                Vec::new()
+            },
+        );
+
+        let _ = agent.prompt("run echo").await.expect("prompt succeeds");
+        let rows = captured.lock().expect("capture lock");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "/tmp/extensions");
+        assert_eq!(rows[0].1, "pre-tool-call");
+        assert_eq!(rows[1].1, "post-tool-call");
+        assert_eq!(rows[0].2["data"]["tool_name"], "echo");
+        assert_eq!(rows[1].2["data"]["tool_name"], "echo");
+    }
+
+    #[tokio::test]
+    async fn regression_register_runtime_extension_tool_hook_subscriber_disabled_noops() {
+        let mut agent = build_tool_loop_agent();
+        let captured = Arc::new(Mutex::new(Vec::<String>::new()));
+        let sink = Arc::clone(&captured);
+
+        register_runtime_extension_tool_hook_subscriber(
+            &mut agent,
+            false,
+            Path::new("/tmp/extensions").to_path_buf(),
+            move |_root, hook, _payload| {
+                sink.lock().expect("capture lock").push(hook.to_string());
+                Vec::new()
+            },
+        );
+
+        let _ = agent.prompt("run echo").await.expect("prompt succeeds");
+        assert!(captured.lock().expect("capture lock").is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- moved extension runtime hook subscriber orchestration into `tau-onboarding::startup_local_runtime`
- added onboarding helper APIs for hook diagnostics routing and runtime subscriber registration
- reduced `tau-coding-agent` to a thin adapter that injects extension runtime dispatch diagnostics
- added onboarding unit/functional/integration/regression coverage for hook dispatch and subscriber behavior

## Validation
- cargo fmt --all
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

## Issue
- refs #999