### PR TITLE
refactor: extract events CLI runtime into tau-events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tau-ai",
+ "tau-cli",
  "tau-core",
  "tau-runtime",
  "tempfile",

--- a/crates/tau-coding-agent/src/events.rs
+++ b/crates/tau-coding-agent/src/events.rs
@@ -1,27 +1,29 @@
-use std::{path::Path, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use tau_agent_core::{Agent, AgentConfig, AgentEvent};
 use tau_ai::{LlmClient, Message, MessageRole};
 use tau_events::{
-    dry_run_events, enforce_events_dry_run_gate, inspect_events,
-    run_event_scheduler as run_core_event_scheduler, simulate_events, validate_events_definitions,
-    EventRunner, EventSchedulerConfig as CoreEventSchedulerConfig, EventTemplateSchedule,
-    EventsDryRunConfig, EventsDryRunGateConfig, EventsInspectConfig, EventsSimulateConfig,
-    EventsTemplateConfig, EventsValidateConfig,
-};
-
-use crate::tools::ToolPolicy;
-use crate::{
-    channel_store::ChannelLogEntry, current_unix_timestamp_ms, run_prompt_with_cancellation, Cli,
-    CliEventTemplateSchedule, PromptRunStatus, RenderOptions, SessionRuntime,
+    run_event_scheduler as run_core_event_scheduler, EventRunner,
+    EventSchedulerConfig as CoreEventSchedulerConfig,
 };
 use tau_session::SessionStore;
 
+use crate::tools::ToolPolicy;
+use crate::{
+    channel_store::ChannelLogEntry, run_prompt_with_cancellation, PromptRunStatus, RenderOptions,
+    SessionRuntime,
+};
+
 pub(crate) use tau_events::{
-    EventDefinition, EventsDryRunReport, EventsInspectReport, EventsSimulateReport,
-    EventsValidateReport,
+    execute_events_dry_run_command, execute_events_inspect_command,
+    execute_events_simulate_command, execute_events_template_write_command,
+    execute_events_validate_command, EventDefinition,
 };
 
 #[derive(Clone)]
@@ -41,182 +43,6 @@ pub(crate) struct EventSchedulerConfig {
     pub poll_interval: Duration,
     pub queue_limit: usize,
     pub stale_immediate_max_age_seconds: u64,
-}
-
-pub(crate) fn execute_events_inspect_command(cli: &Cli) -> Result<()> {
-    let report = inspect_events(
-        &EventsInspectConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            queue_limit: cli.events_queue_limit.max(1),
-            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
-        },
-        current_unix_timestamp_ms(),
-    )?;
-
-    if cli.events_inspect_json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report)
-                .context("failed to render events inspect json")?
-        );
-    } else {
-        println!("{}", render_events_inspect_report(&report));
-    }
-    Ok(())
-}
-
-pub(crate) fn execute_events_validate_command(cli: &Cli) -> Result<()> {
-    let report = validate_events_definitions(
-        &EventsValidateConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-        },
-        current_unix_timestamp_ms(),
-    )?;
-
-    if cli.events_validate_json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report)
-                .context("failed to render events validate json")?
-        );
-    } else {
-        println!("{}", render_events_validate_report(&report));
-    }
-
-    if report.failed_files > 0 {
-        bail!(
-            "events validate failed: failed_files={} invalid_files={} malformed_files={}",
-            report.failed_files,
-            report.invalid_files,
-            report.malformed_files
-        );
-    }
-    Ok(())
-}
-
-pub(crate) fn execute_events_template_write_command(cli: &Cli) -> Result<()> {
-    let target_path = cli
-        .events_template_write
-        .as_ref()
-        .ok_or_else(|| anyhow!("--events-template-write is required"))?;
-
-    let now_unix_ms = current_unix_timestamp_ms();
-    let schedule = match cli.events_template_schedule {
-        CliEventTemplateSchedule::Immediate => EventTemplateSchedule::Immediate,
-        CliEventTemplateSchedule::At => EventTemplateSchedule::At,
-        CliEventTemplateSchedule::Periodic => EventTemplateSchedule::Periodic,
-    };
-
-    let at_unix_ms = if matches!(cli.events_template_schedule, CliEventTemplateSchedule::At) {
-        Some(
-            cli.events_template_at_unix_ms
-                .unwrap_or_else(|| now_unix_ms.saturating_add(300_000)),
-        )
-    } else {
-        None
-    };
-
-    let cron = if matches!(
-        cli.events_template_schedule,
-        CliEventTemplateSchedule::Periodic
-    ) {
-        Some(
-            cli.events_template_cron
-                .clone()
-                .unwrap_or_else(|| "0 0/15 * * * * *".to_string()),
-        )
-    } else {
-        None
-    };
-
-    let config = EventsTemplateConfig {
-        target_path: target_path.to_path_buf(),
-        overwrite: cli.events_template_overwrite,
-        schedule,
-        channel: cli
-            .events_template_channel
-            .clone()
-            .unwrap_or_else(|| "slack/C123".to_string()),
-        prompt: cli.events_template_prompt.clone().unwrap_or_default(),
-        event_id: cli.events_template_id.clone(),
-        at_unix_ms,
-        cron,
-        timezone: Some(cli.events_template_timezone.clone()),
-    };
-
-    let report = tau_events::write_event_template(&config, now_unix_ms)?;
-
-    println!(
-        "events template write: path={} schedule={} event_id={} channel={} overwrite={}",
-        report.path.display(),
-        report.schedule,
-        report.event_id,
-        report.channel,
-        report.overwrite,
-    );
-    Ok(())
-}
-
-pub(crate) fn execute_events_simulate_command(cli: &Cli) -> Result<()> {
-    let report = simulate_events(
-        &EventsSimulateConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            horizon_seconds: cli.events_simulate_horizon_seconds,
-            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
-        },
-        current_unix_timestamp_ms(),
-    )?;
-
-    if cli.events_simulate_json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report)
-                .context("failed to render events simulate json")?
-        );
-    } else {
-        println!("{}", render_events_simulate_report(&report));
-    }
-    Ok(())
-}
-
-pub(crate) fn execute_events_dry_run_command(cli: &Cli) -> Result<()> {
-    let report = dry_run_events(
-        &EventsDryRunConfig {
-            events_dir: cli.events_dir.clone(),
-            state_path: cli.events_state_path.clone(),
-            queue_limit: cli.events_queue_limit.max(1),
-            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
-        },
-        current_unix_timestamp_ms(),
-    )?;
-
-    if cli.events_dry_run_json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report)
-                .context("failed to render events dry run json")?
-        );
-    } else {
-        println!("{}", render_events_dry_run_report(&report));
-    }
-
-    let max_error_rows = if cli.events_dry_run_strict {
-        Some(0)
-    } else {
-        cli.events_dry_run_max_error_rows
-            .map(|value| value as usize)
-    };
-    let gate_config = EventsDryRunGateConfig {
-        max_error_rows,
-        max_execute_rows: cli
-            .events_dry_run_max_execute_rows
-            .map(|value| value as usize),
-    };
-    enforce_events_dry_run_gate(&report, &gate_config)?;
-    Ok(())
 }
 
 pub(crate) async fn run_event_scheduler(config: EventSchedulerConfig) -> Result<()> {
@@ -394,151 +220,4 @@ fn collect_assistant_reply(messages: &[Message]) -> String {
     } else {
         content
     }
-}
-
-fn render_events_inspect_report(report: &EventsInspectReport) -> String {
-    format!(
-        "events inspect: events_dir={} state_path={} now_unix_ms={} discovered_events={} malformed_events={} enabled_events={} disabled_events={} due_now_events={} queued_now_events={} not_due_events={} stale_immediate_events={} due_eval_failed_events={} schedule_immediate_events={} schedule_at_events={} schedule_periodic_events={} periodic_with_last_run_state={} periodic_missing_last_run_state={} queue_limit={} stale_immediate_max_age_seconds={}",
-        report.events_dir,
-        report.state_path,
-        report.now_unix_ms,
-        report.discovered_events,
-        report.malformed_events,
-        report.enabled_events,
-        report.disabled_events,
-        report.due_now_events,
-        report.queued_now_events,
-        report.not_due_events,
-        report.stale_immediate_events,
-        report.due_eval_failed_events,
-        report.schedule_immediate_events,
-        report.schedule_at_events,
-        report.schedule_periodic_events,
-        report.periodic_with_last_run_state,
-        report.periodic_missing_last_run_state,
-        report.queue_limit,
-        report.stale_immediate_max_age_seconds,
-    )
-}
-
-fn render_events_validate_report(report: &EventsValidateReport) -> String {
-    let mut lines = vec![format!(
-        "events validate: events_dir={} state_path={} now_unix_ms={} total_files={} valid_files={} invalid_files={} malformed_files={} failed_files={} disabled_files={}",
-        report.events_dir,
-        report.state_path,
-        report.now_unix_ms,
-        report.total_files,
-        report.valid_files,
-        report.invalid_files,
-        report.malformed_files,
-        report.failed_files,
-        report.disabled_files,
-    )];
-
-    for diagnostic in &report.diagnostics {
-        lines.push(format!(
-            "events validate error: path={} event_id={} reason_code={} message={}",
-            diagnostic.path,
-            diagnostic
-                .event_id
-                .as_deref()
-                .filter(|value| !value.is_empty())
-                .unwrap_or("none"),
-            diagnostic.reason_code,
-            diagnostic.message
-        ));
-    }
-
-    lines.join("\n")
-}
-
-fn render_events_simulate_report(report: &EventsSimulateReport) -> String {
-    let mut lines = vec![format!(
-        "events simulate: events_dir={} state_path={} now_unix_ms={} horizon_seconds={} total_files={} simulated_rows={} malformed_files={} invalid_rows={} due_now_rows={} within_horizon_rows={}",
-        report.events_dir,
-        report.state_path,
-        report.now_unix_ms,
-        report.horizon_seconds,
-        report.total_files,
-        report.simulated_rows,
-        report.malformed_files,
-        report.invalid_rows,
-        report.due_now_rows,
-        report.within_horizon_rows,
-    )];
-
-    for row in &report.rows {
-        lines.push(format!(
-            "events simulate row: path={} event_id={} schedule={} enabled={} next_due_unix_ms={} due_now={} within_horizon={} last_run_unix_ms={} channel={}",
-            row.path,
-            row.event_id,
-            row.schedule,
-            row.enabled,
-            row.next_due_unix_ms
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-            row.due_now,
-            row.within_horizon,
-            row.last_run_unix_ms
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-            row.channel,
-        ));
-    }
-
-    for diagnostic in &report.diagnostics {
-        lines.push(format!(
-            "events simulate error: path={} event_id={} reason_code={} message={}",
-            diagnostic.path,
-            diagnostic
-                .event_id
-                .as_deref()
-                .filter(|value| !value.is_empty())
-                .unwrap_or("none"),
-            diagnostic.reason_code,
-            diagnostic.message
-        ));
-    }
-
-    lines.join("\n")
-}
-
-fn render_events_dry_run_report(report: &EventsDryRunReport) -> String {
-    let mut lines = vec![format!(
-        "events dry run: events_dir={} state_path={} now_unix_ms={} queue_limit={} total_files={} evaluated_rows={} execute_rows={} skipped_rows={} error_rows={} malformed_files={}",
-        report.events_dir,
-        report.state_path,
-        report.now_unix_ms,
-        report.queue_limit,
-        report.total_files,
-        report.evaluated_rows,
-        report.execute_rows,
-        report.skipped_rows,
-        report.error_rows,
-        report.malformed_files,
-    )];
-
-    for row in &report.rows {
-        lines.push(format!(
-            "events dry run row: path={} event_id={} schedule={} enabled={} decision={} reason_code={} queue_position={} last_run_unix_ms={} channel={} message={}",
-            row.path,
-            row.event_id.as_deref().unwrap_or("none"),
-            row.schedule.as_deref().unwrap_or("none"),
-            row.enabled
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-            row.decision,
-            row.reason_code,
-            row.queue_position
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-            row.last_run_unix_ms
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-            row.channel.as_deref().unwrap_or("none"),
-            row.message.as_deref().unwrap_or("none"),
-        ));
-    }
-
-    lines.join("\n")
 }

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -245,6 +245,8 @@ pub(crate) use tau_cli::validation::{
 };
 pub(crate) use tau_cli::Cli;
 #[cfg(test)]
