### PR TITLE
feat(ai): utilize provider tool choice/json mode/retry-after

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,7 @@ name = "tau-ai"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "futures-util",
  "httpmock",
  "reqwest 0.12.28",

--- a/crates/tau-ai/Cargo.toml
+++ b/crates/tau-ai/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+chrono.workspace = true
 futures-util.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/tau-ai/src/lib.rs
+++ b/crates/tau-ai/src/lib.rs
@@ -12,5 +12,5 @@ pub use openai::{OpenAiAuthScheme, OpenAiClient, OpenAiConfig};
 pub use provider::{ModelRef, ModelRefParseError, Provider};
 pub use types::{
     ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError, ToolCall, ToolDefinition,
+    StreamDeltaHandler, TauAiError, ToolCall, ToolChoice, ToolDefinition,
 };

--- a/crates/tau-ai/src/types.rs
+++ b/crates/tau-ai/src/types.rs
@@ -153,12 +153,26 @@ pub struct ToolDefinition {
     pub parameters: Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+/// Enumerates supported `ToolChoice` values.
+pub enum ToolChoice {
+    Auto,
+    None,
+    Required,
+    Tool { name: String },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Public struct `ChatRequest` used across Tau components.
 pub struct ChatRequest {
     pub model: String,
     pub messages: Vec<Message>,
     pub tools: Vec<ToolDefinition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(default)]
+    pub json_mode: bool,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f32>,
 }

--- a/crates/tau-ai/tests/provider_contract_conformance.rs
+++ b/crates/tau-ai/tests/provider_contract_conformance.rs
@@ -3,7 +3,8 @@ use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 use tau_ai::{
     AnthropicClient, AnthropicConfig, ChatRequest, ChatResponse, GoogleClient, GoogleConfig,
-    LlmClient, Message, OpenAiAuthScheme, OpenAiClient, OpenAiConfig, TauAiError, ToolDefinition,
+    LlmClient, Message, OpenAiAuthScheme, OpenAiClient, OpenAiConfig, TauAiError, ToolChoice,
+    ToolDefinition,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -57,6 +58,8 @@ fn tool_request(model: &str) -> ChatRequest {
             description: "Read a file".to_string(),
             parameters: json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}),
         }],
+        tool_choice: Some(ToolChoice::Auto),
+        json_mode: false,
         max_tokens: Some(128),
         temperature: Some(0.0),
     }
@@ -67,6 +70,8 @@ fn prompt_request(model: &str) -> ChatRequest {
         model: model.to_string(),
         messages: vec![Message::user("hello")],
         tools: vec![],
+        tool_choice: None,
+        json_mode: false,
         max_tokens: None,
         temperature: None,
     }

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -293,6 +293,8 @@ fn test_chat_request() -> ChatRequest {
         model: "placeholder-model".to_string(),
         messages: vec![Message::user("hello")],
         tools: vec![],
+        tool_choice: None,
+        json_mode: false,
         max_tokens: None,
         temperature: None,
     }

--- a/crates/tau-provider/src/claude_cli_client.rs
+++ b/crates/tau-provider/src/claude_cli_client.rs
@@ -318,6 +318,8 @@ mod tests {
                     "required": ["path"]
                 }),
             }],
+            tool_choice: Some(tau_ai::ToolChoice::Auto),
+            json_mode: false,
             max_tokens: None,
             temperature: None,
         }

--- a/crates/tau-provider/src/codex_cli_client.rs
+++ b/crates/tau-provider/src/codex_cli_client.rs
@@ -298,6 +298,8 @@ mod tests {
                     "required": ["path"]
                 }),
             }],
+            tool_choice: Some(tau_ai::ToolChoice::Auto),
+            json_mode: false,
             max_tokens: None,
             temperature: None,
         }

--- a/crates/tau-provider/src/fallback.rs
+++ b/crates/tau-provider/src/fallback.rs
@@ -321,6 +321,8 @@ mod tests {
             model: "placeholder-model".to_string(),
             messages: vec![Message::user("hello")],
             tools: Vec::new(),
+            tool_choice: None,
+            json_mode: false,
             max_tokens: None,
             temperature: None,
         }

--- a/crates/tau-provider/src/gemini_cli_client.rs
+++ b/crates/tau-provider/src/gemini_cli_client.rs
@@ -279,6 +279,8 @@ mod tests {
                     "required": ["path"]
                 }),
             }],
