### PR TITLE
feat(agent-core): add estimated token budget enforcement

### DIFF
--- a/crates/tau-onboarding/src/startup_local_runtime.rs
+++ b/crates/tau-onboarding/src/startup_local_runtime.rs
@@ -51,6 +51,7 @@ pub fn build_local_runtime_agent(
             request_retry_max_backoff_ms: settings.request_retry_max_backoff_ms,
             request_timeout_ms: settings.request_timeout_ms,
             tool_timeout_ms: settings.tool_timeout_ms,
+            ..AgentConfig::default()
         },
     );
     register_builtin_tools(&mut agent, tool_policy);


### PR DESCRIPTION
## Summary
- add estimated token budget controls to `AgentConfig`
  - `max_estimated_input_tokens` (default: `Some(120_000)`)
  - `max_estimated_total_tokens` (default: `None`)
- add preflight request token estimation and enforcement in `tau-agent-core`
  - request is rejected before provider dispatch when estimated budgets are exceeded
  - new error variant: `AgentError::TokenBudgetExceeded`
- include estimator coverage for messages, tool call blocks, tool definitions, and requested `max_tokens`
- update onboarding agent construction to include `..AgentConfig::default()` for forward compatibility

## Tests
- `cargo fmt --all`
- `cargo test -p tau-agent-core`
- `cargo test -p tau-onboarding --lib startup_local_runtime::tests`
- `cargo check -p tau-coding-agent`
- `cargo clippy -p tau-agent-core -p tau-onboarding -p tau-coding-agent --all-targets -- -D warnings`

## Behavior Notes
- budget failures are fail-closed and occur before any provider call
- setting both budget fields to `None` disables the estimation gate

Closes #1183
