### PR TITLE
refactor(startup): centralize contract transport mode selection

### DIFF
--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -5,14 +5,15 @@ use crate::channel_adapters::{
 use std::sync::Arc;
 use tau_onboarding::startup_transport_modes::{
     build_events_runner_cli_config, build_github_issues_bridge_cli_config,
-    build_slack_bridge_cli_config, resolve_multi_channel_transport_mode,
-    run_browser_automation_contract_runner_if_requested,
+    build_slack_bridge_cli_config, resolve_contract_transport_mode,
+    resolve_multi_channel_transport_mode, run_browser_automation_contract_runner_if_requested,
     run_custom_command_contract_runner_if_requested, run_dashboard_contract_runner_if_requested,
     run_deployment_contract_runner_if_requested, run_gateway_contract_runner_if_requested,
     run_gateway_openresponses_server_if_requested, run_memory_contract_runner_if_requested,
     run_multi_agent_contract_runner_if_requested, run_multi_channel_contract_runner_if_requested,
     run_multi_channel_live_connectors_if_requested, run_multi_channel_live_runner_if_requested,
-    run_voice_contract_runner_if_requested, validate_transport_mode_cli, MultiChannelTransportMode,
+    run_voice_contract_runner_if_requested, validate_transport_mode_cli, ContractTransportMode,
+    MultiChannelTransportMode,
 };
 
 fn build_multi_channel_runtime_dependencies(
@@ -300,36 +301,40 @@ pub(crate) async fn run_transport_mode_if_requested(
         MultiChannelTransportMode::None => {}
     }
 
-    if run_multi_agent_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_browser_automation_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_memory_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_dashboard_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_gateway_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_deployment_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_custom_command_contract_runner_if_requested(cli).await? {
-        return Ok(true);
-    }
-
-    if run_voice_contract_runner_if_requested(cli).await? {
-        return Ok(true);
+    match resolve_contract_transport_mode(cli) {
+        ContractTransportMode::MultiAgent => {
+            run_multi_agent_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::BrowserAutomation => {
+            run_browser_automation_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::Memory => {
+            run_memory_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::Dashboard => {
+            run_dashboard_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::Gateway => {
+            run_gateway_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::Deployment => {
+            run_deployment_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::CustomCommand => {
+            run_custom_command_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::Voice => {
+            run_voice_contract_runner_if_requested(cli).await?;
+            return Ok(true);
+        }
+        ContractTransportMode::None => {}
     }
 
     Ok(false)


### PR DESCRIPTION
## Summary
- add onboarding-owned `ContractTransportMode` and `resolve_contract_transport_mode` helper
- preserve precedence for contract-runner transport flags in one selector
- switch coding-agent transport dispatch to a single `match` over the resolved mode
- add unit/functional/integration/regression tests for contract transport mode resolution

## Testing
- cargo fmt --all
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

Refs #999