### PR TITLE
refactor(startup): move preflight adapter wiring into onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "tau-provider",
  "tau-release-channel",
  "tau-skills",
+ "tau-startup",
  "tau-tools",
  "tau-voice",
  "tempfile",

--- a/crates/tau-coding-agent/src/startup_preflight.rs
+++ b/crates/tau-coding-agent/src/startup_preflight.rs
@@ -1,159 +1,49 @@
 use super::*;
-
-struct TauStartupPreflightActions;
-
-impl tau_startup::StartupPreflightActions for TauStartupPreflightActions {
-    fn execute_onboarding_command(&self, cli: &Cli) -> Result<()> {
-        execute_onboarding_command(cli)
-    }
-
-    fn execute_multi_channel_send_command(&self, cli: &Cli) -> Result<()> {
-        crate::channel_send::execute_multi_channel_send_command(cli)
-    }
-
-    fn execute_multi_channel_channel_lifecycle_command(&self, cli: &Cli) -> Result<()> {
-        crate::channel_lifecycle::execute_multi_channel_channel_lifecycle_command(cli)
-    }
-
-    fn execute_deployment_wasm_package_command(&self, cli: &Cli) -> Result<()> {
-        crate::deployment_wasm::execute_deployment_wasm_package_command(cli)
-    }
-
-    fn execute_deployment_wasm_inspect_command(&self, cli: &Cli) -> Result<()> {
-        crate::deployment_wasm::execute_deployment_wasm_inspect_command(cli)
-    }
-
-    fn execute_project_index_command(&self, cli: &Cli) -> Result<()> {
-        execute_project_index_command(cli)
-    }
-
-    fn execute_channel_store_admin_command(&self, cli: &Cli) -> Result<()> {
-        execute_channel_store_admin_command(cli)
-    }
-
-    fn execute_multi_channel_live_readiness_preflight_command(&self, cli: &Cli) -> Result<()> {
-        execute_multi_channel_live_readiness_preflight_command(cli)
-    }
-
-    fn execute_browser_automation_preflight_command(&self, cli: &Cli) -> Result<()> {
-        execute_browser_automation_preflight_command(cli)
-    }
-
-    fn execute_extension_exec_command(&self, cli: &Cli) -> Result<()> {
-        execute_extension_exec_command(cli)
-    }
-
-    fn execute_extension_list_command(&self, cli: &Cli) -> Result<()> {
-        execute_extension_list_command(cli)
-    }
-
-    fn execute_extension_show_command(&self, cli: &Cli) -> Result<()> {
-        execute_extension_show_command(cli)
-    }
-
-    fn execute_extension_validate_command(&self, cli: &Cli) -> Result<()> {
-        execute_extension_validate_command(cli)
-    }
-
-    fn execute_package_validate_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_validate_command(cli)
-    }
-
-    fn execute_package_show_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_show_command(cli)
-    }
-
-    fn execute_package_install_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_install_command(cli)
-    }
-
-    fn execute_package_update_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_update_command(cli)
-    }
-
-    fn execute_package_list_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_list_command(cli)
-    }
-
-    fn execute_package_remove_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_remove_command(cli)
-    }
-
-    fn execute_package_rollback_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_rollback_command(cli)
-    }
-
-    fn execute_package_conflicts_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_conflicts_command(cli)
-    }
-
-    fn execute_package_activate_command(&self, cli: &Cli) -> Result<()> {
-        execute_package_activate_command(cli)
-    }
-
-    fn execute_qa_loop_preflight_command(&self, cli: &Cli) -> Result<()> {
-        execute_qa_loop_preflight_command(cli)
-    }
-
-    fn execute_mcp_server_command(&self, cli: &Cli) -> Result<()> {
-        execute_mcp_server_command(cli)
-    }
-
-    fn execute_rpc_capabilities_command(&self, cli: &Cli) -> Result<()> {
-        execute_rpc_capabilities_command(cli)
-    }
-
-    fn execute_rpc_validate_frame_command(&self, cli: &Cli) -> Result<()> {
-        execute_rpc_validate_frame_command(cli)
-    }
-
-    fn execute_rpc_dispatch_frame_command(&self, cli: &Cli) -> Result<()> {
-        execute_rpc_dispatch_frame_command(cli)
-    }
-
-    fn execute_rpc_dispatch_ndjson_command(&self, cli: &Cli) -> Result<()> {
-        execute_rpc_dispatch_ndjson_command(cli)
-    }
-
-    fn execute_rpc_serve_ndjson_command(&self, cli: &Cli) -> Result<()> {
-        execute_rpc_serve_ndjson_command(cli)
-    }
-
-    fn execute_events_inspect_command(&self, cli: &Cli) -> Result<()> {
-        execute_events_inspect_command(cli)
-    }
-
-    fn execute_events_validate_command(&self, cli: &Cli) -> Result<()> {
-        execute_events_validate_command(cli)
-    }
-
-    fn execute_events_simulate_command(&self, cli: &Cli) -> Result<()> {
-        execute_events_simulate_command(cli)
-    }
-
-    fn execute_events_dry_run_command(&self, cli: &Cli) -> Result<()> {
-        execute_events_dry_run_command(cli)
-    }
-
-    fn execute_events_template_write_command(&self, cli: &Cli) -> Result<()> {
-        execute_events_template_write_command(cli)
-    }
-
-    fn resolve_secret_from_cli_or_store_id(
-        &self,
-        cli: &Cli,
-        direct_secret: Option<&str>,
-        secret_id: Option<&str>,
-        secret_id_flag: &str,
-    ) -> Result<Option<String>> {
-        resolve_secret_from_cli_or_store_id(cli, direct_secret, secret_id, secret_id_flag)
-    }
-
-    fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool> {
-        tau_onboarding::startup_daemon_preflight::handle_daemon_commands(cli)
-    }
-}
+use tau_onboarding::startup_preflight::{
+    execute_startup_preflight as execute_onboarding_startup_preflight, StartupPreflightCallbacks,
+};
 
 pub(crate) fn execute_startup_preflight(cli: &Cli) -> Result<bool> {
-    tau_startup::execute_startup_preflight(cli, &TauStartupPreflightActions)
+    let callbacks = StartupPreflightCallbacks {
+        execute_onboarding_command,
+        execute_multi_channel_send_command: crate::channel_send::execute_multi_channel_send_command,
+        execute_multi_channel_channel_lifecycle_command:
+            crate::channel_lifecycle::execute_multi_channel_channel_lifecycle_command,
+        execute_deployment_wasm_package_command:
+            crate::deployment_wasm::execute_deployment_wasm_package_command,
+        execute_deployment_wasm_inspect_command:
+            crate::deployment_wasm::execute_deployment_wasm_inspect_command,
+        execute_project_index_command,
+        execute_channel_store_admin_command,
+        execute_multi_channel_live_readiness_preflight_command,
+        execute_browser_automation_preflight_command,
+        execute_extension_exec_command,
+        execute_extension_list_command,
+        execute_extension_show_command,
+        execute_extension_validate_command,
+        execute_package_validate_command,
+        execute_package_show_command,
+        execute_package_install_command,
+        execute_package_update_command,
+        execute_package_list_command,
+        execute_package_remove_command,
+        execute_package_rollback_command,
+        execute_package_conflicts_command,
+        execute_package_activate_command,
+        execute_qa_loop_preflight_command,
+        execute_mcp_server_command,
+        execute_rpc_capabilities_command,
+        execute_rpc_validate_frame_command,
+        execute_rpc_dispatch_frame_command,
+        execute_rpc_dispatch_ndjson_command,
+        execute_rpc_serve_ndjson_command,
+        execute_events_inspect_command,
+        execute_events_validate_command,
+        execute_events_simulate_command,
+        execute_events_dry_run_command,
+        execute_events_template_write_command,
+        resolve_secret_from_cli_or_store_id,
+        handle_daemon_commands: tau_onboarding::startup_daemon_preflight::handle_daemon_commands,
+    };
+    execute_onboarding_startup_preflight(cli, &callbacks)
 }

