### PR TITLE
Refactor local runtime command defaults into tau-onboarding

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -223,7 +223,9 @@ pub(crate) use crate::skills_commands::{
 pub(crate) use crate::skills_commands::{
     render_skills_lock_write_success, render_skills_sync_drift_details,
 };
-pub(crate) use crate::startup_config::{build_auth_command_config, build_profile_defaults};
+pub(crate) use crate::startup_config::build_auth_command_config;
+#[cfg(test)]
+pub(crate) use crate::startup_config::build_profile_defaults;
 use crate::startup_dispatch::run_cli;
 #[cfg(test)]
 pub(crate) use crate::startup_local_runtime::register_runtime_extension_tool_hook_subscriber;

--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -3,15 +3,16 @@ use crate::extension_manifest::{
     discover_extension_runtime_registrations, ExtensionRuntimeRegistrationSummary,
 };
 use tau_onboarding::startup_local_runtime::{
-    build_local_runtime_doctor_config as build_onboarding_local_runtime_doctor_config,
+    build_local_runtime_command_defaults as build_onboarding_local_runtime_command_defaults,
     build_local_runtime_extension_bootstrap as build_onboarding_local_runtime_extension_bootstrap,
     execute_prompt_or_command_file_entry_mode as execute_onboarding_prompt_or_command_file_entry_mode,
     register_runtime_event_reporter_if_configured as register_onboarding_runtime_event_reporter_if_configured,
     register_runtime_extension_tool_hook_subscriber as register_onboarding_runtime_extension_tool_hook_subscriber,
     register_runtime_extension_tools as register_onboarding_runtime_extension_tools,
     register_runtime_json_event_subscriber as register_onboarding_runtime_json_event_subscriber,
-    resolve_local_runtime_entry_mode, resolve_session_runtime, LocalRuntimeExtensionBootstrap,
-    PromptEntryRuntimeMode, PromptOrCommandFileEntryOutcome, SessionBootstrapOutcome,
+    resolve_local_runtime_entry_mode, resolve_session_runtime, LocalRuntimeCommandDefaults,
+    LocalRuntimeExtensionBootstrap, PromptEntryRuntimeMode, PromptOrCommandFileEntryOutcome,
+    SessionBootstrapOutcome,
 };
 
 pub(crate) struct LocalRuntimeConfig<'a> {
@@ -133,20 +134,23 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         cli.orchestrator_mode == CliOrchestratorMode::PlanFirst,
         cli.command_file.as_deref(),
     );
+    let LocalRuntimeCommandDefaults {
+        profile_defaults,
+        auth_command_config,
+        doctor_config,
+    } = build_onboarding_local_runtime_command_defaults(
+        cli,
+        model_ref,
+        fallback_model_refs,
+        skills_dir,
+        skills_lock_path,
+    );
     let skills_sync_command_config = SkillsSyncCommandConfig {
         skills_dir: skills_dir.to_path_buf(),
         default_lock_path: skills_lock_path.to_path_buf(),
         default_trust_root_path: cli.skill_trust_root_file.clone(),
-        doctor_config: build_onboarding_local_runtime_doctor_config(
-            cli,
-            model_ref,
-            fallback_model_refs,
-            skills_dir,
-            skills_lock_path,
-        ),
+        doctor_config,
     };
-    let profile_defaults = build_profile_defaults(cli);
-    let auth_command_config = build_auth_command_config(cli);
     let command_context = CommandExecutionContext {
         tool_policy_json,
         session_import_mode: cli.session_import_mode.into(),


### PR DESCRIPTION
## Summary
- add onboarding-owned local runtime command-defaults helper `build_local_runtime_command_defaults`
- centralize construction of local runtime profile defaults, auth command config, and doctor config in `tau-onboarding`
- rewire coding-agent local runtime startup to consume onboarding command-defaults output
- keep strict clippy compatibility by limiting `build_profile_defaults` re-export in coding-agent main to test-only
- add onboarding tests across unit/functional/integration/regression coverage for the new helper

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1`

Refs: #999
