### PR TITLE
feat(demo): harden remote-access runbook, demo, and smoke contracts

### DIFF
--- a/.github/demo-smoke-manifest.json
+++ b/.github/demo-smoke-manifest.json
@@ -68,7 +68,7 @@
       "name": "multi-channel-live-ingest-telegram",
       "args": [
         "--multi-channel-live-ingest-file",
-        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/telegram-update.json",
+        "./crates/tau-multi-channel/testdata/multi-channel-live-ingress/raw/telegram-update.json",
         "--multi-channel-live-ingest-transport",
         "telegram",
         "--multi-channel-live-ingest-provider",
@@ -81,7 +81,7 @@
       "name": "multi-channel-live-ingest-discord",
       "args": [
         "--multi-channel-live-ingest-file",
-        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/discord-message.json",
+        "./crates/tau-multi-channel/testdata/multi-channel-live-ingress/raw/discord-message.json",
         "--multi-channel-live-ingest-transport",
         "discord",
         "--multi-channel-live-ingest-provider",
@@ -94,7 +94,7 @@
       "name": "multi-channel-live-ingest-whatsapp",
       "args": [
         "--multi-channel-live-ingest-file",
-        "./crates/tau-coding-agent/testdata/multi-channel-live-ingress/raw/whatsapp-message.json",
+        "./crates/tau-multi-channel/testdata/multi-channel-live-ingress/raw/whatsapp-message.json",
         "--multi-channel-live-ingest-transport",
         "whatsapp",
         "--multi-channel-live-ingest-provider",
@@ -137,7 +137,7 @@
       "args": [
         "--gateway-contract-runner",
         "--gateway-fixture",
-        "./crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json",
+        "./crates/tau-gateway/testdata/gateway-contract/rollout-pass.json",
         "--gateway-state-dir",
         ".tau/ci-smoke/gateway"
       ]
@@ -173,6 +173,41 @@
         "token",
         "--gateway-openresponses-auth-token",
         "ci-smoke-token",
+        "--gateway-openresponses-bind",
+        "127.0.0.1:8787",
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-auth"
+      ]
+    },
+    {
+      "name": "gateway-remote-plan-tailscale-serve",
+      "args": [
+        "--gateway-remote-plan",
+        "--gateway-remote-plan-json",
+        "--gateway-remote-profile",
+        "tailscale-serve",
+        "--gateway-openresponses-server",
+        "--gateway-openresponses-auth-mode",
+        "token",
+        "--gateway-openresponses-auth-token",
+        "ci-smoke-token",
+        "--gateway-openresponses-bind",
+        "127.0.0.1:8787",
+        "--gateway-state-dir",
+        ".tau/ci-smoke/gateway-auth"
+      ]
+    },
+    {
+      "name": "gateway-remote-plan-fails-closed-missing-funnel-password",
+      "expected_exit_code": 1,
+      "stderr_contains": "tailscale_funnel_missing_password",
+      "args": [
+        "--gateway-remote-plan",
+        "--gateway-remote-profile",
+        "tailscale-funnel",
+        "--gateway-openresponses-server",
+        "--gateway-openresponses-auth-mode",
+        "password-session",
         "--gateway-openresponses-bind",
         "127.0.0.1:8787",
         "--gateway-state-dir",

--- a/.github/scripts/test_demo_index.py
+++ b/.github/scripts/test_demo_index.py
@@ -30,11 +30,18 @@ class DemoIndexTests(unittest.TestCase):
         scenario_ids = [entry["id"] for entry in payload["scenarios"]]
         self.assertEqual(
             scenario_ids,
-            ["onboarding", "gateway-auth", "multi-channel-live", "deployment-wasm"],
+            [
+                "onboarding",
+                "gateway-auth",
+                "gateway-remote-access",
+                "multi-channel-live",
+                "deployment-wasm",
+            ],
         )
         wrappers = {entry["id"]: entry["wrapper"] for entry in payload["scenarios"]}
         self.assertEqual(wrappers["onboarding"], "local.sh")
         self.assertEqual(wrappers["gateway-auth"], "gateway-auth.sh")
+        self.assertEqual(wrappers["gateway-remote-access"], "gateway-remote-access.sh")
         self.assertEqual(wrappers["multi-channel-live"], "multi-channel.sh")
         self.assertEqual(wrappers["deployment-wasm"], "deployment.sh")
 
@@ -43,6 +50,7 @@ class DemoIndexTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("onboarding", result.stdout)
         self.assertIn("gateway-auth", result.stdout)
+        self.assertIn("gateway-remote-access", result.stdout)
         self.assertIn("multi-channel-live", result.stdout)
         self.assertIn("deployment-wasm", result.stdout)
         self.assertIn("expected_marker:", result.stdout)
@@ -73,11 +81,11 @@ class DemoIndexTests(unittest.TestCase):
                     str(DEMO_ALL_SCRIPT),
                     "--list",
                     "--only",
-                    "gateway-auth",
+                    "gateway-remote-access",
                 ]
             )
             self.assertEqual(all_list_result.returncode, 0, msg=all_list_result.stderr)
-            self.assertIn("gateway-auth.sh", all_list_result.stdout)
+            self.assertIn("gateway-remote-access.sh", all_list_result.stdout)
 
     def test_regression_demo_index_alias_filter_and_unknown_filter_handling(self):
         alias_result = run_command(
@@ -87,7 +95,7 @@ class DemoIndexTests(unittest.TestCase):
                 "--list",
                 "--json",
                 "--only",
-                "local,gatewayauth,multi-channel,deployment",
+                "local,gatewayauth,gatewayremoteaccess,multi-channel,deployment",
             ]
         )
         self.assertEqual(alias_result.returncode, 0, msg=alias_result.stderr)
