### PR TITLE
feat(agent-core): add dynamic and scoped tool lifecycle APIs

### DIFF
--- a/docs/tau-coding-agent/dynamic-tool-registration.md
+++ b/docs/tau-coding-agent/dynamic-tool-registration.md
@@ -1,0 +1,43 @@
+# Dynamic Tool Registration
+
+## Purpose
+Enable runtime-managed tool catalogs with explicit lifecycle controls so tools can be added, replaced, and removed safely during agent execution.
+
+## Scope
+Implemented in `crates/tau-agent-core/src/lib.rs` on `Agent`.
+
+## New Runtime APIs
+- `register_tool(...)`
+  - now replaces existing tools by name safely
+  - clears tool-result cache on replacement to prevent stale result reuse
+- `has_tool(name)`
+- `registered_tool_names()`
+- `unregister_tool(name)`
+- `clear_tools()`
+- `with_scoped_tool(...)`
+- `with_scoped_tools(...)`
+
+## Scoped Lifecycle Behavior
+Scoped registration helpers:
+1. register temporary tools
+2. clear tool-result cache before execution
+3. run provided async workload
+4. restore previous tool catalog state
+5. clear tool-result cache again
+
+This ensures scoped overrides do not leak stale cached outputs or persist unexpectedly after the scope exits.
+
+## Compatibility
+- Existing startup-time `register_tool(...)` usage remains unchanged.
+- No CLI argument changes are required.
+
+## Validation Coverage
+Added in `crates/tau-agent-core/src/lib.rs`:
+- Unit:
+  - registry presence/lifecycle helpers
+- Functional:
+  - scoped tool visible only during scope
+- Integration:
+  - scoped tool lifecycle supports real prompt tool execution
+- Regression:
+  - scoped replacement restores original tool and avoids stale cache reuse


### PR DESCRIPTION
## Summary
- add runtime tool lifecycle APIs to `Agent`: `has_tool`, `registered_tool_names`, `unregister_tool`, `clear_tools`
- add scoped lifecycle helpers: `with_scoped_tool` and `with_scoped_tools`
- harden dynamic replacement by clearing tool-result cache on replacement/scope transitions
- add focused dynamic-tool lifecycle docs in `docs/tau-coding-agent/dynamic-tool-registration.md`
- add unit, functional, integration, and regression coverage for dynamic/scoped behavior

## Validation
- cargo fmt --all
- cargo test -p tau-agent-core
- cargo test -p tau-runtime
- cargo test -p tau-coding-agent run_prompt_with_cancellation
- cargo test -p tau-provider
- cargo check --workspace
- cargo clippy -p tau-agent-core -p tau-runtime -p tau-coding-agent --all-targets -- -D warnings

Closes #1193
