### PR TITLE
refactor: move package manifest runtime into tau-skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tau-cli",
  "tau-core",
  "tempfile",
  "tokio",

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -21,7 +21,6 @@ mod model_catalog;
 mod multi_agent_router;
 mod observability_loggers;
 mod orchestrator_bridge;
-mod package_manifest;
 mod project_index;
 mod qa_loop_commands;
 mod release_channel_commands;
@@ -59,6 +58,8 @@ use serde_json::Value;
 use tau_agent_core::{Agent, AgentEvent};
 use tau_ai::{LlmClient, Message, MessageRole, ModelRef, Provider};
 pub(crate) use tau_extensions as extension_manifest;
+pub(crate) use tau_skills as package_manifest;
+#[cfg(test)]
 pub(crate) use tau_skills as skills;
 pub(crate) use tau_skills as skills_commands;
 
@@ -159,7 +160,6 @@ pub(crate) use crate::runtime_types::{
 };
 #[cfg(test)]
 pub(crate) use crate::skills::default_skills_lock_path;
-use crate::skills::TrustedKey;
 #[cfg(test)]
 pub(crate) use crate::skills_commands::{
     derive_skills_prune_candidates, parse_skills_lock_diff_args, parse_skills_prune_args,
@@ -292,11 +292,11 @@ pub(crate) use tau_onboarding::startup_model_resolution::{
 pub(crate) use tau_onboarding::startup_prompt_composition::compose_startup_system_prompt;
 #[cfg(test)]
 pub(crate) use tau_onboarding::startup_resolution::apply_trust_root_mutations;
+pub(crate) use tau_onboarding::startup_resolution::ensure_non_empty_text;
+#[cfg(test)]
+pub(crate) use tau_onboarding::startup_resolution::resolve_skill_trust_roots;
 #[cfg(test)]
 pub(crate) use tau_onboarding::startup_resolution::resolve_system_prompt;
-pub(crate) use tau_onboarding::startup_resolution::{
-    ensure_non_empty_text, resolve_skill_trust_roots,
-};
 pub(crate) use tau_onboarding::startup_skills_bootstrap::run_startup_skills_bootstrap;
 #[cfg(test)]
 pub(crate) use tau_orchestrator::parse_numbered_plan_steps;

--- a/crates/tau-skills/Cargo.toml
+++ b/crates/tau-skills/Cargo.toml
@@ -11,9 +11,10 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tau-cli = { path = "../tau-cli" }
 tau-core = { path = "../tau-core" }
+tokio.workspace = true
 
 [dev-dependencies]
 httpmock = "0.8"
 tempfile = "3"
-tokio.workspace = true

--- a/crates/tau-skills/src/lib.rs
+++ b/crates/tau-skills/src/lib.rs
@@ -12,9 +12,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 mod commands;
+mod package_manifest;
 pub mod trust_roots;
 
 pub use commands::*;
+pub use package_manifest::*;
 pub use trust_roots::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- move `package_manifest.rs` from `tau-coding-agent` into `tau-skills`
- add package-manifest exports from `tau-skills` and route coding-agent package wiring through crate alias
- embed trust-root resolution for package install/update in `tau-skills` package runtime (no `tau-onboarding` dependency)
- remove final local package manifest module shim from `tau-coding-agent`

## Testing
- cargo fmt --all
- cargo test -p tau-skills -- --test-threads=1
- cargo clippy -p tau-skills --all-targets -- -D warnings
- cargo test -p tau-access -- --test-threads=1
- cargo clippy -p tau-access --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --all-targets -- -D warnings
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Closes #964
