### PR TITLE
docs(runtime): add rustdoc comments to split modules

### DIFF
--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/github_api_client.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/github_api_client.rs
@@ -34,6 +34,7 @@ pub(super) struct GithubApiClient {
 }
 
 impl GithubApiClient {
+    /// Builds an authenticated GitHub API client with retry configuration.
     pub(super) fn new(
         api_base: String,
         token: String,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
@@ -63,6 +63,7 @@ pub(super) fn default_demo_index_binary_path() -> PathBuf {
     })
 }
 
+/// Parses a single issue comment body into a supported `/tau` command variant.
 pub(super) fn parse_tau_issue_command(body: &str) -> Option<TauIssueCommand> {
     let usage = tau_shared_command_usage("/tau");
     let parsed = parse_shared_issue_command(

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
@@ -1,5 +1,6 @@
 use super::{EventAction, TauIssueAuthCommandKind, TauIssueCommand};
 
+/// Maps parsed issue events to RBAC action identifiers used by policy checks.
 pub(super) fn rbac_action_for_event(action: &EventAction) -> String {
     match action {
         EventAction::RunPrompt { .. } => "command:/tau-run".to_string(),

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
@@ -15,6 +15,7 @@ use tau_github_issues::issue_render::{
 use super::{DownloadedGithubAttachment, PromptRunReport, RepoRef, GITHUB_COMMENT_MAX_CHARS};
 use crate::PromptRunStatus;
 
+/// Renders the prompt payload passed to the agent for a single GitHub event.
 pub(super) fn render_event_prompt(
     repo: &RepoRef,
     event: &GithubBridgeEvent,
@@ -45,6 +46,7 @@ pub(super) fn render_event_prompt(
     )
 }
 
+/// Produces status and detail blocks for the final run response comment.
 pub(super) fn render_issue_comment_response_parts(
     event: &GithubBridgeEvent,
     run: &PromptRunReport,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_run_task.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_run_task.rs
@@ -48,6 +48,7 @@ pub(super) struct CommentUpdateOutcome {
     pub(super) append_count: usize,
 }
 
+/// Executes one issue event run and posts the resulting GitHub comment updates.
 pub(super) async fn execute_issue_run_task(params: IssueRunTaskParams) -> RunTaskResult {
     let IssueRunTaskParams {
         github_client,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
@@ -6,6 +6,7 @@ use tau_session::SessionStore;
 
 use crate::SessionRuntime;
 
+/// Loads or initializes issue chat session state and primes agent history.
 pub(super) fn initialize_issue_session_runtime(
     session_path: &Path,
     system_prompt: &str,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_state_store.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_state_store.rs
@@ -89,6 +89,7 @@ pub(super) struct GithubIssuesBridgeStateStore {
 }
 
 impl GithubIssuesBridgeStateStore {
+    /// Loads persisted bridge state and rebuilds in-memory de-duplication indexes.
     pub(super) fn load(path: PathBuf, cap: usize) -> Result<Self> {
         let mut state = if path.exists() {
             let raw = std::fs::read_to_string(&path)

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/prompt_execution.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/prompt_execution.rs
@@ -66,6 +66,7 @@ pub(super) struct DownloadedGithubAttachment {
     pub(super) expires_unix_ms: Option<u64>,
 }
 
+/// Runs a single GitHub issue prompt against the agent and records artifacts.
 pub(super) async fn run_prompt_for_event(
     request: RunPromptForEventRequest<'_>,
 ) -> Result<PromptRunReport> {

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/artifact_workflows.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/artifact_workflows.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// Confirms artifact listing and retrieval behavior across run and TTL states.
 #[tokio::test]
 async fn functional_render_issue_artifacts_filters_by_run_id() {
     let server = MockServer::start();

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/chat_and_controls.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/chat_and_controls.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// Validates control command responses and chat session lifecycle operations.
 #[tokio::test]
 async fn integration_bridge_commands_status_stop_and_health_produce_control_comments() {
     let server = MockServer::start();

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/command_workflows.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/command_workflows.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// Verifies demo-index command rendering and run/report wiring in bridge flows.
 #[tokio::test]
 async fn functional_bridge_demo_index_list_command_reports_inventory() {
     let server = MockServer::start();

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/core_and_parsing.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/core_and_parsing.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// Covers baseline parsing and filtering helpers for issue event ingestion.
 #[test]
 fn unit_normalize_artifact_retention_days_maps_zero_to_none() {
     assert_eq!(normalize_shared_artifact_retention_days(0), None);

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/polling_and_replay.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/polling_and_replay.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// Exercises polling retry and replay-safe comment update behavior.
 #[tokio::test]
 async fn integration_github_api_client_retries_rate_limits() {
     let server = MockServer::start();

--- a/crates/tau-ops/src/channel_store_admin/command_parsing_helpers.rs
+++ b/crates/tau-ops/src/channel_store_admin/command_parsing_helpers.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, bail, Result};
 
 use super::TransportHealthInspectTarget;
 
+/// Parses CLI transport-health selectors into typed inspection targets.
 pub(super) fn parse_transport_health_inspect_target(
     raw: &str,
 ) -> Result<TransportHealthInspectTarget> {

--- a/crates/tau-ops/src/channel_store_admin/render_helpers.rs
+++ b/crates/tau-ops/src/channel_store_admin/render_helpers.rs
@@ -9,6 +9,7 @@ use super::{
     OperatorControlSummaryReport, TransportHealthInspectRow, VoiceStatusInspectReport,
 };
 
+/// Renders the top-level operator control summary block used by CLI status output.
 pub(super) fn render_operator_control_summary_report(
     report: &OperatorControlSummaryReport,
 ) -> String {


### PR DESCRIPTION
Closes #1289

## Summary of behavior changes
- Added concise rustdoc `///` comments to 15 newly split module files from recent decomposition work.
- Covered extracted GitHub Issues runtime helper modules, extracted runtime test modules, and split `channel_store_admin` helper modules.
- No runtime logic changes; docs-only update to improve API/module discoverability and review clarity.

## Risks and compatibility notes
- Low risk: documentation-only changes.
- No behavior, schema, or interface contract changes expected.

## Validation evidence
- `cargo fmt --all --check`
- `cargo clippy -p tau-github-issues-runtime -p tau-ops --all-targets -- -D warnings`
- `cargo test -p tau-github-issues-runtime` (82 passed)
- `cargo test -p tau-ops` (78 passed)