### PR TITLE
Story #1196: add image/audio content blocks

### DIFF
--- a/crates/tau-ai/src/anthropic.rs
+++ b/crates/tau-ai/src/anthropic.rs
@@ -10,8 +10,8 @@ use crate::{
         is_retryable_http_error, new_request_id, parse_retry_after_ms, provider_retry_delay_ms,
         retry_budget_allows_delay, should_retry_status,
     },
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
 };
 
 #[derive(Debug, Clone)]
@@ -273,46 +273,18 @@ fn to_anthropic_messages(messages: &[Message]) -> Value {
             .filter_map(|message| match message.role {
                 MessageRole::System => None,
                 MessageRole::User => {
-                    let text = message.text_content();
-                    if text.trim().is_empty() {
+                    let parts = to_anthropic_content_parts(message, false);
+                    if parts.is_empty() {
                         None
                     } else {
                         Some(json!({
                             "role": "user",
-                            "content": [{
-                                "type": "text",
-                                "text": text,
-                            }]
+                            "content": parts,
                         }))
                     }
                 }
                 MessageRole::Assistant => {
-                    let mut parts = Vec::new();
-                    for block in &message.content {
-                        match block {
-                            ContentBlock::Text { text } => {
-                                if !text.trim().is_empty() {
-                                    parts.push(json!({
-                                        "type": "text",
-                                        "text": text,
-                                    }));
-                                }
-                            }
-                            ContentBlock::ToolCall {
-                                id,
-                                name,
-                                arguments,
-                            } => {
-                                parts.push(json!({
-                                    "type": "tool_use",
-                                    "id": id,
-                                    "name": name,
-                                    "input": arguments,
-                                }));
-                            }
-                        }
-                    }
-
+                    let parts = to_anthropic_content_parts(message, true);
                     if parts.is_empty() {
                         None
                     } else {
@@ -348,6 +320,70 @@ fn to_anthropic_messages(messages: &[Message]) -> Value {
     )
 }
 
+fn to_anthropic_content_parts(message: &Message, allow_tool_calls: bool) -> Vec<Value> {
+    let mut parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    parts.push(json!({
+                        "type": "text",
+                        "text": text,
+                    }));
+                }
+            }
+            ContentBlock::ToolCall {
+                id,
+                name,
+                arguments,
+            } if allow_tool_calls => {
+                parts.push(json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": arguments,
+                }));
+            }
+            ContentBlock::ToolCall { .. } => {}
+            ContentBlock::Image { source } => match source {
+                MediaSource::Url { url } => {
+                    parts.push(json!({
+                        "type": "text",
+                        "text": format!("[tau-image:url:{url}]"),
+                    }));
+                }
+                MediaSource::Base64 { mime_type, data } => {
+                    parts.push(json!({
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": mime_type,
+                            "data": data,
+                        }
+                    }));
+                }
+            },
+            ContentBlock::Audio { source } => {
+                parts.push(json!({
+                    "type": "text",
+                    "text": format!("[tau-audio:{}]", media_source_descriptor(source)),
+                }));
+            }
+        }
+    }
+
+    parts
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
+    }
+}
+
 fn parse_messages_response(raw: &str) -> Result<ChatResponse, TauAiError> {
     let parsed: AnthropicMessageResponse = serde_json::from_str(raw)?;
 
@@ -368,6 +404,52 @@ fn parse_messages_response(raw: &str) -> Result<ChatResponse, TauAiError> {
                     arguments: input,
                 });
             }
+            AnthropicContent::Image {
+                source:
+                    AnthropicMediaSource::Base64 {
+                        media_type, data, ..
+                    },
+            } => {
+                blocks.push(ContentBlock::Image {
+                    source: MediaSource::Base64 {
+                        mime_type: media_type,
+                        data,
+                    },
+                });
+            }
+            AnthropicContent::Image {
+                source: AnthropicMediaSource::Url { url, .. },
+            } => {
+                blocks.push(ContentBlock::Image {
+                    source: MediaSource::Url { url },
+                });
+            }
+            AnthropicContent::Image {
+                source: AnthropicMediaSource::Other,
+            } => {}
+            AnthropicContent::Audio {
+                source:
+                    AnthropicMediaSource::Base64 {
+                        media_type, data, ..
+                    },
+            } => {
+                blocks.push(ContentBlock::Audio {
+                    source: MediaSource::Base64 {
+                        mime_type: media_type,
+                        data,
+                    },
+                });
+            }
+            AnthropicContent::Audio {
+                source: AnthropicMediaSource::Url { url, .. },
+            } => {
+                blocks.push(ContentBlock::Audio {
+                    source: MediaSource::Url { url },
+                });
+            }
+            AnthropicContent::Audio {
+                source: AnthropicMediaSource::Other,
+            } => {}
             AnthropicContent::Other => {}
         }
     }
@@ -661,6 +743,25 @@ enum AnthropicContent {
         name: String,
         input: Value,
     },