@@ -95,7 +103,13 @@ class DemoIndexTests(unittest.TestCase):
         alias_ids = [entry["id"] for entry in alias_payload["scenarios"]]
         self.assertEqual(
             alias_ids,
-            ["onboarding", "gateway-auth", "multi-channel-live", "deployment-wasm"],
+            [
+                "onboarding",
+                "gateway-auth",
+                "gateway-remote-access",
+                "multi-channel-live",
+                "deployment-wasm",
+            ],
         )
 
         unknown_result = run_command(
@@ -109,6 +123,11 @@ class DemoIndexTests(unittest.TestCase):
         command_names = [entry["name"] for entry in manifest["commands"]]
         self.assertIn("onboard-non-interactive", command_names)
         self.assertIn("gateway-remote-profile-token-auth", command_names)
+        self.assertIn("gateway-remote-plan-tailscale-serve", command_names)
+        self.assertIn(
+            "gateway-remote-plan-fails-closed-missing-funnel-password",
+            command_names,
+        )
         self.assertIn("deployment-wasm-package", command_names)
         self.assertIn("deployment-channel-store-inspect-edge-wasm", command_names)
 

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -21,7 +21,7 @@ List available scenarios without execution:
 Run only selected scenarios:
 
 ```bash
-./scripts/demo/index.sh --only onboarding,gateway-auth --fail-fast
+./scripts/demo/index.sh --only onboarding,gateway-auth,gateway-remote-access --fail-fast
 ```
 
 Write deterministic JSON summary:
@@ -50,6 +50,15 @@ Write deterministic JSON summary:
 - Troubleshooting checkpoint:
   - verify `--gateway-openresponses-auth-mode` and required token/password flags.
 
+### gateway-remote-access
+- Wrapper: `./scripts/demo/gateway-remote-access.sh`
+- Purpose: validate wave-9 profile inspect + remote-plan fail-closed guardrail behavior.
+- Expected markers:
+  - `[demo:gateway-remote-access] PASS gateway-remote-plan-export-tailscale-serve`
+  - `[demo:gateway-remote-access] PASS gateway-remote-plan-fails-closed-for-missing-password`
+- Troubleshooting checkpoint:
+  - inspect `.tau/demo-gateway-remote-access/trace.log`, then verify auth/profile flags.
+
 ### multi-channel-live
 - Wrapper: `./scripts/demo/multi-channel.sh`
 - Purpose: ingest live fixtures and verify transport health for Telegram, Discord, and WhatsApp.
@@ -75,6 +84,7 @@ The repository smoke manifest (`.github/demo-smoke-manifest.json`) includes ligh
 commands that cover the same workflow classes:
 - onboarding bootstrap
 - gateway auth posture inspect
+- gateway remote plan export + fail-closed guardrail contract
 - multi-channel live ingress (Telegram/Discord/WhatsApp)
 - deployment WASM package and inspect
 

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -59,6 +59,8 @@ Remote-access profile posture:
 - `--gateway-remote-profile local-only` (default)
 - `--gateway-remote-profile password-remote`
 - `--gateway-remote-profile proxy-remote`
+- `--gateway-remote-profile tailscale-serve`
+- `--gateway-remote-profile tailscale-funnel`
 
 Inspect remote-access posture without starting the gateway:
 
@@ -66,6 +68,14 @@ Inspect remote-access posture without starting the gateway:
 cargo run -p tau-coding-agent -- \
   --gateway-remote-profile-inspect \
   --gateway-remote-profile-json
+```
+
+Export remote workflow plans (fails closed when selected profile is unsafe):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-plan \
+  --gateway-remote-plan-json
 ```
 
 Detailed setup and rollback guidance:
@@ -221,6 +231,7 @@ Configurable guardrail thresholds (runner flags):
 
 ```bash
 ./scripts/demo/gateway.sh
+./scripts/demo/gateway-remote-access.sh
 ```
 
 ## Rollout plan with guardrails

--- a/docs/guides/gateway-remote-access.md
+++ b/docs/guides/gateway-remote-access.md
@@ -4,14 +4,20 @@ Run all commands from repository root.
 
 ## Scope
 
-This runbook covers safe remote-access posture checks for the OpenResponses gateway.
+This runbook covers safe remote-access posture checks for the OpenResponses gateway,
+including wave-9 profiles and deterministic guardrail validation.
 
-Profiles:
+Remote profiles:
 - `local-only`
 - `password-remote`
 - `proxy-remote`
 - `tailscale-serve`
 - `tailscale-funnel`
+
+Remote plan workflows exported by `--gateway-remote-plan`:
+- `tailscale-serve`
+- `tailscale-funnel`
+- `ssh-tunnel-fallback`
 
 ## Inspect posture without starting the gateway
 
@@ -30,57 +36,63 @@ cargo run -p tau-coding-agent -- \
   --gateway-remote-profile-json
 ```
 
-Inspect a proxy-remote plan before rollout:
+Inspect a tailscale-serve rollout posture:
 
 ```bash
 cargo run -p tau-coding-agent -- \
   --gateway-remote-profile-inspect \
   --gateway-openresponses-server \
-  --gateway-remote-profile proxy-remote \
+  --gateway-remote-profile tailscale-serve \
+  --gateway-openresponses-auth-mode token \
+  --gateway-openresponses-auth-token edge-token \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-remote-profile-json
+```
+
+Export the remote workflow plan (JSON):
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --gateway-remote-plan \
+  --gateway-remote-plan-json \
+  --gateway-openresponses-server \
+  --gateway-remote-profile tailscale-serve \
   --gateway-openresponses-auth-mode token \
   --gateway-openresponses-auth-token edge-token \
   --gateway-openresponses-bind 127.0.0.1:8787
 ```
 
-Inspect a tailscale-funnel plan before rollout:
+## Profile selection matrix
+
+| Profile | Intended exposure | Required auth mode | Required secret | Bind requirement | Common hold reason codes |
+| --- | --- | --- | --- | --- | --- |
+| `local-only` | workstation/local service | any | none | loopback recommended | `local_only_non_loopback_bind` |
+| `password-remote` | controlled remote operators | `password-session` | `--gateway-openresponses-auth-password` | loopback recommended | `password_remote_auth_mode_mismatch`, `password_remote_missing_password` |
+| `proxy-remote` | reverse proxy or private tunnel | `token` | `--gateway-openresponses-auth-token` | loopback recommended | `proxy_remote_auth_mode_mismatch`, `proxy_remote_missing_token` |
+| `tailscale-serve` | private tailnet access | `token` or `password-session` | token or password | loopback required | `tailscale_serve_non_loopback_bind`, `tailscale_serve_localhost_dev_auth_unsupported` |
+| `tailscale-funnel` | public funnel exposure | `password-session` | `--gateway-openresponses-auth-password` | loopback required | `tailscale_funnel_auth_mode_mismatch`, `tailscale_funnel_missing_password`, `tailscale_funnel_non_loopback_bind` |
+
+## Fail-closed troubleshooting
+
+- Symptom: `--gateway-remote-plan` exits non-zero.
+  Action: read `reason_codes` in stderr, then run `--gateway-remote-profile-inspect --gateway-remote-profile-json` with the same flags.
+- Symptom: selected `tailscale-funnel` profile fails with `tailscale_funnel_missing_password`.
+  Action: set non-empty `--gateway-openresponses-auth-password` and keep `--gateway-openresponses-auth-mode password-session`.
+- Symptom: selected profile fails with `*_non_loopback_bind`.
+  Action: force loopback bind (`127.0.0.1:8787` or `::1:8787`) and expose via tunnel/proxy.
+- Symptom: selected `tailscale-serve` profile fails with `tailscale_serve_localhost_dev_auth_unsupported`.
+  Action: switch to `token` or `password-session` auth mode and set the corresponding secret.
+- Symptom: profile fails with `*_server_disabled`.
+  Action: add `--gateway-openresponses-server` before remote profile/plan evaluation.
+
+## Deterministic demo path
 
 ```bash
-cargo run -p tau-coding-agent -- \
-  --gateway-remote-profile-inspect \
-  --gateway-openresponses-server \
-  --gateway-remote-profile tailscale-funnel \
-  --gateway-openresponses-auth-mode password-session \
-  --gateway-openresponses-auth-password edge-password \
-  --gateway-openresponses-bind 127.0.0.1:8787
+./scripts/demo/gateway-remote-access.sh
 ```
 
-## Profile guidance
-
-`local-only`:
-- intended for workstation/local service usage.
-- keep loopback bind (`127.0.0.1` or `::1`).
-
-`password-remote`:
-- intended for controlled remote operator access with session-token exchange.
-- requires `--gateway-openresponses-auth-mode password-session`.
-- requires non-empty `--gateway-openresponses-auth-password`.
-
-`proxy-remote`:
-- intended for exposure behind a trusted reverse proxy or tunnel.
-- requires `--gateway-openresponses-auth-mode token`.
-- requires non-empty `--gateway-openresponses-auth-token`.
-
-`tailscale-serve`:
-- intended for tailnet-only exposure while preserving loopback bind on host.
-- requires loopback bind (`127.0.0.1` or `::1`).
-- requires auth mode `token` or `password-session` (localhost-dev is rejected).
-- requires corresponding non-empty auth secret.
-
-`tailscale-funnel`:
-- intended for public exposure through Tailscale Funnel.
-- requires loopback bind (`127.0.0.1` or `::1`).
-- requires `--gateway-openresponses-auth-mode password-session`.
-- requires non-empty `--gateway-openresponses-auth-password`.
+Artifacts:
+- `.tau/demo-gateway-remote-access/trace.log` (deterministic command trace)
 
 ## Security recommendations
 

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -537,7 +537,7 @@ state persistence, and channel-store snapshots.
 cargo run -p tau-coding-agent -- \
   --model openai/gpt-4o-mini \
   --gateway-contract-runner \
-  --gateway-fixture crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
+  --gateway-fixture crates/tau-gateway/testdata/gateway-contract/rollout-pass.json \
   --gateway-state-dir .tau/gateway \
   --gateway-guardrail-failure-streak-threshold 2 \
   --gateway-guardrail-retryable-failures-threshold 2

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -24,6 +24,7 @@ demo_scripts=(
   "dashboard.sh"
   "gateway.sh"
   "gateway-auth.sh"
+  "gateway-remote-access.sh"
   "deployment.sh"
   "custom-command.sh"
   "voice.sh"
@@ -106,6 +107,10 @@ normalize_demo_name() {
       ;;
     gateway-auth|gatewayauth|gateway-auth.sh|gatewayauth.sh)
       echo "gateway-auth.sh"
+      return 0
+      ;;
+    gateway-remote-access|gatewayremoteaccess|gateway-remote-access.sh|gatewayremoteaccess.sh)
+      echo "gateway-remote-access.sh"
       return 0
       ;;
     deployment|deployment.sh)
