### PR TITLE
fix(runtime): close phase-1 runtime bug map items (#1186)

### DIFF
--- a/docs/tau-coding-agent/phase1-runtime-bug-map.md
+++ b/docs/tau-coding-agent/phase1-runtime-bug-map.md
@@ -1,0 +1,33 @@
+# Phase 1 Runtime Bug Map
+
+This document maps the legacy bug IDs referenced by `#1186` to the current Tau runtime implementation.
+
+## Bug #1: Tool calls executed serially inside a turn
+
+- Status: fixed
+- Runtime behavior:
+  - tool calls execute with bounded parallelism via `AgentConfig.max_parallel_tool_calls`
+  - execution path is in `crates/tau-agent-core/src/lib.rs` (`execute_tool_calls`)
+- Coverage:
+  - integration: `integration_parallel_tool_execution_runs_calls_concurrently_and_preserves_order`
+  - regression: `regression_bug_1_max_parallel_tool_calls_zero_clamps_to_safe_serial_execution`
+
+## Bug #3: Streaming render path blocked runtime threads
+
+- Status: fixed
+- Runtime behavior:
+  - async token streaming path uses `tokio::time::sleep` in `run_prompt_with_cancellation`
+  - sync fallback render path no longer applies blocking per-chunk delay
+- Coverage:
+  - unit: `unit_print_assistant_messages_stream_fallback_avoids_blocking_delay`
+  - functional: `functional_run_prompt_with_cancellation_stream_fallback_avoids_blocking_delay`
+
+## Bug #6: No safe parallel execution API for library consumers
+
+- Status: fixed
+- Runtime behavior:
+  - `Agent::fork` clones runtime state for isolated runs
+  - `Agent::run_parallel_prompts` executes bounded concurrent prompts with deterministic ordering
+- Coverage:
+  - integration: `integration_run_parallel_prompts_executes_runs_concurrently_with_ordered_results`
+  - integration: `integration_bug_6_run_parallel_prompts_allows_zero_parallel_limit`


### PR DESCRIPTION
## Summary
- remove blocking per-chunk sleep from sync fallback assistant rendering in `tau-runtime`
- add explicit regression coverage for bug-map items #1 and #6 in `tau-agent-core`
- add functional coverage in `tau-coding-agent` to ensure stream fallback no longer blocks on `stream_delay_ms`
- add documentation mapping for legacy bug IDs and their current runtime/test coverage (`docs/tau-coding-agent/phase1-runtime-bug-map.md`)

## Testing
- `cargo fmt --all`
- `cargo test -p tau-runtime`
- `cargo test -p tau-agent-core`
- `cargo test -p tau-coding-agent run_prompt_with_cancellation`
- `cargo check --workspace`
- `cargo clippy -p tau-runtime -p tau-agent-core -p tau-coding-agent --all-targets -- -D warnings`

Closes #1186
