### PR TITLE
feat(provider): add circuit breaker to fallback routing

### DIFF
--- a/crates/tau-provider/src/fallback.rs
+++ b/crates/tau-provider/src/fallback.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -6,10 +6,36 @@ use tau_ai::{
     ChatRequest, ChatResponse, LlmClient, ModelRef, Provider, StreamDeltaHandler, TauAiError,
 };
 use tau_cli::Cli;
+use tau_core::current_unix_timestamp_ms;
 
 use crate::client::build_provider_client;
 
 type FallbackEventSink = Arc<dyn Fn(serde_json::Value) + Send + Sync>;
+type ClockFn = Arc<dyn Fn() -> u64 + Send + Sync>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Public struct `CircuitBreakerConfig` used across Tau components.
+pub struct CircuitBreakerConfig {
+    pub enabled: bool,
+    pub failure_threshold: usize,
+    pub cooldown_ms: u64,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            failure_threshold: 3,
+            cooldown_ms: 30_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct RouteCircuitState {
+    consecutive_failures: usize,
+    open_until_unix_ms: Option<u64>,
+}
 
 #[derive(Clone)]
 /// Public struct `ClientRoute` used across Tau components.
@@ -29,11 +55,42 @@ impl ClientRoute {
 pub struct FallbackRoutingClient {
     routes: Vec<ClientRoute>,
     event_sink: Option<FallbackEventSink>,
+    circuit_breaker: CircuitBreakerConfig,
+    route_circuit_state: Mutex<Vec<RouteCircuitState>>,
+    clock: ClockFn,
 }
 
 impl FallbackRoutingClient {
     pub fn new(routes: Vec<ClientRoute>, event_sink: Option<FallbackEventSink>) -> Self {
-        Self { routes, event_sink }
+        Self::with_circuit_breaker(routes, event_sink, CircuitBreakerConfig::default())
+    }
+
+    pub fn with_circuit_breaker(
+        routes: Vec<ClientRoute>,
+        event_sink: Option<FallbackEventSink>,
+        circuit_breaker: CircuitBreakerConfig,
+    ) -> Self {
+        Self::new_with_clock(
+            routes,
+            event_sink,
+            circuit_breaker,
+            Arc::new(current_unix_timestamp_ms),
+        )
+    }
+
+    fn new_with_clock(
+        routes: Vec<ClientRoute>,
+        event_sink: Option<FallbackEventSink>,
+        circuit_breaker: CircuitBreakerConfig,
+        clock: ClockFn,
+    ) -> Self {
+        Self {
+            route_circuit_state: Mutex::new(vec![RouteCircuitState::default(); routes.len()]),
+            routes,
+            event_sink,
+            circuit_breaker,
+            clock,
+        }
     }
 
     fn emit_fallback_event(
@@ -57,6 +114,87 @@ impl FallbackRoutingClient {
         }));
     }
 
+    fn emit_circuit_opened_event(
+        &self,
+        route: &ClientRoute,
+        route_index: usize,
+        opened_until: u64,
+    ) {
+        let Some(sink) = &self.event_sink else {
+            return;
+        };
+        sink(serde_json::json!({
+            "type": "provider_circuit_opened",
+            "model": route.model_ref(),
+            "route_index": route_index,
+            "failure_threshold": self.circuit_breaker.failure_threshold,
+            "cooldown_ms": self.circuit_breaker.cooldown_ms,
+            "open_until_unix_ms": opened_until,
+        }));
+    }
+
+    fn emit_circuit_skip_event(&self, route: &ClientRoute, route_index: usize, open_until: u64) {
+        let Some(sink) = &self.event_sink else {
+            return;
+        };
+        sink(serde_json::json!({
+            "type": "provider_circuit_skip",
+            "model": route.model_ref(),
+            "route_index": route_index,
+            "open_until_unix_ms": open_until,
+        }));
+    }
+
+    fn route_open_until(&self, route_index: usize, now_unix_ms: u64) -> Option<u64> {
+        if !self.circuit_breaker.enabled {
+            return None;
+        }
+        let mut state = self
+            .route_circuit_state
+            .lock()
+            .expect("route circuit state lock");
+        let route_state = state.get_mut(route_index)?;
+        let open_until = route_state.open_until_unix_ms?;
+        if now_unix_ms < open_until {
+            return Some(open_until);
+        }
+        route_state.open_until_unix_ms = None;
+        route_state.consecutive_failures = 0;
+        None
+    }
+
+    fn record_route_success(&self, route_index: usize) {
+        let mut state = self
+            .route_circuit_state
+            .lock()
+            .expect("route circuit state lock");
+        let Some(route_state) = state.get_mut(route_index) else {
+            return;
+        };
+        route_state.open_until_unix_ms = None;
+        route_state.consecutive_failures = 0;
+    }
+
+    fn record_retryable_route_failure(&self, route_index: usize, now_unix_ms: u64) -> Option<u64> {
+        if !self.circuit_breaker.enabled {
+            return None;
+        }
+        let mut state = self
+            .route_circuit_state
+            .lock()
+            .expect("route circuit state lock");
+        let route_state = state.get_mut(route_index)?;
+        route_state.consecutive_failures = route_state.consecutive_failures.saturating_add(1);
+        let threshold = self.circuit_breaker.failure_threshold.max(1);
+        if route_state.consecutive_failures < threshold {
+            return None;
+        }
+        let open_until = now_unix_ms.saturating_add(self.circuit_breaker.cooldown_ms);
+        route_state.open_until_unix_ms = Some(open_until);
+        route_state.consecutive_failures = 0;
+        Some(open_until)
+    }
+
     async fn complete_inner(
         &self,
         request: ChatRequest,
@@ -68,7 +206,15 @@ impl FallbackRoutingClient {
             ));
         }
 
