### PR TITLE
feat(agent-core): enforce per-request and per-tool timeouts

### DIFF
--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde_json::Value;
 #[cfg(test)]
 use tau_agent_core::Agent;
-use tau_agent_core::AgentEvent;
+use tau_agent_core::{AgentConfig, AgentEvent};
 use tau_ai::{LlmClient, ModelRef};
 use tau_cli::Cli;
 use tau_session::initialize_session;
@@ -68,6 +68,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
         skills_lock_path,
     } = config;
 
+    let agent_defaults = AgentConfig::default();
     let mut agent = build_onboarding_local_runtime_agent(
         client,
         model_ref,
@@ -79,6 +80,8 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
             request_max_retries: cli.agent_request_max_retries,
             request_retry_initial_backoff_ms: cli.agent_request_retry_initial_backoff_ms,
             request_retry_max_backoff_ms: cli.agent_request_retry_max_backoff_ms,
+            request_timeout_ms: agent_defaults.request_timeout_ms,
+            tool_timeout_ms: agent_defaults.tool_timeout_ms,
         },
         tool_policy,
     );

--- a/crates/tau-onboarding/src/startup_local_runtime.rs
+++ b/crates/tau-onboarding/src/startup_local_runtime.rs
@@ -25,6 +25,8 @@ pub struct LocalRuntimeAgentSettings {
     pub request_max_retries: usize,
     pub request_retry_initial_backoff_ms: u64,
     pub request_retry_max_backoff_ms: u64,
+    pub request_timeout_ms: Option<u64>,
+    pub tool_timeout_ms: Option<u64>,
 }
 
 pub fn build_local_runtime_agent(
@@ -47,6 +49,8 @@ pub fn build_local_runtime_agent(
             request_max_retries: settings.request_max_retries,
             request_retry_initial_backoff_ms: settings.request_retry_initial_backoff_ms,
             request_retry_max_backoff_ms: settings.request_retry_max_backoff_ms,
+            request_timeout_ms: settings.request_timeout_ms,
+            tool_timeout_ms: settings.tool_timeout_ms,
         },
     );
     register_builtin_tools(&mut agent, tool_policy);
@@ -1022,6 +1026,8 @@ mod tests {
                 request_max_retries: 2,
                 request_retry_initial_backoff_ms: 200,
                 request_retry_max_backoff_ms: 2_000,
+                request_timeout_ms: Some(120_000),
+                tool_timeout_ms: Some(120_000),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1052,6 +1058,8 @@ mod tests {
                 request_max_retries: 2,
                 request_retry_initial_backoff_ms: 200,
                 request_retry_max_backoff_ms: 2_000,
+                request_timeout_ms: Some(120_000),
+                tool_timeout_ms: Some(120_000),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1085,6 +1093,8 @@ mod tests {
                 request_max_retries: 2,
                 request_retry_initial_backoff_ms: 200,
                 request_retry_max_backoff_ms: 2_000,
+                request_timeout_ms: Some(120_000),
+                tool_timeout_ms: Some(120_000),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1112,6 +1122,8 @@ mod tests {
                 request_max_retries: 2,
                 request_retry_initial_backoff_ms: 200,
                 request_retry_max_backoff_ms: 2_000,
+                request_timeout_ms: Some(120_000),
+                tool_timeout_ms: Some(120_000),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );


### PR DESCRIPTION
## Summary
- add request and tool timeout controls to `AgentConfig` with safe defaults
  - `request_timeout_ms: Some(120_000)`
  - `tool_timeout_ms: Some(120_000)`
- enforce per-request timeout in `complete_with_retry` with retry-aware behavior
  - timeout errors now surface as `AgentError::RequestTimeout`
- enforce per-tool timeout in tool execution path and return structured tool error payloads on timeout
- propagate new timeout settings through onboarding and local runtime agent wiring

## Tests
- `cargo fmt --all`
- `cargo test -p tau-agent-core`
- `cargo test -p tau-onboarding --lib startup_local_runtime::tests`
- `cargo check -p tau-coding-agent`
- `cargo clippy -p tau-agent-core -p tau-onboarding -p tau-coding-agent --all-targets -- -D warnings`

## Behavior Notes
- request timeouts retry only when retries remain and streaming is disabled (existing retry policy preserved)
- tool timeouts fail closed as tool-result errors without crashing the turn

Closes #1182
