### PR TITLE
Extract startup dispatch runtime context assembly into onboarding

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -239,8 +239,9 @@ pub(crate) use crate::startup_model_catalog::{
     resolve_startup_model_catalog, validate_startup_model_catalog,
 };
 pub(crate) use crate::startup_model_resolution::{resolve_startup_models, StartupModelResolution};
-pub(crate) use crate::startup_policy::{resolve_startup_policy, StartupPolicyBundle};
+pub(crate) use crate::startup_policy::StartupPolicyBundle;
 pub(crate) use crate::startup_preflight::execute_startup_preflight;
+#[cfg(test)]
 pub(crate) use crate::startup_prompt_composition::compose_startup_system_prompt;
 #[cfg(test)]
 pub(crate) use crate::startup_resolution::apply_trust_root_mutations;

--- a/crates/tau-coding-agent/src/startup_prompt_composition.rs
+++ b/crates/tau-coding-agent/src/startup_prompt_composition.rs
@@ -1,1 +1,2 @@
+#[cfg(test)]
 pub use tau_onboarding::startup_prompt_composition::*;

--- a/crates/tau-onboarding/src/startup_dispatch.rs
+++ b/crates/tau-onboarding/src/startup_dispatch.rs
@@ -1,7 +1,36 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
 use tau_cli::Cli;
 use tau_skills::default_skills_lock_path;
+
+use crate::startup_policy::{resolve_startup_policy, StartupPolicyBundle};
+use crate::startup_prompt_composition::compose_startup_system_prompt;
+
+pub struct StartupRuntimeDispatchContext {
+    pub effective_skills_dir: PathBuf,
+    pub skills_lock_path: PathBuf,
+    pub system_prompt: String,
+    pub startup_policy: StartupPolicyBundle,
+}
+
+pub fn build_startup_runtime_dispatch_context(
+    cli: &Cli,
+    bootstrap_lock_path: &Path,
+    activation_applied: bool,
+) -> Result<StartupRuntimeDispatchContext> {
+    let effective_skills_dir = resolve_runtime_skills_dir(cli, activation_applied);
+    let skills_lock_path =
+        resolve_runtime_skills_lock_path(cli, bootstrap_lock_path, &effective_skills_dir);
+    let system_prompt = compose_startup_system_prompt(cli, &effective_skills_dir)?;
+    let startup_policy = resolve_startup_policy(cli)?;
+    Ok(StartupRuntimeDispatchContext {
+        effective_skills_dir,
+        skills_lock_path,
+        system_prompt,
+        startup_policy,
+    })
+}
 
 pub fn resolve_runtime_skills_dir(cli: &Cli, activation_applied: bool) -> PathBuf {
     if !activation_applied {
@@ -28,7 +57,10 @@ pub fn resolve_runtime_skills_lock_path(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_runtime_skills_dir, resolve_runtime_skills_lock_path};
+    use super::{
+        build_startup_runtime_dispatch_context, resolve_runtime_skills_dir,
+        resolve_runtime_skills_lock_path,
+    };
     use clap::Parser;
     use std::path::PathBuf;
     use tau_cli::Cli;
@@ -96,5 +128,64 @@ mod tests {
 
         assert_eq!(resolved, default_skills_lock_path(&activated_skills_dir));
         assert_ne!(resolved, PathBuf::from(bootstrap_lock_path));
+    }
+
+    #[test]
+    fn functional_build_startup_runtime_dispatch_context_prefers_activated_runtime_paths() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        cli.system_prompt = "You are Tau.".to_string();
+        cli.skills_dir = workspace.path().join(".tau/skills");
+        cli.package_activate_destination = workspace.path().join("packages-active");
+        std::fs::create_dir_all(&cli.skills_dir).expect("create skills dir");
+        let activated_skills_dir = cli.package_activate_destination.join("skills");
+        std::fs::create_dir_all(&activated_skills_dir).expect("create activated skills dir");
+
+        let bootstrap_lock_path = workspace.path().join(".tau/skills.lock.json");
+        let context =
+            build_startup_runtime_dispatch_context(&cli, &bootstrap_lock_path, true).expect("ok");
+
+        assert_eq!(context.effective_skills_dir, activated_skills_dir);
+        assert_eq!(
+            context.skills_lock_path,
+            default_skills_lock_path(&context.effective_skills_dir)
+        );
+        assert!(context.system_prompt.contains("You are Tau."));
+        assert!(context.startup_policy.tool_policy_json.is_object());
+    }
+
+    #[test]
+    fn integration_build_startup_runtime_dispatch_context_honors_system_prompt_file() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        cli.skills_dir = workspace.path().join(".tau/skills");
+        std::fs::create_dir_all(&cli.skills_dir).expect("create skills dir");
+        let prompt_path = workspace.path().join("system_prompt.txt");
+        std::fs::write(&prompt_path, "System prompt from file.").expect("write system prompt");
+        cli.system_prompt_file = Some(prompt_path);
+        let bootstrap_lock_path = workspace.path().join(".tau/skills.lock.json");
+
+        let context =
+            build_startup_runtime_dispatch_context(&cli, &bootstrap_lock_path, false).expect("ok");
+
+        assert!(context.system_prompt.contains("System prompt from file."));
+        assert_eq!(context.skills_lock_path, bootstrap_lock_path);
+    }
+
+    #[test]
+    fn regression_build_startup_runtime_dispatch_context_uses_bootstrap_lock_without_switch() {
+        let mut cli = parse_cli_with_stack();
+        let workspace = tempdir().expect("tempdir");
+        cli.system_prompt = "Tau system prompt".to_string();
+        cli.skills_dir = workspace.path().join(".tau/skills");
+        std::fs::create_dir_all(&cli.skills_dir).expect("create skills dir");
+        let bootstrap_lock_path = workspace.path().join(".tau/skills.lock.json");
+
+        let context =
+            build_startup_runtime_dispatch_context(&cli, &bootstrap_lock_path, false).expect("ok");
+
+        assert_eq!(context.effective_skills_dir, cli.skills_dir);
+        assert_eq!(context.skills_lock_path, bootstrap_lock_path);
+        assert!(context.system_prompt.contains("Tau system prompt"));
     }
 }


### PR DESCRIPTION
## Summary
- added onboarding-owned startup dispatch context assembly via `build_startup_runtime_dispatch_context`
- centralized effective skills dir/lock resolution, system prompt composition, and startup policy resolution in `tau-onboarding`
- rewired `tau-coding-agent` startup dispatch to consume onboarding context instead of inlining those orchestration steps
- added onboarding unit/functional/integration/regression tests for activated-path selection, system prompt file handling, and bootstrap lock behavior
- marked startup prompt composition compatibility re-export as test-only to avoid non-test warning noise

## Validation
- cargo fmt --all
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

## Issue
- refs #999