@@ -230,14 +235,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/memory/dashboard/gateway/gateway-auth/deployment/custom-command/voice) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/memory/dashboard/gateway/gateway-auth/gateway-remote-access/deployment/custom-command/voice) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,memory,dashboard,gateway,gateway-auth,deployment,custom-command,voice)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,memory,dashboard,gateway,gateway-auth,gateway-remote-access,deployment,custom-command,voice)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/gateway-remote-access.sh
+++ b/scripts/demo/gateway-remote-access.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "gateway-remote-access" "Run deterministic remote-access profile inspect + fail-closed guardrail demo commands." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+demo_state_dir=".tau/demo-gateway-remote-access"
+trace_log_path="${TAU_DEMO_REPO_ROOT}/${demo_state_dir}/trace.log"
+
+tau_demo_common_prepare_binary
+
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+mkdir -p "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+export TAU_DEMO_TRACE_LOG="${trace_log_path}"
+: >"${trace_log_path}"
+
+tau_demo_common_run_step \
+  "gateway-remote-profile-inspect-local-only" \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile-json \
+  --gateway-state-dir "${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "gateway-remote-profile-inspect-tailscale-serve-token" \
+  --gateway-remote-profile-inspect \
+  --gateway-remote-profile tailscale-serve \
+  --gateway-openresponses-server \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-openresponses-auth-mode token \
+  --gateway-openresponses-auth-token demo-tailscale-token \
+  --gateway-remote-profile-json \
+  --gateway-state-dir "${demo_state_dir}"
+
+tau_demo_common_run_step \
+  "gateway-remote-plan-export-tailscale-serve" \
+  --gateway-remote-plan \
+  --gateway-remote-plan-json \
+  --gateway-remote-profile tailscale-serve \
+  --gateway-openresponses-server \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-openresponses-auth-mode token \
+  --gateway-openresponses-auth-token demo-tailscale-token \
+  --gateway-state-dir "${demo_state_dir}"
+
+tau_demo_common_run_expect_failure \
+  "gateway-remote-plan-fails-closed-for-missing-password" \
+  1 \
+  "tailscale_funnel_missing_password" \
+  --gateway-remote-plan \
+  --gateway-remote-profile tailscale-funnel \
+  --gateway-openresponses-server \
+  --gateway-openresponses-bind 127.0.0.1:8787 \
+  --gateway-openresponses-auth-mode password-session \
+  --gateway-state-dir "${demo_state_dir}"
+
+tau_demo_common_finish