+    #[serde(rename = "image")]
+    Image { source: AnthropicMediaSource },
+    #[serde(rename = "audio")]
+    Audio { source: AnthropicMediaSource },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum AnthropicMediaSource {
+    #[serde(rename = "base64")]
+    Base64 {
+        #[serde(rename = "media_type")]
+        media_type: String,
+        data: String,
+    },
+    #[serde(rename = "url")]
+    Url { url: String },
     #[serde(other)]
     Other,
 }
@@ -688,7 +789,7 @@ mod tests {
         apply_anthropic_stream_event, build_messages_request_body,
         finalize_anthropic_stream_response, parse_messages_response,
     };
-    use crate::{ChatRequest, ContentBlock, Message, ToolChoice, ToolDefinition};
+    use crate::{ChatRequest, ContentBlock, Message, MessageRole, ToolChoice, ToolDefinition};
 
     #[test]
     fn serializes_tool_messages() {
@@ -785,6 +886,68 @@ mod tests {
         assert_eq!(response.message.tool_calls().len(), 1);
         assert_eq!(response.finish_reason.as_deref(), Some("tool_use"));
         assert_eq!(response.usage.total_tokens, 13);
+    }
+
+    #[test]
+    fn unit_serializes_multimodal_blocks_for_anthropic() {
+        let request = ChatRequest {
+            model: "claude-sonnet-4-20250514".to_string(),
+            messages: vec![Message {
+                role: MessageRole::User,
+                content: vec![
+                    ContentBlock::text("describe"),
+                    ContentBlock::image_base64("image/png", "aW1hZ2VEYXRh"),
+                    ContentBlock::audio_base64("audio/wav", "YXVkaW9EYXRh"),
+                ],
+                tool_call_id: None,
+                tool_name: None,
+                is_error: false,
+            }],
+            tools: vec![],
+            tool_choice: None,
+            json_mode: false,
+            max_tokens: None,
+            temperature: None,
+        };
+
+        let body = build_messages_request_body(&request);
+        assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][1]["type"], "image");
+        assert_eq!(
+            body["messages"][0]["content"][1]["source"]["media_type"],
+            "image/png"
+        );
+        assert_eq!(body["messages"][0]["content"][2]["type"], "text");
+        assert!(body["messages"][0]["content"][2]["text"]
+            .as_str()
+            .expect("audio fallback marker should be a string")
+            .contains("[tau-audio:"));
+    }
+
+    #[test]
+    fn functional_parses_multimodal_response_for_anthropic() {
+        let raw = r#"{
+            "content": [
+                {"type":"text","text":"Working..."},
+                {"type":"image","source":{"type":"url","url":"https://example.com/cat.png"}},
+                {"type":"audio","source":{"type":"base64","media_type":"audio/wav","data":"YXVkaW9EYXRh"}}
+            ],
+            "stop_reason":"end_turn",
+            "usage":{"input_tokens":10,"output_tokens":3}
+        }"#;
+
+        let response = parse_messages_response(raw).expect("response should parse");
+        assert_eq!(response.message.text_content(), "Working...");
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Image { .. })));
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Audio { .. })));
     }
 
     #[test]

--- a/crates/tau-ai/src/google.rs
+++ b/crates/tau-ai/src/google.rs
@@ -9,8 +9,8 @@ use crate::{
         is_retryable_http_error, new_request_id, parse_retry_after_ms, provider_retry_delay_ms,
         retry_budget_allows_delay, should_retry_status,
     },
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
 };
 
 #[derive(Debug, Clone)]
