### PR TITLE
refactor: extract session status/import/export/branches runtime into tau-session

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -143,9 +143,7 @@ pub(crate) use crate::runtime_loop::{
 };
 #[cfg(test)]
 pub(crate) use crate::runtime_output::stream_text_chunks;
-pub(crate) use crate::runtime_output::{
-    event_to_json, persist_messages, print_assistant_messages, summarize_message,
-};
+pub(crate) use crate::runtime_output::{event_to_json, persist_messages, print_assistant_messages};
 pub(crate) use crate::runtime_types::{
     AuthCommandConfig, CommandExecutionContext, ProfileDefaults, RenderOptions,
     SkillsSyncCommandConfig,
@@ -341,6 +339,8 @@ pub(crate) use tau_session::execute_session_graph_export_command;
 #[cfg(test)]
 pub(crate) use tau_session::format_id_list;
 #[cfg(test)]
+pub(crate) use tau_session::format_remap_ids;
+#[cfg(test)]
 pub(crate) use tau_session::validate_session_file;
 use tau_session::SessionImportMode;
 #[cfg(test)]
@@ -367,9 +367,7 @@ pub(crate) use tau_session::{
     resolve_session_graph_format, SessionGraphFormat,
 };
 pub(crate) use tau_session::{execute_branch_alias_command, execute_session_bookmark_command};
-pub(crate) use tau_session::{
-    format_remap_ids, initialize_session, session_lineage_messages, SessionRuntime,
-};
+pub(crate) use tau_session::{initialize_session, session_lineage_messages, SessionRuntime};
 pub(crate) use tau_session::{session_message_preview, session_message_role};
 #[cfg(test)]
 pub(crate) use tau_startup::command_file_error_mode_label;

--- a/crates/tau-coding-agent/src/runtime_output.rs
+++ b/crates/tau-coding-agent/src/runtime_output.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-pub(crate) fn summarize_message(message: &Message) -> String {
-    tau_runtime::runtime_output_runtime::summarize_message(message)
-}
-
 pub(crate) fn persist_messages(
     session_runtime: &mut Option<SessionRuntime>,
     new_messages: &[Message],


### PR DESCRIPTION
## Summary
- extract `/session`, `/session-export`, `/session-import`, and `/branches` runtime handlers from `tau-coding-agent::commands` into `tau-session::session_runtime_commands`
- keep `tau-coding-agent` as a thin orchestrator for those paths (session-disabled checks + lineage reload after imports)
- add focused `tau-session` unit/functional/integration/regression tests for the extracted runtime command surface
- remove now-unused `summarize_message` shim from `tau-coding-agent::runtime_output`

## Validation
- `cargo fmt --all`
- `cargo test -p tau-session`
- `cargo test -p tau-coding-agent --bin tau-coding-agent execute_command_file -- --test-threads=1`
- `cargo test -p tau-coding-agent --bin tau-coding-agent command_file_error_mode_label_matches_cli_values -- --test-threads=1`
- `cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1`
- `cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1`
- `cargo test -p tau-coding-agent --test examples_assets`
- `cargo clippy -p tau-session --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings`

Refs #933
