### PR TITLE
refactor(coding-agent): decouple rpc/runtime_types from root re-exports

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -131,6 +131,7 @@ pub(crate) use crate::macro_profile_commands::{
 pub(crate) use crate::mcp_server::execute_mcp_server_command;
 #[cfg(test)]
 pub(crate) use crate::model_catalog::default_model_catalog_cache_path;
+#[cfg(test)]
 pub(crate) use crate::model_catalog::ModelCatalog;
 #[cfg(test)]
 pub(crate) use crate::model_catalog::{

--- a/crates/tau-coding-agent/src/rpc_protocol.rs
+++ b/crates/tau-coding-agent/src/rpc_protocol.rs
@@ -2,8 +2,7 @@ use std::io::BufReader;
 
 use anyhow::{bail, Context, Result};
 use serde_json::json;
-
-use crate::Cli;
+use tau_cli::Cli;
 
 pub(crate) use tau_runtime::{
     dispatch_rpc_ndjson_input, dispatch_rpc_raw_with_error_envelope, serve_rpc_ndjson_reader,

--- a/crates/tau-coding-agent/src/runtime_types.rs
+++ b/crates/tau-coding-agent/src/runtime_types.rs
@@ -1,10 +1,10 @@
 use crate::extension_manifest::ExtensionRegisteredCommand;
-use crate::ModelCatalog;
 pub(crate) use tau_onboarding::startup_config::ProfileDefaults;
 #[cfg(test)]
 pub(crate) use tau_onboarding::startup_config::{
     ProfileAuthDefaults, ProfileMcpDefaults, ProfilePolicyDefaults, ProfileSessionDefaults,
 };
+use tau_provider::ModelCatalog;
 use tau_session::SessionImportMode;
 pub(crate) use tau_startup::runtime_types::{
     AuthCommandConfig, RenderOptions, SkillsSyncCommandConfig,


### PR DESCRIPTION
## Summary
- switch `crates/tau-coding-agent/src/rpc_protocol.rs` to import `tau_cli::Cli` directly instead of relying on root re-exports
- switch `crates/tau-coding-agent/src/runtime_types.rs` to import `tau_provider::ModelCatalog` directly
- make `ModelCatalog` root re-export test-only in `crates/tau-coding-agent/src/main.rs`

## Validation
- `cargo check -p tau-coding-agent --tests`
- `cargo test -p tau-coding-agent --quiet`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`

Refs #933