@@ -286,40 +286,18 @@ fn to_google_contents(messages: &[Message]) -> Value {
             .filter_map(|message| match message.role {
                 MessageRole::System => None,
                 MessageRole::User => {
-                    let text = message.text_content();
-                    if text.trim().is_empty() {
+                    let parts = to_google_parts(message, false);
+                    if parts.is_empty() {
                         None
                     } else {
                         Some(json!({
                             "role": "user",
-                            "parts": [{ "text": text }],
+                            "parts": parts,
                         }))
                     }
                 }
                 MessageRole::Assistant => {
-                    let mut parts = Vec::new();
-                    for block in &message.content {
-                        match block {
-                            ContentBlock::Text { text } => {
-                                if !text.trim().is_empty() {
-                                    parts.push(json!({ "text": text }));
-                                }
-                            }
-                            ContentBlock::ToolCall {
-                                id: _,
-                                name,
-                                arguments,
-                            } => {
-                                parts.push(json!({
-                                    "functionCall": {
-                                        "name": name,
-                                        "args": arguments,
-                                    }
-                                }));
-                            }
-                        }
-                    }
-
+                    let parts = to_google_parts(message, true);
                     if parts.is_empty() {
                         None
                     } else {
@@ -343,7 +321,7 @@ fn to_google_contents(messages: &[Message]) -> Value {
                                 "name": name,
                                 "response": {
                                     "tool_call_id": tool_call_id,
-                                    "content": message.text_content(),
+                                    "content": flatten_message_with_media_markers(message),
                                     "is_error": message.is_error,
                                 }
                             }
@@ -353,6 +331,94 @@ fn to_google_contents(messages: &[Message]) -> Value {
             })
             .collect(),
     )
+}
+
+fn to_google_parts(message: &Message, allow_tool_calls: bool) -> Vec<Value> {
+    let mut parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    parts.push(json!({ "text": text }));
+                }
+            }
+            ContentBlock::ToolCall {
+                id: _,
+                name,
+                arguments,
+            } if allow_tool_calls => {
+                parts.push(json!({
+                    "functionCall": {
+                        "name": name,
+                        "args": arguments,
+                    }
+                }));
+            }
+            ContentBlock::ToolCall { .. } => {}
+            ContentBlock::Image { source } => {
+                parts.push(to_google_media_part(source, "image"));
+            }
+            ContentBlock::Audio { source } => {
+                parts.push(to_google_media_part(source, "audio"));
+            }
+        }
+    }
+    parts
+}
+
+fn to_google_media_part(source: &MediaSource, media_kind: &str) -> Value {
+    match source {
+        MediaSource::Url { url } => json!({
+            "fileData": {
+                "mimeType": default_mime_type(media_kind),
+                "fileUri": url,
+            }
+        }),
+        MediaSource::Base64 { mime_type, data } => json!({
+            "inlineData": {
+                "mimeType": mime_type,
+                "data": data,
+            }
+        }),
+    }
+}
+
+fn flatten_message_with_media_markers(message: &Message) -> String {
+    let mut parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    parts.push(text.clone());
+                }
+            }
+            ContentBlock::ToolCall { .. } => {}
+            ContentBlock::Image { source } => {
+                parts.push(format!("[tau-image:{}]", media_source_descriptor(source)));
+            }
+            ContentBlock::Audio { source } => {
+                parts.push(format!("[tau-audio:{}]", media_source_descriptor(source)));
+            }
+        }
+    }
+    parts.join("\n")
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
+    }
+}
+
+fn default_mime_type(media_kind: &str) -> &'static str {
+    if media_kind == "audio" {
+        "audio/wav"
+    } else {
+        "image/png"
+    }
 }
 
 fn parse_generate_content_response(raw: &str) -> Result<ChatResponse, TauAiError> {
@@ -371,18 +437,22 @@ fn parse_generate_content_response(raw: &str) -> Result<ChatResponse, TauAiError
     let mut blocks = Vec::new();
 
     for (index, part) in parts.into_iter().enumerate() {
-        if let Some(text) = part.text {
+        if let Some(text) = part.text.as_ref() {
             if !text.trim().is_empty() {
-                blocks.push(ContentBlock::Text { text });
+                blocks.push(ContentBlock::Text { text: text.clone() });
             }
         }
 
-        if let Some(function_call) = part.function_call {
+        if let Some(function_call) = part.function_call.as_ref() {
             blocks.push(ContentBlock::ToolCall {
                 id: format!("google_call_{}", index + 1),
-                name: function_call.name,
-                arguments: function_call.args.unwrap_or_else(|| json!({})),
+                name: function_call.name.clone(),
+                arguments: function_call.args.clone().unwrap_or_else(|| json!({})),
             });
+        }
+
+        if let Some(media_block) = parse_google_media_part(&part) {
+            blocks.push(media_block);
         }
     }
 
@@ -493,18 +563,21 @@ fn apply_google_stream_data(
                 continue;
             };
             for part in parts {
-                if let Some(delta_text) = part.text {
+                if let Some(delta_text) = part.text.as_ref() {
                     if !delta_text.is_empty() {
-                        text.push_str(&delta_text);
-                        on_delta(delta_text);
+                        text.push_str(delta_text);
+                        on_delta(delta_text.clone());
                     }
                 }
-                if let Some(function_call) = part.function_call {
+                if let Some(function_call) = part.function_call.as_ref() {
                     tool_calls.push(ContentBlock::ToolCall {
                         id: format!("google_stream_call_{}", tool_calls.len() + 1),
-                        name: function_call.name,
-                        arguments: function_call.args.unwrap_or_else(|| json!({})),
+                        name: function_call.name.clone(),
+                        arguments: function_call.args.clone().unwrap_or_else(|| json!({})),
                     });
+                }
+                if let Some(media_block) = parse_google_media_part(&part) {
+                    tool_calls.push(media_block);
                 }
             }
         }
@@ -532,6 +605,37 @@ fn finalize_google_stream_response(
     }
 }
 
+fn parse_google_media_part(part: &GenerateContentPart) -> Option<ContentBlock> {
+    if let Some(inline_data) = &part.inline_data {
+        return Some(media_block_from_mime(
+            &inline_data.mime_type,
+            MediaSource::Base64 {
+                mime_type: inline_data.mime_type.clone(),
+                data: inline_data.data.clone(),
+            },
+        ));
+    }
+
+    if let Some(file_data) = &part.file_data {
+        return Some(media_block_from_mime(
+            &file_data.mime_type,
+            MediaSource::Url {
+                url: file_data.file_uri.clone(),
+            },
+        ));
+    }
+
+    None
+}
+
+fn media_block_from_mime(mime_type: &str, source: MediaSource) -> ContentBlock {
+    if mime_type.to_ascii_lowercase().starts_with("audio/") {
+        ContentBlock::Audio { source }
+    } else {
+        ContentBlock::Image { source }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct GenerateContentResponse {
     candidates: Option<Vec<GenerateContentCandidate>>,
@@ -556,12 +660,31 @@ struct GenerateContentPart {
     text: Option<String>,
     #[serde(rename = "functionCall")]
     function_call: Option<GenerateContentFunctionCall>,
+    #[serde(rename = "inlineData")]
+    inline_data: Option<GenerateContentInlineData>,
+    #[serde(rename = "fileData")]
+    file_data: Option<GenerateContentFileData>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GenerateContentFunctionCall {
     name: String,
     args: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenerateContentInlineData {
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    data: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenerateContentFileData {
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    #[serde(rename = "fileUri")]
+    file_uri: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -583,7 +706,7 @@ mod tests {
         apply_google_stream_data, build_generate_content_body, finalize_google_stream_response,
         parse_generate_content_response,
     };
-    use crate::{ChatRequest, ContentBlock, Message, ToolChoice, ToolDefinition};
+    use crate::{ChatRequest, ContentBlock, Message, MessageRole, ToolChoice, ToolDefinition};
 
     #[test]
     fn serializes_tool_calls_and_responses() {
@@ -702,6 +825,78 @@ mod tests {
     }
 
     #[test]
+    fn unit_serializes_multimodal_parts_for_google() {
+        let request = ChatRequest {
+            model: "gemini-2.5-pro".to_string(),
+            messages: vec![Message {
+                role: MessageRole::User,
+                content: vec![
+                    ContentBlock::text("describe"),
+                    ContentBlock::image_base64("image/png", "aW1hZ2VEYXRh"),
+                    ContentBlock::audio_url("https://example.com/audio.wav"),
+                ],
+                tool_call_id: None,
+                tool_name: None,
+                is_error: false,
+            }],
+            tools: vec![],
+            tool_choice: None,
+            json_mode: false,
+            max_tokens: None,
+            temperature: None,
+        };
+
+        let body = build_generate_content_body(&request);
+        assert_eq!(body["contents"][0]["parts"][0]["text"], "describe");
+        assert_eq!(
+            body["contents"][0]["parts"][1]["inlineData"]["mimeType"],
+            "image/png"
+        );
+        assert_eq!(
+            body["contents"][0]["parts"][2]["fileData"]["fileUri"],
+            "https://example.com/audio.wav"
+        );
+        assert_eq!(
+            body["contents"][0]["parts"][2]["fileData"]["mimeType"],
+            "audio/wav"
+        );
+    }
+
+    #[test]
+    fn functional_parses_multimodal_parts_from_google_response() {
+        let raw = r#"{
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {"text": "Working"},
+                        {"fileData": {"mimeType": "image/png", "fileUri": "https://example.com/cat.png"}},
+                        {"inlineData": {"mimeType": "audio/mpeg", "data": "QUJDREVGRw=="}}
+                    ]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 8,
+                "candidatesTokenCount": 4,
+                "totalTokenCount": 12
+            }
+        }"#;
+
+        let response = parse_generate_content_response(raw).expect("response must parse");
+        assert_eq!(response.message.text_content(), "Working");
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Image { .. })));
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Audio { .. })));
+    }
+
+    #[test]
     fn functional_google_stream_data_parses_text_and_function_calls() {
         let streamed = Arc::new(Mutex::new(String::new()));
         let sink_streamed = streamed.clone();
@@ -749,6 +944,32 @@ mod tests {
             response.message.tool_calls()[0].arguments,
             json!({"path":"README.md"})
         );
+    }
+
+    #[test]
+    fn regression_google_stream_data_parses_media_parts_without_error() {
+        let sink: crate::StreamDeltaHandler = Arc::new(|_delta: String| {});
+        let mut text = String::new();
+        let mut tool_calls = Vec::new();
+        let mut finish_reason = None;
+        let mut usage = crate::ChatUsage::default();
+
+        apply_google_stream_data(
+            r#"{"candidates":[{"content":{"parts":[{"fileData":{"mimeType":"image/png","fileUri":"https://example.com/cat.png"}}]},"finishReason":"STOP"}]}"#,
+            &sink,
+            &mut text,
+            &mut tool_calls,
+            &mut finish_reason,
+            &mut usage,
+        )
+        .expect("media stream chunk parses");
+
+        let response = finalize_google_stream_response(text, tool_calls, finish_reason, usage);
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Image { .. })));
     }
 
     #[test]