+        let mut attempted_route = false;
         for (index, route) in self.routes.iter().enumerate() {
+            let now_unix_ms = (self.clock)();
+            if let Some(open_until) = self.route_open_until(index, now_unix_ms) {
+                self.emit_circuit_skip_event(route, index, open_until);
+                continue;
+            }
+            attempted_route = true;
+
             let mut routed_request = request.clone();
             routed_request.model = route.model.clone();
 
@@ -82,18 +228,32 @@ impl FallbackRoutingClient {
             };
 
             match response {
-                Ok(response) => return Ok(response),
+                Ok(response) => {
+                    self.record_route_success(index);
+                    return Ok(response);
+                }
                 Err(error) => {
-                    let Some(next_route) = self.routes.get(index + 1) else {
-                        return Err(error);
-                    };
                     if is_retryable_provider_error(&error) {
-                        self.emit_fallback_event(route, next_route, &error, index + 1);
-                        continue;
+                        if let Some(open_until) =
+                            self.record_retryable_route_failure(index, now_unix_ms)
+                        {
+                            self.emit_circuit_opened_event(route, index, open_until);
+                        }
+                        if let Some(next_route) = self.routes.get(index + 1) {
+                            self.emit_fallback_event(route, next_route, &error, index + 1);
+                            continue;
+                        }
                     }
                     return Err(error);
                 }
             }
+        }
+
+        if !attempted_route {
+            return Err(TauAiError::InvalidResponse(
+                "all provider routes are temporarily unavailable (circuit breaker open)"
+                    .to_string(),
+            ));
         }
 
         Err(TauAiError::InvalidResponse(
@@ -221,7 +381,10 @@ pub fn build_client_with_fallbacks(
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::sync::Mutex;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    };
 
     use serde_json::Value;
     use tau_ai::Message;
@@ -359,6 +522,14 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn unit_circuit_breaker_defaults_are_production_safe() {
+        let defaults = CircuitBreakerConfig::default();
+        assert!(defaults.enabled);
+        assert_eq!(defaults.failure_threshold, 3);
+        assert_eq!(defaults.cooldown_ms, 30_000);
+    }
+
     #[tokio::test]
     async fn functional_fallback_client_handoffs_on_retryable_error_and_emits_event() {
         let primary = MockLlmClient::new(
@@ -471,6 +642,166 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn functional_circuit_breaker_opens_and_skips_temporarily_unhealthy_route() {
+        let primary = MockLlmClient::new(
+            vec![
+                Err(TauAiError::HttpStatus {
+                    status: 429,
+                    body: "rate limited".to_string(),
+                }),
+                Err(TauAiError::HttpStatus {
+                    status: 429,
+                    body: "rate limited".to_string(),
+                }),
+            ],
+            Vec::new(),
+        );
+        let secondary = MockLlmClient::new(
+            vec![
+                Ok(assistant_text_response("fallback-1")),
+                Ok(assistant_text_response("fallback-2")),
+                Ok(assistant_text_response("fallback-3")),
+            ],
+            Vec::new(),
+        );
+
+        let events = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let events_sink = events.clone();
+        let event_sink: FallbackEventSink =
+            Arc::new(move |event| events_sink.lock().expect("events lock").push(event));
+
+        let now_ms = Arc::new(AtomicU64::new(10_000));
+        let clock: ClockFn = {
+            let now_ms = now_ms.clone();
+            Arc::new(move || now_ms.load(Ordering::Relaxed))
+        };
+
+        let router = FallbackRoutingClient::new_with_clock(
+            vec![
+                ClientRoute {
+                    provider: Provider::OpenAi,
+                    model: "gpt-4o-mini".to_string(),
+                    client: Arc::new(primary.clone()),
+                },
+                ClientRoute {
+                    provider: Provider::Anthropic,
+                    model: "claude-sonnet-4-20250514".to_string(),
+                    client: Arc::new(secondary.clone()),
+                },
+            ],
+            Some(event_sink),
+            CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: 2,
+                cooldown_ms: 5_000,
+            },
+            clock,
+        );
+
+        let _ = router
+            .complete(test_request())
+            .await
+            .expect("first fallback");
+        let _ = router
+            .complete(test_request())
+            .await
+            .expect("second fallback");
+        let response = router
+            .complete(test_request())
+            .await
+            .expect("third request should skip unhealthy primary");
+
+        assert_eq!(response.message.text_content(), "fallback-3");
+        assert_eq!(primary.observed_models().len(), 2);
+        assert_eq!(secondary.observed_models().len(), 3);
+
+        let events = events.lock().expect("events lock");
+        assert!(
+            events
+                .iter()
+                .any(|event| event["type"] == "provider_circuit_opened"),
+            "circuit should open after threshold failures"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event["type"] == "provider_circuit_skip"),
+            "open circuit should skip primary route"
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_circuit_breaker_retries_primary_after_cooldown_expires() {
+        let primary = MockLlmClient::new(
+            vec![
+                Err(TauAiError::HttpStatus {
+                    status: 503,
+                    body: "unavailable".to_string(),
+                }),
+                Err(TauAiError::HttpStatus {
+                    status: 503,
+                    body: "unavailable".to_string(),
+                }),
+                Ok(assistant_text_response("primary recovered")),
+            ],
+            Vec::new(),
+        );
+        let secondary = MockLlmClient::new(
+            vec![
+                Ok(assistant_text_response("fallback-1")),
+                Ok(assistant_text_response("fallback-2")),
+            ],
+            Vec::new(),
+        );
+
+        let now_ms = Arc::new(AtomicU64::new(5_000));
+        let clock: ClockFn = {
+            let now_ms = now_ms.clone();
+            Arc::new(move || now_ms.load(Ordering::Relaxed))
+        };
+
+        let router = FallbackRoutingClient::new_with_clock(
+            vec![
+                ClientRoute {
+                    provider: Provider::OpenAi,
+                    model: "gpt-4o-mini".to_string(),
+                    client: Arc::new(primary.clone()),
+                },
+                ClientRoute {
+                    provider: Provider::Google,
+                    model: "gemini-2.5-pro".to_string(),
+                    client: Arc::new(secondary.clone()),
+                },
+            ],
+            None,
+            CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: 2,
+                cooldown_ms: 1_000,
+            },
+            clock,
+        );
+
+        let _ = router
+            .complete(test_request())
+            .await
+            .expect("first fallback");
+        let _ = router
+            .complete(test_request())
+            .await
+            .expect("second fallback");
+        now_ms.store(6_200, Ordering::Relaxed);
+
+        let recovered = router
+            .complete(test_request())
+            .await
+            .expect("primary should be retried after cooldown");
+        assert_eq!(recovered.message.text_content(), "primary recovered");
+        assert_eq!(primary.observed_models().len(), 3);
+        assert_eq!(secondary.observed_models().len(), 2);
+    }
+
+    #[tokio::test]
     async fn regression_non_retryable_error_does_not_fallback_to_next_route() {
         let primary = MockLlmClient::new(
             vec![Err(TauAiError::HttpStatus {
@@ -513,5 +844,144 @@ mod tests {
 
         assert_eq!(primary.observed_models(), vec!["gpt-4o-mini".to_string()]);
         assert!(secondary.observed_models().is_empty());
+    }
+
+    #[tokio::test]
+    async fn regression_non_retryable_error_does_not_trip_circuit_breaker() {
+        let primary = MockLlmClient::new(
+            vec![
+                Err(TauAiError::HttpStatus {
+                    status: 401,
+                    body: "unauthorized".to_string(),
+                }),
+                Ok(assistant_text_response("primary-ok")),
+            ],
+            Vec::new(),
+        );
+        let secondary = MockLlmClient::new(
+            vec![Ok(assistant_text_response("should-not-run"))],
+            Vec::new(),
+        );
+        let events = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let events_sink = events.clone();
+        let event_sink: FallbackEventSink =
+            Arc::new(move |event| events_sink.lock().expect("events lock").push(event));
+        let now_ms = Arc::new(AtomicU64::new(1_000));
+        let clock: ClockFn = {
+            let now_ms = now_ms.clone();
+            Arc::new(move || now_ms.load(Ordering::Relaxed))
+        };
+
+        let router = FallbackRoutingClient::new_with_clock(
+            vec![
+                ClientRoute {
+                    provider: Provider::OpenAi,
+                    model: "gpt-4o-mini".to_string(),
+                    client: Arc::new(primary.clone()),
+                },
+                ClientRoute {
+                    provider: Provider::Anthropic,
+                    model: "claude-sonnet-4-20250514".to_string(),
+                    client: Arc::new(secondary.clone()),
+                },
+            ],
+            Some(event_sink),
+            CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: 1,
+                cooldown_ms: 30_000,
+            },
+            clock,
+        );
+
+        let first_error = router
+            .complete(test_request())
+            .await
+            .expect_err("first call should return non-retryable error");
+        assert!(matches!(
+            first_error,
+            TauAiError::HttpStatus { status: 401, .. }
+        ));
+
+        let second = router
+            .complete(test_request())
+            .await
+            .expect("second call should still attempt primary");
+        assert_eq!(second.message.text_content(), "primary-ok");
+        assert_eq!(primary.observed_models().len(), 2);
+        assert!(secondary.observed_models().is_empty());
+
+        let events = events.lock().expect("events lock");
+        assert!(
+            events
+                .iter()
+                .all(|event| event["type"] != "provider_circuit_opened"),
+            "non-retryable errors must not open the circuit"
+        );
+    }
+
+    #[tokio::test]
+    async fn regression_all_open_circuit_routes_fail_fast_until_cooldown() {
+        let primary = MockLlmClient::new(
+            vec![Err(TauAiError::HttpStatus {
+                status: 503,
+                body: "primary unavailable".to_string(),
+            })],
+            Vec::new(),
+        );
+        let secondary = MockLlmClient::new(
+            vec![Err(TauAiError::HttpStatus {
+                status: 503,
+                body: "secondary unavailable".to_string(),
+            })],
+            Vec::new(),
+        );
+        let now_ms = Arc::new(AtomicU64::new(2_000));
+        let clock: ClockFn = {
+            let now_ms = now_ms.clone();
+            Arc::new(move || now_ms.load(Ordering::Relaxed))
+        };
+
+        let router = FallbackRoutingClient::new_with_clock(
+            vec![
+                ClientRoute {
+                    provider: Provider::OpenAi,
+                    model: "gpt-4o-mini".to_string(),
+                    client: Arc::new(primary.clone()),
+                },
+                ClientRoute {
+                    provider: Provider::Google,
+                    model: "gemini-2.5-pro".to_string(),
+                    client: Arc::new(secondary.clone()),
+                },
+            ],
+            None,
+            CircuitBreakerConfig {
+                enabled: true,
+                failure_threshold: 1,
+                cooldown_ms: 10_000,
+            },
+            clock,
+        );
+
+        let first = router
+            .complete(test_request())
+            .await
+            .expect_err("first run should fail and open both circuits");
+        assert!(matches!(first, TauAiError::HttpStatus { status: 503, .. }));
+
+        let second = router
+            .complete(test_request())
+            .await
+            .expect_err("second run should fail fast while both circuits remain open");
+        match second {
+            TauAiError::InvalidResponse(message) => {
+                assert!(message.contains("circuit breaker open"))
+            }
+            other => panic!("expected circuit-open invalid response, got {other:?}"),
+        }
+
+        assert_eq!(primary.observed_models().len(), 1);
+        assert_eq!(secondary.observed_models().len(), 1);
     }
 }

--- a/docs/tau-coding-agent/provider-fallback-circuit-breaker.md
+++ b/docs/tau-coding-agent/provider-fallback-circuit-breaker.md
@@ -1,0 +1,49 @@
+# Provider Fallback Circuit Breaker
+
+## Purpose
+Add circuit-breaker behavior to provider fallback routing so unhealthy routes are temporarily skipped after repeated retryable failures.
+
+## Scope
+- Implemented in `crates/tau-provider/src/fallback.rs`
+- Applied to `FallbackRoutingClient` failover flow
+- Enabled by default with production-safe limits
+
+## Default Behavior
+- `enabled = true`
+- `failure_threshold = 3`
+- `cooldown_ms = 30000`
+
+For each route:
+- Retryable failures increment a consecutive-failure counter.
+- When counter reaches threshold, the route is marked open until `now + cooldown_ms`.
+- Open routes are skipped until cooldown expires.
+- Successful route responses reset that route's failure state.
+
+## Retryable Error Classes
+Circuit-breaker accounting uses the same retryability rules as fallback handoff:
+- HTTP status: `408`, `409`, `425`, `429`, `>=500`
+- transport-level retryable HTTP errors (timeout/connect/request/body)
+
+Non-retryable failures do not open the circuit.
+
+## Observability Events
+When `event_sink` is configured, fallback emits:
+- `provider_fallback`
+- `provider_circuit_opened`
+- `provider_circuit_skip`
+
+These events include route/model identity and routing metadata to support debugging and incident analysis.
+
+## Validation Coverage
+Added/updated in `crates/tau-provider/src/fallback.rs`:
+- Unit:
+  - default circuit-breaker config values
+  - retryable error classification
+- Functional:
+  - circuit opens and skips unhealthy route after threshold failures
+- Integration:
+  - route is retried after cooldown expiration and can recover
+  - streaming fallback behavior remains intact
+- Regression:
+  - non-retryable errors do not trip circuit
+  - all-open routes fail fast with deterministic error behavior


### PR DESCRIPTION
## Summary
- add `CircuitBreakerConfig` to `FallbackRoutingClient` with default-on production-safe limits
- track per-route failure state and open routes after consecutive retryable failures
- skip open routes during cooldown and retry them after cooldown expiration
- emit observability events for circuit openings and route skips
- document behavior in `docs/tau-coding-agent/provider-fallback-circuit-breaker.md`

## Validation
- cargo fmt --all
- cargo test -p tau-provider
- cargo test -p tau-provider fallback::tests
- cargo test -p tau-coding-agent fallback_routing_client
- cargo check --workspace
- cargo clippy -p tau-provider -p tau-coding-agent --all-targets -- -D warnings

Closes #1192
