### PR TITLE
refactor(github-issues): extract demo-index command parser

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -65,6 +65,9 @@ use tau_github_issues::issue_comment::{
     IssueCommentUsageView,
 };
 use tau_github_issues::issue_demo_index::parse_demo_index_run_command as parse_shared_demo_index_run_command;
+use tau_github_issues::issue_demo_index_command::{
+    parse_demo_index_issue_command as parse_shared_demo_index_issue_command, DemoIndexIssueCommand,
+};
 use tau_github_issues::issue_doctor_command::{
     parse_issue_doctor_command as parse_shared_issue_doctor_command, IssueDoctorCommand,
 };
@@ -5260,21 +5263,12 @@ fn parse_tau_issue_command(body: &str) -> Option<TauIssueCommand> {
 }
 
 fn parse_demo_index_command(remainder: &str) -> TauIssueCommand {
-    let mut parts = remainder.splitn(2, char::is_whitespace);
-    let subcommand = parts.next().unwrap_or_default().trim();
-    let sub_remainder = parts.next().unwrap_or_default().trim();
-    match subcommand {
-        "list" if sub_remainder.is_empty() => TauIssueCommand::DemoIndexList,
-        "report" if sub_remainder.is_empty() => TauIssueCommand::DemoIndexReport,
-        "run" => match parse_demo_index_run_command(sub_remainder) {
-            Ok(command) => TauIssueCommand::DemoIndexRun { command },
-            Err(error_message) => TauIssueCommand::Invalid {
-                message: error_message,
-            },
-        },
-        _ => TauIssueCommand::Invalid {
-            message: demo_index_command_usage(),
-        },
+    let usage = demo_index_command_usage();
+    match parse_shared_demo_index_issue_command(remainder, &usage, parse_demo_index_run_command) {
+        Ok(DemoIndexIssueCommand::List) => TauIssueCommand::DemoIndexList,
+        Ok(DemoIndexIssueCommand::Report) => TauIssueCommand::DemoIndexReport,
+        Ok(DemoIndexIssueCommand::Run(command)) => TauIssueCommand::DemoIndexRun { command },
+        Err(message) => TauIssueCommand::Invalid { message },
     }
 }
 

--- a/crates/tau-github-issues/src/issue_demo_index_command.rs
+++ b/crates/tau-github-issues/src/issue_demo_index_command.rs
@@ -1,0 +1,71 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DemoIndexIssueCommand<RunCommand> {
+    List,
+    Report,
+    Run(RunCommand),
+}
+
+pub fn parse_demo_index_issue_command<RunCommand, F>(
+    remainder: &str,
+    usage_message: &str,
+    parse_run_command: F,
+) -> std::result::Result<DemoIndexIssueCommand<RunCommand>, String>
+where
+    F: Fn(&str) -> std::result::Result<RunCommand, String>,
+{
+    let mut parts = remainder.splitn(2, char::is_whitespace);
+    let subcommand = parts.next().unwrap_or_default().trim();
+    let sub_remainder = parts.next().unwrap_or_default().trim();
+    match subcommand {
+        "list" if sub_remainder.is_empty() => Ok(DemoIndexIssueCommand::List),
+        "report" if sub_remainder.is_empty() => Ok(DemoIndexIssueCommand::Report),
+        "run" => parse_run_command(sub_remainder).map(DemoIndexIssueCommand::Run),
+        _ => Err(usage_message.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_demo_index_issue_command, DemoIndexIssueCommand};
+
+    const USAGE: &str = "Usage: /tau demo-index <list|run ...|report>";
+
+    #[test]
+    fn unit_parse_demo_index_issue_command_parses_list() {
+        let parsed = parse_demo_index_issue_command::<String, _>("list", USAGE, |_raw| {
+            Ok("ignored".to_string())
+        })
+        .expect("parse list command");
+        assert!(matches!(parsed, DemoIndexIssueCommand::List));
+    }
+
+    #[test]
+    fn functional_parse_demo_index_issue_command_parses_report() {
+        let parsed = parse_demo_index_issue_command::<String, _>("report", USAGE, |_raw| {
+            Ok("ignored".to_string())
+        })
+        .expect("parse report command");
+        assert!(matches!(parsed, DemoIndexIssueCommand::Report));
+    }
+
+    #[test]
+    fn integration_parse_demo_index_issue_command_delegates_run_parser() {
+        let parsed = parse_demo_index_issue_command("run smoke --timeout 20", USAGE, |raw| {
+            Ok(raw.to_string())
+        })
+        .expect("parse run command");
+        assert!(matches!(
+            parsed,
+            DemoIndexIssueCommand::Run(args) if args == "smoke --timeout 20"
+        ));
+    }
+
+    #[test]
+    fn regression_parse_demo_index_issue_command_surfaces_usage_for_unknown_subcommand() {
+        let error = parse_demo_index_issue_command::<String, _>("invalid", USAGE, |_raw| {
+            Ok("ignored".to_string())
+        })
+        .expect_err("unknown subcommand should fail");
+        assert_eq!(error, USAGE);
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -9,6 +9,7 @@ pub mod issue_auth_helpers;
 pub mod issue_command_usage;
 pub mod issue_comment;
 pub mod issue_demo_index;
+pub mod issue_demo_index_command;
 pub mod issue_doctor_command;
 pub mod issue_event_collection;
 pub mod issue_filter;


### PR DESCRIPTION
## Summary
- add shared `tau-github-issues::issue_demo_index_command` module with:
  - `DemoIndexIssueCommand`
  - `parse_demo_index_issue_command`
- move `demo-index` command parsing dispatch logic out of `tau-coding-agent` and into shared crate
- keep `tau-coding-agent` behavior unchanged via a thin conversion wrapper to `TauIssueCommand`
- add unit/functional/integration/regression tests for shared demo-index command parsing behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

## Tracking
- part of #992
