### PR TITLE
refactor: extract session command dispatch runtime into tau-session

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -10,10 +10,11 @@ use tau_cli::{canonical_command_name, normalize_help_topic, parse_command, Comma
 pub(crate) use tau_ops::COMMAND_NAMES;
 use tau_session::{
     execute_branch_switch_command, execute_branches_command, execute_resume_command,
-    execute_session_compact_command, execute_session_diff_command, execute_session_export_command,
-    execute_session_import_command, execute_session_repair_command, execute_session_search_command,
-    execute_session_stats_command, execute_session_status_command, parse_session_diff_args,
-    parse_session_stats_args,
+    execute_session_compact_command, execute_session_diff_runtime_command,
+    execute_session_export_command, execute_session_graph_export_runtime_command,
+    execute_session_import_command, execute_session_repair_command,
+    execute_session_search_runtime_command, execute_session_stats_runtime_command,
+    execute_session_status_command,
 };
 use tau_startup::{execute_command_file_with_handler, CommandFileAction};
 
@@ -326,12 +327,8 @@ pub(crate) fn handle_command_with_session_import_mode(
             println!("session is disabled");
             return Ok(CommandAction::Continue);
         };
-        if command_args.trim().is_empty() {
-            println!("usage: /session-search <query> [--role <role>] [--limit <n>]");
-            return Ok(CommandAction::Continue);
-        }
-
-        println!("{}", execute_session_search_command(runtime, command_args));
+        let outcome = execute_session_search_runtime_command(command_args, runtime);
+        println!("{}", outcome.message);
         return Ok(CommandAction::Continue);
     }
 
@@ -340,15 +337,8 @@ pub(crate) fn handle_command_with_session_import_mode(
             println!("session is disabled");
             return Ok(CommandAction::Continue);
         };
-        let format = match parse_session_stats_args(command_args) {
-            Ok(format) => format,
-            Err(_) => {
-                println!("usage: /session-stats [--json]");
-                return Ok(CommandAction::Continue);
-            }
-        };
-
-        println!("{}", execute_session_stats_command(runtime, format));
+        let outcome = execute_session_stats_runtime_command(command_args, runtime);
+        println!("{}", outcome.message);
         return Ok(CommandAction::Continue);
     }
 
@@ -357,15 +347,8 @@ pub(crate) fn handle_command_with_session_import_mode(
             println!("session is disabled");
             return Ok(CommandAction::Continue);
         };
-        let heads = match parse_session_diff_args(command_args) {
-            Ok(heads) => heads,
-            Err(_) => {
-                println!("usage: /session-diff [<left-id> <right-id>]");
-                return Ok(CommandAction::Continue);
-            }
-        };
-
-        println!("{}", execute_session_diff_command(runtime, heads));
+        let outcome = execute_session_diff_runtime_command(command_args, runtime);
+        println!("{}", outcome.message);
         return Ok(CommandAction::Continue);
     }
 
@@ -387,15 +370,8 @@ pub(crate) fn handle_command_with_session_import_mode(
             println!("session is disabled");
             return Ok(CommandAction::Continue);
         };
-        if command_args.trim().is_empty() {
-            println!("usage: /session-graph-export <path>");
-            return Ok(CommandAction::Continue);
-        }
-
-        println!(
-            "{}",
-            execute_session_graph_export_command(runtime, command_args)
-        );
+        let outcome = execute_session_graph_export_runtime_command(command_args, runtime);
+        println!("{}", outcome.message);
         return Ok(CommandAction::Continue);
     }
 

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -335,6 +335,7 @@ pub(crate) use tau_provider::{
 };
 #[cfg(test)]
 pub(crate) use tau_provider::{parse_integration_auth_command, IntegrationAuthCommand};
+#[cfg(test)]
 pub(crate) use tau_session::execute_session_graph_export_command;
 #[cfg(test)]
 pub(crate) use tau_session::format_id_list;


### PR DESCRIPTION
## Summary
- extract session command-dispatch runtime for `/session-search`, `/session-stats`, `/session-diff`, and `/session-graph-export` from `tau-coding-agent::commands` into `tau-session::session_runtime_commands`
- keep `tau-coding-agent` as orchestration-only for those paths (session-disabled checks + output printing)
- add focused `tau-session` tests (unit/functional/integration/regression) for the extracted runtime-dispatch surface
- harden `tau-session` runtime-command test fixtures with an atomic counter to avoid temp-path lock collisions under parallel tests

## Validation
- `cargo fmt --all`
- `cargo test -p tau-session`
- `cargo test -p tau-coding-agent --bin tau-coding-agent execute_command_file -- --test-threads=1`
- `cargo test -p tau-coding-agent --bin tau-coding-agent command_file_error_mode_label_matches_cli_values -- --test-threads=1`
- `cargo test -p tau-coding-agent --bin tau-coding-agent -- --test-threads=1`
- `cargo test -p tau-coding-agent --test cli_integration -- --test-threads=1`
- `cargo test -p tau-coding-agent --test examples_assets`
- `cargo clippy -p tau-session --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --bin tau-coding-agent --tests -- -D warnings`

Refs #933
