### PR TITLE
chore(fmt): normalize coding-agent test imports

### DIFF
--- a/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
@@ -1,4 +1,3 @@
-use super::make_script_executable;
 use super::super::{
     branch_alias_path_for_session, build_multi_channel_incident_timeline_report,
     build_multi_channel_route_inspect_report, command_file_error_mode_label,
@@ -18,21 +17,21 @@ use super::super::{
     execute_skills_trust_rotate_command, execute_skills_verify_command, format_id_list,
     format_remap_ids, handle_command, handle_command_with_session_import_mode, load_branch_aliases,
     load_macro_file, load_profile_store, load_session_bookmarks, load_trust_root_records,
-    parse_branch_alias_command, parse_command_file, parse_macro_command,
-    parse_profile_command, parse_session_bookmark_command, parse_skills_lock_diff_args,
-    parse_skills_prune_args, parse_skills_search_args, parse_skills_trust_list_args,
-    parse_skills_trust_mutation_args, parse_skills_verify_args, render_command_help,
-    render_help_overview, render_macro_list, render_macro_show, render_profile_diffs,
-    render_profile_list, render_profile_show, render_skills_list, render_skills_lock_diff_drift,
-    render_skills_lock_diff_in_sync, render_skills_lock_write_success, render_skills_search,
-    render_skills_show, render_skills_sync_drift_details, render_skills_trust_list,
-    render_skills_verify_report, resolve_prompt_input, resolve_prunable_skill_file_name,
-    resolve_secret_from_cli_or_store_id, resolve_skills_lock_path, save_branch_aliases,
-    save_macro_file, save_profile_store, save_session_bookmarks, session_bookmark_path_for_session,
-    session_lineage_messages, set_workspace_tau_paths, skills_command_config, tempdir,
-    test_auth_command_config, test_cli, test_command_context, test_profile_defaults,
-    test_tool_policy_json, trust_record_status, unknown_command_message,
-    validate_branch_alias_name, validate_custom_command_contract_runner_cli, validate_daemon_cli,
+    parse_branch_alias_command, parse_command_file, parse_macro_command, parse_profile_command,
+    parse_session_bookmark_command, parse_skills_lock_diff_args, parse_skills_prune_args,
+    parse_skills_search_args, parse_skills_trust_list_args, parse_skills_trust_mutation_args,
+    parse_skills_verify_args, render_command_help, render_help_overview, render_macro_list,
+    render_macro_show, render_profile_diffs, render_profile_list, render_profile_show,
+    render_skills_list, render_skills_lock_diff_drift, render_skills_lock_diff_in_sync,
+    render_skills_lock_write_success, render_skills_search, render_skills_show,
+    render_skills_sync_drift_details, render_skills_trust_list, render_skills_verify_report,
+    resolve_prompt_input, resolve_prunable_skill_file_name, resolve_secret_from_cli_or_store_id,
+    resolve_skills_lock_path, save_branch_aliases, save_macro_file, save_profile_store,
+    save_session_bookmarks, session_bookmark_path_for_session, session_lineage_messages,
+    set_workspace_tau_paths, skills_command_config, tempdir, test_auth_command_config, test_cli,
+    test_command_context, test_profile_defaults, test_tool_policy_json, trust_record_status,
+    unknown_command_message, validate_branch_alias_name,
+    validate_custom_command_contract_runner_cli, validate_daemon_cli,
     validate_dashboard_contract_runner_cli, validate_deployment_contract_runner_cli,
     validate_deployment_wasm_inspect_cli, validate_deployment_wasm_package_cli,
     validate_event_webhook_ingest_cli, validate_events_runner_cli,
@@ -60,6 +59,7 @@ use super::super::{
     SESSION_BOOKMARK_USAGE, SKILLS_PRUNE_USAGE, SKILLS_TRUST_ADD_USAGE, SKILLS_TRUST_LIST_USAGE,
     SKILLS_VERIFY_USAGE,
 };
+use super::make_script_executable;
 
 #[test]
 fn unit_default_macro_config_path_uses_project_local_file_location() {

--- a/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
@@ -1,13 +1,12 @@
-use super::{make_script_executable, write_route_table_fixture};
 use super::super::{
     apply_trust_root_mutations, build_tool_policy, default_skills_lock_path,
     discover_extension_runtime_registrations, execute_rpc_capabilities_command,
     execute_rpc_dispatch_frame_command, execute_rpc_dispatch_ndjson_command,
     execute_rpc_serve_ndjson_command, execute_rpc_validate_frame_command,
     execute_startup_preflight, handle_command, handle_command_with_session_import_mode,
-    initialize_session, load_multi_agent_route_table,
-    parse_numbered_plan_steps, parse_sandbox_command_tokens, parse_trust_rotation_spec,
-    parse_trusted_root_spec, pending, percentile_duration_ms, ready, register_extension_tools,
+    initialize_session, load_multi_agent_route_table, parse_numbered_plan_steps,
+    parse_sandbox_command_tokens, parse_trust_rotation_spec, parse_trusted_root_spec, pending,
+    percentile_duration_ms, ready, register_extension_tools,
     register_runtime_extension_tool_hook_subscriber, render_audit_summary,
     resolve_skill_trust_roots, resolve_system_prompt, restore_env_vars, rpc_capabilities_payload,
     run_plan_first_prompt, run_plan_first_prompt_with_policy_context,
@@ -15,17 +14,18 @@ use super::super::{
     set_workspace_tau_paths, skills_command_config, snapshot_env_vars, stream_text_chunks,
     summarize_audit_file, tempdir, test_auth_command_config, test_cli, test_profile_defaults,
     test_render_options, test_tool_policy_json, tool_audit_event_json, tool_policy_to_json,
-    validate_rpc_frame_file, validate_session_file, Agent, AgentConfig,
-    AgentEvent, Arc, AsyncMutex, BashCommandProfile, ChatResponse, ChatUsage, CliBashProfile,
-    CliDaemonProfile, CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode,
-    CliGatewayRemoteProfile, CliMultiChannelOutboundMode, CliMultiChannelTransport,
-    CliOsSandboxMode, CliToolPolicyPreset, CommandAction, ContentBlock, Duration, HashMap, Instant,
-    Message, MessageRole, ModelCatalog, MultiAgentRouteTable, NoopClient, OsSandboxMode, Path,
-    PathBuf, PromptRunStatus, PromptTelemetryLogger, QueueClient, RenderOptions,
-    RuntimeExtensionHooksConfig, SequenceClient, SessionImportMode, SessionRuntime, SessionStore,
-    SlowClient, SuccessClient, TauAiError, ToolAuditLogger, ToolExecutionResult, ToolPolicyPreset,
-    TrustedRootRecord, VecDeque, AUTH_ENV_TEST_LOCK,
+    validate_rpc_frame_file, validate_session_file, Agent, AgentConfig, AgentEvent, Arc,
+    AsyncMutex, BashCommandProfile, ChatResponse, ChatUsage, CliBashProfile, CliDaemonProfile,
+    CliEventTemplateSchedule, CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile,
+    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOsSandboxMode, CliToolPolicyPreset,
+    CommandAction, ContentBlock, Duration, HashMap, Instant, Message, MessageRole, ModelCatalog,
+    MultiAgentRouteTable, NoopClient, OsSandboxMode, Path, PathBuf, PromptRunStatus,
+    PromptTelemetryLogger, QueueClient, RenderOptions, RuntimeExtensionHooksConfig, SequenceClient,
+    SessionImportMode, SessionRuntime, SessionStore, SlowClient, SuccessClient, TauAiError,
+    ToolAuditLogger, ToolExecutionResult, ToolPolicyPreset, TrustedRootRecord, VecDeque,
+    AUTH_ENV_TEST_LOCK,
 };
+use super::{make_script_executable, write_route_table_fixture};
 
 #[test]
 fn unit_rpc_capabilities_payload_includes_protocol_and_capabilities() {

--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 
+use tau_cli::validation::validate_project_index_cli;
 use tau_cli::{
     CliCredentialStoreEncryptionMode, CliDaemonProfile, CliDeploymentWasmRuntimeProfile,
     CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile, CliMultiChannelLiveConnectorMode,
     CliMultiChannelOutboundMode, CliMultiChannelTransport, CliProviderAuthMode,
 };
-use tau_cli::validation::validate_project_index_cli;
 
 use super::{parse_cli_with_stack, try_parse_cli_with_stack};
 


### PR DESCRIPTION
Closes #1264

## Summary of behavior changes
- Apply rustfmt-consistent import ordering/wrapping in:
  - `crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs`
  - `crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs`
  - `crates/tau-coding-agent/src/tests/cli_validation.rs`
- No runtime behavior changes; formatting-only normalization to satisfy repository formatting gate.

## Risks and compatibility notes
- Low risk: non-functional formatting/import layout changes only.
- No interface, protocol, or data format changes.

## Validation evidence
- `cargo fmt --all --check`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent`
