### PR TITLE
refactor(github-issues): extract prompt helpers

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -64,6 +64,10 @@ use tau_github_issues::issue_demo_index::parse_demo_index_run_command as parse_s
 use tau_github_issues::issue_filter::{
     build_required_issue_labels, issue_matches_required_labels, issue_matches_required_numbers,
 };
+use tau_github_issues::issue_prompt_helpers::{
+    build_summarize_prompt as build_shared_summarize_prompt,
+    collect_assistant_reply as collect_shared_assistant_reply,
+};
 use tau_github_issues::issue_render::{
     render_event_prompt as render_shared_event_prompt,
     render_issue_artifact_markdown as render_shared_issue_artifact_markdown,
@@ -4944,18 +4948,7 @@ fn initialize_issue_session_runtime(
 }
 
 fn collect_assistant_reply(messages: &[tau_ai::Message]) -> String {
-    let content = messages
-        .iter()
-        .filter(|message| message.role == tau_ai::MessageRole::Assistant)
-        .map(|message| message.text_content())
-        .filter(|text| !text.trim().is_empty())
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    if content.trim().is_empty() {
-        "I couldn't generate a textual response for this event.".to_string()
-    } else {
-        content
-    }
+    collect_shared_assistant_reply(messages)
 }
 
 fn render_event_prompt(
@@ -5440,19 +5433,7 @@ fn build_summarize_prompt(
     event: &GithubBridgeEvent,
     focus: Option<&str>,
 ) -> String {
-    match focus {
-        Some(focus) => format!(
-            "Summarize the current GitHub issue thread for {} issue #{} with focus on: {}.\nInclude decisions, open questions, blockers, and immediate next steps.",
-            repo.as_slug(),
-            event.issue_number,
-            focus
-        ),
-        None => format!(
-            "Summarize the current GitHub issue thread for {} issue #{}.\nInclude decisions, open questions, blockers, and immediate next steps.",
-            repo.as_slug(),
-            event.issue_number
-        ),
-    }
+    build_shared_summarize_prompt(&repo.as_slug(), event.issue_number, focus)
 }
 
 fn compact_issue_session(

--- a/crates/tau-github-issues/src/issue_prompt_helpers.rs
+++ b/crates/tau-github-issues/src/issue_prompt_helpers.rs
@@ -1,0 +1,75 @@
+pub fn collect_assistant_reply(messages: &[tau_ai::Message]) -> String {
+    let content = messages
+        .iter()
+        .filter(|message| message.role == tau_ai::MessageRole::Assistant)
+        .map(|message| message.text_content())
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if content.trim().is_empty() {
+        "I couldn't generate a textual response for this event.".to_string()
+    } else {
+        content
+    }
+}
+
+pub fn build_summarize_prompt(repo_slug: &str, issue_number: u64, focus: Option<&str>) -> String {
+    match focus {
+        Some(focus) => format!(
+            "Summarize the current GitHub issue thread for {} issue #{} with focus on: {}.\nInclude decisions, open questions, blockers, and immediate next steps.",
+            repo_slug,
+            issue_number,
+            focus
+        ),
+        None => format!(
+            "Summarize the current GitHub issue thread for {} issue #{}.\nInclude decisions, open questions, blockers, and immediate next steps.",
+            repo_slug,
+            issue_number
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tau_ai::Message;
+
+    use super::{build_summarize_prompt, collect_assistant_reply};
+
+    #[test]
+    fn unit_collect_assistant_reply_returns_default_when_no_assistant_text_exists() {
+        let messages = vec![Message::user("hello"), Message::assistant_text("   ")];
+        assert_eq!(
+            collect_assistant_reply(&messages),
+            "I couldn't generate a textual response for this event."
+        );
+    }
+
+    #[test]
+    fn functional_collect_assistant_reply_concatenates_non_empty_assistant_messages() {
+        let messages = vec![
+            Message::assistant_text("first response"),
+            Message::user("ignored"),
+            Message::assistant_text("second response"),
+        ];
+        assert_eq!(
+            collect_assistant_reply(&messages),
+            "first response\n\nsecond response"
+        );
+    }
+
+    #[test]
+    fn integration_build_summarize_prompt_with_focus_includes_focus_and_context() {
+        let prompt = build_summarize_prompt("owner/repo", 42, Some("test failures"));
+        assert!(prompt.contains("owner/repo issue #42"));
+        assert!(prompt.contains("focus on: test failures"));
+    }
+
+    #[test]
+    fn regression_build_summarize_prompt_without_focus_stable_shape() {
+        let prompt = build_summarize_prompt("owner/repo", 7, None);
+        assert_eq!(
+            prompt,
+            "Summarize the current GitHub issue thread for owner/repo issue #7.\nInclude decisions, open questions, blockers, and immediate next steps."
+        );
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -9,6 +9,7 @@ pub mod issue_command_usage;
 pub mod issue_comment;
 pub mod issue_demo_index;
 pub mod issue_filter;
+pub mod issue_prompt_helpers;
 pub mod issue_render;
 pub mod issue_runtime_helpers;
 pub mod issue_session_helpers;


### PR DESCRIPTION
## Summary
- add `tau_github_issues::issue_prompt_helpers` with shared helpers:
  - `collect_assistant_reply`
  - `build_summarize_prompt`
- add shared helper tests spanning unit/functional/integration/regression behavior
- rewire `tau-coding-agent` wrappers to delegate to the shared prompt helper module

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Refs #992
