### PR TITLE
refactor: extract shared runtime config types into tau-startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,6 +3217,7 @@ dependencies = [
  "tau-core",
  "tau-diagnostics",
  "tau-events",
+ "tau-extensions",
  "tau-gateway",
  "tau-multi-channel",
  "tau-provider",

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -1,40 +1,18 @@
-use std::path::PathBuf;
-
 use crate::extension_manifest::ExtensionRegisteredCommand;
-use crate::{Cli, ModelCatalog};
-pub(crate) use tau_diagnostics::DoctorCommandConfig;
-#[cfg(test)]
-pub(crate) use tau_diagnostics::{DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus};
+use crate::ModelCatalog;
 pub(crate) use tau_onboarding::startup_config::ProfileDefaults;
 #[cfg(test)]
 pub(crate) use tau_onboarding::startup_config::{
     ProfileAuthDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
 };
-pub(crate) use tau_provider::AuthCommandConfig;
 use tau_session::SessionImportMode;
-
-#[derive(Debug, Clone)]
-pub(crate) struct SkillsSyncCommandConfig {
-    pub(crate) skills_dir: PathBuf,
-    pub(crate) default_lock_path: PathBuf,
-    pub(crate) default_trust_root_path: Option<PathBuf>,
-    pub(crate) doctor_config: DoctorCommandConfig,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct RenderOptions {
-    pub(crate) stream_output: bool,
-    pub(crate) stream_delay_ms: u64,
-}
-
-impl RenderOptions {
-    pub(crate) fn from_cli(cli: &Cli) -> Self {
-        Self {
-            stream_output: cli.stream_output,
-            stream_delay_ms: cli.stream_delay_ms,
-        }
-    }
-}
+pub(crate) use tau_startup::runtime_types::{
+    AuthCommandConfig, DoctorCommandConfig, RenderOptions, SkillsSyncCommandConfig,
+};
+#[cfg(test)]
+pub(crate) use tau_startup::runtime_types::{
+    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus,
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct CommandExecutionContext<'a> {

--- a/crates/tau-startup/Cargo.toml
+++ b/crates/tau-startup/Cargo.toml
@@ -25,6 +25,9 @@ path = "../tau-events"
 [dependencies.tau-diagnostics]
 path = "../tau-diagnostics"
 
+[dependencies.tau-extensions]
+path = "../tau-extensions"
+
 [dependencies.tau-gateway]
 path = "../tau-gateway"
 

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -19,10 +19,12 @@ use tau_gateway::{
 };
 use tau_session::validate_session_file;
 
+pub mod runtime_types;
 pub mod startup_model_catalog;
 pub mod startup_multi_channel_adapters;
 pub mod startup_multi_channel_commands;
 
+pub use runtime_types::*;
 pub use startup_model_catalog::*;
 pub use startup_multi_channel_adapters::*;
 pub use startup_multi_channel_commands::*;

--- a/crates/tau-startup/src/runtime_types.rs
+++ b/crates/tau-startup/src/runtime_types.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use tau_cli::Cli;
+pub use tau_diagnostics::DoctorCommandConfig;
+pub use tau_diagnostics::{DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus};
+pub use tau_provider::AuthCommandConfig;
+
+#[derive(Debug, Clone)]
+pub struct SkillsSyncCommandConfig {
+    pub skills_dir: PathBuf,
+    pub default_lock_path: PathBuf,
+    pub default_trust_root_path: Option<PathBuf>,
+    pub doctor_config: DoctorCommandConfig,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RenderOptions {
+    pub stream_output: bool,
+    pub stream_delay_ms: u64,
+}
+
+impl RenderOptions {
+    pub fn from_cli(cli: &Cli) -> Self {
+        Self {
+            stream_output: cli.stream_output,
+            stream_delay_ms: cli.stream_delay_ms,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move shared runtime config types (`RenderOptions`, `SkillsSyncCommandConfig`, auth/doctor config aliases) from `tau-coding-agent` into `tau-startup::runtime_types`
- keep `tau-coding-agent` ownership of `CommandExecutionContext` to avoid introducing a `tau-startup` <-> `tau-onboarding` dependency cycle
- update `tau-coding-agent::runtime_types` to a thin compatibility wrapper over `tau-startup` exports for moved types

## Validation
- cargo fmt --all
- cargo clippy -p tau-startup --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings
- cargo test -p tau-startup
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Refs #933
