### PR TITLE
refactor(runtime): remove include-based bridge wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,7 @@ dependencies = [
  "tau-extensions",
  "tau-gateway",
  "tau-github-issues",
+ "tau-github-issues-runtime",
  "tau-memory",
  "tau-multi-channel",
  "tau-onboarding",
@@ -2872,6 +2873,7 @@ dependencies = [
  "tau-runtime",
  "tau-session",
  "tau-skills",
+ "tau-slack-runtime",
  "tau-startup",
  "tau-tools",
  "tau-voice",
@@ -3040,6 +3042,29 @@ dependencies = [
 [[package]]
 name = "tau-github-issues-runtime"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "httpmock",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tau-access",
+ "tau-agent-core",
+ "tau-ai",
+ "tau-core",
+ "tau-diagnostics",
+ "tau-github-issues",
+ "tau-ops",
+ "tau-orchestrator",
+ "tau-provider",
+ "tau-runtime",
+ "tau-session",
+ "tau-startup",
+ "tau-tools",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "tau-memory"
@@ -3234,6 +3259,27 @@ dependencies = [
 [[package]]
 name = "tau-slack-runtime"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures-util",
+ "httpmock",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tau-access",
+ "tau-agent-core",
+ "tau-ai",
+ "tau-core",
+ "tau-ops",
+ "tau-runtime",
+ "tau-session",
+ "tau-startup",
+ "tau-tools",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+]
 
 [[package]]
 name = "tau-startup"

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -35,10 +35,12 @@ tau-release-channel = { path = "../tau-release-channel" }
 tau-ops = { path = "../tau-ops" }
 tau-memory = { path = "../tau-memory" }
 tau-github-issues = { path = "../tau-github-issues" }
+tau-github-issues-runtime = { path = "../tau-github-issues-runtime" }
 tau-dashboard = { path = "../tau-dashboard" }
 tau-custom-command = { path = "../tau-custom-command" }
 tau-browser-automation = { path = "../tau-browser-automation" }
 tau-voice = { path = "../tau-voice" }
+tau-slack-runtime = { path = "../tau-slack-runtime" }
 tau-tools = { path = "../tau-tools" }
 tau-onboarding = { path = "../tau-onboarding" }
 tau-agent-core = { path = "../tau-agent-core" }

--- a/crates/tau-coding-agent/src/github_issues.rs
+++ b/crates/tau-coding-agent/src/github_issues.rs
@@ -1,4 +1,0 @@
-include!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../tau-github-issues-runtime/src/github_issues_runtime.rs"
-));

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -14,7 +14,6 @@ mod custom_command_contract;
 mod dashboard_contract;
 mod deployment_wasm;
 mod events;
-mod github_issues;
 mod macro_profile_commands;
 mod mcp_server;
 mod memory_contract;
@@ -30,7 +29,6 @@ mod rpc_protocol;
 mod runtime_loop;
 mod runtime_output;
 mod runtime_types;
-mod slack;
 mod slack_helpers;
 mod startup_dispatch;
 mod startup_local_runtime;
@@ -41,6 +39,7 @@ mod tool_policy_config;
 mod tools;
 #[cfg(test)]
 mod transport_conformance;
+#[cfg(test)]
 mod transport_health;
 mod voice_contract;
 
@@ -61,10 +60,14 @@ pub(crate) use tau_ai::Provider;
 use tau_ai::{LlmClient, Message, ModelRef};
 pub(crate) use tau_extensions as extension_manifest;
 #[cfg(test)]
+use tau_github_issues_runtime::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
+#[cfg(test)]
 pub(crate) use tau_skills as package_manifest;
 #[cfg(test)]
 pub(crate) use tau_skills as skills;
 pub(crate) use tau_skills as skills_commands;
+#[cfg(test)]
+use tau_slack_runtime::{run_slack_bridge, SlackBridgeRuntimeConfig};
 
 pub(crate) use crate::auth_commands::execute_auth_command;
 #[cfg(test)]
@@ -173,6 +176,7 @@ pub(crate) use crate::runtime_loop::{
     resolve_prompt_input, run_interactive, run_plan_first_prompt_with_runtime_hooks, run_prompt,
     InteractiveRuntimeConfig, RuntimeExtensionHooksConfig,
 };
+#[cfg(test)]
 pub(crate) use crate::runtime_loop::{run_prompt_with_cancellation, PromptRunStatus};
 #[cfg(test)]
 pub(crate) use crate::runtime_output::event_to_json;
@@ -180,9 +184,10 @@ pub(crate) use crate::runtime_output::event_to_json;
 pub(crate) use crate::runtime_output::stream_text_chunks;
 #[cfg(test)]
 pub(crate) use crate::runtime_output::{persist_messages, print_assistant_messages};
+#[cfg(test)]
+pub(crate) use crate::runtime_types::RenderOptions;
 pub(crate) use crate::runtime_types::{
-    AuthCommandConfig, CommandExecutionContext, ProfileDefaults, RenderOptions,
-    SkillsSyncCommandConfig,
+    AuthCommandConfig, CommandExecutionContext, ProfileDefaults, SkillsSyncCommandConfig,
 };
 #[cfg(test)]
 pub(crate) use crate::runtime_types::{
@@ -232,22 +237,23 @@ pub(crate) use crate::tool_policy_config::build_tool_policy;
 pub(crate) use crate::tool_policy_config::parse_sandbox_command_tokens;
 #[cfg(test)]
 pub(crate) use crate::tool_policy_config::tool_policy_to_json;
+#[cfg(test)]
 pub(crate) use crate::transport_health::TransportHealthSnapshot;
-#[cfg(test)]
-use github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
-#[cfg(test)]
-use slack::{run_slack_bridge, SlackBridgeRuntimeConfig};
 pub(crate) use tau_access::approvals::{
     evaluate_approval_gate, execute_approvals_command, ApprovalAction, ApprovalGateResult,
 };
+#[cfg(test)]
 pub(crate) use tau_access::pairing::{
-    evaluate_pairing_access, execute_pair_command, execute_unpair_command,
-    pairing_policy_for_state_dir, PairingDecision,
+    evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision,
+};
+pub(crate) use tau_access::pairing::{execute_pair_command, execute_unpair_command};
+#[cfg(test)]
+pub(crate) use tau_access::rbac::{
+    authorize_action_for_principal_with_policy_path, github_principal,
+    rbac_policy_path_for_state_dir, slack_principal,
 };
 pub(crate) use tau_access::rbac::{
-    authorize_action_for_principal_with_policy_path, authorize_command_for_principal,
-    execute_rbac_command, github_principal, rbac_policy_path_for_state_dir,
-    resolve_local_principal, slack_principal, RbacDecision,
+    authorize_command_for_principal, execute_rbac_command, resolve_local_principal, RbacDecision,
 };
 #[cfg(test)]
 pub(crate) use tau_access::trust_roots::{
@@ -303,7 +309,9 @@ pub(crate) use tau_cli::{CliMultiChannelOutboundMode, CliWebhookSignatureAlgorit
 pub(crate) use tau_cli::{CommandFileEntry, CommandFileReport};
 #[cfg(test)]
 pub(crate) use tau_core::current_unix_timestamp;
+#[cfg(test)]
 pub(crate) use tau_core::current_unix_timestamp_ms;
+#[cfg(test)]
 pub(crate) use tau_core::write_text_atomic;
 #[cfg(test)]
 pub(crate) use tau_diagnostics::build_doctor_command_config;
@@ -421,6 +429,7 @@ pub(crate) use tau_session::{
 };
 pub(crate) use tau_session::{execute_branch_alias_command, execute_session_bookmark_command};
 pub(crate) use tau_session::{session_lineage_messages, SessionRuntime};
+#[cfg(test)]
 pub(crate) use tau_session::{session_message_preview, session_message_role};
 #[cfg(test)]
 pub(crate) use tau_startup::command_file_error_mode_label;

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -7,11 +7,11 @@ pub(crate) use tau_onboarding::startup_config::{
 };
 use tau_session::SessionImportMode;
 pub(crate) use tau_startup::runtime_types::{
-    AuthCommandConfig, DoctorCommandConfig, RenderOptions, SkillsSyncCommandConfig,
+    AuthCommandConfig, RenderOptions, SkillsSyncCommandConfig,
 };
 #[cfg(test)]
 pub(crate) use tau_startup::runtime_types::{
-    DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus,
+    DoctorCommandConfig, DoctorMultiChannelReadinessConfig, DoctorProviderKeyStatus,
 };
 
 #[derive(Clone, Copy)]

--- a/crates/tau-coding-agent/src/slack.rs
+++ b/crates/tau-coding-agent/src/slack.rs
@@ -1,4 +1,0 @@
-include!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../tau-slack-runtime/src/slack_runtime.rs"
-));

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tau_ai::{LlmClient, ModelRef};
 use tau_cli::Cli;
+use tau_github_issues_runtime::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use tau_onboarding::startup_config::build_auth_command_config;
 use tau_onboarding::startup_transport_modes::{
     build_transport_doctor_config as build_onboarding_transport_doctor_config,
@@ -24,14 +25,13 @@ use tau_onboarding::startup_transport_modes::{
     run_voice_contract_runner_if_requested, TransportRuntimeExecutor,
 };
 use tau_provider::resolve_secret_from_cli_or_store_id;
+use tau_slack_runtime::{run_slack_bridge, SlackBridgeRuntimeConfig};
 
 use crate::channel_adapters::{
     build_multi_channel_command_handlers, build_multi_channel_pairing_evaluator,
 };
 use crate::events::{run_event_scheduler, EventSchedulerConfig};
-use crate::github_issues::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
 use crate::runtime_types::RenderOptions;
-use crate::slack::{run_slack_bridge, SlackBridgeRuntimeConfig};
 use crate::tools::ToolPolicy;
 
 struct CodingAgentTransportRuntimeExecutor<'a> {

--- a/crates/tau-github-issues-runtime/Cargo.toml
+++ b/crates/tau-github-issues-runtime/Cargo.toml
@@ -4,3 +4,26 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tau-access = { path = "../tau-access" }
+tau-agent-core = { path = "../tau-agent-core" }
+tau-ai = { path = "../tau-ai" }
+tau-core = { path = "../tau-core" }
+tau-diagnostics = { path = "../tau-diagnostics" }
+tau-github-issues = { path = "../tau-github-issues" }
+tau-ops = { path = "../tau-ops" }
+tau-orchestrator = { path = "../tau-orchestrator" }
+tau-provider = { path = "../tau-provider" }
+tau-runtime = { path = "../tau-runtime" }
+tau-session = { path = "../tau-session" }
+tau-startup = { path = "../tau-startup" }
+tau-tools = { path = "../tau-tools" }
+
+[dev-dependencies]
+httpmock = "0.8"
+tempfile = "3"

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
@@ -148,7 +148,7 @@ const DEMO_INDEX_SCENARIOS: [&str; 4] = [
 ];
 
 #[derive(Clone)]
-pub(crate) struct GithubIssuesBridgeRuntimeConfig {
+pub struct GithubIssuesBridgeRuntimeConfig {
     pub client: Arc<dyn LlmClient>,
     pub model: String,
     pub system_prompt: String,
@@ -704,8 +704,9 @@ impl GithubApiClient {
             let since_value = since.map(ToOwned::to_owned);
             let chunk: Vec<GithubIssue> = self
                 .request_json("list issues", || {
-                    let mut request =
-                        self.http.get(format!("{}/repos/{owner}/{repo}/issues", api_base));
+                    let mut request = self
+                        .http
+                        .get(format!("{}/repos/{owner}/{repo}/issues", api_base));
                     request = request.query(&[
                         ("state", "open"),
                         ("sort", "updated"),
@@ -1196,9 +1197,7 @@ pub(crate) struct PollCycleReport {
     pub failed_events: usize,
 }
 
-pub(crate) async fn run_github_issues_bridge(
-    config: GithubIssuesBridgeRuntimeConfig,
-) -> Result<()> {
+pub async fn run_github_issues_bridge(config: GithubIssuesBridgeRuntimeConfig) -> Result<()> {
     let mut runtime = GithubIssuesBridgeRuntime::new(config).await?;
     runtime.run().await
 }

--- a/crates/tau-github-issues-runtime/src/lib.rs
+++ b/crates/tau-github-issues-runtime/src/lib.rs
@@ -1,7 +1,183 @@
-//! GitHub issues bridge runtime crate for Tau transport automation.
+//! GitHub Issues bridge runtime for Tau.
 //!
-//! This crate hosts the GitHub bridge runtime implementation used by Tau's
-//! transport layer while extraction from the coding-agent crate continues.
+//! Exposes the GitHub transport bridge runtime and its configuration as a
+//! standalone crate dependency used by `tau-coding-agent`.
 
-/// Marker type used to keep this crate non-empty while extraction is in progress.
-pub struct GithubIssuesRuntimeCrate;
+use std::{
+    future::Future,
+    io::Write,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use tau_agent_core::{Agent, AgentError, CooperativeCancellationToken};
+use tau_ai::StreamDeltaHandler;
+use tau_session::SessionRuntime;
+use tokio::sync::mpsc;
+
+pub mod github_issues_runtime;
+
+pub use github_issues_runtime::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
+pub use tau_access::pairing::{
+    evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision,
+};
+pub use tau_access::rbac::{
+    authorize_action_for_principal_with_policy_path, github_principal,
+    rbac_policy_path_for_state_dir, RbacDecision,
+};
+pub use tau_core::{current_unix_timestamp_ms, write_text_atomic};
+pub use tau_ops::{
+    execute_canvas_command, CanvasCommandConfig, CanvasEventOrigin, CanvasSessionLinkContext,
+};
+pub use tau_provider::{AuthCommandConfig, CredentialStoreEncryptionMode, ProviderAuthMethod};
+pub use tau_runtime::TransportHealthSnapshot;
+pub use tau_session::{session_message_preview, session_message_role};
+pub use tau_startup::runtime_types::RenderOptions;
+pub use tau_startup::runtime_types::{DoctorCommandConfig, DoctorMultiChannelReadinessConfig};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptRunStatus {
+    Completed,
+    Cancelled,
+    TimedOut,
+}
+
+pub async fn run_prompt_with_cancellation<F>(
+    agent: &mut Agent,
+    session_runtime: &mut Option<SessionRuntime>,
+    prompt: &str,
+    turn_timeout_ms: u64,
+    cancellation_signal: F,
+    render_options: RenderOptions,
+) -> Result<PromptRunStatus>
+where
+    F: Future,
+{
+    let checkpoint = agent.messages().to_vec();
+    let cancellation_token = CooperativeCancellationToken::new();
+    agent.set_cancellation_token(Some(cancellation_token.clone()));
+    let streamed_output = Arc::new(AtomicBool::new(false));
+    let (stream_delta_handler, mut stream_task) = if render_options.stream_output {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let streamed_output = Arc::clone(&streamed_output);
+        let stream_delay_ms = render_options.stream_delay_ms;
+        let task = tokio::spawn(async move {
+            while let Some(delta) = rx.recv().await {
+                if delta.is_empty() {
+                    continue;
+                }
+                streamed_output.store(true, Ordering::Relaxed);
+                print!("{delta}");
+                let _ = std::io::stdout().flush();
+                if stream_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(stream_delay_ms)).await;
+                }
+            }
+        });
+        (
+            Some(Arc::new(move |delta: String| {
+                let _ = tx.send(delta);
+            }) as StreamDeltaHandler),
+            Some(task),
+        )
+    } else {
+        (None, None)
+    };
+    tokio::pin!(cancellation_signal);
+
+    enum PromptOutcome<T> {
+        Result(T),
+        Cancelled,
+        TimedOut,
+    }
+
+    let prompt_result = {
+        let mut prompt_future =
+            std::pin::pin!(agent.prompt_with_stream(prompt, stream_delta_handler.clone()));
+        if turn_timeout_ms == 0 {
+            tokio::select! {
+                result = &mut prompt_future => PromptOutcome::Result(result),
+                _ = &mut cancellation_signal => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::Cancelled
+                },
+            }
+        } else {
+            let timeout = tokio::time::sleep(Duration::from_millis(turn_timeout_ms));
+            tokio::pin!(timeout);
+            tokio::select! {
+                result = &mut prompt_future => PromptOutcome::Result(result),
+                _ = &mut cancellation_signal => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::Cancelled
+                },
+                _ = &mut timeout => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::TimedOut
+                },
+            }
+        }
+    };
+    agent.set_cancellation_token(None);
+
+    drop(stream_delta_handler);
+    if let Some(task) = stream_task.take() {
+        let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
+    }
+
+    let prompt_result = match prompt_result {
+        PromptOutcome::Result(result) => result,
+        PromptOutcome::Cancelled => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::Cancelled);
+        }
+        PromptOutcome::TimedOut => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::TimedOut);
+        }
+    };
+
+    let new_messages = match prompt_result {
+        Ok(messages) => messages,
+        Err(AgentError::Cancelled) => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::Cancelled);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    tau_runtime::persist_messages(session_runtime, &new_messages)?;
+    tau_runtime::print_assistant_messages(
+        &new_messages,
+        render_options.stream_output,
+        render_options.stream_delay_ms,
+        streamed_output.load(Ordering::Relaxed),
+    );
+    Ok(PromptRunStatus::Completed)
+}
+
+mod auth_commands {
+    pub use tau_provider::{
+        execute_auth_command, parse_auth_command, AuthCommand, AUTH_MATRIX_USAGE, AUTH_STATUS_USAGE,
+    };
+}
+
+mod channel_store {
+    pub use tau_runtime::{
+        ChannelArtifactRecord, ChannelAttachmentRecord, ChannelLogEntry, ChannelStore,
+    };
+}
+
+mod runtime_types {
+    pub use tau_startup::runtime_types::{AuthCommandConfig, DoctorCommandConfig};
+}
+
+mod tools {
+    pub use tau_tools::tools::{register_builtin_tools, ToolPolicy};
+}

--- a/crates/tau-slack-runtime/Cargo.toml
+++ b/crates/tau-slack-runtime/Cargo.toml
@@ -4,3 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+futures-util.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tokio-tungstenite.workspace = true
+tau-access = { path = "../tau-access" }
+tau-agent-core = { path = "../tau-agent-core" }
+tau-ai = { path = "../tau-ai" }
+tau-core = { path = "../tau-core" }
+tau-ops = { path = "../tau-ops" }
+tau-runtime = { path = "../tau-runtime" }
+tau-session = { path = "../tau-session" }
+tau-startup = { path = "../tau-startup" }
+tau-tools = { path = "../tau-tools" }
+
+[dev-dependencies]
+httpmock = "0.8"
+tempfile = "3"

--- a/crates/tau-slack-runtime/src/lib.rs
+++ b/crates/tau-slack-runtime/src/lib.rs
@@ -1,7 +1,175 @@
-//! Slack bridge runtime crate for Tau transport automation.
+//! Slack bridge runtime for Tau.
 //!
-//! This crate hosts the Slack bridge runtime implementation used by Tau's
-//! transport layer while extraction from the coding-agent crate continues.
+//! Exposes the Slack transport bridge runtime and its configuration as a
+//! standalone crate dependency used by `tau-coding-agent`.
 
-/// Marker type used to keep this crate non-empty while extraction is in progress.
-pub struct SlackRuntimeCrate;
+use std::{
+    future::Future,
+    io::Write,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use tau_agent_core::{Agent, AgentError, CooperativeCancellationToken};
+use tau_ai::StreamDeltaHandler;
+use tau_session::SessionRuntime;
+use tokio::sync::mpsc;
+
+pub mod slack_runtime;
+
+pub use slack_runtime::{run_slack_bridge, SlackBridgeRuntimeConfig};
+pub use tau_access::pairing::{
+    evaluate_pairing_access, pairing_policy_for_state_dir, PairingDecision,
+};
+pub use tau_access::rbac::{
+    authorize_action_for_principal_with_policy_path, rbac_policy_path_for_state_dir,
+    slack_principal, RbacDecision,
+};
+pub use tau_core::{current_unix_timestamp_ms, write_text_atomic};
+pub use tau_ops::{
+    execute_canvas_command, CanvasCommandConfig, CanvasEventOrigin, CanvasSessionLinkContext,
+};
+pub use tau_runtime::TransportHealthSnapshot;
+pub use tau_startup::runtime_types::RenderOptions;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptRunStatus {
+    Completed,
+    Cancelled,
+    TimedOut,
+}
+
+pub async fn run_prompt_with_cancellation<F>(
+    agent: &mut Agent,
+    session_runtime: &mut Option<SessionRuntime>,
+    prompt: &str,
+    turn_timeout_ms: u64,
+    cancellation_signal: F,
+    render_options: RenderOptions,
+) -> Result<PromptRunStatus>
+where
+    F: Future,
+{
+    let checkpoint = agent.messages().to_vec();
+    let cancellation_token = CooperativeCancellationToken::new();
+    agent.set_cancellation_token(Some(cancellation_token.clone()));
+    let streamed_output = Arc::new(AtomicBool::new(false));
+    let (stream_delta_handler, mut stream_task) = if render_options.stream_output {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let streamed_output = Arc::clone(&streamed_output);
+        let stream_delay_ms = render_options.stream_delay_ms;
+        let task = tokio::spawn(async move {
+            while let Some(delta) = rx.recv().await {
+                if delta.is_empty() {
+                    continue;
+                }
+                streamed_output.store(true, Ordering::Relaxed);
+                print!("{delta}");
+                let _ = std::io::stdout().flush();
+                if stream_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(stream_delay_ms)).await;
+                }
+            }
+        });
+        (
+            Some(Arc::new(move |delta: String| {
+                let _ = tx.send(delta);
+            }) as StreamDeltaHandler),
+            Some(task),
+        )
+    } else {
+        (None, None)
+    };
+    tokio::pin!(cancellation_signal);
+
+    enum PromptOutcome<T> {
+        Result(T),
+        Cancelled,
+        TimedOut,
+    }
+
+    let prompt_result = {
+        let mut prompt_future =
+            std::pin::pin!(agent.prompt_with_stream(prompt, stream_delta_handler.clone()));
+        if turn_timeout_ms == 0 {
+            tokio::select! {
+                result = &mut prompt_future => PromptOutcome::Result(result),
+                _ = &mut cancellation_signal => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::Cancelled
+                },
+            }
+        } else {
+            let timeout = tokio::time::sleep(Duration::from_millis(turn_timeout_ms));
+            tokio::pin!(timeout);
+            tokio::select! {
+                result = &mut prompt_future => PromptOutcome::Result(result),
+                _ = &mut cancellation_signal => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::Cancelled
+                },
+                _ = &mut timeout => {
+                    cancellation_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut prompt_future).await;
+                    PromptOutcome::TimedOut
+                },
+            }
+        }
+    };
+    agent.set_cancellation_token(None);
+
+    drop(stream_delta_handler);
+    if let Some(task) = stream_task.take() {
+        let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
+    }
+
+    let prompt_result = match prompt_result {
+        PromptOutcome::Result(result) => result,
+        PromptOutcome::Cancelled => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::Cancelled);
+        }
+        PromptOutcome::TimedOut => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::TimedOut);
+        }
+    };
+
+    let new_messages = match prompt_result {
+        Ok(messages) => messages,
+        Err(AgentError::Cancelled) => {
+            agent.replace_messages(checkpoint);
+            return Ok(PromptRunStatus::Cancelled);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    tau_runtime::persist_messages(session_runtime, &new_messages)?;
+    tau_runtime::print_assistant_messages(
+        &new_messages,
+        render_options.stream_output,
+        render_options.stream_delay_ms,
+        streamed_output.load(Ordering::Relaxed),
+    );
+    Ok(PromptRunStatus::Completed)
+}
+
+mod channel_store {
+    pub use tau_runtime::{ChannelArtifactRecord, ChannelLogEntry, ChannelStore};
+}
+
+mod slack_helpers {
+    pub use tau_runtime::slack_helpers_runtime::{
+        is_retryable_slack_status, is_retryable_transport_error, parse_retry_after, retry_delay,
+        sanitize_for_path, truncate_for_error, truncate_for_slack,
+    };
+}
+
+mod tools {
+    pub use tau_tools::tools::{register_builtin_tools, ToolPolicy};
+}

--- a/crates/tau-slack-runtime/src/slack_runtime.rs
+++ b/crates/tau-slack-runtime/src/slack_runtime.rs
@@ -37,7 +37,7 @@ const SLACK_METADATA_MARKER_PREFIX: &str = "<!-- tau-slack-event:";
 const SLACK_METADATA_MARKER_SUFFIX: &str = " -->";
 
 #[derive(Clone)]
-pub(crate) struct SlackBridgeRuntimeConfig {
+pub struct SlackBridgeRuntimeConfig {
     pub client: Arc<dyn LlmClient>,
     pub model: String,
     pub system_prompt: String,
@@ -690,7 +690,7 @@ pub(crate) struct PollCycleReport {
     pub failed_events: usize,
 }
 
-pub(crate) async fn run_slack_bridge(config: SlackBridgeRuntimeConfig) -> Result<()> {
+pub async fn run_slack_bridge(config: SlackBridgeRuntimeConfig) -> Result<()> {
     let mut runtime = SlackBridgeRuntime::new(config).await?;
     runtime.run().await
 }


### PR DESCRIPTION
## Summary
- remove include-based bridge wiring from `tau-coding-agent`
- make `tau-github-issues-runtime` and `tau-slack-runtime` real standalone runtime crates with exported bridge APIs
- wire coding-agent transport startup to call runtime crates directly

## Key Changes
- deleted `crates/tau-coding-agent/src/github_issues.rs` and `crates/tau-coding-agent/src/slack.rs`
- added direct dependencies in `crates/tau-coding-agent/Cargo.toml` on runtime crates
- updated `crates/tau-coding-agent/src/startup_transport_modes.rs` to import bridge runtime APIs from runtime crates
- expanded runtime crate `lib.rs` files with needed re-exports and prompt-execution runtime helper
- made bridge runtime config structs and entrypoints public in:
  - `crates/tau-github-issues-runtime/src/github_issues_runtime.rs`
  - `crates/tau-slack-runtime/src/slack_runtime.rs`
- added runtime crate dependencies/dev-dependencies so their full tests run as standalone crates

## Validation
- `cargo fmt --all`
- `cargo check -p tau-github-issues-runtime -p tau-slack-runtime -p tau-coding-agent`
- `cargo test -p tau-github-issues-runtime -p tau-slack-runtime --quiet`
- `cargo test -p tau-coding-agent --quiet`
- `cargo clippy -p tau-github-issues-runtime -p tau-slack-runtime -p tau-coding-agent --all-targets -- -D warnings`

Closes #1234.
