### PR TITLE
refactor(github-issues): extract shared time/path/runtime guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,7 @@ dependencies = [
 name = "tau-github-issues"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "reqwest 0.12.28",
 ]
 

--- a/crates/tau-github-issues/Cargo.toml
+++ b/crates/tau-github-issues/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 reqwest = { workspace = true }
+chrono = { workspace = true }


### PR DESCRIPTION
## Summary
- extend `tau-github-issues::issue_runtime_helpers` with shared runtime utilities:
  - `parse_rfc3339_to_unix_ms`
  - `sanitize_for_path`
  - `is_expired_at`
- add shared coverage for parse/path/expiry helper behavior
- convert `tau-coding-agent` bridge helpers (`parse_rfc3339_to_unix_ms`, `sanitize_for_path`, artifact-expiry check) into thin wrappers over shared helpers
- add `chrono` workspace dependency to `tau-github-issues` for RFC3339 parsing

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Part of #992.