+            tool_choice: Some(tau_ai::ToolChoice::Auto),
+            json_mode: false,
             max_tokens: None,
             temperature: None,
         }

--- a/docs/tau-coding-agent/provider-feature-utilization.md
+++ b/docs/tau-coding-agent/provider-feature-utilization.md
@@ -1,0 +1,70 @@
+# Provider Feature Utilization (Issue #1189)
+
+Tau now uses provider-specific request features for tool routing, structured JSON output, and Retry-After handling.
+
+## What changed
+
+- Extended `tau-ai::ChatRequest` with provider hint fields:
+  - `tool_choice: Option<ToolChoice>`
+  - `json_mode: bool`
+- Added `ToolChoice` variants:
+  - `Auto`
+  - `None`
+  - `Required`
+  - `Tool { name }`
+
+## Runtime behavior updates
+
+- `tau-agent-core` now emits explicit request hints:
+  - normal tool-enabled turns use `tool_choice=Auto`
+  - `prompt_json` and `continue_turn_json` run with `json_mode=true`
+  - structured-output retries remain in `json_mode=true`
+
+## Provider adapter utilization
+
+- OpenAI (`tau-ai/src/openai.rs`)
+  - maps `tool_choice` to OpenAI `tool_choice`
+  - enables `response_format: { type: \"json_object\" }` when `json_mode=true`
+  - uses Retry-After header floor when retrying HTTP status failures
+
+- Anthropic (`tau-ai/src/anthropic.rs`)
+  - maps `tool_choice` to Anthropic `tool_choice` (`auto`/`any`/named `tool`)
+  - applies JSON-only system steering when `json_mode=true`
+  - uses Retry-After header floor when retrying HTTP status failures
+
+- Google (`tau-ai/src/google.rs`)
+  - maps `tool_choice` to Gemini `toolConfig.functionCallingConfig`
+  - enables `generationConfig.responseMimeType=\"application/json\"` when `json_mode=true`
+  - uses Retry-After header floor when retrying HTTP status failures
+
+## Retry-After support
+
+- Added shared helpers in `tau-ai/src/retry.rs`:
+  - `parse_retry_after_ms(...)` (seconds and HTTP date)
+  - `provider_retry_delay_ms(...)` (max of base backoff and Retry-After floor)
+
+## Test coverage added/updated
+
+- Unit:
+  - provider body serialization for `tool_choice` and `json_mode`
+  - Retry-After parsing and delay selection helpers
+- Functional:
+  - structured-output request path sets `json_mode=true`
+  - Anthropic/Google named and none tool-choice mappings
+- Integration:
+  - OpenAI Retry-After floor respected with mocked 429 response
+  - request-shaping assertions in `tau-agent-core`
+- Regression:
+  - tool-choice omission behavior for unsupported/no-tool scenarios
+  - generation config merge with JSON mode
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo test -p tau-ai`
+- `cargo test -p tau-agent-core`
+- `cargo test -p tau-provider`
+- `cargo test -p tau-runtime`
+- `cargo test -p tau-coding-agent run_prompt_with_cancellation`
+- `cargo check --workspace`
+- `cargo clippy -p tau-ai -p tau-agent-core -p tau-provider -p tau-runtime -p tau-coding-agent --all-targets -- -D warnings`


### PR DESCRIPTION
## Summary
- extend `ChatRequest` with provider hint fields (`tool_choice`, `json_mode`) and add `ToolChoice`
- wire provider feature usage in adapters:
  - OpenAI tool_choice + json_object response mode
  - Google functionCallingConfig + JSON MIME mode
  - Anthropic tool_choice mapping + JSON-only steering prompt path
- add shared Retry-After parsing and delay-floor logic for provider retries
- update `tau-agent-core` request shaping so structured-output paths run in JSON mode and tool-enabled turns use explicit auto tool choice
- document implementation and validation in `docs/tau-coding-agent/provider-feature-utilization.md`

## Testing
- cargo fmt --all
- cargo test -p tau-ai
- cargo test -p tau-agent-core
- cargo test -p tau-provider
- cargo test -p tau-runtime
- cargo test -p tau-coding-agent run_prompt_with_cancellation
- cargo check --workspace
- cargo clippy -p tau-ai -p tau-agent-core -p tau-provider -p tau-runtime -p tau-coding-agent --all-targets -- -D warnings

Closes #1189