--- a/scripts/demo/gateway.sh
+++ b/scripts/demo/gateway.sh
@@ -14,7 +14,7 @@ if [[ "${init_rc}" -ne 0 ]]; then
   exit "${init_rc}"
 fi
 
-fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json"
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-gateway/testdata/gateway-contract/rollout-pass.json"
 demo_state_dir=".tau/demo-gateway"
 
 tau_demo_common_require_file "${fixture_path}"
@@ -30,7 +30,7 @@ tau_demo_common_run_step \
 tau_demo_common_run_step \
   "gateway-runner" \
   --gateway-contract-runner \
-  --gateway-fixture ./crates/tau-coding-agent/testdata/gateway-contract/rollout-pass.json \
+  --gateway-fixture ./crates/tau-gateway/testdata/gateway-contract/rollout-pass.json \
   --gateway-state-dir "${demo_state_dir}"
 
 tau_demo_common_run_step \

--- a/scripts/demo/index.sh
+++ b/scripts/demo/index.sh
@@ -15,6 +15,7 @@ timeout_seconds=""
 scenario_ids=(
   "onboarding"
   "gateway-auth"
+  "gateway-remote-access"
   "multi-channel-live"
   "deployment-wasm"
 )
@@ -86,6 +87,9 @@ scenario_wrapper() {
     gateway-auth)
       echo "gateway-auth.sh"
       ;;
