### PR TITLE
refactor(github-issues-runtime): split runtime helper modules

### DIFF
--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
@@ -1,0 +1,216 @@
+use std::path::{Path, PathBuf};
+
+use tau_github_issues::issue_artifacts_command::{
+    parse_issue_artifacts_command as parse_shared_issue_artifacts_command, ArtifactsIssueCommand,
+};
+use tau_github_issues::issue_auth_command::{
+    parse_issue_auth_command as parse_shared_issue_auth_command, TauIssueAuthCommandKind,
+};
+use tau_github_issues::issue_chat_command::{
+    parse_issue_chat_command as parse_shared_issue_chat_command, IssueChatCommand,
+    IssueChatParseConfig,
+};
+use tau_github_issues::issue_command_parser::{
+    parse_issue_command as parse_shared_issue_command, ParsedIssueCommand,
+};
+use tau_github_issues::issue_command_usage::{
+    artifacts_command_usage as artifacts_shared_command_usage,
+    chat_command_usage as chat_shared_command_usage,
+    chat_search_command_usage as chat_search_shared_command_usage,
+    chat_show_command_usage as chat_show_shared_command_usage,
+    demo_index_command_usage as demo_index_shared_command_usage,
+    doctor_command_usage as doctor_shared_command_usage,
+    issue_auth_command_usage as issue_auth_shared_command_usage,
+    tau_command_usage as tau_shared_command_usage,
+};
+use tau_github_issues::issue_core_command::{
+    parse_issue_core_command as parse_shared_issue_core_command, IssueCoreCommand,
+};
+use tau_github_issues::issue_demo_index::parse_demo_index_run_command as parse_shared_demo_index_run_command;
+use tau_github_issues::issue_demo_index_command::{
+    parse_demo_index_issue_command as parse_shared_demo_index_issue_command, DemoIndexIssueCommand,
+};
+use tau_github_issues::issue_doctor_command::parse_issue_doctor_command as parse_shared_issue_doctor_command;
+use tau_session::parse_session_search_args;
+
+use super::{
+    DemoIndexRunCommand, TauIssueCommand, CHAT_SEARCH_MAX_LIMIT, CHAT_SHOW_DEFAULT_LIMIT,
+    CHAT_SHOW_MAX_LIMIT, DEMO_INDEX_DEFAULT_TIMEOUT_SECONDS, DEMO_INDEX_MAX_TIMEOUT_SECONDS,
+    DEMO_INDEX_SCENARIOS,
+};
+use crate::auth_commands::{parse_auth_command, AuthCommand, AUTH_MATRIX_USAGE, AUTH_STATUS_USAGE};
+
+pub(super) fn default_demo_index_repo_root() -> PathBuf {
+    let manifest_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .to_path_buf();
+    if manifest_root.join("scripts/demo/index.sh").exists() {
+        return manifest_root;
+    }
+    if let Ok(current_dir) = std::env::current_dir() {
+        if current_dir.join("scripts/demo/index.sh").exists() {
+            return current_dir;
+        }
+    }
+    manifest_root
+}
+
+pub(super) fn default_demo_index_binary_path() -> PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/debug/tau-coding-agent")
+            .to_path_buf()
+    })
+}
+
+pub(super) fn parse_tau_issue_command(body: &str) -> Option<TauIssueCommand> {
+    let usage = tau_shared_command_usage("/tau");
+    let parsed = parse_shared_issue_command(
+        body,
+        "/tau",
+        &usage,
+        parse_shared_issue_core_command,
+        |command, remainder| match command {
+            "auth" => Some(Ok(parse_issue_auth_command(remainder))),
+            "doctor" => Some(Ok(parse_doctor_issue_command(remainder))),
+            "chat" => Some(Ok(parse_chat_command(remainder))),
+            "artifacts" => Some(Ok(parse_artifacts_command(remainder))),
+            "demo-index" => Some(Ok(parse_demo_index_command(remainder))),
+            _ => None,
+        },
+    )?;
+
+    let parsed = match parsed {
+        ParsedIssueCommand::Core(core) => map_issue_core_command(core),
+        ParsedIssueCommand::Special(command) => command,
+        ParsedIssueCommand::Invalid { message } => TauIssueCommand::Invalid { message },
+        ParsedIssueCommand::Unknown { command } => TauIssueCommand::Invalid {
+            message: format!(
+                "Unknown command `{}`.\n\n{}",
+                command,
+                tau_shared_command_usage("/tau")
+            ),
+        },
+    };
+    Some(parsed)
+}
+
+fn map_issue_core_command(command: IssueCoreCommand) -> TauIssueCommand {
+    match command {
+        IssueCoreCommand::Run { prompt } => TauIssueCommand::Run { prompt },
+        IssueCoreCommand::Stop => TauIssueCommand::Stop,
+        IssueCoreCommand::Status => TauIssueCommand::Status,
+        IssueCoreCommand::Health => TauIssueCommand::Health,
+        IssueCoreCommand::Compact => TauIssueCommand::Compact,
+        IssueCoreCommand::Help => TauIssueCommand::Help,
+        IssueCoreCommand::Canvas { args } => TauIssueCommand::Canvas { args },
+        IssueCoreCommand::Summarize { focus } => TauIssueCommand::Summarize { focus },
+    }
+}
+
+fn parse_demo_index_command(remainder: &str) -> TauIssueCommand {
+    let usage = demo_index_shared_command_usage(
+        "/tau",
+        &DEMO_INDEX_SCENARIOS,
+        DEMO_INDEX_DEFAULT_TIMEOUT_SECONDS,
+        DEMO_INDEX_MAX_TIMEOUT_SECONDS,
+    );
+    match parse_shared_demo_index_issue_command(remainder, &usage, |raw| {
+        let parsed = parse_shared_demo_index_run_command(
+            raw,
+            &DEMO_INDEX_SCENARIOS,
+            DEMO_INDEX_DEFAULT_TIMEOUT_SECONDS,
+            DEMO_INDEX_MAX_TIMEOUT_SECONDS,
+            &usage,
+        )?;
+        Ok(DemoIndexRunCommand {
+            scenarios: parsed.scenarios,
+            timeout_seconds: parsed.timeout_seconds,
+        })
+    }) {
+        Ok(DemoIndexIssueCommand::List) => TauIssueCommand::DemoIndexList,
+        Ok(DemoIndexIssueCommand::Report) => TauIssueCommand::DemoIndexReport,
+        Ok(DemoIndexIssueCommand::Run(command)) => TauIssueCommand::DemoIndexRun { command },
+        Err(message) => TauIssueCommand::Invalid { message },
+    }
+}
+
+fn parse_doctor_issue_command(remainder: &str) -> TauIssueCommand {
+    let usage = doctor_shared_command_usage("/tau");
+    match parse_shared_issue_doctor_command(remainder, &usage) {
+        Ok(command) => TauIssueCommand::Doctor { command },
+        Err(message) => TauIssueCommand::Invalid { message },
+    }
+}
+
+fn parse_issue_auth_command(remainder: &str) -> TauIssueCommand {
+    let usage = issue_auth_shared_command_usage("/tau", AUTH_STATUS_USAGE, AUTH_MATRIX_USAGE);
+    match parse_shared_issue_auth_command(remainder, &usage, |args| {
+        match parse_auth_command(args) {
+            Ok(AuthCommand::Status { .. }) => Ok(Some(TauIssueAuthCommandKind::Status)),
+            Ok(AuthCommand::Matrix { .. }) => Ok(Some(TauIssueAuthCommandKind::Matrix)),
+            Ok(_) => Ok(None),
+            Err(error) => Err(error.to_string()),
+        }
+    }) {
+        Ok(command) => TauIssueCommand::Auth { command },
+        Err(message) => TauIssueCommand::Invalid { message },
+    }
+}
+
+fn parse_chat_command(remainder: &str) -> TauIssueCommand {
+    let usage = chat_shared_command_usage("/tau");
+    let show_usage = chat_show_shared_command_usage("/tau");
+    let search_usage = chat_search_shared_command_usage("/tau");
+    match parse_shared_issue_chat_command(
+        remainder,
+        IssueChatParseConfig {
+            show_default_limit: CHAT_SHOW_DEFAULT_LIMIT,
+            show_max_limit: CHAT_SHOW_MAX_LIMIT,
+            search_max_limit: CHAT_SEARCH_MAX_LIMIT,
+            usage: &usage,
+            show_usage: &show_usage,
+            search_usage: &search_usage,
+        },
+        |raw| {
+            parse_session_search_args(raw)
+                .map(|args| (args.query, args.role, args.limit))
+                .map_err(|error| error.to_string())
+        },
+    ) {
+        Ok(IssueChatCommand::Start) => TauIssueCommand::ChatStart,
+        Ok(IssueChatCommand::Resume) => TauIssueCommand::ChatResume,
+        Ok(IssueChatCommand::Reset) => TauIssueCommand::ChatReset,
+        Ok(IssueChatCommand::Export) => TauIssueCommand::ChatExport,
+        Ok(IssueChatCommand::Status) => TauIssueCommand::ChatStatus,
+        Ok(IssueChatCommand::Summary) => TauIssueCommand::ChatSummary,
+        Ok(IssueChatCommand::Replay) => TauIssueCommand::ChatReplay,
+        Ok(IssueChatCommand::Show { limit }) => TauIssueCommand::ChatShow { limit },
+        Ok(IssueChatCommand::Search { query, role, limit }) => {
+            TauIssueCommand::ChatSearch { query, role, limit }
+        }
+        Err(message) => TauIssueCommand::Invalid { message },
+    }
+}
+
+fn parse_artifacts_command(remainder: &str) -> TauIssueCommand {
+    let usage = artifacts_shared_command_usage("/tau");
+    match parse_shared_issue_artifacts_command(remainder, &usage) {
+        Ok(ArtifactsIssueCommand::List) => TauIssueCommand::Artifacts {
+            purge: false,
+            run_id: None,
+        },
+        Ok(ArtifactsIssueCommand::Purge) => TauIssueCommand::Artifacts {
+            purge: true,
+            run_id: None,
+        },
+        Ok(ArtifactsIssueCommand::Run { run_id }) => TauIssueCommand::Artifacts {
+            purge: false,
+            run_id: Some(run_id),
+        },
+        Ok(ArtifactsIssueCommand::Show { artifact_id }) => {
+            TauIssueCommand::ArtifactShow { artifact_id }
+        }
+        Err(message) => TauIssueCommand::Invalid { message },
+    }
+}

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
@@ -1,0 +1,148 @@
+use tau_diagnostics::DoctorStatus;
+use tau_github_issues::issue_comment::{
+    render_issue_comment_chunks_with_footer,
+    render_issue_comment_response_parts as render_shared_issue_comment_response_parts,
+    IssueCommentArtifactView, IssueCommentAttachmentView, IssueCommentRunView,
+    IssueCommentUsageView,
+};
+use tau_github_issues::issue_event_collection::GithubBridgeEvent;
+use tau_github_issues::issue_render::{
+    render_event_prompt as render_shared_event_prompt,
+    render_issue_artifact_markdown as render_shared_issue_artifact_markdown,
+    IssueArtifactAttachmentView, IssueEventPromptAttachmentView,
+};
+
+use super::{DownloadedGithubAttachment, PromptRunReport, RepoRef, GITHUB_COMMENT_MAX_CHARS};
+use crate::PromptRunStatus;
+
+pub(super) fn render_event_prompt(
+    repo: &RepoRef,
+    event: &GithubBridgeEvent,
+    prompt: &str,
+    downloaded_attachments: &[DownloadedGithubAttachment],
+) -> String {
+    let repo_slug = repo.as_slug();
+    let attachment_views = downloaded_attachments
+        .iter()
+        .map(|attachment| IssueEventPromptAttachmentView {
+            source_url: &attachment.source_url,
+            original_name: &attachment.original_name,
+            path: &attachment.path,
+            content_type: attachment.content_type.as_deref(),
+            bytes: attachment.bytes,
+            policy_reason_code: &attachment.policy_reason_code,
+            expires_unix_ms: attachment.expires_unix_ms,
+        })
+        .collect::<Vec<_>>();
+    render_shared_event_prompt(
+        &repo_slug,
+        event.issue_number,
+        &event.issue_title,
+        &event.author_login,
+        event.kind.as_str(),
+        prompt,
+        &attachment_views,
+    )
+}
+
+pub(super) fn render_issue_comment_response_parts(
+    event: &GithubBridgeEvent,
+    run: &PromptRunReport,
+) -> (String, String) {
+    let usage = &run.usage;
+    let status = format!("{:?}", run.status).to_lowercase();
+    let usage_view = IssueCommentUsageView {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        total_tokens: usage.total_tokens,
+    };
+    let artifact_view = IssueCommentArtifactView {
+        relative_path: &run.artifact.relative_path,
+        checksum_sha256: &run.artifact.checksum_sha256,
+        bytes: run.artifact.bytes,
+    };
+    let attachment_views = run
+        .downloaded_attachments
+        .iter()
+        .map(|attachment| IssueCommentAttachmentView {
+            policy_reason_code: &attachment.policy_reason_code,
+        })
+        .collect::<Vec<_>>();
+    let run_view = IssueCommentRunView {
+        event_key: &event.key,
+        run_id: &run.run_id,
+        status: &status,
+        model: &run.model,
+        assistant_reply: &run.assistant_reply,
+        usage: usage_view,
+        artifact: artifact_view,
+    };
+    render_shared_issue_comment_response_parts(run_view, &attachment_views)
+}
+
+pub(super) fn render_issue_comment_chunks(
+    event: &GithubBridgeEvent,
+    run: &PromptRunReport,
+) -> Vec<String> {
+    render_issue_comment_chunks_with_limit(event, run, GITHUB_COMMENT_MAX_CHARS)
+}
+
+pub(super) fn render_issue_comment_chunks_with_limit(
+    event: &GithubBridgeEvent,
+    run: &PromptRunReport,
+    max_chars: usize,
+) -> Vec<String> {
+    let (content, footer) = render_issue_comment_response_parts(event, run);
+    render_issue_comment_chunks_with_footer(&content, &footer, max_chars)
+}
+
+pub(super) fn render_issue_artifact_markdown(
+    repo: &RepoRef,
+    event: &GithubBridgeEvent,
+    run_id: &str,
+    status: PromptRunStatus,
+    assistant_reply: &str,
+    downloaded_attachments: &[DownloadedGithubAttachment],
+) -> String {
+    let repo_slug = repo.as_slug();
+    let attachment_views = downloaded_attachments
+        .iter()
+        .map(|attachment| IssueArtifactAttachmentView {
+            source_url: &attachment.source_url,
+            original_name: &attachment.original_name,
+            path: &attachment.path,
+            relative_path: &attachment.relative_path,
+            content_type: attachment.content_type.as_deref(),
+            bytes: attachment.bytes,
+            checksum_sha256: &attachment.checksum_sha256,
+            policy_reason_code: &attachment.policy_reason_code,
+            created_unix_ms: attachment.created_unix_ms,
+            expires_unix_ms: attachment.expires_unix_ms,
+        })
+        .collect::<Vec<_>>();
+    render_shared_issue_artifact_markdown(
+        &repo_slug,
+        event.issue_number,
+        &event.key,
+        run_id,
+        prompt_status_label(status),
+        assistant_reply,
+        &attachment_views,
+    )
+}
+
+pub(super) fn prompt_status_label(status: PromptRunStatus) -> &'static str {
+    match status {
+        PromptRunStatus::Completed => "completed",
+        PromptRunStatus::Cancelled => "cancelled",
+        PromptRunStatus::TimedOut => "timed_out",
+    }
+}
+
+pub(super) fn doctor_status_label(status: DoctorStatus) -> &'static str {
+    match status {
+        DoctorStatus::Pass => "pass",
+        DoctorStatus::Warn => "warn",
+        DoctorStatus::Fail => "fail",
+    }
+}

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tau_agent_core::Agent;
+use tau_session::SessionStore;
+
+use crate::SessionRuntime;
+
+pub(super) fn initialize_issue_session_runtime(
+    session_path: &Path,
+    system_prompt: &str,
+    lock_wait_ms: u64,
+    lock_stale_ms: u64,
+    agent: &mut Agent,
+) -> Result<SessionRuntime> {
+    if let Some(parent) = session_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    let mut store = SessionStore::load(session_path)?;
+    store.set_lock_policy(lock_wait_ms.max(1), lock_stale_ms);
+    let active_head = store.ensure_initialized(system_prompt)?;
+    let lineage = store.lineage_messages(active_head)?;
+    if !lineage.is_empty() {
+        agent.replace_messages(lineage);
+    }
+    Ok(SessionRuntime { store, active_head })
+}


