### PR TITLE
docs: replace crate-root boilerplate docs with substantive descriptions

### DIFF
--- a/crates/tau-access/src/lib.rs
+++ b/crates/tau-access/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Access-control primitives for Tau runtimes.
+//!
+//! Provides approval workflows, pairing policy checks, RBAC authorization,
+//! and trust-root management shared across local and transport runtimes.
+
 pub mod approvals;
 pub mod pairing;
 pub mod rbac;

--- a/crates/tau-ai/src/lib.rs
+++ b/crates/tau-ai/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Provider clients and shared AI transport types for Tau.
+//!
+//! Defines request/response schemas, model/provider abstractions, and retry
+//! behavior used by OpenAI-, Anthropic-, and Google-compatible backends.
+
 mod anthropic;
 mod google;
 mod openai;

--- a/crates/tau-browser-automation/src/lib.rs
+++ b/crates/tau-browser-automation/src/lib.rs
@@ -1,3 +1,7 @@
-//! Core library surface for the crates crate.
+//! Browser automation contracts and runtime execution for Tau.
+//!
+//! Includes fixture-driven contract replay and live browser automation runtime
+//! components used by diagnostics and integration workflows.
+
 pub mod browser_automation_contract;
 pub mod browser_automation_runtime;

--- a/crates/tau-cli/src/lib.rs
+++ b/crates/tau-cli/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! CLI argument models and validation utilities for Tau binaries.
+//!
+//! Exposes clap-backed command/flag types plus validation helpers shared by
+//! startup, diagnostics, and runtime command dispatch layers.
+
 pub mod cli_args;
 pub mod cli_types;
 pub mod command_file;

--- a/crates/tau-core/src/lib.rs
+++ b/crates/tau-core/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Foundational low-level utilities shared across Tau crates.
+//!
+//! Provides atomic file-write helpers and time utilities used by runtime state,
+//! cache persistence, and expiry calculations.
+
 pub mod atomic_io;
 pub mod time_utils;
 

--- a/crates/tau-custom-command/src/lib.rs
+++ b/crates/tau-custom-command/src/lib.rs
@@ -1,3 +1,7 @@
-//! Core library surface for the crates crate.
+//! Custom-command contract and runtime support for Tau.
+//!
+//! Hosts fixture contracts and execution runtime logic for user-defined custom
+//! command workflows in the operator control plane.
+
 pub mod custom_command_contract;
 pub mod custom_command_runtime;

--- a/crates/tau-dashboard/src/lib.rs
+++ b/crates/tau-dashboard/src/lib.rs
@@ -1,3 +1,7 @@
-//! Core library surface for the crates crate.
+//! Dashboard contract fixtures and runtime orchestration for Tau.
+//!
+//! Contains deterministic contract replay plus dashboard runtime behavior used
+//! for operator summaries and status surfaces.
+
 pub mod dashboard_contract;
 pub mod dashboard_runtime;

--- a/crates/tau-deployment/src/lib.rs
+++ b/crates/tau-deployment/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Deployment contracts and runtime tooling for Tau artifacts.
+//!
+//! Includes deployment fixture replay plus WASM packaging/inspection flows used
+//! for channel and control-plane deployment deliverables.
+
 pub mod deployment_contract;
 pub mod deployment_runtime;
 pub mod deployment_wasm;

--- a/crates/tau-diagnostics/src/lib.rs
+++ b/crates/tau-diagnostics/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Runtime diagnostics, doctor checks, and audit reporting for Tau.
+//!
+//! Implements readiness checks, structured report generation, and operator
+//! inspection commands consumed by startup and transport workflows.
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/tau-events/src/lib.rs
+++ b/crates/tau-events/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Event scheduling, templates, and runtime execution primitives for Tau.
+//!
+//! Defines event manifests plus scheduler/runner plumbing used by autonomous
+//! event-driven prompt execution in channel-store runtimes.
+
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},