+pub(crate) use tau_cli::CliEventTemplateSchedule;
+#[cfg(test)]
 pub(crate) use tau_cli::CliProviderAuthMode;
 #[cfg(test)]
 pub(crate) use tau_cli::{
@@ -252,7 +254,7 @@ pub(crate) use tau_cli::{
     CliGatewayOpenResponsesAuthMode, CliMultiChannelLiveConnectorMode, CliMultiChannelTransport,
     CliOsSandboxMode, CliSessionImportMode, CliToolPolicyPreset,
 };
-pub(crate) use tau_cli::{CliCommandFileErrorMode, CliEventTemplateSchedule, CliOrchestratorMode};
+pub(crate) use tau_cli::{CliCommandFileErrorMode, CliOrchestratorMode};
 #[cfg(test)]
 pub(crate) use tau_cli::{CliDaemonProfile, CliGatewayRemoteProfile};
 #[cfg(test)]

--- a/crates/tau-events/Cargo.toml
+++ b/crates/tau-events/Cargo.toml
@@ -13,6 +13,7 @@ hmac.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tau-cli = { path = "../tau-cli" }
 tau-core = { path = "../tau-core" }
 tau-runtime = { path = "../tau-runtime" }
 tokio.workspace = true

--- a/crates/tau-events/src/events_cli_commands.rs
+++ b/crates/tau-events/src/events_cli_commands.rs
@@ -1,0 +1,334 @@
+use anyhow::{anyhow, bail, Context, Result};
+use tau_cli::{Cli, CliEventTemplateSchedule};
+use tau_core::current_unix_timestamp_ms;
+
+use crate::{
+    dry_run_events, enforce_events_dry_run_gate, inspect_events, simulate_events,
+    validate_events_definitions, write_event_template, EventTemplateSchedule, EventsDryRunConfig,
+    EventsDryRunGateConfig, EventsDryRunReport, EventsInspectConfig, EventsInspectReport,
+    EventsSimulateConfig, EventsSimulateReport, EventsTemplateConfig, EventsValidateConfig,
+    EventsValidateReport,
+};
+
+pub fn execute_events_inspect_command(cli: &Cli) -> Result<()> {
+    let report = inspect_events(
+        &EventsInspectConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            queue_limit: cli.events_queue_limit.max(1),
+            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
+        },
+        current_unix_timestamp_ms(),
+    )?;
+
+    if cli.events_inspect_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to render events inspect json")?
+        );
+    } else {
+        println!("{}", render_events_inspect_report(&report));
+    }
+    Ok(())
+}
+
+pub fn execute_events_validate_command(cli: &Cli) -> Result<()> {
+    let report = validate_events_definitions(
+        &EventsValidateConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+        },
+        current_unix_timestamp_ms(),
+    )?;
+
+    if cli.events_validate_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to render events validate json")?
+        );
+    } else {
+        println!("{}", render_events_validate_report(&report));
+    }
+
+    if report.failed_files > 0 {
+        bail!(
+            "events validate failed: failed_files={} invalid_files={} malformed_files={}",
+            report.failed_files,
+            report.invalid_files,
+            report.malformed_files
+        );
+    }
+    Ok(())
+}
+
+pub fn execute_events_template_write_command(cli: &Cli) -> Result<()> {
+    let target_path = cli
+        .events_template_write
+        .as_ref()
+        .ok_or_else(|| anyhow!("--events-template-write is required"))?;
+
+    let now_unix_ms = current_unix_timestamp_ms();
+    let schedule = match cli.events_template_schedule {
+        CliEventTemplateSchedule::Immediate => EventTemplateSchedule::Immediate,
+        CliEventTemplateSchedule::At => EventTemplateSchedule::At,
+        CliEventTemplateSchedule::Periodic => EventTemplateSchedule::Periodic,
+    };
+
+    let at_unix_ms = if matches!(cli.events_template_schedule, CliEventTemplateSchedule::At) {
+        Some(
+            cli.events_template_at_unix_ms
+                .unwrap_or_else(|| now_unix_ms.saturating_add(300_000)),
+        )
+    } else {
+        None
+    };
+
+    let cron = if matches!(
+        cli.events_template_schedule,
+        CliEventTemplateSchedule::Periodic
+    ) {
+        Some(
+            cli.events_template_cron
+                .clone()
+                .unwrap_or_else(|| "0 0/15 * * * * *".to_string()),
+        )
+    } else {
+        None
+    };
+
+    let config = EventsTemplateConfig {
+        target_path: target_path.to_path_buf(),
+        overwrite: cli.events_template_overwrite,
+        schedule,
+        channel: cli
+            .events_template_channel
+            .clone()
+            .unwrap_or_else(|| "slack/C123".to_string()),
+        prompt: cli.events_template_prompt.clone().unwrap_or_default(),
+        event_id: cli.events_template_id.clone(),
+        at_unix_ms,
+        cron,
+        timezone: Some(cli.events_template_timezone.clone()),
+    };
+
+    let report = write_event_template(&config, now_unix_ms)?;
+
+    println!(
+        "events template write: path={} schedule={} event_id={} channel={} overwrite={}",
+        report.path.display(),
+        report.schedule,
+        report.event_id,
+        report.channel,
+        report.overwrite,
+    );
+    Ok(())
+}
+
+pub fn execute_events_simulate_command(cli: &Cli) -> Result<()> {
+    let report = simulate_events(
+        &EventsSimulateConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            horizon_seconds: cli.events_simulate_horizon_seconds,
+            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
+        },
+        current_unix_timestamp_ms(),
+    )?;
+
+    if cli.events_simulate_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to render events simulate json")?
+        );
+    } else {
+        println!("{}", render_events_simulate_report(&report));
+    }
+    Ok(())
+}
+
+pub fn execute_events_dry_run_command(cli: &Cli) -> Result<()> {
+    let report = dry_run_events(
+        &EventsDryRunConfig {
+            events_dir: cli.events_dir.clone(),
+            state_path: cli.events_state_path.clone(),
+            queue_limit: cli.events_queue_limit.max(1),
+            stale_immediate_max_age_seconds: cli.events_stale_immediate_max_age_seconds,
+        },
+        current_unix_timestamp_ms(),
+    )?;
+
+    if cli.events_dry_run_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to render events dry run json")?
+        );
+    } else {
+        println!("{}", render_events_dry_run_report(&report));
+    }
+
+    let max_error_rows = if cli.events_dry_run_strict {
+        Some(0)
+    } else {
+        cli.events_dry_run_max_error_rows
+            .map(|value| value as usize)
+    };
+    let gate_config = EventsDryRunGateConfig {
+        max_error_rows,
+        max_execute_rows: cli
+            .events_dry_run_max_execute_rows
+            .map(|value| value as usize),
+    };
+    enforce_events_dry_run_gate(&report, &gate_config)?;
+    Ok(())
+}
+
+fn render_events_inspect_report(report: &EventsInspectReport) -> String {
+    format!(
+        "events inspect: events_dir={} state_path={} now_unix_ms={} discovered_events={} malformed_events={} enabled_events={} disabled_events={} due_now_events={} queued_now_events={} not_due_events={} stale_immediate_events={} due_eval_failed_events={} schedule_immediate_events={} schedule_at_events={} schedule_periodic_events={} periodic_with_last_run_state={} periodic_missing_last_run_state={} queue_limit={} stale_immediate_max_age_seconds={}",
+        report.events_dir,
+        report.state_path,
+        report.now_unix_ms,
+        report.discovered_events,
+        report.malformed_events,
+        report.enabled_events,
+        report.disabled_events,
+        report.due_now_events,
+        report.queued_now_events,
+        report.not_due_events,
+        report.stale_immediate_events,
+        report.due_eval_failed_events,
+        report.schedule_immediate_events,
+        report.schedule_at_events,
+        report.schedule_periodic_events,
+        report.periodic_with_last_run_state,
+        report.periodic_missing_last_run_state,
+        report.queue_limit,
+        report.stale_immediate_max_age_seconds,
+    )
+}
+
+fn render_events_validate_report(report: &EventsValidateReport) -> String {
+    let mut lines = vec![format!(
+        "events validate: events_dir={} state_path={} now_unix_ms={} total_files={} valid_files={} invalid_files={} malformed_files={} failed_files={} disabled_files={}",
+        report.events_dir,
+        report.state_path,
+        report.now_unix_ms,
+        report.total_files,
+        report.valid_files,
+        report.invalid_files,
+        report.malformed_files,
+        report.failed_files,
+        report.disabled_files,
+    )];
+
+    for diagnostic in &report.diagnostics {
+        lines.push(format!(
+            "events validate error: path={} event_id={} reason_code={} message={}",
+            diagnostic.path,
+            diagnostic
+                .event_id
+                .as_deref()
+                .filter(|value| !value.is_empty())
+                .unwrap_or("none"),
+            diagnostic.reason_code,
+            diagnostic.message
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_events_simulate_report(report: &EventsSimulateReport) -> String {
+    let mut lines = vec![format!(
+        "events simulate: events_dir={} state_path={} now_unix_ms={} horizon_seconds={} total_files={} simulated_rows={} malformed_files={} invalid_rows={} due_now_rows={} within_horizon_rows={}",
+        report.events_dir,
+        report.state_path,
+        report.now_unix_ms,
+        report.horizon_seconds,
+        report.total_files,
+        report.simulated_rows,
+        report.malformed_files,
+        report.invalid_rows,
+        report.due_now_rows,
+        report.within_horizon_rows,
+    )];
+
+    for row in &report.rows {
+        lines.push(format!(
+            "events simulate row: path={} event_id={} schedule={} enabled={} next_due_unix_ms={} due_now={} within_horizon={} last_run_unix_ms={} channel={}",
+            row.path,
+            row.event_id,
+            row.schedule,
+            row.enabled,
+            row.next_due_unix_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            row.due_now,
+            row.within_horizon,
+            row.last_run_unix_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            row.channel,
+        ));
+    }
+
+    for diagnostic in &report.diagnostics {
+        lines.push(format!(
+            "events simulate error: path={} event_id={} reason_code={} message={}",
+            diagnostic.path,
+            diagnostic
+                .event_id
+                .as_deref()
+                .filter(|value| !value.is_empty())
+                .unwrap_or("none"),
+            diagnostic.reason_code,
+            diagnostic.message
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_events_dry_run_report(report: &EventsDryRunReport) -> String {
+    let mut lines = vec![format!(
+        "events dry run: events_dir={} state_path={} now_unix_ms={} queue_limit={} total_files={} evaluated_rows={} execute_rows={} skipped_rows={} error_rows={} malformed_files={}",
+        report.events_dir,
+        report.state_path,
+        report.now_unix_ms,
+        report.queue_limit,
+        report.total_files,
+        report.evaluated_rows,
+        report.execute_rows,
+        report.skipped_rows,
+        report.error_rows,
+        report.malformed_files,
+    )];
+
+    for row in &report.rows {
+        lines.push(format!(
+            "events dry run row: path={} event_id={} schedule={} enabled={} decision={} reason_code={} queue_position={} last_run_unix_ms={} channel={} message={}",
+            row.path,
+            row.event_id.as_deref().unwrap_or("none"),
+            row.schedule.as_deref().unwrap_or("none"),
+            row.enabled
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            row.decision,
+            row.reason_code,
+            row.queue_position
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            row.last_run_unix_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            row.channel.as_deref().unwrap_or("none"),
+            row.message.as_deref().unwrap_or("none"),
+        ));
+    }
+
+    lines.join("\n")
+}

--- a/crates/tau-events/src/lib.rs
+++ b/crates/tau-events/src/lib.rs
@@ -16,6 +16,9 @@ use sha2::Sha256;
 use tau_core::{current_unix_timestamp_ms, write_text_atomic};
 use tau_runtime::channel_store::{ChannelLogEntry, ChannelStore};
 
+mod events_cli_commands;
+pub use events_cli_commands::*;
+
 const EVENT_RUNNER_STATE_SCHEMA_VERSION: u32 = 1;
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- move events CLI command handlers and deterministic report rendering from `tau-coding-agent` into `tau-events`
- keep `tau-coding-agent` `events` module focused on event-runner orchestration bridge only
- add `tau-cli` dependency to `tau-events` for command option parsing surface
- preserve existing events preflight output/error contracts

## Testing
- cargo fmt --all
- cargo clippy -p tau-events --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings
- cargo test -p tau-events
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Refs #933
