### PR TITLE
refactor(startup): extract command-file runtime from coding-agent

### DIFF
--- a/crates/tau-coding-agent/src/bootstrap_helpers.rs
+++ b/crates/tau-coding-agent/src/bootstrap_helpers.rs
@@ -1,15 +1,6 @@
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
-use crate::CliCommandFileErrorMode;
-
-pub(crate) fn command_file_error_mode_label(mode: CliCommandFileErrorMode) -> &'static str {
-    match mode {
-        CliCommandFileErrorMode::FailFast => "fail-fast",
-        CliCommandFileErrorMode::ContinueOnError => "continue-on-error",
-    }
-}
-
 pub(crate) fn init_tracing() {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::WARN.into())

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -64,7 +64,7 @@ pub(crate) use tau_skills as skills_commands;
 pub(crate) use crate::auth_commands::execute_auth_command;
 #[cfg(test)]
 pub(crate) use crate::auth_commands::{parse_auth_command, AuthCommand};
-pub(crate) use crate::bootstrap_helpers::{command_file_error_mode_label, init_tracing};
+pub(crate) use crate::bootstrap_helpers::init_tracing;
 pub(crate) use crate::canvas::{
     execute_canvas_command, CanvasCommandConfig, CanvasEventOrigin, CanvasSessionLinkContext,
 };
@@ -369,6 +369,8 @@ pub(crate) use tau_session::{
     format_id_list, format_remap_ids, initialize_session, session_lineage_messages, SessionRuntime,
 };
 pub(crate) use tau_session::{session_message_preview, session_message_role};