--- a/crates/tau-ai/src/lib.rs
+++ b/crates/tau-ai/src/lib.rs
@@ -11,6 +11,6 @@ pub use google::{GoogleClient, GoogleConfig};
 pub use openai::{OpenAiAuthScheme, OpenAiClient, OpenAiConfig};
 pub use provider::{ModelRef, ModelRefParseError, Provider};
 pub use types::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError, ToolCall, ToolChoice, ToolDefinition,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError, ToolCall, ToolChoice, ToolDefinition,
 };

--- a/crates/tau-ai/src/openai.rs
+++ b/crates/tau-ai/src/openai.rs
@@ -10,8 +10,8 @@ use crate::{
         is_retryable_http_error, new_request_id, parse_retry_after_ms, provider_retry_delay_ms,
         retry_budget_allows_delay, should_retry_status,
     },
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError, ToolChoice, ToolDefinition,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -294,11 +294,11 @@ fn to_openai_messages(messages: &[Message]) -> Result<Vec<Value>, TauAiError> {
         match message.role {
             MessageRole::System => serialized.push(json!({
                 "role": "system",
-                "content": message.text_content(),
+                "content": flatten_message_with_media_markers(message),
             })),
             MessageRole::User => serialized.push(json!({
                 "role": "user",
-                "content": message.text_content(),
+                "content": to_openai_user_content(message),
             })),
             MessageRole::Assistant => {
                 let tool_calls: Vec<Value> = message
@@ -316,7 +316,7 @@ fn to_openai_messages(messages: &[Message]) -> Result<Vec<Value>, TauAiError> {
                     })
                     .collect();
 
-                let text = message.text_content();
+                let text = flatten_message_with_media_markers(message);
                 let content = if text.trim().is_empty() && !tool_calls.is_empty() {
                     Value::Null
                 } else {
@@ -346,7 +346,7 @@ fn to_openai_messages(messages: &[Message]) -> Result<Vec<Value>, TauAiError> {
                 let mut tool_message = json!({
                     "role": "tool",
                     "tool_call_id": tool_call_id,
-                    "content": message.text_content(),
+                    "content": flatten_message_with_media_markers(message),
                 });
 
                 if let Some(name) = &message.tool_name {
@@ -361,6 +361,92 @@ fn to_openai_messages(messages: &[Message]) -> Result<Vec<Value>, TauAiError> {
     Ok(serialized)
 }
 
+fn to_openai_user_content(message: &Message) -> Value {
+    let has_non_text_block = message
+        .content
+        .iter()
+        .any(|block| !matches!(block, ContentBlock::Text { .. }));
+    if !has_non_text_block {
+        return Value::String(message.text_content());
+    }
+
+    let mut parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    parts.push(json!({
+                        "type": "text",
+                        "text": text,
+                    }));
+                }
+            }
+            ContentBlock::Image { source } => {
+                parts.push(to_openai_image_part(source));
+            }
+            ContentBlock::Audio { source } => {
+                parts.push(json!({
+                    "type": "text",
+                    "text": format!("[tau-audio:{}]", media_source_descriptor(source)),
+                }));
+            }
+            ContentBlock::ToolCall { .. } => {}
+        }
+    }
+
+    if parts.is_empty() {
+        Value::String(String::new())
+    } else {
+        Value::Array(parts)
+    }
+}
+
+fn to_openai_image_part(source: &MediaSource) -> Value {
+    match source {
+        MediaSource::Url { url } => json!({
+            "type": "image_url",
+            "image_url": { "url": url },
+        }),
+        MediaSource::Base64 { mime_type, data } => {
+            let data_url = format!("data:{mime_type};base64,{data}");
+            json!({
+                "type": "image_url",
+                "image_url": { "url": data_url },
+            })
+        }
+    }
+}
+
+fn flatten_message_with_media_markers(message: &Message) -> String {
+    let mut parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    parts.push(text.clone());
+                }
+            }
+            ContentBlock::ToolCall { .. } => {}
+            ContentBlock::Image { source } => {
+                parts.push(format!("[tau-image:{}]", media_source_descriptor(source)));
+            }
+            ContentBlock::Audio { source } => {
+                parts.push(format!("[tau-audio:{}]", media_source_descriptor(source)));
+            }
+        }
+    }
+    parts.join("\n")
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
+    }
+}
+
 fn parse_chat_response(raw: &str) -> Result<ChatResponse, TauAiError> {
     let parsed: OpenAiChatResponse = serde_json::from_str(raw)?;
     let choice =
@@ -368,11 +454,7 @@ fn parse_chat_response(raw: &str) -> Result<ChatResponse, TauAiError> {
             TauAiError::InvalidResponse("response contained no choices".to_string())
         })?;
 
