### PR TITLE
refactor(ops): extract macro command domain from coding-agent

### DIFF
--- a/crates/tau-coding-agent/src/macro_profile_commands.rs
+++ b/crates/tau-coding-agent/src/macro_profile_commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+
 pub(crate) use tau_onboarding::profile_commands::execute_profile_command;
 #[cfg(test)]
 pub(crate) use tau_onboarding::profile_commands::{
@@ -13,242 +14,23 @@ pub(crate) use tau_onboarding::profile_store::{
 #[cfg(test)]
 pub(crate) use tau_onboarding::profile_store::{ProfileStoreFile, PROFILE_SCHEMA_VERSION};
 
-pub(crate) const MACRO_SCHEMA_VERSION: u32 = 1;
-pub(crate) const MACRO_USAGE: &str = "usage: /macro <save|run|list|show|delete> ...";
+#[cfg(test)]
+use tau_ops::validate_macro_command_entry as validate_macro_command_entry_with_command_names;
+use tau_ops::validate_macro_commands as validate_macro_commands_with_command_names;
+pub(crate) use tau_ops::{
+    default_macro_config_path, load_macro_commands, load_macro_file, parse_macro_command,
+    render_macro_list, render_macro_show, save_macro_file, MacroCommand,
+};
+#[cfg(test)]
+pub(crate) use tau_ops::{validate_macro_name, MacroFile, MACRO_SCHEMA_VERSION, MACRO_USAGE};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum MacroCommand {
-    List,
-    Save {
-        name: String,
-        commands_file: PathBuf,
-    },
-    Run {
-        name: String,
-        dry_run: bool,
-    },
-    Show {
-        name: String,
-    },
-    Delete {
-        name: String,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct MacroFile {
-    pub(crate) schema_version: u32,
-    pub(crate) macros: BTreeMap<String, Vec<String>>,
-}
-
-pub(crate) fn default_macro_config_path() -> Result<PathBuf> {
-    Ok(std::env::current_dir()
-        .context("failed to resolve current working directory")?
-        .join(".tau")
-        .join("macros.json"))
-}
-
-pub(crate) fn validate_macro_name(name: &str) -> Result<()> {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        bail!("macro name must not be empty");
-    };
-    if !first.is_ascii_alphabetic() {
-        bail!("macro name '{}' must start with an ASCII letter", name);
-    }
-    if !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')) {
-        bail!(
-            "macro name '{}' must contain only ASCII letters, digits, '-' or '_'",
-            name
-        );
-    }
-    Ok(())
-}
-
-pub(crate) fn parse_macro_command(command_args: &str) -> Result<MacroCommand> {
-    const USAGE_LIST: &str = "usage: /macro list";
-    const USAGE_SAVE: &str = "usage: /macro save <name> <commands_file>";
-    const USAGE_RUN: &str = "usage: /macro run <name> [--dry-run]";
-    const USAGE_SHOW: &str = "usage: /macro show <name>";
-    const USAGE_DELETE: &str = "usage: /macro delete <name>";
-
-    let tokens = command_args
-        .split_whitespace()
-        .filter(|token| !token.is_empty())
-        .collect::<Vec<_>>();
-    if tokens.is_empty() {
-        bail!("{MACRO_USAGE}");
-    }
-
-    match tokens[0] {
-        "list" => {
-            if tokens.len() != 1 {
-                bail!("{USAGE_LIST}");
-            }
-            Ok(MacroCommand::List)
-        }
-        "save" => {
-            if tokens.len() != 3 {
-                bail!("{USAGE_SAVE}");
-            }
-            validate_macro_name(tokens[1])?;
-            Ok(MacroCommand::Save {
-                name: tokens[1].to_string(),
-                commands_file: PathBuf::from(tokens[2]),
-            })
-        }
-        "run" => {
-            if !(2..=3).contains(&tokens.len()) {
-                bail!("{USAGE_RUN}");
-            }
-            validate_macro_name(tokens[1])?;
-            let dry_run = if tokens.len() == 3 {
-                if tokens[2] != "--dry-run" {
-                    bail!("{USAGE_RUN}");
-                }
-                true
-            } else {
-                false
-            };
-            Ok(MacroCommand::Run {
-                name: tokens[1].to_string(),
-                dry_run,
-            })
-        }
-        "show" => {
-            if tokens.len() != 2 {
-                bail!("{USAGE_SHOW}");
-            }
-            validate_macro_name(tokens[1])?;
-            Ok(MacroCommand::Show {
-                name: tokens[1].to_string(),
-            })
-        }
-        "delete" => {
-            if tokens.len() != 2 {
-                bail!("{USAGE_DELETE}");
-            }
-            validate_macro_name(tokens[1])?;
-            Ok(MacroCommand::Delete {
-                name: tokens[1].to_string(),
-            })
-        }
-        other => bail!("unknown subcommand '{}'; {MACRO_USAGE}", other),
-    }
-}
-
-pub(crate) fn load_macro_file(path: &Path) -> Result<BTreeMap<String, Vec<String>>> {
-    if !path.exists() {
-        return Ok(BTreeMap::new());
-    }
-
-    let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read macro file {}", path.display()))?;
-    let parsed = serde_json::from_str::<MacroFile>(&raw)
-        .with_context(|| format!("failed to parse macro file {}", path.display()))?;
-    if parsed.schema_version != MACRO_SCHEMA_VERSION {
-        bail!(
-            "unsupported macro schema_version {} in {} (expected {})",
-            parsed.schema_version,
-            path.display(),
-            MACRO_SCHEMA_VERSION
-        );
-    }
-    Ok(parsed.macros)
-}
-
-pub(crate) fn save_macro_file(path: &Path, macros: &BTreeMap<String, Vec<String>>) -> Result<()> {
-    let payload = MacroFile {
-        schema_version: MACRO_SCHEMA_VERSION,
-        macros: macros.clone(),
-    };
-    let mut encoded = serde_json::to_string_pretty(&payload).context("failed to encode macros")?;
-    encoded.push('\n');
-    let parent = path.parent().ok_or_else(|| {
-        anyhow!(
-            "macro config path {} does not have a parent directory",
-            path.display()
-        )
-    })?;
-    std::fs::create_dir_all(parent).with_context(|| {
-        format!(
-            "failed to create macro config directory {}",
-            parent.display()
-        )
-    })?;
-    write_text_atomic(path, &encoded)
-}
-
-fn load_macro_commands(commands_file: &Path) -> Result<Vec<String>> {
-    let raw = std::fs::read_to_string(commands_file)
-        .with_context(|| format!("failed to read commands file {}", commands_file.display()))?;
-    let commands = raw
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .filter(|line| !line.starts_with('#'))
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-    if commands.is_empty() {
-        bail!(
-            "commands file {} does not contain runnable commands",
-            commands_file.display()
-        );
-    }
-    Ok(commands)
-}
-
+#[cfg(test)]
 pub(crate) fn validate_macro_command_entry(command: &str) -> Result<()> {
-    let parsed = parse_command(command)
-        .ok_or_else(|| anyhow!("invalid macro command '{command}': command must start with '/'"))?;
-    let name = canonical_command_name(parsed.name);
-    if !COMMAND_NAMES.contains(&name) {
-        bail!("invalid macro command '{command}': unknown command '{name}'");
-    }
-    if matches!(name, "/quit" | "/exit") {
-        bail!("invalid macro command '{command}': exit commands are not allowed");
-    }
-    if name == "/macro" {
-        bail!("invalid macro command '{command}': nested /macro commands are not allowed");
-    }
-    Ok(())
+    validate_macro_command_entry_with_command_names(command, COMMAND_NAMES)
 }
 
 fn validate_macro_commands(commands: &[String]) -> Result<()> {
-    for (index, command) in commands.iter().enumerate() {
-        validate_macro_command_entry(command)
-            .with_context(|| format!("macro command #{index} failed validation"))?;
-    }
-    Ok(())
-}
-
-pub(crate) fn render_macro_list(path: &Path, macros: &BTreeMap<String, Vec<String>>) -> String {
-    let mut lines = vec![format!(
-        "macro list: path={} count={}",
-        path.display(),
-        macros.len()
-    )];
-    if macros.is_empty() {
-        lines.push("macros: none".to_string());
-        return lines.join("\n");
-    }
-    for (name, commands) in macros {
-        lines.push(format!("macro: name={} commands={}", name, commands.len()));
-    }
-    lines.join("\n")
-}
-
-pub(crate) fn render_macro_show(path: &Path, name: &str, commands: &[String]) -> String {
-    let mut lines = vec![format!(
-        "macro show: path={} name={} commands={}",
-        path.display(),
-        name,
-        commands.len()
-    )];
-    for (index, command) in commands.iter().enumerate() {
-        lines.push(format!("command: index={} value={command}", index));
-    }
-    lines.join("\n")
+    validate_macro_commands_with_command_names(commands, COMMAND_NAMES)
 }
 
 pub(crate) fn execute_macro_command(

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -44,7 +44,7 @@ mod transport_health;
 mod voice_contract;
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     io::Write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -53,7 +53,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 use tau_agent_core::{Agent, AgentEvent};
 use tau_ai::{LlmClient, Message, MessageRole, ModelRef, Provider};
@@ -218,6 +218,8 @@ pub(crate) use tau_access::trust_roots::{
     load_trust_root_records, parse_trust_rotation_spec, parse_trusted_root_spec, TrustedRootRecord,
 };
 #[cfg(test)]
+pub(crate) use tau_cli::parse_command;
+#[cfg(test)]
 pub(crate) use tau_cli::parse_command_file;
 #[cfg(test)]
 pub(crate) use tau_cli::validation::validate_gateway_remote_profile_inspect_cli;
@@ -244,7 +246,6 @@ pub(crate) use tau_cli::validation::{
 pub(crate) use tau_cli::Cli;
 #[cfg(test)]
 pub(crate) use tau_cli::CliProviderAuthMode;
-pub(crate) use tau_cli::{canonical_command_name, parse_command};
 #[cfg(test)]
 pub(crate) use tau_cli::{
     CliBashProfile, CliCredentialStoreEncryptionMode, CliDeploymentWasmRuntimeProfile,

--- a/crates/tau-ops/src/lib.rs
+++ b/crates/tau-ops/src/lib.rs
@@ -1,11 +1,13 @@
 mod channel_store_admin;
 mod daemon_runtime;
+mod macro_commands;
 mod project_index;
 mod qa_loop_commands;
 mod transport_health;
 
 pub use channel_store_admin::*;
 pub use daemon_runtime::*;
+pub use macro_commands::*;
 pub use project_index::*;
 pub use qa_loop_commands::*;
 pub use transport_health::*;

--- a/crates/tau-ops/src/macro_commands.rs
+++ b/crates/tau-ops/src/macro_commands.rs
@@ -1,0 +1,431 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use tau_cli::{canonical_command_name, parse_command};
+use tau_core::write_text_atomic;
+
+pub const MACRO_SCHEMA_VERSION: u32 = 1;
+pub const MACRO_USAGE: &str = "usage: /macro <save|run|list|show|delete> ...";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacroCommand {
+    List,
+    Save {
+        name: String,
+        commands_file: PathBuf,
+    },
+    Run {
+        name: String,
+        dry_run: bool,
+    },
+    Show {
+        name: String,
+    },
+    Delete {
+        name: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MacroFile {
+    pub schema_version: u32,
+    pub macros: BTreeMap<String, Vec<String>>,
+}
+
+pub fn default_macro_config_path() -> Result<PathBuf> {
+    Ok(std::env::current_dir()
+        .context("failed to resolve current working directory")?
+        .join(".tau")
+        .join("macros.json"))
+}
+
+pub fn validate_macro_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        bail!("macro name must not be empty");
+    };
+    if !first.is_ascii_alphabetic() {
+        bail!("macro name '{}' must start with an ASCII letter", name);
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')) {
+        bail!(
+            "macro name '{}' must contain only ASCII letters, digits, '-' or '_'",
+            name
+        );
+    }
+    Ok(())
+}
+
+pub fn parse_macro_command(command_args: &str) -> Result<MacroCommand> {
+    const USAGE_LIST: &str = "usage: /macro list";
+    const USAGE_SAVE: &str = "usage: /macro save <name> <commands_file>";
+    const USAGE_RUN: &str = "usage: /macro run <name> [--dry-run]";
+    const USAGE_SHOW: &str = "usage: /macro show <name>";
+    const USAGE_DELETE: &str = "usage: /macro delete <name>";
+
+    let tokens = command_args
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    if tokens.is_empty() {
+        bail!("{MACRO_USAGE}");
+    }
+
+    match tokens[0] {
+        "list" => {
+            if tokens.len() != 1 {
+                bail!("{USAGE_LIST}");
+            }
+            Ok(MacroCommand::List)
+        }
+        "save" => {
+            if tokens.len() != 3 {
+                bail!("{USAGE_SAVE}");
+            }
+            validate_macro_name(tokens[1])?;
+            Ok(MacroCommand::Save {
+                name: tokens[1].to_string(),
+                commands_file: PathBuf::from(tokens[2]),
+            })
+        }
+        "run" => {
+            if !(2..=3).contains(&tokens.len()) {
+                bail!("{USAGE_RUN}");
+            }
+            validate_macro_name(tokens[1])?;
+            let dry_run = if tokens.len() == 3 {
+                if tokens[2] != "--dry-run" {
+                    bail!("{USAGE_RUN}");
+                }
+                true
+            } else {
+                false
+            };
+            Ok(MacroCommand::Run {
+                name: tokens[1].to_string(),
+                dry_run,
+            })
+        }
+        "show" => {
+            if tokens.len() != 2 {
+                bail!("{USAGE_SHOW}");
+            }
+            validate_macro_name(tokens[1])?;
+            Ok(MacroCommand::Show {
+                name: tokens[1].to_string(),
+            })
+        }
+        "delete" => {
+            if tokens.len() != 2 {
+                bail!("{USAGE_DELETE}");
+            }
+            validate_macro_name(tokens[1])?;
+            Ok(MacroCommand::Delete {
+                name: tokens[1].to_string(),
+            })
+        }
+        other => bail!("unknown subcommand '{}'; {MACRO_USAGE}", other),
+    }
+}
+
+pub fn load_macro_file(path: &Path) -> Result<BTreeMap<String, Vec<String>>> {
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read macro file {}", path.display()))?;
+    let parsed = serde_json::from_str::<MacroFile>(&raw)
+        .with_context(|| format!("failed to parse macro file {}", path.display()))?;
+    if parsed.schema_version != MACRO_SCHEMA_VERSION {
+        bail!(
+            "unsupported macro schema_version {} in {} (expected {})",
+            parsed.schema_version,
+            path.display(),
+            MACRO_SCHEMA_VERSION
+        );
+    }
+    Ok(parsed.macros)
+}
+
+pub fn save_macro_file(path: &Path, macros: &BTreeMap<String, Vec<String>>) -> Result<()> {
+    let payload = MacroFile {
+        schema_version: MACRO_SCHEMA_VERSION,
+        macros: macros.clone(),
+    };
+    let mut encoded = serde_json::to_string_pretty(&payload).context("failed to encode macros")?;
+    encoded.push('\n');
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "macro config path {} does not have a parent directory",
+            path.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create macro config directory {}",
+            parent.display()
+        )
+    })?;
+    write_text_atomic(path, &encoded)
+}
+
+pub fn load_macro_commands(commands_file: &Path) -> Result<Vec<String>> {
+    let raw = std::fs::read_to_string(commands_file)
+        .with_context(|| format!("failed to read commands file {}", commands_file.display()))?;
+    let commands = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with('#'))
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if commands.is_empty() {
+        bail!(
+            "commands file {} does not contain runnable commands",
+            commands_file.display()
+        );
+    }
+    Ok(commands)
+}
+
+pub fn validate_macro_command_entry(command: &str, command_names: &[&str]) -> Result<()> {
+    let parsed = parse_command(command)
+        .ok_or_else(|| anyhow!("invalid macro command '{command}': command must start with '/'"))?;
+    let name = canonical_command_name(parsed.name);
+    if !command_names.contains(&name) {
+        bail!("invalid macro command '{command}': unknown command '{name}'");
+    }
+    if matches!(name, "/quit" | "/exit") {
+        bail!("invalid macro command '{command}': exit commands are not allowed");
+    }
+    if name == "/macro" {
+        bail!("invalid macro command '{command}': nested /macro commands are not allowed");
+    }
+    Ok(())
+}
+
+pub fn validate_macro_commands(commands: &[String], command_names: &[&str]) -> Result<()> {
+    for (index, command) in commands.iter().enumerate() {
+        validate_macro_command_entry(command, command_names)
+            .with_context(|| format!("macro command #{index} failed validation"))?;
+    }
+    Ok(())
+}
+
+pub fn render_macro_list(path: &Path, macros: &BTreeMap<String, Vec<String>>) -> String {
+    let mut lines = vec![format!(
+        "macro list: path={} count={}",
+        path.display(),
+        macros.len()
+    )];
+    if macros.is_empty() {
+        lines.push("macros: none".to_string());
+        return lines.join("\n");
+    }
+    for (name, commands) in macros {
+        lines.push(format!("macro: name={} commands={}", name, commands.len()));
+    }
+    lines.join("\n")
+}
+
+pub fn render_macro_show(path: &Path, name: &str, commands: &[String]) -> String {
+    let mut lines = vec![format!(
+        "macro show: path={} name={} commands={}",
+        path.display(),
+        name,
+        commands.len()
+    )];
+    for (index, command) in commands.iter().enumerate() {
+        lines.push(format!("command: index={} value={command}", index));
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use super::{
+        load_macro_commands, load_macro_file, parse_macro_command, render_macro_list,
+        render_macro_show, save_macro_file, validate_macro_command_entry, validate_macro_commands,
+        validate_macro_name, MacroCommand, MacroFile, MACRO_SCHEMA_VERSION, MACRO_USAGE,
+    };
+
+    const TEST_COMMAND_NAMES: &[&str] = &["/help", "/session", "/skills-list", "/macro"];
+
+    #[test]
+    fn unit_validate_macro_name_accepts_and_rejects_expected_inputs() {
+        validate_macro_name("quick_check-1").expect("valid macro name");
+
+        let error = validate_macro_name("").expect_err("empty macro name should fail");
+        assert!(error.to_string().contains("must not be empty"));
+
+        let error =
+            validate_macro_name("1quick").expect_err("macro name starting with digit should fail");
+        assert!(error
+            .to_string()
+            .contains("must start with an ASCII letter"));
+
+        let error = validate_macro_name("quick.check")
+            .expect_err("macro name with punctuation should fail");
+        assert!(error
+            .to_string()
+            .contains("must contain only ASCII letters, digits, '-' or '_'"));
+    }
+
+    #[test]
+    fn functional_parse_macro_command_supports_lifecycle_and_usage_rules() {
+        assert_eq!(
+            parse_macro_command("list").expect("parse list"),
+            MacroCommand::List
+        );
+        assert_eq!(
+            parse_macro_command("save quick /tmp/quick.commands").expect("parse save"),
+            MacroCommand::Save {
+                name: "quick".to_string(),
+                commands_file: PathBuf::from("/tmp/quick.commands"),
+            }
+        );
+        assert_eq!(
+            parse_macro_command("run quick").expect("parse run"),
+            MacroCommand::Run {
+                name: "quick".to_string(),
+                dry_run: false,
+            }
+        );
+        assert_eq!(
+            parse_macro_command("run quick --dry-run").expect("parse dry run"),
+            MacroCommand::Run {
+                name: "quick".to_string(),
+                dry_run: true,
+            }
+        );
+        assert_eq!(
+            parse_macro_command("show quick").expect("parse show"),
+            MacroCommand::Show {
+                name: "quick".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_macro_command("delete quick").expect("parse delete"),
+            MacroCommand::Delete {
+                name: "quick".to_string(),
+            }
+        );
+
+        let error = parse_macro_command("").expect_err("missing args should fail");
+        assert!(error.to_string().contains(MACRO_USAGE));
+
+        let error =
+            parse_macro_command("run quick --apply").expect_err("unknown run flag should fail");
+        assert!(error
+            .to_string()
+            .contains("usage: /macro run <name> [--dry-run]"));
+    }
+
+    #[test]
+    fn unit_save_and_load_macro_file_round_trip_schema_and_values() {
+        let temp = tempdir().expect("tempdir");
+        let macro_path = temp.path().join(".tau").join("macros.json");
+        let macros = BTreeMap::from([
+            (
+                "quick".to_string(),
+                vec!["/help".to_string(), "/session".to_string()],
+            ),
+            ("lint".to_string(), vec!["/skills-list".to_string()]),
+        ]);
+
+        save_macro_file(&macro_path, &macros).expect("save macros");
+        let loaded = load_macro_file(&macro_path).expect("load macros");
+        assert_eq!(loaded, macros);
+
+        let raw = std::fs::read_to_string(&macro_path).expect("read macro file");
+        let parsed = serde_json::from_str::<MacroFile>(&raw).expect("parse macro file");
+        assert_eq!(parsed.schema_version, MACRO_SCHEMA_VERSION);
+        assert_eq!(parsed.macros, macros);
+    }
+
+    #[test]
+    fn regression_load_macro_file_rejects_schema_mismatch() {
+        let temp = tempdir().expect("tempdir");
+        let macro_path = temp.path().join(".tau").join("macros.json");
+        std::fs::create_dir_all(macro_path.parent().expect("macro parent")).expect("create parent");
+        let payload = MacroFile {
+            schema_version: MACRO_SCHEMA_VERSION + 1,
+            macros: BTreeMap::new(),
+        };
+        std::fs::write(
+            &macro_path,
+            serde_json::to_string_pretty(&payload).expect("encode mismatch payload"),
+        )
+        .expect("write mismatch payload");
+
+        let error = load_macro_file(&macro_path).expect_err("schema mismatch should fail");
+        assert!(error
+            .to_string()
+            .contains("unsupported macro schema_version"));
+    }
+
+    #[test]
+    fn functional_load_macro_commands_and_render_helpers_are_deterministic() {
+        let temp = tempdir().expect("tempdir");
+        let commands_file = temp.path().join("quick.commands");
+        std::fs::write(
+            &commands_file,
+            "# comment\n\n  /help  \n/session\n   # another comment\n",
+        )
+        .expect("write command file");
+
+        let commands = load_macro_commands(&commands_file).expect("load commands");
+        assert_eq!(commands, vec!["/help".to_string(), "/session".to_string()]);
+
+        let mut macros = BTreeMap::new();
+        macros.insert("zeta".to_string(), vec!["/session".to_string()]);
+        macros.insert("alpha".to_string(), vec!["/help".to_string()]);
+
+        let list_output = render_macro_list(&commands_file, &macros);
+        assert!(list_output.contains("macro list: path="));
+        let alpha_index = list_output.find("macro: name=alpha").expect("alpha row");
+        let zeta_index = list_output.find("macro: name=zeta").expect("zeta row");
+        assert!(alpha_index < zeta_index);
+
+        let show_output = render_macro_show(&commands_file, "alpha", &macros["alpha"]);
+        assert!(show_output.contains("macro show: path="));
+        assert!(show_output.contains("name=alpha"));
+        assert!(show_output.contains("command: index=0 value=/help"));
+    }
+
+    #[test]
+    fn unit_validate_macro_command_entry_and_collection_reject_invalid_commands() {
+        validate_macro_command_entry("/help", TEST_COMMAND_NAMES).expect("known command");
+
+        let nested_error = validate_macro_command_entry("/macro list", TEST_COMMAND_NAMES)
+            .expect_err("nested macro should fail");
+        assert!(nested_error
+            .to_string()
+            .contains("nested /macro commands are not allowed"));
+
+        let unknown_error = validate_macro_command_entry("/unknown", TEST_COMMAND_NAMES)
+            .expect_err("unknown command should fail");
+        assert!(unknown_error.to_string().contains("unknown command"));
+
+        let exit_error = validate_macro_command_entry("/exit", &["/quit"])
+            .expect_err("exit command should fail");
+        assert!(exit_error
+            .to_string()
+            .contains("exit commands are not allowed"));
+
+        let invalid_batch = vec!["/help".to_string(), "not-command".to_string()];
+        let error = validate_macro_commands(&invalid_batch, TEST_COMMAND_NAMES)
+            .expect_err("batch validation should fail");
+        assert!(error
+            .to_string()
+            .contains("macro command #1 failed validation"));
+    }
+}


### PR DESCRIPTION
## Summary
- extract macro command parse/store/validation/render domain logic from `tau-coding-agent` into `tau-ops::macro_commands`
- keep `tau-coding-agent` as an orchestration shim for macro execution while delegating domain functions to `tau-ops`
- add focused `tau-ops` tests for macro command parsing, schema round-trip, command-file loading, deterministic rendering, and invalid-command regressions

## Validation
- cargo fmt --all
- cargo clippy -p tau-ops --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings
- cargo test -p tau-ops
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Part of #933.