--- a/crates/tau-extensions/src/lib.rs
+++ b/crates/tau-extensions/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Extension manifest, command execution, and runtime hook support for Tau.
+//!
+//! Provides extension discovery/validation and process-hook dispatch used to
+//! customize runtime behavior and command surfaces.
+
 use std::{
     collections::HashSet,
     fs,

--- a/crates/tau-gateway/src/lib.rs
+++ b/crates/tau-gateway/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Gateway contracts and HTTP/WebSocket runtime surface for Tau.
+//!
+//! Exposes gateway contract replay, OpenResponses-compatible endpoints,
+//! service-mode lifecycle helpers, and remote profile planning utilities.
+
 pub mod gateway_contract;
 pub mod gateway_openresponses;
 pub mod gateway_runtime;

--- a/crates/tau-github-issues-runtime/src/lib.rs
+++ b/crates/tau-github-issues-runtime/src/lib.rs
@@ -1,7 +1,7 @@
-//! Runtime-source crate for the Tau GitHub issues bridge.
+//! GitHub issues bridge runtime crate for Tau transport automation.
 //!
-//! The GitHub issues runtime implementation is consumed by `tau-coding-agent`
-//! via source include during incremental crate extraction.
+//! This crate hosts the GitHub bridge runtime implementation used by Tau's
+//! transport layer while extraction from the coding-agent crate continues.
 
 /// Marker type used to keep this crate non-empty while extraction is in progress.
 pub struct GithubIssuesRuntimeCrate;

--- a/crates/tau-memory/src/lib.rs
+++ b/crates/tau-memory/src/lib.rs
@@ -1,3 +1,7 @@
-//! Core library surface for the crates crate.
+//! Memory contract fixtures and runtime execution for Tau.
+//!
+//! Contains memory-specific contract replay and runtime plumbing used by
+//! channel memory workflows and validation suites.
+
 pub mod memory_contract;
 pub mod memory_runtime;

--- a/crates/tau-multi-channel/src/lib.rs
+++ b/crates/tau-multi-channel/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Multi-channel transport runtime building blocks for Tau.
+//!
+//! Provides connector, routing, lifecycle, ingress, outbound, policy, and
+//! telemetry components for Telegram/Discord/WhatsApp-style channels.
+
 pub mod multi_channel_contract;
 pub mod multi_channel_credentials;
 pub mod multi_channel_lifecycle;

--- a/crates/tau-onboarding/src/lib.rs
+++ b/crates/tau-onboarding/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Onboarding and startup bootstrap orchestration for Tau.
+//!
+//! Implements onboarding flows, startup configuration resolution, model/runtime
+//! dispatch, and transport-mode bootstrap helpers.
+
 pub mod onboarding_command;
 pub mod onboarding_daemon;
 pub mod onboarding_paths;

--- a/crates/tau-ops/src/lib.rs
+++ b/crates/tau-ops/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Operator command runtime implementations for Tau.
+//!
+//! Contains command catalog and runtime handlers for canvas, daemon, macros,
+//! project indexing, QA loops, channel store admin, and transport health ops.
+
 mod canvas_commands;
 mod channel_store_admin;
 mod command_catalog;

--- a/crates/tau-orchestrator/src/lib.rs
+++ b/crates/tau-orchestrator/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Planning/orchestration and multi-agent runtime components for Tau.
+//!
+//! Provides planner/executor orchestration, routed multi-agent collaboration,
+//! and contract fixtures for orchestrated prompt execution.
+
 pub mod multi_agent_contract;
 pub mod multi_agent_router;
 pub mod multi_agent_runtime;

--- a/crates/tau-provider/src/lib.rs
+++ b/crates/tau-provider/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Provider auth, credential, and fallback routing infrastructure for Tau.
+//!
+//! Includes provider client construction, credential-store operations,
+//! integration auth commands, and model fallback/circuit-breaker logic.
+
 mod auth;
 mod auth_commands_runtime;
 mod claude_cli_client;

--- a/crates/tau-release-channel/src/lib.rs
+++ b/crates/tau-release-channel/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Release-channel lookup, cache, and command runtime for Tau.
+//!
+//! Defines release metadata/cache models and runtime commands used by doctor
+//! and startup workflows for release awareness.
+
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};

