### PR TITLE
refactor: finish tau-cli boundary for coding-agent CLI surface

### DIFF
--- a/crates/tau-coding-agent/src/cli_args.rs
+++ b/crates/tau-coding-agent/src/cli_args.rs
@@ -1,1 +1,0 @@
-pub use tau_cli::cli_args::*;

--- a/crates/tau-coding-agent/src/cli_types.rs
+++ b/crates/tau-coding-agent/src/cli_types.rs
@@ -1,1 +1,0 @@
-pub use tau_cli::cli_types::*;

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -6,7 +6,9 @@ use crate::extension_manifest::{
 use crate::runtime_types::{
     ProfileAuthDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
 };
-pub(crate) use tau_cli::{CommandFileEntry, CommandFileReport, CommandSpec, ParsedCommand};
+use tau_cli::{
+    canonical_command_name, normalize_help_topic, parse_command, CommandFileReport, CommandSpec,
+};
 use tau_session::{
     execute_session_diff_command, execute_session_search_command, execute_session_stats_command,
     parse_session_diff_args, parse_session_stats_args,
@@ -407,10 +409,6 @@ pub(crate) const COMMAND_NAMES: &[&str] = &[
     "/exit",
 ];
 
-pub(crate) fn parse_command_file(path: &Path) -> Result<Vec<CommandFileEntry>> {
-    tau_cli::parse_command_file(path)
-}
-
 pub(crate) fn execute_command_file(
     path: &Path,
     mode: CliCommandFileErrorMode,
@@ -418,7 +416,7 @@ pub(crate) fn execute_command_file(
     session_runtime: &mut Option<SessionRuntime>,
     command_context: CommandExecutionContext<'_>,
 ) -> Result<CommandFileReport> {
-    let entries = parse_command_file(path)?;
+    let entries = tau_cli::parse_command_file(path)?;
     let mut report = CommandFileReport {
         total: entries.len(),
         executed: 0,
@@ -1316,23 +1314,11 @@ pub(crate) fn handle_command_with_session_import_mode(
     Ok(CommandAction::Continue)
 }
 
-pub(crate) fn parse_command(input: &str) -> Option<ParsedCommand<'_>> {
-    tau_cli::parse_command(input)
-}
-
-pub(crate) fn canonical_command_name(name: &str) -> &str {
-    tau_cli::canonical_command_name(name)
-}
-
 pub(crate) fn session_import_mode_label(mode: SessionImportMode) -> &'static str {
     match mode {
         SessionImportMode::Merge => "merge",
         SessionImportMode::Replace => "replace",
     }
-}
-
-pub(crate) fn normalize_help_topic(topic: &str) -> String {
-    tau_cli::normalize_help_topic(topic)
 }
 
 pub(crate) fn render_help_overview() -> String {

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -7,9 +7,7 @@ mod channel_lifecycle;
 mod channel_send;
 mod channel_store;
 mod channel_store_admin;
-mod cli_args;
 mod cli_executable;
-mod cli_types;
 mod commands;
 mod credentials;
 mod custom_command_contract;
@@ -74,32 +72,14 @@ pub(crate) use crate::canvas::{
     CANVAS_USAGE,
 };
 pub(crate) use crate::channel_store_admin::execute_channel_store_admin_command;
-pub(crate) use crate::cli_args::Cli;
-#[cfg(test)]
-pub(crate) use crate::cli_types::CliProviderAuthMode;
-#[cfg(test)]
-pub(crate) use crate::cli_types::{
-    CliBashProfile, CliCredentialStoreEncryptionMode, CliDeploymentWasmRuntimeProfile,
-    CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode, CliMultiChannelTransport,
-    CliOsSandboxMode, CliSessionImportMode, CliToolPolicyPreset,
-};
-pub(crate) use crate::cli_types::{
-    CliCommandFileErrorMode, CliEventTemplateSchedule, CliOrchestratorMode,
-};
-#[cfg(test)]
-pub(crate) use crate::cli_types::{CliDaemonProfile, CliGatewayRemoteProfile};
-#[cfg(test)]
-pub(crate) use crate::cli_types::{CliMultiChannelOutboundMode, CliWebhookSignatureAlgorithm};
 #[cfg(test)]
 pub(crate) use crate::commands::handle_command;
 pub(crate) use crate::commands::{
-    canonical_command_name, execute_command_file, handle_command_with_session_import_mode,
-    parse_command, CommandAction, COMMAND_NAMES,
+    execute_command_file, handle_command_with_session_import_mode, CommandAction, COMMAND_NAMES,
 };
 #[cfg(test)]
 pub(crate) use crate::commands::{
-    parse_command_file, render_command_help, render_help_overview, unknown_command_message,
-    CommandFileEntry, CommandFileReport,
+    render_command_help, render_help_overview, unknown_command_message,
 };
 pub(crate) use crate::credentials::{
     execute_integration_auth_command, resolve_non_empty_cli_value,
@@ -249,6 +229,8 @@ pub(crate) use tau_access::trust_roots::{
     parse_trusted_root_spec, save_trust_root_records, TrustedRootRecord,
 };
 #[cfg(test)]
+pub(crate) use tau_cli::parse_command_file;
+#[cfg(test)]
 pub(crate) use tau_cli::validation::validate_gateway_remote_profile_inspect_cli;
 #[cfg(test)]
 pub(crate) use tau_cli::validation::validate_multi_channel_live_connectors_runner_cli;
@@ -270,6 +252,23 @@ pub(crate) use tau_cli::validation::{
     validate_multi_channel_incident_timeline_cli, validate_multi_channel_live_ingest_cli,
     validate_multi_channel_send_cli, validate_project_index_cli,
 };
+pub(crate) use tau_cli::Cli;
+#[cfg(test)]
+pub(crate) use tau_cli::CliProviderAuthMode;
+pub(crate) use tau_cli::{canonical_command_name, parse_command};
+#[cfg(test)]
+pub(crate) use tau_cli::{
+    CliBashProfile, CliCredentialStoreEncryptionMode, CliDeploymentWasmRuntimeProfile,
+    CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode, CliMultiChannelTransport,
+    CliOsSandboxMode, CliSessionImportMode, CliToolPolicyPreset,
+};
+pub(crate) use tau_cli::{CliCommandFileErrorMode, CliEventTemplateSchedule, CliOrchestratorMode};
+#[cfg(test)]
+pub(crate) use tau_cli::{CliDaemonProfile, CliGatewayRemoteProfile};
+#[cfg(test)]
+pub(crate) use tau_cli::{CliMultiChannelOutboundMode, CliWebhookSignatureAlgorithm};
+#[cfg(test)]
+pub(crate) use tau_cli::{CommandFileEntry, CommandFileReport};
 pub(crate) use tau_core::write_text_atomic;
 pub(crate) use tau_core::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- remove `crates/tau-coding-agent/src/cli_args.rs` and `crates/tau-coding-agent/src/cli_types.rs` shim modules
- switch `tau-coding-agent` root exports to consume `tau_cli` directly for CLI args/types
- remove duplicate parser/file helper wrappers from `commands.rs` and call `tau_cli` APIs directly
- keep command-dispatch behavior unchanged while tightening crate boundaries for issue #968

## Testing
- cargo fmt --all
- cargo test -p tau-cli -- --test-threads=1
- cargo clippy -p tau-cli --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --all-targets -- -D warnings
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Closes #968
