### PR TITLE
refactor: harden production expect paths and enforce unsafe-free policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,16 @@ jobs:
         if: steps.rust_scope.outputs.rust_changed == 'true'
         run: cargo fmt --all --check
 
+      - name: Verify unsafe-free policy
+        if: steps.rust_scope.outputs.rust_changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if rg -n --glob '!**/target/**' '\bunsafe\s+fn\b|\bunsafe\s*\{' crates; then
+            echo "::error::unsafe Rust blocks/functions are prohibited by repository policy"
+            exit 1
+          fi
+
       - name: Lint (full lane)
         if: steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode != 'codex-light'
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/tau-access/src/approvals.rs
+++ b/crates/tau-access/src/approvals.rs
@@ -659,9 +659,10 @@ fn normalize_decision_actor(decision_actor: Option<&str>) -> String {
 
 fn approval_store_guard() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("approvals store lock poisoned")
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 fn load_approval_policy(path: &Path) -> Result<ApprovalPolicyFile> {

--- a/crates/tau-provider/src/model_catalog.rs
+++ b/crates/tau-provider/src/model_catalog.rs
@@ -91,12 +91,22 @@ impl Default for ModelListArgs {
 
 impl ModelCatalog {
     pub fn built_in() -> Self {
-        Self::from_file(
+        match Self::from_file(
             built_in_model_catalog_file(),
             ModelCatalogSource::BuiltIn,
             None,
-        )
-        .expect("built-in model catalog should be valid")
+        ) {
+            Ok(catalog) => catalog,
+            Err(error) => {
+                eprintln!("warning: built-in model catalog failed to load: {error}");
+                Self {
+                    entries: Vec::new(),
+                    index: HashMap::new(),
+                    source: ModelCatalogSource::BuiltIn,
+                    cache_age: None,
+                }
+            }
+        }
     }
 
     pub fn entries(&self) -> &[ModelCatalogEntry] {


### PR DESCRIPTION
## Summary
- remove production `expect()` panic paths in runtime code and replace with fallible behavior / poison-lock recovery
- harden provider + bridge retry paths to avoid panic-on-clone/lock invariants
- add CI enforcement step to fail builds if `unsafe fn` or `unsafe {}` appears under `crates/`

## Files
- `.github/workflows/ci.yml`
- `crates/tau-access/src/approvals.rs`
- `crates/tau-agent-core/src/lib.rs`
- `crates/tau-github-issues-runtime/src/github_issues_runtime.rs`
- `crates/tau-provider/src/fallback.rs`
- `crates/tau-provider/src/model_catalog.rs`
- `crates/tau-tools/src/mcp_server_runtime.rs`

## Validation
- `cargo fmt --all`
- `cargo check -p tau-agent-core -p tau-provider -p tau-access -p tau-tools -p tau-coding-agent`
- `cargo clippy --workspace -- -D clippy::expect_used`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tau-agent-core -p tau-provider -p tau-access -p tau-tools -p tau-coding-agent --quiet`
- `rg -n '\\bunsafe\\s+fn\\b|\\bunsafe\\s*\\{' crates --glob '!**/target/**'`

Closes #1228
Closes #1229
Part of #1227
