### PR TITLE
refactor: extract rpc capabilities command into tau-startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,7 @@ dependencies = [
  "tau-gateway",
  "tau-multi-channel",
  "tau-provider",
+ "tau-runtime",
  "tau-session",
 ]
 

--- a/crates/tau-coding-agent/src/rpc_capabilities.rs
+++ b/crates/tau-coding-agent/src/rpc_capabilities.rs
@@ -1,17 +1,3 @@
-use anyhow::Result;
-
-use crate::Cli;
-
-use tau_runtime::render_rpc_capabilities_payload_pretty;
 #[cfg(test)]
 pub(crate) use tau_runtime::rpc_capabilities_payload;
-
-pub(crate) fn execute_rpc_capabilities_command(cli: &Cli) -> Result<()> {
-    if !cli.rpc_capabilities {
-        return Ok(());
-    }
-
-    let payload = render_rpc_capabilities_payload_pretty()?;
-    println!("{payload}");
-    Ok(())
-}
+pub(crate) use tau_startup::execute_rpc_capabilities_command;

--- a/crates/tau-startup/Cargo.toml
+++ b/crates/tau-startup/Cargo.toml
@@ -37,5 +37,8 @@ path = "../tau-multi-channel"
 [dependencies.tau-provider]
 path = "../tau-provider"
 
+[dependencies.tau-runtime]
+path = "../tau-runtime"
+
 [dependencies.tau-session]
 path = "../tau-session"

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -23,11 +23,13 @@ pub mod runtime_types;
 pub mod startup_model_catalog;
 pub mod startup_multi_channel_adapters;
 pub mod startup_multi_channel_commands;
+pub mod startup_rpc_capabilities_command;
 
 pub use runtime_types::*;
 pub use startup_model_catalog::*;
 pub use startup_multi_channel_adapters::*;
 pub use startup_multi_channel_commands::*;
+pub use startup_rpc_capabilities_command::*;
 
 pub trait StartupPreflightActions {
     fn execute_onboarding_command(&self, cli: &Cli) -> Result<()>;

--- a/crates/tau-startup/src/startup_rpc_capabilities_command.rs
+++ b/crates/tau-startup/src/startup_rpc_capabilities_command.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use tau_cli::Cli;
+
+pub fn execute_rpc_capabilities_command(cli: &Cli) -> Result<()> {
+    if !cli.rpc_capabilities {
+        return Ok(());
+    }
+
+    let payload = tau_runtime::render_rpc_capabilities_payload_pretty()?;
+    println!("{payload}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move `execute_rpc_capabilities_command` from `tau-coding-agent` into `tau-startup::startup_rpc_capabilities_command`
- keep `tau-coding-agent::rpc_capabilities` as a thin compatibility shim
- retain `rpc_capabilities_payload` test re-export in `tau-coding-agent` to preserve existing test surface

## Testing
- cargo fmt --all
- cargo clippy -p tau-startup --all-targets -- -D warnings
- cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings
- cargo test -p tau-startup
- cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1
- cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1

Refs #933