-    let text = extract_text(&choice.message.content);
-    let mut content = Vec::new();
-    if !text.trim().is_empty() {
-        content.push(ContentBlock::Text { text });
-    }
+    let mut content = parse_openai_content_blocks(&choice.message.content);
 
     if let Some(tool_calls) = choice.message.tool_calls {
         for tool_call in tool_calls {
@@ -599,31 +681,127 @@ fn finalize_stream_response(
     }
 }
 
-fn extract_text(content: &Option<Value>) -> String {
+fn parse_openai_content_blocks(content: &Option<Value>) -> Vec<ContentBlock> {
     match content {
-        None | Some(Value::Null) => String::new(),
-        Some(Value::String(text)) => text.clone(),
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::String(text)) => {
+            if text.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![ContentBlock::Text { text: text.clone() }]
+            }
+        }
         Some(Value::Array(parts)) => parts
             .iter()
             .filter_map(|part| part.as_object())
-            .filter_map(|obj| {
-                if obj.get("type").and_then(Value::as_str) == Some("text") {
-                    obj.get("text")
-                } else {
-                    None
-                }
-            })
-            .filter_map(Value::as_str)
-            .collect::<Vec<_>>()
-            .join(""),
-        Some(other) => match other {
-            Value::Number(number) => number.to_string(),
-            Value::Bool(flag) => flag.to_string(),
-            Value::Object(_) | Value::Array(_) => other.to_string(),
-            Value::String(text) => text.clone(),
-            Value::Null => String::new(),
-        },
+            .filter_map(parse_openai_array_part)
+            .collect(),
+        Some(other) => {
+            let rendered = match other {
+                Value::Number(number) => number.to_string(),
+                Value::Bool(flag) => flag.to_string(),
+                Value::Object(_) | Value::Array(_) => other.to_string(),
+                Value::String(text) => text.clone(),
+                Value::Null => String::new(),
+            };
+            if rendered.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![ContentBlock::Text { text: rendered }]
+            }
+        }
     }
