### PR TITLE
refactor(github-issues): extract artifacts command parser

### DIFF
--- a/crates/tau-github-issues/src/issue_artifacts_command.rs
+++ b/crates/tau-github-issues/src/issue_artifacts_command.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactsIssueCommand {
+    List,
+    Purge,
+    Run { run_id: String },
+    Show { artifact_id: String },
+}
+
+pub fn parse_issue_artifacts_command(
+    remainder: &str,
+    usage: &str,
+) -> std::result::Result<ArtifactsIssueCommand, String> {
+    let trimmed = remainder.trim();
+    if trimmed.is_empty() {
+        return Ok(ArtifactsIssueCommand::List);
+    }
+    if trimmed == "purge" {
+        return Ok(ArtifactsIssueCommand::Purge);
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("run"), Some(run_id), None) => Ok(ArtifactsIssueCommand::Run {
+            run_id: run_id.to_string(),
+        }),
+        (Some("show"), Some(artifact_id), None) => Ok(ArtifactsIssueCommand::Show {
+            artifact_id: artifact_id.to_string(),
+        }),
+        _ => Err(usage.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_issue_artifacts_command, ArtifactsIssueCommand};
+
+    const USAGE: &str = "Usage: /tau artifacts [purge|run <run_id>|show <artifact_id>]";
+
+    #[test]
+    fn unit_parse_issue_artifacts_command_supports_list_by_default() {
+        let parsed = parse_issue_artifacts_command("", USAGE).expect("parse");
+        assert_eq!(parsed, ArtifactsIssueCommand::List);
+    }
+
+    #[test]
+    fn functional_parse_issue_artifacts_command_supports_purge_run_and_show() {
+        let parsed = parse_issue_artifacts_command("purge", USAGE).expect("parse");
+        assert_eq!(parsed, ArtifactsIssueCommand::Purge);
+
+        let parsed = parse_issue_artifacts_command("run run-123", USAGE).expect("parse");
+        assert_eq!(
+            parsed,
+            ArtifactsIssueCommand::Run {
+                run_id: "run-123".to_string(),
+            }
+        );
+
+        let parsed = parse_issue_artifacts_command("show artifact-456", USAGE).expect("parse");
+        assert_eq!(
+            parsed,
+            ArtifactsIssueCommand::Show {
+                artifact_id: "artifact-456".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn integration_parse_issue_artifacts_command_trims_surrounding_whitespace() {
+        let parsed = parse_issue_artifacts_command("  run abc  ", USAGE).expect("parse");
+        assert_eq!(
+            parsed,
+            ArtifactsIssueCommand::Run {
+                run_id: "abc".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn regression_parse_issue_artifacts_command_returns_usage_for_invalid_inputs() {
+        let error = parse_issue_artifacts_command("run", USAGE).expect_err("usage");
+        assert_eq!(error, USAGE);
+
+        let error = parse_issue_artifacts_command("show", USAGE).expect_err("usage");
+        assert_eq!(error, USAGE);
+
+        let error = parse_issue_artifacts_command("purge now", USAGE).expect_err("usage");
+        assert_eq!(error, USAGE);
+    }
+}

--- a/crates/tau-github-issues/src/lib.rs
+++ b/crates/tau-github-issues/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod github_issues_helpers;
 pub mod github_transport_helpers;
+pub mod issue_artifacts_command;
 pub mod issue_auth_command;
 pub mod issue_auth_helpers;
 pub mod issue_command_usage;


### PR DESCRIPTION
## Summary
- extract `/tau artifacts` subcommand parsing into shared module `issue_artifacts_command` under `tau-github-issues`
- expose the parser module from `tau-github-issues::lib`
- rewire `tau-coding-agent` `parse_tau_issue_command` to delegate artifacts parsing through shared parser + local enum mapping

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1
