### PR TITLE
feat(agent-core): add bounded ReAct replanning on tool failure (#1187)

### DIFF
--- a/crates/tau-runtime/src/runtime_output_runtime.rs
+++ b/crates/tau-runtime/src/runtime_output_runtime.rs
@@ -133,6 +133,11 @@ pub fn event_to_json(event: &AgentEvent) -> serde_json::Value {
             "is_error": result.is_error,
             "content": result.content,
         }),
+        AgentEvent::ReplanTriggered { turn, reason } => serde_json::json!({
+            "type": "replan_triggered",
+            "turn": turn,
+            "reason": reason,
+        }),
     }
 }
 
@@ -185,6 +190,18 @@ mod tests {
         assert_eq!(value["tool_name"], "write");
         assert_eq!(value["is_error"], false);
         assert_eq!(value["content"]["ok"], true);
+    }
+
+    #[test]
+    fn unit_event_to_json_maps_replan_triggered_shape() {
+        let event = AgentEvent::ReplanTriggered {
+            turn: 2,
+            reason: "tool failure".to_string(),
+        };
+        let value = event_to_json(&event);
+        assert_eq!(value["type"], "replan_triggered");
+        assert_eq!(value["turn"], 2);
+        assert_eq!(value["reason"], "tool failure");
     }
 
     #[test]

--- a/docs/tau-coding-agent/react-replan-loop.md
+++ b/docs/tau-coding-agent/react-replan-loop.md
@@ -1,0 +1,28 @@
+# ReAct Replan Loop (Issue #1187)
+
+Tau now supports bounded replanning when a tool turn fully fails and the assistant reports failure instead of continuing execution.
+
+## Runtime behavior
+
+- Config:
+  - `AgentConfig.react_max_replans_on_tool_failure` (default `1`)
+- Trigger conditions:
+  - previous turn had tool calls and all tool results were errors
+  - current assistant response has no tool calls
+  - assistant text is empty or contains failure markers (`cannot`, `unable`, `failed`, `error`, etc.)
+- Action:
+  - emits `AgentEvent::ReplanTriggered { turn, reason }`
+  - appends a user replan instruction asking the model to choose an alternative tool path
+  - continues the loop up to the configured replan budget
+
+## Observability
+
+- `AgentEvent::ReplanTriggered` is serialized by runtime event JSON as:
+  - `type: "replan_triggered"`
+  - `turn`
+  - `reason`
+
+## Safety model
+
+- Default behavior is bounded (`1`) to avoid runaway loops.
+- Set `react_max_replans_on_tool_failure` to `0` to disable replanning.


### PR DESCRIPTION
## Summary
- add bounded replanning controls to `AgentConfig` via `react_max_replans_on_tool_failure` (default `1`)
- track per-turn tool execution stats and detect all-failed tool turns
- when all tool calls fail and the next assistant message indicates failure, emit `AgentEvent::ReplanTriggered`, inject a user replan instruction, and continue the loop
- serialize `ReplanTriggered` in runtime JSON events (`type: replan_triggered`)
- add runtime documentation for the replanning model at `docs/tau-coding-agent/react-replan-loop.md`

## Testing
- `cargo fmt --all`
- `cargo test -p tau-agent-core`
- `cargo test -p tau-runtime`
- `cargo test -p tau-coding-agent run_prompt_with_cancellation`
- `cargo check --workspace`
- `cargo clippy -p tau-agent-core -p tau-runtime -p tau-coding-agent --all-targets -- -D warnings`

Closes #1187