+}
+
+fn parse_openai_array_part(part: &serde_json::Map<String, Value>) -> Option<ContentBlock> {
+    match part.get("type").and_then(Value::as_str).unwrap_or("text") {
+        "text" | "output_text" | "input_text" => {
+            let text = part.get("text").and_then(Value::as_str).unwrap_or_default();
+            if text.trim().is_empty() {
+                None
+            } else {
+                Some(ContentBlock::Text {
+                    text: text.to_string(),
+                })
+            }
+        }
+        "image_url" | "input_image" => parse_openai_image_from_part(part),
+        "input_audio" => parse_openai_audio_from_part(part),
+        _ => {
+            let text = part.get("text").and_then(Value::as_str).unwrap_or_default();
+            if text.trim().is_empty() {
+                None
+            } else {
+                Some(ContentBlock::Text {
+                    text: text.to_string(),
+                })
+            }
+        }
+    }
+}
+
+fn parse_openai_image_from_part(part: &serde_json::Map<String, Value>) -> Option<ContentBlock> {
+    if let Some(url) = part
+        .get("image_url")
+        .and_then(Value::as_object)
+        .and_then(|image| image.get("url"))
+        .and_then(Value::as_str)
+    {
+        return Some(ContentBlock::Image {
+            source: MediaSource::Url {
+                url: url.to_string(),
+            },
+        });
+    }
+
+    if let Some(url) = part.get("image_url").and_then(Value::as_str) {
+        return Some(ContentBlock::Image {
+            source: MediaSource::Url {
+                url: url.to_string(),
+            },
+        });
+    }
+
+    None
+}
+
+fn parse_openai_audio_from_part(part: &serde_json::Map<String, Value>) -> Option<ContentBlock> {
+    let audio = part
+        .get("input_audio")
+        .or_else(|| part.get("audio"))
+        .and_then(Value::as_object)?;
+
+    if let Some(url) = audio
+        .get("url")
+        .or_else(|| audio.get("audio_url"))
+        .and_then(Value::as_str)
+    {
+        return Some(ContentBlock::Audio {
+            source: MediaSource::Url {
+                url: url.to_string(),
+            },
+        });
+    }
+
+    if let Some(data) = audio
+        .get("data")
+        .or_else(|| audio.get("audio_data"))
+        .and_then(Value::as_str)
+    {
+        let mime_type = audio
+            .get("mime_type")
+            .or_else(|| audio.get("format"))
+            .and_then(Value::as_str)
+            .unwrap_or("audio/wav");
+        return Some(ContentBlock::Audio {
+            source: MediaSource::Base64 {
+                mime_type: mime_type.to_string(),
+                data: data.to_string(),
+            },
+        });
+    }
+
+    None
 }
 
 #[derive(Debug, Deserialize)]
