### PR TITLE
refactor: flatten local runtime entry dispatch in onboarding

### DIFF
--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -5,13 +5,13 @@ use crate::extension_manifest::{
 use tau_onboarding::startup_local_runtime::{
     build_local_runtime_agent as build_onboarding_local_runtime_agent,
     build_local_runtime_extension_startup as build_onboarding_local_runtime_extension_startup,
-    execute_prompt_or_command_file_entry_mode_with_dispatch as execute_onboarding_prompt_or_command_file_entry_mode_with_dispatch,
+    execute_local_runtime_entry_mode_with_dispatch as execute_onboarding_local_runtime_entry_mode_with_dispatch,
     register_runtime_extension_pipeline as register_onboarding_runtime_extension_pipeline,
     register_runtime_observability_if_configured as register_onboarding_runtime_observability_if_configured,
     resolve_local_runtime_startup_from_cli as resolve_onboarding_local_runtime_startup_from_cli,
     resolve_session_runtime_from_cli as resolve_onboarding_session_runtime_from_cli,
-    LocalRuntimeCommandDefaults, LocalRuntimeExtensionBootstrap, LocalRuntimeExtensionStartup,
-    LocalRuntimeStartupResolution, PromptEntryRuntimeMode, PromptOrCommandFileEntryDispatch,
+    LocalRuntimeCommandDefaults, LocalRuntimeEntryDispatch, LocalRuntimeExtensionBootstrap,
+    LocalRuntimeExtensionStartup, LocalRuntimeStartupResolution,
     RuntimeEventReporterRegistrationConfig,
     RuntimeExtensionPipelineConfig as OnboardingRuntimeExtensionPipelineConfig,
     SessionBootstrapOutcome,
@@ -186,44 +186,42 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         command_context,
     };
 
-    if execute_onboarding_prompt_or_command_file_entry_mode_with_dispatch(
+    if execute_onboarding_local_runtime_entry_mode_with_dispatch(
         &entry_mode,
         |entry_dispatch| async {
             match entry_dispatch {
-                PromptOrCommandFileEntryDispatch::Prompt(prompt_mode) => match prompt_mode {
-                    PromptEntryRuntimeMode::PlanFirstPrompt(prompt) => {
-                        run_plan_first_prompt_with_runtime_hooks(
-                            &mut agent,
-                            &mut session_runtime,
-                            &prompt,
-                            interactive_defaults.turn_timeout_ms,
-                            render_options,
-                            interactive_defaults.orchestrator_max_plan_steps,
-                            interactive_defaults.orchestrator_max_delegated_steps,
-                            interactive_defaults.orchestrator_max_executor_response_chars,
-                            interactive_defaults.orchestrator_max_delegated_step_response_chars,
-                            interactive_defaults.orchestrator_max_delegated_total_response_chars,
-                            interactive_defaults.orchestrator_delegate_steps,
-                            &orchestrator_route_table,
-                            orchestrator_route_trace_log,
-                            tool_policy_json,
-                            &extension_runtime_hooks,
-                        )
-                        .await?;
-                    }
-                    PromptEntryRuntimeMode::Prompt(prompt) => {
-                        run_prompt(
-                            &mut agent,
-                            &mut session_runtime,
-                            &prompt,
-                            interactive_defaults.turn_timeout_ms,
-                            render_options,
-                            &extension_runtime_hooks,
-                        )
-                        .await?;
-                    }
-                },
-                PromptOrCommandFileEntryDispatch::CommandFile(command_file_path) => {
+                LocalRuntimeEntryDispatch::PlanFirstPrompt(prompt) => {
+                    run_plan_first_prompt_with_runtime_hooks(
+                        &mut agent,
+                        &mut session_runtime,
+                        &prompt,
+                        interactive_defaults.turn_timeout_ms,
+                        render_options,
+                        interactive_defaults.orchestrator_max_plan_steps,
+                        interactive_defaults.orchestrator_max_delegated_steps,
+                        interactive_defaults.orchestrator_max_executor_response_chars,
+                        interactive_defaults.orchestrator_max_delegated_step_response_chars,
+                        interactive_defaults.orchestrator_max_delegated_total_response_chars,
+                        interactive_defaults.orchestrator_delegate_steps,
+                        &orchestrator_route_table,
+                        orchestrator_route_trace_log,
+                        tool_policy_json,
+                        &extension_runtime_hooks,
+                    )
+                    .await?;
+                }
+                LocalRuntimeEntryDispatch::Prompt(prompt) => {
+                    run_prompt(
+                        &mut agent,
+                        &mut session_runtime,
+                        &prompt,
+                        interactive_defaults.turn_timeout_ms,
+                        render_options,
+                        &extension_runtime_hooks,
+                    )
+                    .await?;
+                }
+                LocalRuntimeEntryDispatch::CommandFile(command_file_path) => {
                     execute_command_file(
                         &command_file_path,
                         cli.command_file_error_mode,


### PR DESCRIPTION
## Summary
- extract a flattened local runtime entry dispatch helper into `tau-onboarding`
- replace nested `PromptOrCommandFileEntryDispatch::Prompt(PromptEntryRuntimeMode::...)` handling with a single-level `LocalRuntimeEntryDispatch`
- rewire `tau-coding-agent` local runtime startup to consume the extracted helper without behavior changes
- add unit/functional/integration/regression tests for the new onboarding helper

## Testing
- `cargo fmt --all`
- `cargo test -p tau-onboarding -p tau-coding-agent -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Issue
Refs #999
