### PR TITLE
Refactor local runtime doctor config assembly into tau-onboarding

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -293,17 +293,19 @@ pub(crate) use tau_cli::validation::{
 };
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
-pub(crate) use tau_diagnostics::{
-    build_doctor_command_config, execute_audit_summary_command,
-    execute_browser_automation_preflight_command, execute_doctor_cli_command,
-    execute_multi_channel_live_readiness_preflight_command, execute_policy_command,
-};
+#[cfg(test)]
+pub(crate) use tau_diagnostics::build_doctor_command_config;
 #[cfg(test)]
 pub(crate) use tau_diagnostics::{
     evaluate_multi_channel_live_readiness, parse_doctor_command_args, percentile_duration_ms,
     render_audit_summary, render_doctor_report, render_doctor_report_json, run_doctor_checks,
     run_doctor_checks_with_lookup, summarize_audit_file, DoctorCheckOptions, DoctorCheckResult,
     DoctorCommandArgs, DoctorCommandOutputFormat, DoctorStatus,
+};
+pub(crate) use tau_diagnostics::{
+    execute_audit_summary_command, execute_browser_automation_preflight_command,
+    execute_doctor_cli_command, execute_multi_channel_live_readiness_preflight_command,
+    execute_policy_command,
 };
 #[cfg(test)]
 pub(crate) use tau_diagnostics::{execute_doctor_command, execute_doctor_command_with_options};

--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -3,6 +3,7 @@ use crate::extension_manifest::{
     discover_extension_runtime_registrations, ExtensionRuntimeRegistrationSummary,
 };
 use tau_onboarding::startup_local_runtime::{
+    build_local_runtime_doctor_config as build_onboarding_local_runtime_doctor_config,
     execute_command_file_entry_mode as execute_onboarding_command_file_entry_mode,
     execute_prompt_entry_mode as execute_onboarding_prompt_entry_mode,
     register_runtime_event_reporter_if_configured as register_onboarding_runtime_event_reporter_if_configured,
@@ -176,13 +177,13 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         skills_dir: skills_dir.to_path_buf(),
         default_lock_path: skills_lock_path.to_path_buf(),
         default_trust_root_path: cli.skill_trust_root_file.clone(),
-        doctor_config: {
-            let mut doctor_config =
-                build_doctor_command_config(cli, model_ref, fallback_model_refs, skills_lock_path);
-            doctor_config.skills_dir = skills_dir.to_path_buf();
-            doctor_config.skills_lock_path = skills_lock_path.to_path_buf();
-            doctor_config
-        },
+        doctor_config: build_onboarding_local_runtime_doctor_config(
+            cli,
+            model_ref,
+            fallback_model_refs,
+            skills_dir,
+            skills_lock_path,
+        ),
     };
     let profile_defaults = build_profile_defaults(cli);
     let auth_command_config = build_auth_command_config(cli);


### PR DESCRIPTION
## Summary
- add onboarding helper build_local_runtime_doctor_config to centralize local-runtime doctor config assembly
- rewire coding-agent local runtime startup to consume onboarding doctor config helper
- add onboarding unit/functional/integration/regression tests covering runtime skills path overrides, model identity, fallback providers, and no-session behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Refs #999