### PR TITLE
refactor(github-issues): extract issue session path/id helpers

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -59,9 +59,11 @@ use tau_github_issues::issue_render::{
     IssueArtifactAttachmentView, IssueEventPromptAttachmentView,
 };
 use tau_github_issues::issue_runtime_helpers::{
+    issue_session_id as issue_shared_session_id,
     normalize_artifact_retention_days as normalize_shared_artifact_retention_days,
     normalize_relative_channel_path as normalize_shared_relative_channel_path,
     render_issue_artifact_pointer_line as render_shared_issue_artifact_pointer_line,
+    session_path_for_issue as shared_session_path_for_issue,
 };
 use tau_session::SessionStore;
 use tau_session::{parse_session_search_args, search_session_entries};
@@ -5763,13 +5765,11 @@ fn collect_issue_events(
 }
 
 fn session_path_for_issue(repo_state_dir: &Path, issue_number: u64) -> PathBuf {
-    repo_state_dir
-        .join("sessions")
-        .join(format!("issue-{}.jsonl", issue_number))
+    shared_session_path_for_issue(repo_state_dir, issue_number)
 }
 
 fn issue_session_id(issue_number: u64) -> String {
-    format!("issue-{}", issue_number)
+    issue_shared_session_id(issue_number)
 }
 
 fn parse_rfc3339_to_unix_ms(raw: &str) -> Option<u64> {

--- a/crates/tau-github-issues/src/issue_runtime_helpers.rs
+++ b/crates/tau-github-issues/src/issue_runtime_helpers.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn normalize_relative_channel_path(
     path: &Path,
@@ -38,11 +38,21 @@ pub fn render_issue_artifact_pointer_line(
     format!("{label}: id=`{artifact_id}` path=`{relative_path}` bytes=`{bytes}`")
 }
 
+pub fn session_path_for_issue(repo_state_dir: &Path, issue_number: u64) -> PathBuf {
+    repo_state_dir
+        .join("sessions")
+        .join(format!("issue-{issue_number}.jsonl"))
+}
+
+pub fn issue_session_id(issue_number: u64) -> String {
+    format!("issue-{issue_number}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_artifact_retention_days, normalize_relative_channel_path,
-        render_issue_artifact_pointer_line,
+        issue_session_id, normalize_artifact_retention_days, normalize_relative_channel_path,
+        render_issue_artifact_pointer_line, session_path_for_issue,
     };
     use std::path::Path;
 
@@ -82,5 +92,17 @@ mod tests {
         let root_path_error = normalize_relative_channel_path(root, root, "artifact")
             .expect_err("root path should fail");
         assert!(root_path_error.contains("derived empty relative path"));
+    }
+
+    #[test]
+    fn unit_issue_session_id_formats_issue_identifier() {
+        assert_eq!(issue_session_id(42), "issue-42");
+    }
+
+    #[test]
+    fn integration_session_path_for_issue_builds_expected_repo_relative_path() {
+        let root = Path::new("/tmp/repo");
+        let path = session_path_for_issue(root, 9);
+        assert_eq!(path, Path::new("/tmp/repo/sessions/issue-9.jsonl"));
     }
 }


### PR DESCRIPTION
## Summary
- extend `tau-github-issues::issue_runtime_helpers` with shared issue-session helpers:
  - `session_path_for_issue`
  - `issue_session_id`
- convert `tau-coding-agent` issue-session helper functions to thin wrappers over shared helpers
- add shared helper coverage for session ID/path formatting in the helper crate

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Part of #992.
