### PR TITLE
feat(agent-core): add provider-backed memory embeddings with fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,9 @@ name = "tau-agent-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "httpmock",
  "jsonschema",
+ "reqwest 0.12.28",
  "serde_json",
  "tau-ai",
  "thiserror 2.0.18",

--- a/crates/tau-agent-core/Cargo.toml
+++ b/crates/tau-agent-core/Cargo.toml
@@ -7,9 +7,11 @@ license.workspace = true
 [dependencies]
 async-trait.workspace = true
 jsonschema.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tau-ai = { path = "../tau-ai" }
 
 [dev-dependencies]
+httpmock = "0.8"


### PR DESCRIPTION
## Summary
- add real provider/API-backed memory embeddings for agent memory recall
- keep deterministic hash embedding as fallback for reliability and offline behavior
- make memory-recall retrieval async to support embedding API calls

## Changes
- `AgentConfig` adds optional embedding API configuration:
  - `memory_embedding_model`
  - `memory_embedding_api_base`
  - `memory_embedding_api_key`
- memory recall retrieval path now:
  - batches query + candidate texts into OpenAI-compatible `/embeddings` request when configured
  - normalizes and resizes returned vectors to configured dimensions
  - falls back to hash embedding if API is not configured or fails
- request message construction now awaits async memory-recall retrieval

## Tests
- updated defaults test for new config fields
- updated vector retrieval unit test for async retrieval path
- added integration test for embedding API usage with mocked response
- added regression test proving fallback to hash embedding on API failure

## Validation
- `cargo fmt --all`
- `cargo check -p tau-agent-core`
- `cargo test -p tau-agent-core --quiet`
- `cargo clippy -p tau-agent-core --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test -p tau-coding-agent --quiet`
- `cargo clippy -p tau-agent-core -p tau-coding-agent --all-targets -- -D warnings`

Closes #1232.