### PR DESCRIPTION
Closes #1256

## Summary of behavior changes
- Extracts `/tau` command parsing and demo-index path-default helpers from `github_issues_runtime.rs` into `src/github_issues_runtime/issue_command_helpers.rs`.
- Extracts event/comment/artifact rendering helpers and status-label mapping into `src/github_issues_runtime/issue_render_helpers.rs`.
- Extracts issue session initialization helper into `src/github_issues_runtime/issue_session_runtime.rs`.
- Keeps runtime behavior stable while reducing `github_issues_runtime.rs` to orchestration-focused logic.

## Risks and compatibility notes
- No public API surface changes were introduced.
- Primary risk is accidental helper behavior drift during extraction; mitigated by preserving function signatures/call sites and running targeted unit/functional/integration/regression tests.
- Module resolution now relies on file-backed submodules under `src/github_issues_runtime/`.

## Validation evidence
- `cargo fmt --all`
- `cargo check -p tau-github-issues-runtime`
- `cargo test -p tau-github-issues-runtime unit_parse_tau_issue_command_supports_known_commands`
- `cargo test -p tau-github-issues-runtime functional_render_event_prompt_includes_downloaded_attachments`
- `cargo test -p tau-github-issues-runtime integration_bridge_demo_index_run_command_posts_artifact_pointers`
- `cargo test -p tau-github-issues-runtime regression_parse_tau_issue_command_rejects_slash_like_inputs`
- `cargo clippy -p tau-github-issues-runtime --all-targets -- -D warnings`
