### PR TITLE
feat(session): conversation branching merge strategies and /session-merge

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -12,7 +12,7 @@ use tau_session::{
     execute_branch_switch_command, execute_branches_command, execute_resume_command,
     execute_session_compact_command, execute_session_diff_runtime_command,
     execute_session_export_command, execute_session_graph_export_runtime_command,
-    execute_session_import_command, execute_session_repair_command,
+    execute_session_import_command, execute_session_merge_command, execute_session_repair_command,
     execute_session_search_runtime_command, execute_session_stats_runtime_command,
     execute_session_status_command,
 };
@@ -315,6 +315,20 @@ pub(crate) fn handle_command_with_session_import_mode(
         };
 
         let outcome = execute_session_import_command(command_args, runtime, session_import_mode)?;
+        if outcome.reload_active_head {
+            agent.replace_messages(session_lineage_messages(runtime)?);
+        }
+        println!("{}", outcome.message);
+        return Ok(CommandAction::Continue);
+    }
+
+    if command_name == "/session-merge" {
+        let Some(runtime) = session_runtime.as_mut() else {
+            println!("session is disabled");
+            return Ok(CommandAction::Continue);
+        };
+
+        let outcome = execute_session_merge_command(command_args, runtime)?;
         if outcome.reload_active_head {
             agent.replace_messages(session_lineage_messages(runtime)?);
         }

--- a/crates/tau-ops/src/command_catalog.rs
+++ b/crates/tau-ops/src/command_catalog.rs
@@ -95,6 +95,14 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         example: "/session-import /tmp/session-snapshot.jsonl",
     },
     CommandSpec {
+        name: "/session-merge",
+        usage: "/session-merge <source-id> [target-id] [--strategy <append|squash|fast-forward>]",
+        description: "Merge one branch head into another using explicit strategy",
+        details:
+            "Defaults target-id to the active head when omitted. append replays source-only entries, squash writes one summary entry, fast-forward requires target ancestry.",
+        example: "/session-merge 42 24 --strategy squash",
+    },
+    CommandSpec {
         name: "/policy",
         usage: "/policy",
         description: "Print the effective tool policy JSON",
@@ -361,6 +369,7 @@ pub const COMMAND_NAMES: &[&str] = &[
     "/session-graph-export",
     "/session-export",
     "/session-import",
+    "/session-merge",
     "/policy",
     "/audit-summary",
     "/models-list",


### PR DESCRIPTION
## Summary
- add branch merge support in `tau-session` with `append`, `squash`, and `fast-forward` strategies
- add `/session-merge` runtime command wiring through `tau-session`, `tau-ops`, and `tau-coding-agent`
- add unit/functional/integration/regression coverage for store-level merges and command execution paths

## Testing
- cargo fmt --all --check
- cargo test -p tau-session
- cargo test -p tau-ops
- cargo test -p tau-coding-agent session_merge

Closes #1197
