### PR TITLE
refactor(github-issues): extract doctor command parser

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -61,6 +61,9 @@ use tau_github_issues::issue_comment::{
     IssueCommentUsageView,
 };
 use tau_github_issues::issue_demo_index::parse_demo_index_run_command as parse_shared_demo_index_run_command;
+use tau_github_issues::issue_doctor_command::{
+    parse_issue_doctor_command as parse_shared_issue_doctor_command, IssueDoctorCommand,
+};
 use tau_github_issues::issue_event_collection::{
     collect_issue_events as collect_shared_issue_events, GithubBridgeEvent, GithubIssue,
     GithubIssueComment,
@@ -1022,11 +1025,6 @@ struct IssueAuthExecution {
     subscription_strict: bool,
     report_artifact: ChannelArtifactRecord,
     json_artifact: ChannelArtifactRecord,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct IssueDoctorCommand {
-    online: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -5289,23 +5287,9 @@ fn parse_demo_index_command(remainder: &str) -> TauIssueCommand {
 }
 
 fn parse_doctor_issue_command(remainder: &str) -> TauIssueCommand {
-    if remainder.is_empty() {
-        return TauIssueCommand::Doctor {
-            command: IssueDoctorCommand { online: false },
-        };
-    }
-    let tokens = remainder
-        .split_whitespace()
-        .filter(|token| !token.trim().is_empty())
-        .collect::<Vec<_>>();
-    if tokens.len() == 1 && tokens[0] == "--online" {
-        TauIssueCommand::Doctor {
-            command: IssueDoctorCommand { online: true },
-        }
-    } else {
-        TauIssueCommand::Invalid {
-            message: doctor_command_usage(),
-        }
+    match parse_shared_issue_doctor_command(remainder, &doctor_command_usage()) {
+        Ok(command) => TauIssueCommand::Doctor { command },
+        Err(message) => TauIssueCommand::Invalid { message },
     }
 }
 

--- a/crates/tau-github-issues/src/issue_doctor_command.rs
+++ b/crates/tau-github-issues/src/issue_doctor_command.rs
@@ -1,0 +1,55 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IssueDoctorCommand {
+    pub online: bool,
+}
+
+pub fn parse_issue_doctor_command(
+    remainder: &str,
+    usage_message: &str,
+) -> std::result::Result<IssueDoctorCommand, String> {
+    if remainder.is_empty() {
+        return Ok(IssueDoctorCommand { online: false });
+    }
+    let tokens = remainder
+        .split_whitespace()
+        .filter(|token| !token.trim().is_empty())
+        .collect::<Vec<_>>();
+    if tokens.len() == 1 && tokens[0] == "--online" {
+        Ok(IssueDoctorCommand { online: true })
+    } else {
+        Err(usage_message.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_issue_doctor_command, IssueDoctorCommand};
+
+    #[test]
+    fn unit_parse_issue_doctor_command_defaults_to_offline() {
+        let parsed = parse_issue_doctor_command("", "Usage: /tau doctor [--online]")
+            .expect("parse default doctor command");
+        assert_eq!(parsed, IssueDoctorCommand { online: false });
+    }
+
+    #[test]
+    fn functional_parse_issue_doctor_command_supports_online_flag() {
+        let parsed = parse_issue_doctor_command("--online", "Usage: /tau doctor [--online]")
+            .expect("parse online doctor command");
+        assert_eq!(parsed, IssueDoctorCommand { online: true });
+    }
+
+    #[test]
+    fn integration_parse_issue_doctor_command_trims_whitespace_before_tokenization() {
+        let parsed = parse_issue_doctor_command("   --online   ", "Usage: /tau doctor [--online]")
+            .expect("parse online doctor command with whitespace");
+        assert_eq!(parsed, IssueDoctorCommand { online: true });
+    }
+
+    #[test]
+    fn regression_parse_issue_doctor_command_rejects_extra_flags() {
+        let err = parse_issue_doctor_command("--online --verbose", "Usage: /tau doctor [--online]")
+            .expect_err("invalid doctor command should fail");
+        assert_eq!(err, "Usage: /tau doctor [--online]");
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -8,6 +8,7 @@ pub mod issue_auth_helpers;
 pub mod issue_command_usage;
 pub mod issue_comment;
 pub mod issue_demo_index;
+pub mod issue_doctor_command;
 pub mod issue_event_collection;
 pub mod issue_filter;
 pub mod issue_prompt_helpers;


### PR DESCRIPTION
## Summary
- add a shared `tau-github-issues::issue_doctor_command` module with:
  - `IssueDoctorCommand`
  - `parse_issue_doctor_command`
- move doctor command parsing out of `tau-coding-agent` into the shared crate
- keep `tau-coding-agent` behavior unchanged via a thin wrapper in `parse_doctor_issue_command`
- add unit/functional/integration/regression tests for doctor command parsing in the shared module

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

## Tracking
- part of #992