+    gateway-remote-access)
+      echo "gateway-remote-access.sh"
+      ;;
     multi-channel-live)
       echo "multi-channel.sh"
       ;;
@@ -106,6 +110,9 @@ scenario_description() {
       ;;
     gateway-auth)
       echo "Validate gateway remote profile auth posture for token and password-session modes."
+      ;;
+    gateway-remote-access)
+      echo "Validate remote profile inspect + remote plan fail-closed guardrails for wave-9 profiles."
       ;;
     multi-channel-live)
       echo "Exercise Telegram/Discord/WhatsApp fixture ingest and multi-channel routing health."
@@ -129,6 +136,10 @@ scenario_expected_markers() {
     gateway-auth)
       echo "[demo:gateway-auth] PASS gateway-remote-profile-token-mode"
       echo "[demo:gateway-auth] PASS gateway-remote-profile-password-session-mode"
+      ;;
+    gateway-remote-access)
+      echo "[demo:gateway-remote-access] PASS gateway-remote-plan-export-tailscale-serve"
+      echo "[demo:gateway-remote-access] PASS gateway-remote-plan-fails-closed-for-missing-password"
       ;;
     multi-channel-live)
       echo "[demo:multi-channel] PASS multi-channel-live-ingest-telegram"
@@ -154,6 +165,9 @@ scenario_troubleshooting_hint() {
     gateway-auth)
       echo "Check gateway auth flags (--gateway-openresponses-auth-mode/token/password) and rerun ./scripts/demo/gateway-auth.sh."
       ;;