--- a/crates/tau-runtime/src/lib.rs
+++ b/crates/tau-runtime/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Shared runtime adapters and helpers for Tau service components.
+//!
+//! Exposes channel-store, RPC, runtime output, observability, and transport
+//! health modules reused across bridge and startup runtimes.
+
 pub mod channel_store;
 pub mod observability_loggers_runtime;
 pub mod rpc_capabilities_runtime;

--- a/crates/tau-session/src/lib.rs
+++ b/crates/tau-session/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Session storage, lineage, and runtime session command utilities for Tau.
+//!
+//! Implements session persistence, branch/merge/search/stat tooling, and
+//! session graph export helpers shared by local and bridge runtimes.
+
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, OpenOptions},

--- a/crates/tau-skills/src/lib.rs
+++ b/crates/tau-skills/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Skill package management, trust, and verification runtime for Tau.
+//!
+//! Handles skill manifest parsing, install/update/remove, lockfile sync, trust
+//! records, and signature verification workflows.
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/crates/tau-slack-runtime/src/lib.rs
+++ b/crates/tau-slack-runtime/src/lib.rs
@@ -1,7 +1,7 @@
-//! Runtime-source crate for the Tau Slack bridge.
+//! Slack bridge runtime crate for Tau transport automation.
 //!
-//! The Slack runtime implementation is consumed by `tau-coding-agent` via
-//! source include during incremental crate extraction.
+//! This crate hosts the Slack bridge runtime implementation used by Tau's
+//! transport layer while extraction from the coding-agent crate continues.
 
 /// Marker type used to keep this crate non-empty while extraction is in progress.
 pub struct SlackRuntimeCrate;

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Startup preflight and runtime wiring entrypoints for Tau.
+//!
+//! Provides startup policy/transport dispatch helpers, command-file execution,
+//! and startup-time runtime composition primitives.
+
 use anyhow::{anyhow, Context, Result};
 use tau_access::pairing::{evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision};
 use tau_cli::validation::{

--- a/crates/tau-tools/src/lib.rs
+++ b/crates/tau-tools/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Tool policy and MCP server runtime integration for Tau agents.
+//!
+//! Defines tool policy construction plus MCP server/runtime surfaces used by
+//! agent tool execution and extension-mediated workflows.
+
 pub mod mcp_server_runtime;
 pub mod tool_policy_config;
 pub mod tools;

--- a/crates/tau-tui/src/lib.rs
+++ b/crates/tau-tui/src/lib.rs
@@ -1,4 +1,8 @@
-//! Core library surface for the crates crate.
+//! Terminal UI primitives and rendering contracts for Tau interfaces.
+//!
+//! Contains reusable TUI components, view-model types, and rendering helpers
+//! used by interactive terminal surfaces.
+
 use std::{fmt, path::Path};
 
 use serde::{Deserialize, Serialize};

--- a/crates/tau-voice/src/lib.rs
+++ b/crates/tau-voice/src/lib.rs
@@ -1,3 +1,7 @@
-//! Core library surface for the crates crate.
+//! Voice contract fixtures and runtime logic for Tau.
+//!
+//! Provides voice transport contract replay and runtime helpers used by voice
+//! interaction and wake-word related integrations.
+
 pub mod voice_contract;
 pub mod voice_runtime;


### PR DESCRIPTION
## Summary
- replace boilerplate crate-root `//!` docs with substantive, crate-specific descriptions
- document responsibilities and integration roles for 28 crate `src/lib.rs` files
- improve generated docs readability for maintainers and downstream users

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet`

Closes #1231
Part of #1227