@@ -711,7 +889,7 @@ mod tests {
     use super::{
         apply_stream_data, build_chat_request_body, finalize_stream_response, parse_chat_response,
     };
-    use crate::{ChatRequest, ContentBlock, Message, ToolChoice, ToolDefinition};
+    use crate::{ChatRequest, ContentBlock, Message, MessageRole, ToolChoice, ToolDefinition};
 
     #[test]
     fn serializes_assistant_tool_calls_for_openai() {
@@ -822,6 +1000,79 @@ mod tests {
         assert_eq!(response.message.tool_calls().len(), 1);
         assert_eq!(response.usage.total_tokens, 14);
         assert_eq!(response.finish_reason.as_deref(), Some("tool_calls"));
+    }
+
+    #[test]
+    fn unit_serializes_user_multimodal_parts_for_openai() {
+        let multimodal_message = Message {
+            role: MessageRole::User,
+            content: vec![
+                ContentBlock::text("Inspect this"),
+                ContentBlock::image_url("https://example.com/cat.png"),
+                ContentBlock::audio_base64("audio/wav", "UklGRiQAAABXQVZF"),
+            ],
+            tool_call_id: None,
+            tool_name: None,
+            is_error: false,
+        };
+        let request = ChatRequest {
+            model: "gpt-4o-mini".to_string(),
+            messages: vec![multimodal_message],
+            tools: vec![],
+            tool_choice: None,
+            json_mode: false,
+            max_tokens: None,
+            temperature: None,
+        };
+
+        let body = build_chat_request_body(&request).expect("request body must serialize");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][1]["type"], "image_url");
+        assert_eq!(
+            body["messages"][0]["content"][1]["image_url"]["url"],
+            "https://example.com/cat.png"
+        );
+        assert_eq!(body["messages"][0]["content"][2]["type"], "text");
+        assert!(body["messages"][0]["content"][2]["text"]
+            .as_str()
+            .expect("audio fallback marker should be a string")
+            .contains("[tau-audio:"));
+    }
+
+    #[test]
+    fn functional_parses_multimodal_content_blocks_from_response() {
+        let raw = r#"{
+            "choices": [{
+                "message": {
+                    "content": [
+                        {"type":"text","text":"caption"},
+                        {"type":"image_url","image_url":{"url":"https://example.com/cat.png"}},
+                        {"type":"input_audio","input_audio":{"format":"audio/mpeg","data":"QUJDREVGRw=="}}
+                    ],
+                    "tool_calls": null
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 4,
+                "total_tokens": 14
+            }
+        }"#;
+
+        let response = parse_chat_response(raw).expect("response must parse");
+        assert_eq!(response.message.text_content(), "caption");
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Image { .. })));
+        assert!(response
+            .message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Audio { .. })));
     }
 
     #[test]

--- a/crates/tau-provider/src/claude_cli_client.rs
+++ b/crates/tau-provider/src/claude_cli_client.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 use tokio::process::Command;
 
 use tau_ai::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -264,6 +264,12 @@ fn render_claude_prompt(request: &ChatRequest) -> String {
                 } => lines.push(format!(
                     "{{\"tool_call\":{{\"id\":\"{id}\",\"name\":\"{name}\",\"arguments\":{arguments}}}}}"
                 )),
+                ContentBlock::Image { source } => {
+                    lines.push(format!("[tau-image:{}]", media_source_descriptor(source)))
+                }
+                ContentBlock::Audio { source } => {
+                    lines.push(format!("[tau-audio:{}]", media_source_descriptor(source)))
+                }
             }
         }
     }
@@ -284,6 +290,15 @@ fn role_label(role: MessageRole) -> &'static str {
         MessageRole::User => "user",
         MessageRole::Assistant => "assistant",
         MessageRole::Tool => "tool",
+    }
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
     }
 }
 
@@ -494,6 +509,25 @@ printf '{"type":"result","subtype":"success","is_error":false,"result":"late"}'
         assert!(prompt.contains("[assistant]"));
         assert!(prompt.contains("Tau tools available in caller runtime"));
         assert!(prompt.contains("- read: Read a file"));
+    }
+
+    #[test]
+    fn regression_render_claude_prompt_includes_media_markers() {
+        let mut request = test_request();
+        request.messages.push(Message {
+            role: MessageRole::User,
+            content: vec![
+                ContentBlock::image_url("https://example.com/cat.png"),
+                ContentBlock::audio_base64("audio/wav", "YXVkaW8="),
+            ],
+            tool_call_id: None,
+            tool_name: None,
+            is_error: false,
+        });
+
+        let prompt = render_claude_prompt(&request);
+        assert!(prompt.contains("[tau-image:"));
+        assert!(prompt.contains("[tau-audio:"));
     }
 
     #[test]

