### PR TITLE
refactor(github-issues): extract run error comment renderer

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -91,6 +91,7 @@ use tau_github_issues::issue_render::{
     render_issue_artifact_markdown as render_shared_issue_artifact_markdown,
     IssueArtifactAttachmentView, IssueEventPromptAttachmentView,
 };
+use tau_github_issues::issue_run_error_comment::render_issue_run_error_comment as render_shared_issue_run_error_comment;
 use tau_github_issues::issue_runtime_helpers::{
     is_expired_at as is_shared_expired_at, issue_session_id as issue_shared_session_id,
     normalize_artifact_retention_days as normalize_shared_artifact_retention_days,
@@ -5043,13 +5044,12 @@ fn render_issue_run_error_comment(
     run_id: &str,
     error: &anyhow::Error,
 ) -> String {
-    format!(
-        "Tau run `{}` failed for event `{}`.\n\nError: `{}`\n\n---\n{EVENT_KEY_MARKER_PREFIX}{}{EVENT_KEY_MARKER_SUFFIX}\n_Tau run `{}` | status `failed` | model `unavailable` | tokens in/out/total `0/0/0` | cost `unavailable`_",
+    render_shared_issue_run_error_comment(
+        &event.key,
         run_id,
-        event.key,
-        truncate_for_error(&error.to_string(), 600),
-        event.key,
-        run_id
+        &error.to_string(),
+        EVENT_KEY_MARKER_PREFIX,
+        EVENT_KEY_MARKER_SUFFIX,
     )
 }
 

--- a/crates/tau-github-issues/src/issue_run_error_comment.rs
+++ b/crates/tau-github-issues/src/issue_run_error_comment.rs
@@ -1,0 +1,69 @@
+use crate::github_transport_helpers::truncate_for_error;
+
+pub fn render_issue_run_error_comment(
+    event_key: &str,
+    run_id: &str,
+    error_message: &str,
+    event_key_marker_prefix: &str,
+    event_key_marker_suffix: &str,
+) -> String {
+    format!(
+        "Tau run `{}` failed for event `{}`.\n\nError: `{}`\n\n---\n{}{}{}\n_Tau run `{}` | status `failed` | model `unavailable` | tokens in/out/total `0/0/0` | cost `unavailable`_",
+        run_id,
+        event_key,
+        truncate_for_error(error_message, 600),
+        event_key_marker_prefix,
+        event_key,
+        event_key_marker_suffix,
+        run_id
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_issue_run_error_comment;
+
+    const MARKER_PREFIX: &str = "<!-- tau:event-key:";
+    const MARKER_SUFFIX: &str = " -->";
+
+    #[test]
+    fn unit_render_issue_run_error_comment_includes_core_identifiers() {
+        let rendered = render_issue_run_error_comment(
+            "issue-comment-created:1",
+            "run-123",
+            "network timeout",
+            MARKER_PREFIX,
+            MARKER_SUFFIX,
+        );
+        assert!(rendered.contains("Tau run `run-123` failed"));
+        assert!(rendered.contains("event `issue-comment-created:1`"));
+    }
+
+    #[test]
+    fn functional_render_issue_run_error_comment_includes_marker_footer() {
+        let rendered = render_issue_run_error_comment(
+            "issue-opened:42",
+            "run-456",
+            "boom",
+            MARKER_PREFIX,
+            MARKER_SUFFIX,
+        );
+        assert!(rendered.contains("<!-- tau:event-key:issue-opened:42 -->"));
+    }
+
+    #[test]
+    fn integration_render_issue_run_error_comment_truncates_large_errors() {
+        let large = "x".repeat(1200);
+        let rendered =
+            render_issue_run_error_comment("key", "run", &large, MARKER_PREFIX, MARKER_SUFFIX);
+        assert!(rendered.contains("Error: `"));
+        assert!(rendered.contains("..."));
+    }
+
+    #[test]
+    fn regression_render_issue_run_error_comment_handles_blank_error_message() {
+        let rendered =
+            render_issue_run_error_comment("key", "run", "", MARKER_PREFIX, MARKER_SUFFIX);
+        assert!(rendered.contains("Error: ``"));
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -15,5 +15,6 @@ pub mod issue_event_collection;
 pub mod issue_filter;
 pub mod issue_prompt_helpers;
 pub mod issue_render;
+pub mod issue_run_error_comment;
 pub mod issue_runtime_helpers;
 pub mod issue_session_helpers;


### PR DESCRIPTION
## Summary
- add shared `tau-github-issues::issue_run_error_comment` helper module
- move GitHub issue run-error comment rendering into shared crate:
  - `render_issue_run_error_comment`
- rewire `tau-coding-agent` to use the shared renderer via a thin wrapper
- add unit/functional/integration/regression tests for run-error rendering behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

## Tracking
- part of #992
