### PR TITLE
refactor(coding-agent-tests): explicit imports in cli validation suite

### DIFF
--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -1,4 +1,13 @@
-use super::*;
+use std::path::{Path, PathBuf};
+
+use tau_cli::{
+    CliCredentialStoreEncryptionMode, CliDaemonProfile, CliDeploymentWasmRuntimeProfile,
+    CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile, CliMultiChannelLiveConnectorMode,
+    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliProviderAuthMode,
+};
+use tau_cli::validation::validate_project_index_cli;
+
+use super::{parse_cli_with_stack, try_parse_cli_with_stack};
 
 #[test]
 fn unit_cli_provider_retry_flags_accept_explicit_baseline_values() {


### PR DESCRIPTION
## Summary
- replace wildcard `use super::*;` in `crates/tau-coding-agent/src/tests/cli_validation.rs` with explicit imports
- import CLI validation helper directly from `tau_cli::validation`
- preserve all existing CLI test behavior while reducing coupling in the validation suite

## Validation
- `cargo check -p tau-coding-agent --tests`
- `cargo test -p tau-coding-agent --quiet`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`

Refs #933
