### PR TITLE
refactor(runtime): extract github issues RBAC helper

### DIFF
--- a/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
@@ -86,6 +86,7 @@ use tau_session::SessionStore;
 
 mod github_api_client;
 mod issue_command_helpers;
+mod issue_rbac_helpers;
 mod issue_render_helpers;
 mod issue_run_task;
 mod issue_session_runtime;
@@ -96,6 +97,7 @@ use github_api_client::{GithubApiClient, GithubCommentCreateResponse};
 use issue_command_helpers::{
     default_demo_index_binary_path, default_demo_index_repo_root, parse_tau_issue_command,
 };
+use issue_rbac_helpers::rbac_action_for_event;
 use issue_render_helpers::{
     doctor_status_label, prompt_status_label, render_event_prompt, render_issue_artifact_markdown,
     render_issue_comment_chunks,
@@ -3612,42 +3614,6 @@ impl GithubIssuesBridgeRuntime {
             source: "github".to_string(),
             payload,
         })
-    }
-}
-
-fn rbac_action_for_event(action: &EventAction) -> String {
-    match action {
-        EventAction::RunPrompt { .. } => "command:/tau-run".to_string(),
-        EventAction::Command(command) => match command {
-            TauIssueCommand::Run { .. } => "command:/tau-run".to_string(),
-            TauIssueCommand::Stop => "command:/tau-stop".to_string(),
-            TauIssueCommand::Status => "command:/tau-status".to_string(),
-            TauIssueCommand::Health => "command:/tau-health".to_string(),
-            TauIssueCommand::Compact => "command:/tau-compact".to_string(),
-            TauIssueCommand::Help => "command:/tau-help".to_string(),
-            TauIssueCommand::ChatStart => "command:/tau-chat-start".to_string(),
-            TauIssueCommand::ChatResume => "command:/tau-chat-resume".to_string(),
-            TauIssueCommand::ChatReset => "command:/tau-chat-reset".to_string(),
-            TauIssueCommand::ChatExport => "command:/tau-chat-export".to_string(),
-            TauIssueCommand::ChatStatus => "command:/tau-chat-status".to_string(),
-            TauIssueCommand::ChatSummary => "command:/tau-chat-summary".to_string(),
-            TauIssueCommand::ChatReplay => "command:/tau-chat-replay".to_string(),
-            TauIssueCommand::ChatShow { .. } => "command:/tau-chat-show".to_string(),
-            TauIssueCommand::ChatSearch { .. } => "command:/tau-chat-search".to_string(),
-            TauIssueCommand::Artifacts { .. } => "command:/tau-artifacts".to_string(),
-            TauIssueCommand::ArtifactShow { .. } => "command:/tau-artifacts-show".to_string(),
-            TauIssueCommand::DemoIndexList => "command:/tau-demo-index".to_string(),
-            TauIssueCommand::DemoIndexRun { .. } => "command:/tau-demo-index".to_string(),
-            TauIssueCommand::DemoIndexReport => "command:/tau-demo-index".to_string(),
-            TauIssueCommand::Auth { command } => match command.kind {
-                TauIssueAuthCommandKind::Status => "command:/tau-auth-status".to_string(),
-                TauIssueAuthCommandKind::Matrix => "command:/tau-auth-matrix".to_string(),
-            },
-            TauIssueCommand::Doctor { .. } => "command:/tau-doctor".to_string(),
-            TauIssueCommand::Canvas { .. } => "command:/tau-canvas".to_string(),
-            TauIssueCommand::Summarize { .. } => "command:/tau-summarize".to_string(),
-            TauIssueCommand::Invalid { .. } => "command:/tau-invalid".to_string(),
-        },
     }
 }
 

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
@@ -1,0 +1,37 @@
+use super::{EventAction, TauIssueAuthCommandKind, TauIssueCommand};
+
+pub(super) fn rbac_action_for_event(action: &EventAction) -> String {
+    match action {
+        EventAction::RunPrompt { .. } => "command:/tau-run".to_string(),
+        EventAction::Command(command) => match command {
+            TauIssueCommand::Run { .. } => "command:/tau-run".to_string(),
+            TauIssueCommand::Stop => "command:/tau-stop".to_string(),
+            TauIssueCommand::Status => "command:/tau-status".to_string(),
+            TauIssueCommand::Health => "command:/tau-health".to_string(),
+            TauIssueCommand::Compact => "command:/tau-compact".to_string(),
+            TauIssueCommand::Help => "command:/tau-help".to_string(),
+            TauIssueCommand::ChatStart => "command:/tau-chat-start".to_string(),
+            TauIssueCommand::ChatResume => "command:/tau-chat-resume".to_string(),
+            TauIssueCommand::ChatReset => "command:/tau-chat-reset".to_string(),
+            TauIssueCommand::ChatExport => "command:/tau-chat-export".to_string(),
+            TauIssueCommand::ChatStatus => "command:/tau-chat-status".to_string(),
+            TauIssueCommand::ChatSummary => "command:/tau-chat-summary".to_string(),
+            TauIssueCommand::ChatReplay => "command:/tau-chat-replay".to_string(),
+            TauIssueCommand::ChatShow { .. } => "command:/tau-chat-show".to_string(),
+            TauIssueCommand::ChatSearch { .. } => "command:/tau-chat-search".to_string(),
+            TauIssueCommand::Artifacts { .. } => "command:/tau-artifacts".to_string(),
+            TauIssueCommand::ArtifactShow { .. } => "command:/tau-artifacts-show".to_string(),
+            TauIssueCommand::DemoIndexList => "command:/tau-demo-index".to_string(),
+            TauIssueCommand::DemoIndexRun { .. } => "command:/tau-demo-index".to_string(),
+            TauIssueCommand::DemoIndexReport => "command:/tau-demo-index".to_string(),
+            TauIssueCommand::Auth { command } => match command.kind {
+                TauIssueAuthCommandKind::Status => "command:/tau-auth-status".to_string(),
+                TauIssueAuthCommandKind::Matrix => "command:/tau-auth-matrix".to_string(),
+            },
+            TauIssueCommand::Doctor { .. } => "command:/tau-doctor".to_string(),
+            TauIssueCommand::Canvas { .. } => "command:/tau-canvas".to_string(),
+            TauIssueCommand::Summarize { .. } => "command:/tau-summarize".to_string(),
+            TauIssueCommand::Invalid { .. } => "command:/tau-invalid".to_string(),
+        },
+    }
+}


### PR DESCRIPTION
Closes #1286

## Summary of behavior changes
- Moved the RBAC action mapping helper from github_issues_runtime.rs into github_issues_runtime/issue_rbac_helpers.rs.
- Updated runtime module wiring/imports to call the extracted helper module.
- Preserved command/event to RBAC-action mapping behavior exactly.

## Risks and compatibility notes
- Low risk: structural extraction only; no intended behavior change.
- Mapping logic remains centralized and unchanged, with narrower runtime-file surface area.
- Existing authorization path tests continue exercising this mapping through poll handling.

## Validation evidence
- cargo fmt --all --check
- cargo clippy -p tau-github-issues-runtime --all-targets -- -D warnings
- cargo test -p tau-github-issues-runtime (82 passed)