+#[cfg(test)]
+pub(crate) use tau_startup::command_file_error_mode_label;
 
 pub(crate) fn normalize_daemon_subcommand_args(args: Vec<String>) -> Vec<String> {
     if args.len() < 3 || args[1] != "daemon" {

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -21,12 +21,14 @@ use tau_gateway::{
 use tau_session::validate_session_file;
 
 pub mod runtime_types;
+pub mod startup_command_file_runtime;
 pub mod startup_model_catalog;
 pub mod startup_multi_channel_adapters;
 pub mod startup_multi_channel_commands;
 pub mod startup_rpc_capabilities_command;
 
 pub use runtime_types::*;
+pub use startup_command_file_runtime::*;
 pub use startup_model_catalog::*;
 pub use startup_multi_channel_adapters::*;
 pub use startup_multi_channel_commands::*;

--- a/crates/tau-startup/src/startup_command_file_runtime.rs
+++ b/crates/tau-startup/src/startup_command_file_runtime.rs
@@ -1,0 +1,329 @@
+use anyhow::{bail, Result};
+use std::path::Path;
+use tau_cli::{parse_command_file, CliCommandFileErrorMode, CommandFileReport};
+
+/// Public enum `CommandFileAction` used across Tau components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandFileAction {
+    Continue,
+    Exit,
+}
+
+pub fn command_file_error_mode_label(mode: CliCommandFileErrorMode) -> &'static str {
+    match mode {
+        CliCommandFileErrorMode::FailFast => "fail-fast",
+        CliCommandFileErrorMode::ContinueOnError => "continue-on-error",
+    }
+}
+
+pub fn execute_command_file_with_handler<F>(
+    path: &Path,
+    mode: CliCommandFileErrorMode,
+    mut handle_command: F,
+) -> Result<CommandFileReport>
+where
+    F: FnMut(&str) -> Result<CommandFileAction>,
+{
+    let entries = parse_command_file(path)?;
+    let mut report = CommandFileReport {
+        total: entries.len(),
+        executed: 0,
+        succeeded: 0,
+        failed: 0,
+        halted_early: false,
+    };
+
+    for entry in entries {
+        report.executed += 1;
+
+        if !entry.command.starts_with('/') {
+            report.failed += 1;
+            println!(
+                "command file error: path={} line={} command={} error=command must start with '/'",
+                path.display(),
+                entry.line_number,
+                entry.command
+            );
+            if mode == CliCommandFileErrorMode::FailFast {
+                report.halted_early = true;
+                break;
+            }
+            continue;
+        }
+
+        match handle_command(&entry.command) {
+            Ok(CommandFileAction::Continue) => {
+                report.succeeded += 1;
+            }
+            Ok(CommandFileAction::Exit) => {
+                report.succeeded += 1;
+                report.halted_early = true;
+                println!(
+                    "command file notice: path={} line={} command={} action=exit",
+                    path.display(),
+                    entry.line_number,
+                    entry.command
+                );
+                break;
+            }
+            Err(error) => {
+                report.failed += 1;
+                println!(
+                    "command file error: path={} line={} command={} error={error}",
+                    path.display(),
+                    entry.line_number,
+                    entry.command
+                );
+                if mode == CliCommandFileErrorMode::FailFast {
+                    report.halted_early = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    println!(
+        "command file summary: path={} mode={} total={} executed={} succeeded={} failed={} halted_early={}",
+        path.display(),
+        command_file_error_mode_label(mode),
+        report.total,
+        report.executed,
+        report.succeeded,
+        report.failed,
+        report.halted_early
+    );
+
+    if mode == CliCommandFileErrorMode::FailFast && report.failed > 0 {
+        bail!(
+            "command file execution failed: path={} failed={} mode={}",
+            path.display(),
+            report.failed,
+            command_file_error_mode_label(mode)
+        );
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        command_file_error_mode_label, execute_command_file_with_handler, CommandFileAction,
+    };
+    use anyhow::{anyhow, Result};
+    use std::sync::{Arc, Mutex};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tau_cli::CliCommandFileErrorMode;
+
+    struct TempCommandFile {
+        path: PathBuf,
+        root: PathBuf,
+    }
+
+    impl TempCommandFile {
+        fn write(contents: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            let root = std::env::temp_dir()
+                .join("tau-startup-command-file-runtime")
+                .join(format!("case-{unique}"));
+            fs::create_dir_all(&root).expect("create temp command file root");
+            let path = root.join("commands.txt");
+            fs::write(&path, contents).expect("write command file");
+            Self { path, root }
+        }
+    }
+
+    impl Drop for TempCommandFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn unit_command_file_error_mode_label_matches_cli_values() {
+        assert_eq!(
+            command_file_error_mode_label(CliCommandFileErrorMode::FailFast),
+            "fail-fast"
+        );
+        assert_eq!(
+            command_file_error_mode_label(CliCommandFileErrorMode::ContinueOnError),
+            "continue-on-error"
+        );
+    }
+
+    #[test]
+    fn functional_execute_command_file_runs_script_and_returns_summary() {
+        let command_file = TempCommandFile::write("/session\n/help session\n");
+        let observed_commands = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_commands_clone = Arc::clone(&observed_commands);
+
+        let report = execute_command_file_with_handler(
+            &command_file.path,
+            CliCommandFileErrorMode::FailFast,
+            |command| {
+                observed_commands_clone
+                    .lock()
+                    .expect("lock observed commands")
+                    .push(command.to_string());
+                Ok(CommandFileAction::Continue)
+            },
+        )
+        .expect("command file should execute");
+
+        assert_eq!(report.total, 2);
+        assert_eq!(report.executed, 2);
+        assert_eq!(report.succeeded, 2);
+        assert_eq!(report.failed, 0);
+        assert!(!report.halted_early);
+        assert_eq!(
+            observed_commands
+                .lock()
+                .expect("lock observed commands")
+                .as_slice(),
+            ["/session", "/help session"]
+        );
+    }
+
+    #[test]
+    fn integration_execute_command_file_continue_on_error_runs_remaining_commands() {
+        let command_file = TempCommandFile::write("/session\nnot-command\n/help session\n");
+        let observed_commands = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_commands_clone = Arc::clone(&observed_commands);
+
+        let report = execute_command_file_with_handler(
+            &command_file.path,
+            CliCommandFileErrorMode::ContinueOnError,
+            |command| {
+                observed_commands_clone
+                    .lock()
+                    .expect("lock observed commands")
+                    .push(command.to_string());
+                Ok(CommandFileAction::Continue)
+            },
+        )
+        .expect("continue-on-error mode should not fail");
+
+        assert_eq!(report.total, 3);
+        assert_eq!(report.executed, 3);
+        assert_eq!(report.succeeded, 2);
+        assert_eq!(report.failed, 1);
+        assert!(!report.halted_early);
+        assert_eq!(
+            observed_commands
+                .lock()
+                .expect("lock observed commands")
+                .as_slice(),
+            ["/session", "/help session"]
+        );
+    }
+
+    #[test]
+    fn regression_execute_command_file_fail_fast_stops_on_malformed_line() {
+        let command_file = TempCommandFile::write("/session\nnot-command\n/help session\n");
+        let observed_commands = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_commands_clone = Arc::clone(&observed_commands);
+
+        let error = execute_command_file_with_handler(
+            &command_file.path,
+            CliCommandFileErrorMode::FailFast,
+            |command| {
+                observed_commands_clone
+                    .lock()
+                    .expect("lock observed commands")
+                    .push(command.to_string());
+                Ok(CommandFileAction::Continue)
+            },
+        )
+        .expect_err("fail-fast mode should return error for malformed line");
+
+        assert!(error.to_string().contains("command file execution failed"));
+        assert!(error.to_string().contains("mode=fail-fast"));
+        assert_eq!(
+            observed_commands
+                .lock()
+                .expect("lock observed commands")
+                .as_slice(),
+            ["/session"]
+        );
+    }
+
+    #[test]
+    fn regression_execute_command_file_exit_action_halts_early() {
+        let command_file = TempCommandFile::write("/session\n/quit\n/help session\n");
+        let observed_commands = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_commands_clone = Arc::clone(&observed_commands);
+
+        let report = execute_command_file_with_handler(
+            &command_file.path,
+            CliCommandFileErrorMode::FailFast,
+            |command| {
+                observed_commands_clone
+                    .lock()
+                    .expect("lock observed commands")
+                    .push(command.to_string());
+                if command == "/quit" {
+                    Ok(CommandFileAction::Exit)
+                } else {
+                    Ok(CommandFileAction::Continue)
+                }
+            },
+        )
+        .expect("exit action should still return successful report");
+
+        assert_eq!(report.total, 3);
+        assert_eq!(report.executed, 2);
+        assert_eq!(report.succeeded, 2);
+        assert_eq!(report.failed, 0);
+        assert!(report.halted_early);
+        assert_eq!(
+            observed_commands
+                .lock()
+                .expect("lock observed commands")
+                .as_slice(),
+            ["/session", "/quit"]
+        );
+    }
+
+    #[test]
+    fn regression_execute_command_file_continue_on_error_surfaces_handler_errors() {
+        let command_file = TempCommandFile::write("/session\n/help session\n");
+        let observed_commands = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_commands_clone = Arc::clone(&observed_commands);
+
+        let report = execute_command_file_with_handler(
+            &command_file.path,
+            CliCommandFileErrorMode::ContinueOnError,
+            |command| -> Result<CommandFileAction> {
+                observed_commands_clone
+                    .lock()
+                    .expect("lock observed commands")
+                    .push(command.to_string());
+                if command == "/help session" {
+                    return Err(anyhow!("simulated handler failure"));
+                }
+                Ok(CommandFileAction::Continue)
+            },
+        )
+        .expect("continue-on-error should allow handler failure");
+
+        assert_eq!(report.total, 2);
+        assert_eq!(report.executed, 2);
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.failed, 1);
+        assert!(!report.halted_early);
+        assert_eq!(
+            observed_commands
+                .lock()
+                .expect("lock observed commands")
+                .as_slice(),
+            ["/session", "/help session"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- extract command-file runtime (`execute_command_file`) from `tau-coding-agent` into new `tau-startup::startup_command_file_runtime` module
- move command-file error-mode label mapping into `tau-startup` and keep `tau-coding-agent` as a thin compatibility shim
- simplify `tau-coding-agent::commands::execute_command_file` to delegate through a closure adapter
- add focused `tau-startup` tests covering unit/functional/integration/regression command-file execution behavior

## Testing
- `cargo fmt --all`
- `cargo test -p tau-startup`
- `cargo test -p tau-coding-agent execute_command_file -- --test-threads=1`
- `cargo test -p tau-coding-agent command_file_error_mode_label_matches_cli_values -- --test-threads=1`
- `cargo clippy -p tau-startup --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings`

Refs #933