### PR TITLE
refactor(github-issues): extract command usage helpers

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -47,6 +47,12 @@ use tau_github_issues::issue_auth_helpers::{
     build_issue_auth_summary_line as build_shared_issue_auth_summary_line,
     ensure_auth_json_flag as ensure_shared_auth_json_flag, IssueAuthSummaryKind,
 };
+use tau_github_issues::issue_command_usage::{
+    demo_index_command_usage as demo_index_shared_command_usage,
+    doctor_command_usage as doctor_shared_command_usage,
+    issue_auth_command_usage as issue_auth_shared_command_usage,
+    tau_command_usage as tau_shared_command_usage,
+};
 use tau_github_issues::issue_comment::{
     extract_footer_event_keys, issue_command_reason_code, normalize_issue_command_status,
     render_issue_command_comment, render_issue_comment_chunks_with_footer,
@@ -5404,43 +5410,24 @@ fn parse_demo_index_run_command(raw: &str) -> std::result::Result<DemoIndexRunCo
 }
 
 fn doctor_command_usage() -> String {
-    "Usage: /tau doctor [--online]".to_string()
+    doctor_shared_command_usage("/tau")
 }
 
 fn issue_auth_command_usage() -> String {
-    format!(
-        "Usage: /tau auth <status|matrix> ...\n{}\n{}",
-        AUTH_STATUS_USAGE, AUTH_MATRIX_USAGE
-    )
+    issue_auth_shared_command_usage("/tau", AUTH_STATUS_USAGE, AUTH_MATRIX_USAGE)
 }
 
 fn demo_index_command_usage() -> String {
-    format!(
-        "Usage: /tau demo-index <list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report>\nAllowed scenarios: {}\nDefault run timeout: {} seconds (max {}).",
-        DEMO_INDEX_SCENARIOS.join(","),
+    demo_index_shared_command_usage(
+        "/tau",
+        &DEMO_INDEX_SCENARIOS,
         DEMO_INDEX_DEFAULT_TIMEOUT_SECONDS,
-        DEMO_INDEX_MAX_TIMEOUT_SECONDS
+        DEMO_INDEX_MAX_TIMEOUT_SECONDS,
     )
 }
 
 fn tau_command_usage() -> String {
-    [
-        "Supported `/tau` commands:",
-        "- `/tau run <prompt>`",
-        "- `/tau stop`",
-        "- `/tau status`",
-        "- `/tau health`",
-        "- `/tau auth <status|matrix> ...`",
-        "- `/tau doctor [--online]`",
-        "- `/tau compact`",
-        "- `/tau help`",
-        "- `/tau chat <start|resume|reset|export|status|summary|replay|show [limit]|search <query>>`",
-        "- `/tau artifacts [purge|run <run_id>|show <artifact_id>]`",
-        "- `/tau demo-index <list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report>`",
-        "- `/tau canvas <create|update|show|export|import> ...`",
-        "- `/tau summarize [focus]`",
-    ]
-    .join("\n")
+    tau_shared_command_usage("/tau")
 }
 
 fn build_summarize_prompt(

--- a/crates/tau-github-issues/src/issue_command_usage.rs
+++ b/crates/tau-github-issues/src/issue_command_usage.rs
@@ -1,0 +1,108 @@
+fn normalize_prefix(command_prefix: &str) -> &str {
+    let trimmed = command_prefix.trim();
+    if trimmed.is_empty() {
+        "/tau"
+    } else {
+        trimmed
+    }
+}
+
+pub fn doctor_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!("Usage: {prefix} doctor [--online]")
+}
+
+pub fn issue_auth_command_usage(
+    command_prefix: &str,
+    auth_status_usage: &str,
+    auth_matrix_usage: &str,
+) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!(
+        "Usage: {prefix} auth <status|matrix> ...\n{}\n{}",
+        auth_status_usage, auth_matrix_usage
+    )
+}
+
+pub fn demo_index_command_usage(
+    command_prefix: &str,
+    scenarios: &[&str],
+    default_timeout_seconds: u64,
+    max_timeout_seconds: u64,
+) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!(
+        "Usage: {prefix} demo-index <list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report>\nAllowed scenarios: {}\nDefault run timeout: {} seconds (max {}).",
+        scenarios.join(","),
+        default_timeout_seconds,
+        max_timeout_seconds
+    )
+}
+
+pub fn tau_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    [
+        format!("Supported `{prefix}` commands:"),
+        format!("- `{prefix} run <prompt>`"),
+        format!("- `{prefix} stop`"),
+        format!("- `{prefix} status`"),
+        format!("- `{prefix} health`"),
+        format!("- `{prefix} auth <status|matrix> ...`"),
+        format!("- `{prefix} doctor [--online]`"),
+        format!("- `{prefix} compact`"),
+        format!("- `{prefix} help`"),
+        format!(
+            "- `{prefix} chat <start|resume|reset|export|status|summary|replay|show [limit]|search <query>>`"
+        ),
+        format!("- `{prefix} artifacts [purge|run <run_id>|show <artifact_id>]`"),
+        format!(
+            "- `{prefix} demo-index <list|run [scenario[,scenario...]] [--timeout-seconds <n>]|report>`"
+        ),
+        format!("- `{prefix} canvas <create|update|show|export|import> ...`"),
+        format!("- `{prefix} summarize [focus]`"),
+    ]
+    .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        demo_index_command_usage, doctor_command_usage, issue_auth_command_usage, tau_command_usage,
+    };
+
+    #[test]
+    fn unit_doctor_command_usage_uses_requested_prefix() {
+        assert_eq!(
+            doctor_command_usage("/tau"),
+            "Usage: /tau doctor [--online]".to_string()
+        );
+    }
+
+    #[test]
+    fn functional_issue_auth_command_usage_includes_status_and_matrix_help() {
+        let usage = issue_auth_command_usage("/tau", "status help", "matrix help");
+        assert!(usage.contains("Usage: /tau auth <status|matrix> ..."));
+        assert!(usage.contains("status help"));
+        assert!(usage.contains("matrix help"));
+    }
+
+    #[test]
+    fn integration_demo_index_command_usage_lists_scenarios_and_timeout_bounds() {
+        let usage = demo_index_command_usage(
+            "/tau",
+            &["onboarding", "gateway-auth", "multi-channel-live"],
+            180,
+            900,
+        );
+        assert!(usage.contains("Usage: /tau demo-index"));
+        assert!(usage.contains("Allowed scenarios: onboarding,gateway-auth,multi-channel-live"));
+        assert!(usage.contains("Default run timeout: 180 seconds (max 900)."));
+    }
+
+    #[test]
+    fn regression_tau_command_usage_defaults_prefix_when_blank() {
+        let usage = tau_command_usage("   ");
+        assert!(usage.contains("Supported `/tau` commands:"));
+        assert!(usage.contains("- `/tau run <prompt>`"));
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod github_issues_helpers;
 pub mod github_transport_helpers;
 pub mod issue_auth_helpers;
+pub mod issue_command_usage;
 pub mod issue_comment;
 pub mod issue_demo_index;
 pub mod issue_filter;


### PR DESCRIPTION
## Summary
- add `tau_github_issues::issue_command_usage` with shared command usage builders:
  - `doctor_command_usage`
  - `issue_auth_command_usage`
  - `demo_index_command_usage`
  - `tau_command_usage`
- add shared unit/functional/integration/regression tests for usage rendering behavior
- rewire `tau-coding-agent` wrappers to delegate to the shared command usage helpers

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Refs #992
