### PR TITLE
refactor(startup): extract transport runtime dispatcher

### DIFF
--- a/crates/tau-onboarding/Cargo.toml
+++ b/crates/tau-onboarding/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
@@ -30,7 +31,6 @@ tau-ops = { path = "../tau-ops" }
 tau-orchestrator = { path = "../tau-orchestrator" }
 
 [dev-dependencies]
-async-trait = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add onboarding-owned transport runtime dispatcher:
  - `TransportRuntimeExecutor` async trait
  - `execute_transport_runtime_mode` mode-dispatch helper
- rewire coding-agent `run_transport_mode_if_requested` to delegate transport mode execution to onboarding dispatcher via a coding-agent executor adapter
- preserve transport behavior while reducing top-level startup transport match/orchestration in coding-agent
- add onboarding dispatcher tests across categories:
  - unit: `None` mode returns `false`
  - functional: gateway openresponses dispatch
  - integration: multi-channel live runner dispatch
  - regression: executor error propagation

## Testing
- cargo fmt --all
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
- cargo clippy -p tau-onboarding -p tau-coding-agent -- -D warnings

Refs: #999
