### PR TITLE
refactor: extract runtime output utilities into tau-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,7 @@ dependencies = [
  "tau-agent-core",
  "tau-ai",
  "tau-core",
+ "tau-session",
  "tempfile",
 ]
 

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -43,7 +43,6 @@ mod transport_health;
 mod voice_contract;
 
 use std::{
-    io::Write,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -55,7 +54,7 @@ use serde_json::Value;
 use tau_agent_core::{Agent, AgentEvent};
 #[cfg(test)]
 pub(crate) use tau_ai::Provider;
-use tau_ai::{LlmClient, Message, MessageRole, ModelRef};
+use tau_ai::{LlmClient, Message, ModelRef};
 pub(crate) use tau_extensions as extension_manifest;
 pub(crate) use tau_skills as package_manifest;
 #[cfg(test)]

--- a/crates/tau-coding-agent/src/runtime_output.rs
+++ b/crates/tau-coding-agent/src/runtime_output.rs
@@ -1,36 +1,14 @@
 use super::*;
 
 pub(crate) fn summarize_message(message: &Message) -> String {
-    let text = message.text_content().replace('\n', " ");
-    if text.trim().is_empty() {
-        return format!(
-            "{:?} (tool_calls={})",
-            message.role,
-            message.tool_calls().len()
-        );
-    }
-
-    let max = 60;
-    if text.chars().count() <= max {
-        text
-    } else {
-        let summary = text.chars().take(max).collect::<String>();
-        format!("{summary}...")
-    }
+    tau_runtime::runtime_output_runtime::summarize_message(message)
 }
 
 pub(crate) fn persist_messages(
     session_runtime: &mut Option<SessionRuntime>,
     new_messages: &[Message],
 ) -> Result<()> {
-    let Some(runtime) = session_runtime.as_mut() else {
-        return Ok(());
-    };
-
-    runtime.active_head = runtime
-        .store
-        .append_messages(runtime.active_head, new_messages)?;
-    Ok(())
+    tau_runtime::runtime_output_runtime::persist_messages(session_runtime, new_messages)
 }
 
 pub(crate) fn print_assistant_messages(
@@ -38,97 +16,19 @@ pub(crate) fn print_assistant_messages(
     render_options: RenderOptions,
     suppress_first_streamed_text: bool,
 ) {
-    let mut suppressed_once = false;
-    for message in messages {
-        if message.role != MessageRole::Assistant {
-            continue;
-        }
-
-        let text = message.text_content();
-        if !text.trim().is_empty() {
-            if render_options.stream_output && suppress_first_streamed_text && !suppressed_once {
-                suppressed_once = true;
-                println!("\n");
-                continue;
-            }
-            println!();
-            if render_options.stream_output {
-                let mut stdout = std::io::stdout();
-                for chunk in stream_text_chunks(&text) {
-                    print!("{chunk}");
-                    let _ = stdout.flush();
-                    if render_options.stream_delay_ms > 0 {
-                        std::thread::sleep(Duration::from_millis(render_options.stream_delay_ms));
-                    }
-                }
-                println!("\n");
-            } else {
-                println!("{text}\n");
-            }
-            continue;
-        }
-
-        let tool_calls = message.tool_calls();
-        if !tool_calls.is_empty() {
-            println!(
-                "\n[assistant requested {} tool call(s)]\n",
-                tool_calls.len()
-            );
-        }
-    }
+    tau_runtime::runtime_output_runtime::print_assistant_messages(
+        messages,
+        render_options.stream_output,
+        render_options.stream_delay_ms,
+        suppress_first_streamed_text,
+    );
 }
 
+#[cfg(test)]
 pub(crate) fn stream_text_chunks(text: &str) -> Vec<&str> {
-    text.split_inclusive(char::is_whitespace).collect()
+    tau_runtime::runtime_output_runtime::stream_text_chunks(text)
 }
 
 pub(crate) fn event_to_json(event: &AgentEvent) -> serde_json::Value {
-    match event {
-        AgentEvent::AgentStart => serde_json::json!({ "type": "agent_start" }),
-        AgentEvent::AgentEnd { new_messages } => {
-            serde_json::json!({ "type": "agent_end", "new_messages": new_messages })
-        }
-        AgentEvent::TurnStart { turn } => serde_json::json!({ "type": "turn_start", "turn": turn }),
-        AgentEvent::TurnEnd {
-            turn,
-            tool_results,
-            request_duration_ms,
-            usage,
-            finish_reason,
-        } => serde_json::json!({
-            "type": "turn_end",
-            "turn": turn,
-            "tool_results": tool_results,
-            "request_duration_ms": request_duration_ms,
-            "usage": usage,
-            "finish_reason": finish_reason,
-        }),
-        AgentEvent::MessageAdded { message } => serde_json::json!({
-            "type": "message_added",
-            "role": format!("{:?}", message.role).to_lowercase(),
-            "text": message.text_content(),
-            "tool_calls": message.tool_calls().len(),
-        }),
-        AgentEvent::ToolExecutionStart {
-            tool_call_id,
-            tool_name,
-            arguments,
-        } => serde_json::json!({
-            "type": "tool_execution_start",
-            "tool_call_id": tool_call_id,
-            "tool_name": tool_name,
-            "arguments": arguments,
-        }),
-        AgentEvent::ToolExecutionEnd {
-            tool_call_id,
-            tool_name,
-            result,
-        } => serde_json::json!({
-            "type": "tool_execution_end",
-            "tool_call_id": tool_call_id,
-            "tool_name": tool_name,
-            "is_error": result.is_error,
-            "content": result.content,
-        }),
-    }
+    tau_runtime::runtime_output_runtime::event_to_json(event)
 }

--- a/crates/tau-runtime/Cargo.toml
+++ b/crates/tau-runtime/Cargo.toml
@@ -12,6 +12,7 @@ sha2.workspace = true
 tau-ai = { path = "../tau-ai" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-core = { path = "../tau-core" }
+tau-session = { path = "../tau-session" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tau-runtime/src/lib.rs
+++ b/crates/tau-runtime/src/lib.rs
@@ -2,10 +2,12 @@ pub mod channel_store;
 pub mod observability_loggers_runtime;
 pub mod rpc_capabilities_runtime;
 pub mod rpc_protocol_runtime;
+pub mod runtime_output_runtime;
 pub mod transport_health;
 
 pub use channel_store::*;
 pub use observability_loggers_runtime::*;
 pub use rpc_capabilities_runtime::*;
 pub use rpc_protocol_runtime::*;
+pub use runtime_output_runtime::*;
 pub use transport_health::*;

--- a/crates/tau-runtime/src/runtime_output_runtime.rs
+++ b/crates/tau-runtime/src/runtime_output_runtime.rs
@@ -1,0 +1,190 @@
+use std::{io::Write, time::Duration};
+
+use anyhow::Result;
+use tau_agent_core::AgentEvent;
+use tau_ai::{Message, MessageRole};
+use tau_session::SessionRuntime;
+
+pub fn summarize_message(message: &Message) -> String {
+    let text = message.text_content().replace('\n', " ");
+    if text.trim().is_empty() {
+        return format!(
+            "{:?} (tool_calls={})",
+            message.role,
+            message.tool_calls().len()
+        );
+    }
+
+    let max = 60;
+    if text.chars().count() <= max {
+        text
+    } else {
+        let summary = text.chars().take(max).collect::<String>();
+        format!("{summary}...")
+    }
+}
+
+pub fn persist_messages(
+    session_runtime: &mut Option<SessionRuntime>,
+    new_messages: &[Message],
+) -> Result<()> {
+    let Some(runtime) = session_runtime.as_mut() else {
+        return Ok(());
+    };
+
+    runtime.active_head = runtime
+        .store
+        .append_messages(runtime.active_head, new_messages)?;
+    Ok(())
+}
+
+pub fn print_assistant_messages(
+    messages: &[Message],
+    stream_output: bool,
+    stream_delay_ms: u64,
+    suppress_first_streamed_text: bool,
+) {
+    let mut suppressed_once = false;
+    for message in messages {
+        if message.role != MessageRole::Assistant {
+            continue;
+        }
+
+        let text = message.text_content();
+        if !text.trim().is_empty() {
+            if stream_output && suppress_first_streamed_text && !suppressed_once {
+                suppressed_once = true;
+                println!("\n");
+                continue;
+            }
+            println!();
+            if stream_output {
+                let mut stdout = std::io::stdout();
+                for chunk in stream_text_chunks(&text) {
+                    print!("{chunk}");
+                    let _ = stdout.flush();
+                    if stream_delay_ms > 0 {
+                        std::thread::sleep(Duration::from_millis(stream_delay_ms));
+                    }
+                }
+                println!("\n");
+            } else {
+                println!("{text}\n");
+            }
+            continue;
+        }
+
+        let tool_calls = message.tool_calls();
+        if !tool_calls.is_empty() {
+            println!(
+                "\n[assistant requested {} tool call(s)]\n",
+                tool_calls.len()
+            );
+        }
+    }
+}
+
+pub fn stream_text_chunks(text: &str) -> Vec<&str> {
+    text.split_inclusive(char::is_whitespace).collect()
+}
+
+pub fn event_to_json(event: &AgentEvent) -> serde_json::Value {
+    match event {
+        AgentEvent::AgentStart => serde_json::json!({ "type": "agent_start" }),
+        AgentEvent::AgentEnd { new_messages } => {
+            serde_json::json!({ "type": "agent_end", "new_messages": new_messages })
+        }
+        AgentEvent::TurnStart { turn } => serde_json::json!({ "type": "turn_start", "turn": turn }),
+        AgentEvent::TurnEnd {
+            turn,
+            tool_results,
+            request_duration_ms,
+            usage,
+            finish_reason,
+        } => serde_json::json!({
+            "type": "turn_end",
+            "turn": turn,
+            "tool_results": tool_results,
+            "request_duration_ms": request_duration_ms,
+            "usage": usage,
+            "finish_reason": finish_reason,
+        }),
+        AgentEvent::MessageAdded { message } => serde_json::json!({
+            "type": "message_added",
+            "role": format!("{:?}", message.role).to_lowercase(),
+            "text": message.text_content(),
+            "tool_calls": message.tool_calls().len(),
+        }),
+        AgentEvent::ToolExecutionStart {
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => serde_json::json!({
+            "type": "tool_execution_start",
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+        }),
+        AgentEvent::ToolExecutionEnd {
+            tool_call_id,
+            tool_name,
+            result,
+        } => serde_json::json!({
+            "type": "tool_execution_end",
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "is_error": result.is_error,
+            "content": result.content,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{event_to_json, stream_text_chunks, summarize_message};
+    use tau_agent_core::{AgentEvent, ToolExecutionResult};
+    use tau_ai::{ContentBlock, Message, ToolCall};
+
+    #[test]
+    fn unit_stream_text_chunks_preserve_whitespace_boundaries() {
+        let chunks = stream_text_chunks("hello world\nnext");
+        assert_eq!(chunks, vec!["hello ", "world\n", "next"]);
+    }
+
+    #[test]
+    fn regression_stream_text_chunks_handles_empty_and_single_word() {
+        assert!(stream_text_chunks("").is_empty());
+        assert_eq!(stream_text_chunks("token"), vec!["token"]);
+    }
+
+    #[test]
+    fn unit_summarize_message_truncates_long_text_and_reports_tool_calls_for_empty_text() {
+        let short = Message::assistant_text("short text");
+        assert_eq!(summarize_message(&short), "short text");
+
+        let long = Message::assistant_text("a".repeat(80));
+        assert!(summarize_message(&long).ends_with("..."));
+
+        let tool_call = Message::assistant_blocks(vec![ContentBlock::tool_call(ToolCall {
+            id: "call-1".to_string(),
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({ "path": "README.md" }),
+        })]);
+        assert_eq!(summarize_message(&tool_call), "Assistant (tool_calls=1)");
+    }
+
+    #[test]
+    fn unit_event_to_json_maps_tool_execution_end_shape() {
+        let event = AgentEvent::ToolExecutionEnd {
+            tool_call_id: "call-1".to_string(),
+            tool_name: "write".to_string(),
+            result: ToolExecutionResult::ok(serde_json::json!({ "ok": true })),
+        };
+        let value = event_to_json(&event);
+        assert_eq!(value["type"], "tool_execution_end");
+        assert_eq!(value["tool_call_id"], "call-1");
+        assert_eq!(value["tool_name"], "write");
+        assert_eq!(value["is_error"], false);
+        assert_eq!(value["content"]["ok"], true);
+    }
+}


### PR DESCRIPTION
## Summary
- move runtime output utilities (`summarize_message`, `persist_messages`, `print_assistant_messages`, `stream_text_chunks`, `event_to_json`) from `tau-coding-agent` into `tau-runtime`
- keep `tau-coding-agent` runtime output module as a thin compatibility wrapper around `tau-runtime`
- add focused `tau-runtime` runtime-output tests for chunking, summarization, and JSON event shaping

## Validation
- cargo fmt --all
- cargo clippy -p tau-runtime --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings
- cargo test -p tau-runtime
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Refs #933
