### PR TITLE
refactor(github-issues): extract chat/artifacts usage helpers

### DIFF
--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -62,6 +62,10 @@ use tau_github_issues::issue_command_parser::{
     parse_issue_command as parse_shared_issue_command, ParsedIssueCommand,
 };
 use tau_github_issues::issue_command_usage::{
+    artifacts_command_usage as artifacts_shared_command_usage,
+    chat_command_usage as chat_shared_command_usage,
+    chat_search_command_usage as chat_search_shared_command_usage,
+    chat_show_command_usage as chat_show_shared_command_usage,
     demo_index_command_usage as demo_index_shared_command_usage,
     doctor_command_usage as doctor_shared_command_usage,
     issue_auth_command_usage as issue_auth_shared_command_usage,
@@ -5143,15 +5147,18 @@ fn parse_issue_auth_command(remainder: &str) -> TauIssueCommand {
 }
 
 fn parse_chat_command(remainder: &str) -> TauIssueCommand {
+    let usage = chat_shared_command_usage("/tau");
+    let show_usage = chat_show_shared_command_usage("/tau");
+    let search_usage = chat_search_shared_command_usage("/tau");
     match parse_shared_issue_chat_command(
         remainder,
         IssueChatParseConfig {
             show_default_limit: CHAT_SHOW_DEFAULT_LIMIT,
             show_max_limit: CHAT_SHOW_MAX_LIMIT,
             search_max_limit: CHAT_SEARCH_MAX_LIMIT,
-            usage: chat_command_usage(),
-            show_usage: chat_show_command_usage(),
-            search_usage: chat_search_command_usage(),
+            usage: &usage,
+            show_usage: &show_usage,
+            search_usage: &search_usage,
         },
         |raw| {
             parse_session_search_args(raw)
@@ -5175,7 +5182,8 @@ fn parse_chat_command(remainder: &str) -> TauIssueCommand {
 }
 
 fn parse_artifacts_command(remainder: &str) -> TauIssueCommand {
-    match parse_shared_issue_artifacts_command(remainder, artifacts_command_usage()) {
+    let usage = artifacts_shared_command_usage("/tau");
+    match parse_shared_issue_artifacts_command(remainder, &usage) {
         Ok(ArtifactsIssueCommand::List) => TauIssueCommand::Artifacts {
             purge: false,
             run_id: None,
@@ -5229,22 +5237,6 @@ fn demo_index_command_usage() -> String {
 
 fn tau_command_usage() -> String {
     tau_shared_command_usage("/tau")
-}
-
-fn artifacts_command_usage() -> &'static str {
-    "Usage: /tau artifacts [purge|run <run_id>|show <artifact_id>]"
-}
-
-fn chat_command_usage() -> &'static str {
-    "Usage: /tau chat <start|resume|reset|export|status|summary|replay|show [limit]|search <query>>"
-}
-
-fn chat_show_command_usage() -> &'static str {
-    "Usage: /tau chat show [limit]"
-}
-
-fn chat_search_command_usage() -> &'static str {
-    "Usage: /tau chat search <query> [--role <role>] [--limit <n>]"
 }
 
 fn build_summarize_prompt(

--- a/crates/tau-github-issues/src/issue_command_usage.rs
+++ b/crates/tau-github-issues/src/issue_command_usage.rs
@@ -39,6 +39,28 @@ pub fn demo_index_command_usage(
     )
 }
 
+pub fn artifacts_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!("Usage: {prefix} artifacts [purge|run <run_id>|show <artifact_id>]")
+}
+
+pub fn chat_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!(
+        "Usage: {prefix} chat <start|resume|reset|export|status|summary|replay|show [limit]|search <query>>"
+    )
+}
+
+pub fn chat_show_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!("Usage: {prefix} chat show [limit]")
+}
+
+pub fn chat_search_command_usage(command_prefix: &str) -> String {
+    let prefix = normalize_prefix(command_prefix);
+    format!("Usage: {prefix} chat search <query> [--role <role>] [--limit <n>]")
+}
+
 pub fn tau_command_usage(command_prefix: &str) -> String {
     let prefix = normalize_prefix(command_prefix);
     [
@@ -67,7 +89,9 @@ pub fn tau_command_usage(command_prefix: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        demo_index_command_usage, doctor_command_usage, issue_auth_command_usage, tau_command_usage,
+        artifacts_command_usage, chat_command_usage, chat_search_command_usage,
+        chat_show_command_usage, demo_index_command_usage, doctor_command_usage,
+        issue_auth_command_usage, tau_command_usage,
     };
 
     #[test]
@@ -97,6 +121,31 @@ mod tests {
         assert!(usage.contains("Usage: /tau demo-index"));
         assert!(usage.contains("Allowed scenarios: onboarding,gateway-auth,multi-channel-live"));
         assert!(usage.contains("Default run timeout: 180 seconds (max 900)."));
+    }
+
+    #[test]
+    fn functional_artifacts_command_usage_renders_prefix_specific_usage() {
+        assert_eq!(
+            artifacts_command_usage("/tau"),
+            "Usage: /tau artifacts [purge|run <run_id>|show <artifact_id>]".to_string()
+        );
+    }
+
+    #[test]
+    fn integration_chat_usage_helpers_include_expected_shapes() {
+        assert_eq!(
+            chat_command_usage("/tau"),
+            "Usage: /tau chat <start|resume|reset|export|status|summary|replay|show [limit]|search <query>>"
+                .to_string()
+        );
+        assert_eq!(
+            chat_show_command_usage("/tau"),
+            "Usage: /tau chat show [limit]".to_string()
+        );
+        assert_eq!(
+            chat_search_command_usage("/tau"),
+            "Usage: /tau chat search <query> [--role <role>] [--limit <n>]".to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extract shared /tau artifacts usage rendering into tau-github-issues::issue_command_usage
- extract shared /tau chat usage, show usage, and search usage rendering into tau-github-issues::issue_command_usage
- rewire tau-coding-agent issue command parsing to consume shared usage helpers
- remove duplicated local usage-string helper functions from github_issues.rs

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p tau-github-issues -- --test-threads=1
- cargo test -p tau-provider --lib -- --test-threads=1
- cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1

Refs #992