+    gateway-remote-access)
+      echo "Check remote profile/auth flags and inspect .tau/demo-gateway-remote-access/trace.log before rerunning ./scripts/demo/gateway-remote-access.sh."
+      ;;
     multi-channel-live)
       echo "Confirm Telegram/Discord/WhatsApp fixture files exist and rerun ./scripts/demo/multi-channel.sh --fail-fast."
       ;;
@@ -175,6 +189,10 @@ normalize_scenario_name() {
       ;;
     gateway-auth|gatewayauth|gateway-auth.sh|gatewayauth.sh)
       echo "gateway-auth"
+      return 0
+      ;;
+    gateway-remote-access|gatewayremoteaccess|gateway-remote-access.sh|gatewayremoteaccess.sh)
+      echo "gateway-remote-access"
       return 0
       ;;
     multi-channel-live|multichannel-live|multi-channel|multi-channel-live.sh|multi-channel.sh)
@@ -329,6 +347,7 @@ Usage: index.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--on
 Run the operator-focused demo index for fresh-clone validation:
 - onboarding
 - gateway-auth
+- gateway-remote-access
 - multi-channel-live (Telegram/Discord/WhatsApp)
 - deployment-wasm
 
@@ -337,7 +356,7 @@ Options:
   --binary PATH      tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build       Skip cargo build and require --binary to exist
   --list             Print selected scenarios and exit without execution
-  --only SCENARIOS   Comma-separated subset (names: onboarding,gateway-auth,multi-channel-live,deployment-wasm)
+  --only SCENARIOS   Comma-separated subset (names: onboarding,gateway-auth,gateway-remote-access,multi-channel-live,deployment-wasm)
   --json             Emit deterministic JSON output for list/summary modes
   --report-file      Write deterministic JSON report artifact to path
   --fail-fast        Stop after first failed scenario


### PR DESCRIPTION
## Summary
- add deterministic `gateway-remote-access` demo wrapper that validates remote-profile inspect and fail-closed guardrail behavior
- extend demo index/all discovery and docs to include the new remote-access scenario plus wave-9 profile guidance
- add expected-failure contract support to demo smoke runner (`expected_exit_code`, `stdout_contains`, `stderr_contains`) and cover it with unit/functional/regression tests
- add CI smoke commands for remote plan export + fail-closed funnel guardrail, and fix stale fixture paths moved to `tau-multi-channel` / `tau-gateway`

## Testing
- `bash -n scripts/demo/common.sh scripts/demo/all.sh scripts/demo/index.sh scripts/demo/gateway-remote-access.sh scripts/demo/gateway.sh`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_smoke_runner.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_demo_index.py"`
- `cargo build -p tau-coding-agent`
- `bash scripts/demo/gateway-remote-access.sh --skip-build --binary target/debug/tau-coding-agent --timeout-seconds 20`
- `python3 .github/scripts/demo_smoke_runner.py --repo-root . --manifest .github/demo-smoke-manifest.json --binary target/debug/tau-coding-agent --log-dir ci-artifacts/demo-smoke-local --summary ci-artifacts/demo-smoke-local/summary.md`
- `bash scripts/demo/all.sh --list --only gateway-remote-access`
- `bash scripts/demo/index.sh --skip-build --binary target/debug/tau-coding-agent --only gateway-remote-access --fail-fast`
- `cargo test -p tau-cli gateway_remote_profile`

Closes #930