--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -23,6 +23,7 @@ tau-multi-channel = { path = "../tau-multi-channel" }
 tau-provider = { path = "../tau-provider" }
 tau-release-channel = { path = "../tau-release-channel" }
 tau-skills = { path = "../tau-skills" }
+tau-startup = { path = "../tau-startup" }
 tau-tools = { path = "../tau-tools" }
 tau-voice = { path = "../tau-voice" }
 tau-ops = { path = "../tau-ops" }

--- a/crates/tau-onboarding/src/lib.rs
+++ b/crates/tau-onboarding/src/lib.rs
@@ -11,6 +11,7 @@ pub mod startup_dispatch;
 pub mod startup_local_runtime;
 pub mod startup_model_resolution;
 pub mod startup_policy;
+pub mod startup_preflight;
 pub mod startup_prompt_composition;
 pub mod startup_resolution;
 pub mod startup_skills_bootstrap;

--- a/crates/tau-onboarding/src/startup_preflight.rs
+++ b/crates/tau-onboarding/src/startup_preflight.rs
@@ -1,0 +1,216 @@
+use anyhow::Result;
+use tau_cli::Cli;
+
+pub type StartupCommandFn = fn(&Cli) -> Result<()>;
+pub type ResolveSecretFn = fn(&Cli, Option<&str>, Option<&str>, &str) -> Result<Option<String>>;
+pub type HandleDaemonCommandsFn = fn(&Cli) -> Result<bool>;
+
+#[derive(Clone, Copy)]
+pub struct StartupPreflightCallbacks {
+    pub execute_onboarding_command: StartupCommandFn,
+    pub execute_multi_channel_send_command: StartupCommandFn,
+    pub execute_multi_channel_channel_lifecycle_command: StartupCommandFn,
+    pub execute_deployment_wasm_package_command: StartupCommandFn,
+    pub execute_deployment_wasm_inspect_command: StartupCommandFn,
+    pub execute_project_index_command: StartupCommandFn,
+    pub execute_channel_store_admin_command: StartupCommandFn,
+    pub execute_multi_channel_live_readiness_preflight_command: StartupCommandFn,
+    pub execute_browser_automation_preflight_command: StartupCommandFn,
+    pub execute_extension_exec_command: StartupCommandFn,
+    pub execute_extension_list_command: StartupCommandFn,
+    pub execute_extension_show_command: StartupCommandFn,
+    pub execute_extension_validate_command: StartupCommandFn,
+    pub execute_package_validate_command: StartupCommandFn,
+    pub execute_package_show_command: StartupCommandFn,
+    pub execute_package_install_command: StartupCommandFn,
+    pub execute_package_update_command: StartupCommandFn,
+    pub execute_package_list_command: StartupCommandFn,
+    pub execute_package_remove_command: StartupCommandFn,
+    pub execute_package_rollback_command: StartupCommandFn,
+    pub execute_package_conflicts_command: StartupCommandFn,
+    pub execute_package_activate_command: StartupCommandFn,
+    pub execute_qa_loop_preflight_command: StartupCommandFn,
+    pub execute_mcp_server_command: StartupCommandFn,
+    pub execute_rpc_capabilities_command: StartupCommandFn,
+    pub execute_rpc_validate_frame_command: StartupCommandFn,
+    pub execute_rpc_dispatch_frame_command: StartupCommandFn,
+    pub execute_rpc_dispatch_ndjson_command: StartupCommandFn,
+    pub execute_rpc_serve_ndjson_command: StartupCommandFn,
+    pub execute_events_inspect_command: StartupCommandFn,
+    pub execute_events_validate_command: StartupCommandFn,
+    pub execute_events_simulate_command: StartupCommandFn,
+    pub execute_events_dry_run_command: StartupCommandFn,
+    pub execute_events_template_write_command: StartupCommandFn,
+    pub resolve_secret_from_cli_or_store_id: ResolveSecretFn,
+    pub handle_daemon_commands: HandleDaemonCommandsFn,
+}
+
+struct CallbackStartupPreflightActions<'a> {
+    callbacks: &'a StartupPreflightCallbacks,
+}
+
+impl tau_startup::StartupPreflightActions for CallbackStartupPreflightActions<'_> {
+    fn execute_onboarding_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_onboarding_command)(cli)
+    }
+
+    fn execute_multi_channel_send_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_multi_channel_send_command)(cli)
+    }
+
+    fn execute_multi_channel_channel_lifecycle_command(&self, cli: &Cli) -> Result<()> {
+        (self
+            .callbacks
+            .execute_multi_channel_channel_lifecycle_command)(cli)
+    }
+
+    fn execute_deployment_wasm_package_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_deployment_wasm_package_command)(cli)
+    }
+
+    fn execute_deployment_wasm_inspect_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_deployment_wasm_inspect_command)(cli)
+    }
+
+    fn execute_project_index_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_project_index_command)(cli)
+    }
+
+    fn execute_channel_store_admin_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_channel_store_admin_command)(cli)
+    }
+
+    fn execute_multi_channel_live_readiness_preflight_command(&self, cli: &Cli) -> Result<()> {
+        (self
+            .callbacks
+            .execute_multi_channel_live_readiness_preflight_command)(cli)
+    }
+
+    fn execute_browser_automation_preflight_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_browser_automation_preflight_command)(cli)
+    }
+
+    fn execute_extension_exec_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_extension_exec_command)(cli)
+    }
+
+    fn execute_extension_list_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_extension_list_command)(cli)
+    }
+
+    fn execute_extension_show_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_extension_show_command)(cli)
+    }
+
+    fn execute_extension_validate_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_extension_validate_command)(cli)
+    }
+
+    fn execute_package_validate_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_validate_command)(cli)
+    }
+
+    fn execute_package_show_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_show_command)(cli)
+    }
+
+    fn execute_package_install_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_install_command)(cli)
+    }
+
+    fn execute_package_update_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_update_command)(cli)
+    }
+
+    fn execute_package_list_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_list_command)(cli)
+    }
+
+    fn execute_package_remove_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_remove_command)(cli)
+    }
+
+    fn execute_package_rollback_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_rollback_command)(cli)
+    }
+
+    fn execute_package_conflicts_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_conflicts_command)(cli)
+    }
+
+    fn execute_package_activate_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_package_activate_command)(cli)
+    }
+
+    fn execute_qa_loop_preflight_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_qa_loop_preflight_command)(cli)
+    }
+
+    fn execute_mcp_server_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_mcp_server_command)(cli)
+    }
+
+    fn execute_rpc_capabilities_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_rpc_capabilities_command)(cli)
+    }
+
+    fn execute_rpc_validate_frame_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_rpc_validate_frame_command)(cli)
+    }
+
+    fn execute_rpc_dispatch_frame_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_rpc_dispatch_frame_command)(cli)
+    }
+
+    fn execute_rpc_dispatch_ndjson_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_rpc_dispatch_ndjson_command)(cli)
+    }
+
+    fn execute_rpc_serve_ndjson_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_rpc_serve_ndjson_command)(cli)
+    }
+
+    fn execute_events_inspect_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_events_inspect_command)(cli)
+    }
+
+    fn execute_events_validate_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_events_validate_command)(cli)
+    }
+
+    fn execute_events_simulate_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_events_simulate_command)(cli)
+    }
+
+    fn execute_events_dry_run_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_events_dry_run_command)(cli)
+    }
+
+    fn execute_events_template_write_command(&self, cli: &Cli) -> Result<()> {
+        (self.callbacks.execute_events_template_write_command)(cli)
+    }
+
+    fn resolve_secret_from_cli_or_store_id(
+        &self,
+        cli: &Cli,
+        direct_secret: Option<&str>,
+        secret_id: Option<&str>,
+        secret_id_flag: &str,
+    ) -> Result<Option<String>> {
+        (self.callbacks.resolve_secret_from_cli_or_store_id)(
+            cli,
+            direct_secret,
+            secret_id,
+            secret_id_flag,
+        )
+    }
+
+    fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool> {
+        (self.callbacks.handle_daemon_commands)(cli)
+    }
+}
+
+pub fn execute_startup_preflight(cli: &Cli, callbacks: &StartupPreflightCallbacks) -> Result<bool> {
+    let actions = CallbackStartupPreflightActions { callbacks };
+    tau_startup::execute_startup_preflight(cli, &actions)
+}


### PR DESCRIPTION
## Summary
- add onboarding-owned startup preflight adapter module:
  - `StartupPreflightCallbacks`
  - onboarding-side callback-backed `StartupPreflightActions` implementation
  - `execute_startup_preflight(cli, callbacks)` delegating to `tau_startup`
- move startup preflight wiring orchestration from coding-agent trait impl into onboarding
- simplify coding-agent startup preflight module to a callback map + onboarding dispatcher call
- keep startup/preflight behavior and CLI surface unchanged

## Testing
- cargo fmt --all
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

Refs #999
