### PR TITLE
refactor(github-issues): extract event action parser

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -71,6 +71,9 @@ use tau_github_issues::issue_demo_index_command::{
 use tau_github_issues::issue_doctor_command::{
     parse_issue_doctor_command as parse_shared_issue_doctor_command, IssueDoctorCommand,
 };
+use tau_github_issues::issue_event_action::{
+    event_action_from_body as event_action_from_shared_body, EventAction as SharedEventAction,
+};
 use tau_github_issues::issue_event_collection::{
     collect_issue_events as collect_shared_issue_events, GithubBridgeEvent, GithubIssue,
     GithubIssueComment,
@@ -1089,11 +1092,7 @@ enum TauIssueCommand {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum EventAction {
-    RunPrompt { prompt: String },
-    Command(TauIssueCommand),
-}
+type EventAction = SharedEventAction<TauIssueCommand>;
 
 #[derive(Debug)]
 struct ActiveIssueRun {
@@ -5054,12 +5053,7 @@ fn render_issue_run_error_comment(
 }
 
 fn event_action_from_body(body: &str) -> EventAction {
-    match parse_tau_issue_command(body) {
-        Some(command) => EventAction::Command(command),
-        None => EventAction::RunPrompt {
-            prompt: body.trim().to_string(),
-        },
-    }
+    event_action_from_shared_body(body, parse_tau_issue_command)
 }
 
 fn parse_tau_issue_command(body: &str) -> Option<TauIssueCommand> {

--- a/crates/tau-github-issues/src/issue_event_action.rs
+++ b/crates/tau-github-issues/src/issue_event_action.rs
@@ -1,0 +1,62 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventAction<Command> {
+    RunPrompt { prompt: String },
+    Command(Command),
+}
+
+pub fn event_action_from_body<Command, F>(body: &str, parse_command: F) -> EventAction<Command>
+where
+    F: Fn(&str) -> Option<Command>,
+{
+    match parse_command(body) {
+        Some(command) => EventAction::Command(command),
+        None => EventAction::RunPrompt {
+            prompt: body.trim().to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{event_action_from_body, EventAction};
+
+    #[test]
+    fn unit_event_action_from_body_wraps_prompt_when_parser_returns_none() {
+        let action = event_action_from_body::<String, _>("  hello  ", |_body| None);
+        assert_eq!(
+            action,
+            EventAction::RunPrompt {
+                prompt: "hello".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn functional_event_action_from_body_returns_command_when_parser_matches() {
+        let action = event_action_from_body("run", |_body| Some("command".to_string()));
+        assert_eq!(action, EventAction::Command("command".to_string()));
+    }
+
+    #[test]
+    fn integration_event_action_from_body_passes_raw_body_to_parser() {
+        let action = event_action_from_body("  /tau status  ", |body| {
+            if body == "  /tau status  " {
+                Some("parsed".to_string())
+            } else {
+                None
+            }
+        });
+        assert_eq!(action, EventAction::Command("parsed".to_string()));
+    }
+
+    #[test]
+    fn regression_event_action_from_body_preserves_empty_prompt_when_trimmed() {
+        let action = event_action_from_body::<String, _>("   ", |_body| None);
+        assert_eq!(
+            action,
+            EventAction::RunPrompt {
+                prompt: "".to_string(),
+            }
+        );
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -11,6 +11,7 @@ pub mod issue_comment;
 pub mod issue_demo_index;
 pub mod issue_demo_index_command;
 pub mod issue_doctor_command;
+pub mod issue_event_action;
 pub mod issue_event_collection;
 pub mod issue_filter;
 pub mod issue_prompt_helpers;


### PR DESCRIPTION
## Summary
- extract `EventAction` and `event_action_from_body` into shared `tau-github-issues` module (`issue_event_action`)
- export the new shared module from `tau-github-issues::lib`
- replace local `tau-coding-agent` `EventAction` enum with a thin shared type alias + wrapper parser call

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