--- a/crates/tau-provider/src/codex_cli_client.rs
+++ b/crates/tau-provider/src/codex_cli_client.rs
@@ -8,8 +8,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 use tau_ai::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError,
 };
 
 const DEFAULT_EXEC_ARGS: &[&str] = &[
@@ -243,6 +243,12 @@ fn render_codex_exec_prompt(request: &ChatRequest) -> String {
                 } => lines.push(format!(
                     "{{\"tool_call\":{{\"id\":\"{id}\",\"name\":\"{name}\",\"arguments\":{arguments}}}}}"
                 )),
+                ContentBlock::Image { source } => {
+                    lines.push(format!("[tau-image:{}]", media_source_descriptor(source)))
+                }
+                ContentBlock::Audio { source } => {
+                    lines.push(format!("[tau-audio:{}]", media_source_descriptor(source)))
+                }
             }
         }
     }
@@ -263,6 +269,15 @@ fn role_label(role: MessageRole) -> &'static str {
         MessageRole::User => "user",
         MessageRole::Assistant => "assistant",
         MessageRole::Tool => "tool",
+    }
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
     }
 }
 
@@ -500,5 +515,24 @@ echo "too late"
         assert!(prompt.contains("[user]"));
         assert!(prompt.contains("Tau tools available in caller runtime"));
         assert!(prompt.contains("- read: Read a file"));
+    }
+
+    #[test]
+    fn regression_render_prompt_includes_media_markers() {
+        let mut request = test_request();
+        request.messages.push(Message {
+            role: MessageRole::User,
+            content: vec![
+                ContentBlock::image_url("https://example.com/cat.png"),
+                ContentBlock::audio_base64("audio/wav", "YXVkaW8="),
+            ],
+            tool_call_id: None,
+            tool_name: None,
+            is_error: false,
+        });
+
+        let prompt = render_codex_exec_prompt(&request);
+        assert!(prompt.contains("[tau-image:"));
+        assert!(prompt.contains("[tau-audio:"));
     }
 }

--- a/crates/tau-provider/src/gemini_cli_client.rs
+++ b/crates/tau-provider/src/gemini_cli_client.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 use tokio::process::Command;
 
 use tau_ai::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, Message, MessageRole,
-    StreamDeltaHandler, TauAiError,
+    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
+    MessageRole, StreamDeltaHandler, TauAiError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -225,6 +225,12 @@ fn render_gemini_prompt(request: &ChatRequest) -> String {
                 } => lines.push(format!(
                     "{{\"tool_call\":{{\"id\":\"{id}\",\"name\":\"{name}\",\"arguments\":{arguments}}}}}"
                 )),
+                ContentBlock::Image { source } => {
+                    lines.push(format!("[tau-image:{}]", media_source_descriptor(source)))
+                }
+                ContentBlock::Audio { source } => {
+                    lines.push(format!("[tau-audio:{}]", media_source_descriptor(source)))
+                }
             }
         }
     }
@@ -245,6 +251,15 @@ fn role_label(role: MessageRole) -> &'static str {
         MessageRole::User => "user",
         MessageRole::Assistant => "assistant",
         MessageRole::Tool => "tool",
+    }
+}
+
+fn media_source_descriptor(source: &MediaSource) -> String {
+    match source {
+        MediaSource::Url { url } => format!("url:{url}"),
+        MediaSource::Base64 { mime_type, data } => {
+            format!("base64:{mime_type}:{}bytes", data.len())
+        }
     }
 }
 
@@ -440,6 +455,25 @@ printf '{"response":"late"}'
         assert!(prompt.contains("[assistant]"));
         assert!(prompt.contains("Tau tools available in caller runtime"));
         assert!(prompt.contains("- read: Read a file"));
+    }
+
+    #[test]
+    fn regression_render_gemini_prompt_includes_media_markers() {
+        let mut request = test_request();
+        request.messages.push(Message {
+            role: MessageRole::User,
+            content: vec![
+                ContentBlock::image_url("https://example.com/cat.png"),
+                ContentBlock::audio_base64("audio/wav", "YXVkaW8="),
+            ],
+            tool_call_id: None,
+            tool_name: None,
+            is_error: false,
+        });
+
+        let prompt = render_gemini_prompt(&request);
+        assert!(prompt.contains("[tau-image:"));
+        assert!(prompt.contains("[tau-audio:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extend the tau-ai content model with image/audio support by adding `ContentBlock::Image`, `ContentBlock::Audio`, and `MediaSource` (`url` or `base64`).
- Add constructors for multimodal blocks and keep existing `text_content`/`tool_calls` behavior stable.
- Update OpenAI, Anthropic, and Google adapters to serialize and parse multimodal blocks with provider-safe fallbacks where required.
- Update CLI bridge prompt rendering (Codex, Claude, Gemini clients) so media context is preserved deterministically in prompts.
- Update tau-agent-core token estimation to include media payload cost.
- Add unit/functional/integration/regression coverage for the multimodal paths.

## Validation
- cargo fmt --all
- cargo check --workspace
- cargo test -p tau-ai
- cargo test -p tau-provider
- cargo test -p tau-agent-core
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1196
