### PR TITLE
feat(agent-core): add concurrent forked-agent execution model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This index maps Tau documentation by audience and task.
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |
 | Contributor to `tau-coding-agent` internals | [Code Map](tau-coding-agent/code-map.md) | Module ownership and architecture navigation |
 | Contributor to `tau-coding-agent` refactor | [Crate Boundary Plan](tau-coding-agent/crate-boundary-plan.md) | Decomposition goals, crate layout, and migration phases |
+| Contributor to runtime concurrency features | [Concurrent Agent Model](tau-coding-agent/concurrent-agent-model.md) | Forking model, parallel prompt API, isolation boundaries, and migration guidance |
 | Provider auth implementer / reviewer | [Provider Auth Capability Matrix](provider-auth/provider-auth-capability-matrix.md) | Provider-mode support and implementation gates |
 
 ## Companion references

--- a/docs/tau-coding-agent/concurrent-agent-model.md
+++ b/docs/tau-coding-agent/concurrent-agent-model.md
@@ -1,0 +1,81 @@
+# Concurrent Agent Model
+
+## Context
+
+`tau-agent-core::Agent` is stateful and historically `&mut self` driven. That made single-agent CLI flows straightforward, but it forced library users to orchestrate concurrency externally.
+
+Wave 3 introduces a library-facing concurrency model that keeps current ergonomics while enabling safe parallel runs.
+
+## Problem
+
+We needed a model that allows concurrent agent execution without:
+
+- sharing mutable message state across runs
+- breaking existing `Agent::prompt` and `Agent::continue_turn` behavior
+- forcing callers to redesign their current single-agent flow
+
+## Options Considered
+
+1. `Arc<Mutex<Agent>>` shared mutable agent
+- Pros: simple surface
+- Cons: serializes work through one lock, weak isolation, harder failure boundaries
+
+2. Split immutable runtime and mutable session state
+- Pros: strongest long-term architecture
+- Cons: larger refactor and migration cost for this wave
+
+3. Clone/fork from a configured base agent (selected)
+- Pros: minimal migration, strong isolation, concurrent execution possible immediately
+- Cons: each fork keeps independent message history (intentional tradeoff)
+
+## Selected Design
+
+### New API surface
+
+- `Agent::fork(&self) -> Agent`
+- `Agent::run_parallel_prompts<I, S>(&self, prompts: I, max_parallel_runs: usize) -> Vec<Result<Vec<Message>, AgentError>>`
+
+where:
+
+- each prompt run executes on an isolated fork
+- tools, provider client, and event subscribers are inherited from the base agent
+- result ordering is deterministic (matches input prompt order)
+- failures are per-run and do not cancel sibling runs
+
+### Safety and state boundaries
+
+- Message history is isolated per fork.
+- Tool implementations remain `Send + Sync` and shared through `Arc`, so no mutable aliasing is introduced in core runtime state.
+- Join failures are converted into typed agent errors, keeping the API fail-closed.
+
+## Behavioral notes
+
+- This model is for concurrent *runs*, not shared mutable transcript collaboration.
+- Callers that need a shared conversation should continue using a single `Agent` instance.
+
+## Migration guidance
+
+Single-agent code remains unchanged:
+
+```rust
+let mut agent = Agent::new(client, config);
+let reply = agent.prompt("hello").await?;
+```
+
+Parallel fan-out code:
+
+```rust
+let agent = Agent::new(client, config);
+let results = agent
+    .run_parallel_prompts(vec!["task A", "task B", "task C"], 3)
+    .await;
+```
+
+## Validation
+
+Added tests cover:
+
+- fork state isolation and inherited tool behavior
+- concurrent parallel execution timing/ordering
+- per-prompt failure isolation
+- empty-input behavior


### PR DESCRIPTION
## Summary
- add `Agent::fork()` for safe per-run state isolation from a configured base agent
- add `Agent::run_parallel_prompts(...)` as a library-facing concurrent execution API with deterministic output ordering
- keep existing single-agent prompt APIs unchanged
- add architecture/design notes in `docs/tau-coding-agent/concurrent-agent-model.md`
- link the new concurrency design note from `docs/README.md`

## Behavior
- parallel runs execute on isolated forks; message history is not shared between runs
- tools/client/subscribers are inherited from the base agent instance
- run failures are isolated per prompt and do not abort sibling runs

## Testing
- cargo fmt --all
- cargo test -p tau-agent-core -- --test-threads=1
- cargo clippy -p tau-agent-core --all-targets -- -D warnings
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Closes #1122
Part of #1119
