### PR TITLE
feat(agent): add cost tracking and budget alert events

### DIFF
--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -69,6 +69,7 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     } = config;
 
     let agent_defaults = AgentConfig::default();
+    let model_catalog_entry = model_catalog.find_model_ref(model_ref);
     let mut agent = build_onboarding_local_runtime_agent(
         client,
         model_ref,
@@ -82,6 +83,12 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
             request_retry_max_backoff_ms: cli.agent_request_retry_max_backoff_ms,
             request_timeout_ms: agent_defaults.request_timeout_ms,
             tool_timeout_ms: agent_defaults.tool_timeout_ms,
+            model_input_cost_per_million: model_catalog_entry
+                .and_then(|entry| entry.input_cost_per_million),
+            model_output_cost_per_million: model_catalog_entry
+                .and_then(|entry| entry.output_cost_per_million),
+            cost_budget_usd: cli.agent_cost_budget_usd,
+            cost_alert_thresholds_percent: cli.agent_cost_alert_threshold_percent.clone(),
         },
         tool_policy,
     );

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -364,6 +364,8 @@ pub(crate) fn test_cli() -> Cli {
         agent_request_max_retries: 2,
         agent_request_retry_initial_backoff_ms: 200,
         agent_request_retry_max_backoff_ms: 2_000,
+        agent_cost_budget_usd: None,
+        agent_cost_alert_threshold_percent: vec![80, 100],
         request_timeout_ms: 120_000,
         provider_max_retries: 2,
         provider_retry_budget_ms: 0,

--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -33,6 +33,43 @@ fn functional_cli_provider_retry_flags_accept_overrides() {
 }
 
 #[test]
+fn unit_cli_agent_cost_budget_flags_default_values_are_stable() {
+    let cli = parse_cli_with_stack(["tau-rs"]);
+    assert_eq!(cli.agent_cost_budget_usd, None);
+    assert_eq!(cli.agent_cost_alert_threshold_percent, vec![80, 100]);
+}
+
+#[test]
+fn functional_cli_agent_cost_budget_flags_accept_overrides() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--agent-cost-budget-usd",
+        "25.5",
+        "--agent-cost-alert-threshold-percent",
+        "40,75,95",
+    ]);
+    assert_eq!(cli.agent_cost_budget_usd, Some(25.5));
+    assert_eq!(cli.agent_cost_alert_threshold_percent, vec![40, 75, 95]);
+}
+
+#[test]
+fn regression_cli_agent_cost_budget_rejects_non_positive_values() {
+    let error = try_parse_cli_with_stack(["tau-rs", "--agent-cost-budget-usd", "0"])
+        .expect_err("zero budget should be rejected");
+    assert!(error
+        .to_string()
+        .contains("value must be a finite number greater than 0"));
+}
+
+#[test]
+fn regression_cli_agent_cost_threshold_rejects_out_of_range_values() {
+    let error =
+        try_parse_cli_with_stack(["tau-rs", "--agent-cost-alert-threshold-percent", "0,101"])
+            .expect_err("out-of-range threshold should be rejected");
+    assert!(error.to_string().contains("value must be in range 1..=100"));
+}
+
+#[test]
 fn unit_cli_model_catalog_flags_default_values_are_stable() {
     let cli = parse_cli_with_stack(["tau-rs"]);
     assert_eq!(cli.model_catalog_url, None);

--- a/crates/tau-runtime/src/runtime_output_runtime.rs
+++ b/crates/tau-runtime/src/runtime_output_runtime.rs
@@ -138,6 +138,30 @@ pub fn event_to_json(event: &AgentEvent) -> serde_json::Value {
             "turn": turn,
             "reason": reason,
         }),
+        AgentEvent::CostUpdated {
+            turn,
+            turn_cost_usd,
+            cumulative_cost_usd,
+            budget_usd,
+        } => serde_json::json!({
+            "type": "cost_updated",
+            "turn": turn,
+            "turn_cost_usd": turn_cost_usd,
+            "cumulative_cost_usd": cumulative_cost_usd,
+            "budget_usd": budget_usd,
+        }),
+        AgentEvent::CostBudgetAlert {
+            turn,
+            threshold_percent,
+            cumulative_cost_usd,
+            budget_usd,
+        } => serde_json::json!({
+            "type": "cost_budget_alert",
+            "turn": turn,
+            "threshold_percent": threshold_percent,
+            "cumulative_cost_usd": cumulative_cost_usd,
+            "budget_usd": budget_usd,
+        }),
     }
 }
 
@@ -202,6 +226,22 @@ mod tests {
         assert_eq!(value["type"], "replan_triggered");
         assert_eq!(value["turn"], 2);
         assert_eq!(value["reason"], "tool failure");
+    }
+
+    #[test]
+    fn unit_event_to_json_maps_cost_budget_alert_shape() {
+        let event = AgentEvent::CostBudgetAlert {
+            turn: 3,
+            threshold_percent: 80,
+            cumulative_cost_usd: 1.25,
+            budget_usd: 1.5,
+        };
+        let value = event_to_json(&event);
+        assert_eq!(value["type"], "cost_budget_alert");
+        assert_eq!(value["turn"], 3);
+        assert_eq!(value["threshold_percent"], 80);
+        assert_eq!(value["cumulative_cost_usd"], 1.25);
+        assert_eq!(value["budget_usd"], 1.5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add model-aware cost accounting to `tau-agent-core` with cumulative cost snapshots
- add configurable cost budget threshold alerts (`CostUpdated` and `CostBudgetAlert` events)
- wire model pricing defaults from model catalog into local runtime agent construction
- add CLI flags for budget alert configuration (`--agent-cost-budget-usd`, `--agent-cost-alert-threshold-percent`)
- extend runtime JSON event output and prompt telemetry logs with cost metadata

## Testing
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p tau-agent-core cost_
- cargo test -p tau-agent-core integration_budget_alerts_emit_once_per_threshold_across_multiple_prompts
- cargo test -p tau-runtime cost_
- cargo test -p tau-onboarding functional_build_local_runtime_agent_applies_cost_budget_and_pricing_settings
- cargo test -p tau-coding-agent cli_agent_cost
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1198
