### PR TITLE
chore(lint): reduce and document allow pragmas

### DIFF
--- a/crates/tau-browser-automation/src/browser_automation_contract.rs
+++ b/crates/tau-browser-automation/src/browser_automation_contract.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 use std::path::Path;
 

--- a/crates/tau-coding-agent/src/browser_automation_contract.rs
+++ b/crates/tau-coding-agent/src/browser_automation_contract.rs
@@ -1,2 +1,3 @@
+// Intentionally kept as a compatibility re-export for contract tooling wiring.
 #[allow(unused_imports)]
 pub use tau_browser_automation::browser_automation_contract::*;

--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -200,6 +200,7 @@ pub(crate) fn handle_command(
     )
 }
 
+// Command execution keeps dependencies explicit to avoid hidden global state.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_command_with_session_import_mode(
     command: &str,

--- a/crates/tau-coding-agent/src/custom_command_contract.rs
+++ b/crates/tau-coding-agent/src/custom_command_contract.rs
@@ -1,2 +1,3 @@
+// Intentionally kept as a compatibility re-export for contract tooling wiring.
 #[allow(unused_imports)]
 pub use tau_custom_command::custom_command_contract::*;

--- a/crates/tau-coding-agent/src/dashboard_contract.rs
+++ b/crates/tau-coding-agent/src/dashboard_contract.rs
@@ -1,2 +1,3 @@
+// Intentionally kept as a compatibility re-export for contract tooling wiring.
 #[allow(unused_imports)]
 pub use tau_dashboard::dashboard_contract::*;

--- a/crates/tau-coding-agent/src/deployment_wasm.rs
+++ b/crates/tau-coding-agent/src/deployment_wasm.rs
@@ -1,2 +1,1 @@
-#[allow(unused_imports)]
 pub(crate) use tau_deployment::deployment_wasm_runtime::*;

--- a/crates/tau-coding-agent/src/memory_contract.rs
+++ b/crates/tau-coding-agent/src/memory_contract.rs
@@ -1,2 +1,3 @@
+// Intentionally kept as a compatibility re-export for contract tooling wiring.
 #[allow(unused_imports)]
 pub use tau_memory::memory_contract::*;

--- a/crates/tau-coding-agent/src/multi_agent_router.rs
+++ b/crates/tau-coding-agent/src/multi_agent_router.rs
@@ -1,3 +1,1 @@
-#![allow(unused_imports)]
-
 pub use tau_orchestrator::multi_agent_router::*;

--- a/crates/tau-coding-agent/src/orchestrator_bridge.rs
+++ b/crates/tau-coding-agent/src/orchestrator_bridge.rs
@@ -67,6 +67,7 @@ impl OrchestratorRuntime for OrchestratorRuntimeAdapter<'_> {
     }
 }
 
+// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt(
     agent: &mut Agent,
@@ -103,6 +104,7 @@ pub(crate) async fn run_plan_first_prompt(
     .await
 }
 
+// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context(
     agent: &mut Agent,
@@ -141,6 +143,7 @@ pub(crate) async fn run_plan_first_prompt_with_policy_context(
     .await
 }
 
+// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context_and_routing(
     agent: &mut Agent,

--- a/crates/tau-coding-agent/src/runtime_loop.rs
+++ b/crates/tau-coding-agent/src/runtime_loop.rs
@@ -505,6 +505,7 @@ where
     }
 }
 
+// Startup/runtime wiring intentionally threads explicit knobs rather than hidden config.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
     agent: &mut Agent,

--- a/crates/tau-coding-agent/src/slack_helpers.rs
+++ b/crates/tau-coding-agent/src/slack_helpers.rs
@@ -1,2 +1,3 @@
+// Re-export retained for runtime helper parity with other transport modules.
 #[allow(unused_imports)]
 pub(crate) use tau_runtime::slack_helpers_runtime::*;

--- a/crates/tau-coding-agent/src/tool_policy_config.rs
+++ b/crates/tau-coding-agent/src/tool_policy_config.rs
@@ -1,2 +1,3 @@
+// Re-export retained for test harness access through `crate::tool_policy_config`.
 #[allow(unused_imports)]
 pub use tau_tools::tool_policy_config::*;

--- a/crates/tau-coding-agent/src/transport_conformance.rs
+++ b/crates/tau-coding-agent/src/transport_conformance.rs
@@ -1,2 +1,1 @@
-#[allow(unused_imports)]
 pub(crate) use tau_runtime::transport_conformance_runtime::*;

--- a/crates/tau-coding-agent/src/voice_contract.rs
+++ b/crates/tau-coding-agent/src/voice_contract.rs
@@ -1,2 +1,3 @@
+// Intentionally kept as a compatibility re-export for contract tooling wiring.
 #[allow(unused_imports)]
 pub use tau_voice::voice_contract::*;

--- a/crates/tau-custom-command/src/custom_command_contract.rs
+++ b/crates/tau-custom-command/src/custom_command_contract.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 use std::path::Path;
 

--- a/crates/tau-deployment/src/deployment_contract.rs
+++ b/crates/tau-deployment/src/deployment_contract.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 use std::path::Path;
 

--- a/crates/tau-gateway/src/gateway_openresponses/types.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/types.rs
@@ -74,7 +74,6 @@ impl IntoResponse for OpenResponsesApiError {
 
 #[derive(Debug, Deserialize)]
 pub(super) struct OpenResponsesRequest {
-    #[allow(dead_code)]
     pub(super) model: Option<String>,
     #[serde(default)]
     pub(super) input: Value,

--- a/crates/tau-onboarding/src/startup_dispatch.rs
+++ b/crates/tau-onboarding/src/startup_dispatch.rs
@@ -157,6 +157,7 @@ where
     })
 }
 
+// Generic startup resolver keeps each injected dependency explicit for testing.
 #[allow(clippy::too_many_arguments)]
 pub async fn resolve_startup_runtime_from_cli<
     TModelRef,
@@ -222,6 +223,7 @@ where
     })
 }
 
+// Generic startup resolver keeps each injected dependency explicit for testing.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_startup_runtime_from_cli_with_modes<
     TModelRef,

--- a/crates/tau-orchestrator/src/orchestrator.rs
+++ b/crates/tau-orchestrator/src/orchestrator.rs
@@ -48,6 +48,7 @@ enum RoutedPromptRunState {
     Interrupted,
 }
 
+// Public orchestration entrypoint keeps policy and budget controls explicit.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -78,6 +79,7 @@ pub async fn run_plan_first_prompt<R: OrchestratorRuntime>(
     .await
 }
 
+// Public orchestration entrypoint keeps policy and budget controls explicit.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt_with_policy_context<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -111,6 +113,7 @@ pub async fn run_plan_first_prompt_with_policy_context<R: OrchestratorRuntime>(
     .await
 }
 
+// Public orchestration entrypoint keeps policy and budget controls explicit.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt_with_policy_context_and_routing<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -368,6 +371,7 @@ pub async fn run_plan_first_prompt_with_policy_context_and_routing<R: Orchestrat
     Ok(())
 }
 
+// Route tracing accepts granular optional fields to keep call sites straightforward.
 #[allow(clippy::too_many_arguments)]
 async fn run_routed_prompt_with_fallback<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -520,6 +524,7 @@ async fn run_routed_prompt_with_fallback<R: OrchestratorRuntime>(
     );
 }
 
+// Route trace emission accepts many optional dimensions to keep logs structured.
 #[allow(clippy::too_many_arguments)]
 fn emit_route_trace(
     route_trace_log_path: Option<&Path>,

--- a/crates/tau-runtime/src/channel_store.rs
+++ b/crates/tau-runtime/src/channel_store.rs
@@ -144,7 +144,6 @@ pub struct ChannelStore {
     channel_id: String,
 }
 
-#[allow(dead_code)]
 impl ChannelStore {
     pub fn open(base_dir: &Path, transport: &str, channel_id: &str) -> Result<Self> {
         let transport = transport.trim();
@@ -624,7 +623,6 @@ where
     write_text_atomic(path, &payload).with_context(|| format!("failed to write {}", path.display()))
 }
 
-#[allow(dead_code)]
 fn read_jsonl_records<T>(path: &Path) -> Result<Vec<T>>
 where
     T: for<'de> Deserialize<'de>,

--- a/crates/tau-voice/src/voice_contract.rs
+++ b/crates/tau-voice/src/voice_contract.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 use std::path::Path;
 


### PR DESCRIPTION
Closes #1290

## Summary of behavior changes
- Audited all Rust `allow` pragmas currently present on `master` and reduced the set from 29 to 19.
- Removed unnecessary `allow` usage in multiple crates (`tau-runtime`, `tau-gateway`, `tau-deployment`, `tau-custom-command`, `tau-voice`, `tau-browser-automation`, and selected `tau-coding-agent` wrappers).
- Added concise rationale comments for intentionally retained `allow` pragmas so scope and intent are explicit.

## Risks and compatibility notes
- Low risk: lint/documentation-only changes, no functional behavior changes intended.
- Contract wrapper re-exports retained where needed to preserve compatibility with existing wiring.

## Validation evidence
- `cargo fmt --all --check`
- `cargo clippy -p tau-coding-agent -p tau-runtime -p tau-gateway -p tau-deployment -p tau-custom-command -p tau-voice -p tau-browser-automation -p tau-onboarding -p tau-orchestrator --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent -p tau-orchestrator -p tau-onboarding -p tau-runtime -p tau-gateway -p tau-deployment -p tau-custom-command -p tau-voice -p tau-browser-automation`
  - `tau-coding-agent` unit: 827 passed
  - `tau-coding-agent` integration: 186 passed
  - `examples_assets`: 4 passed
  - `tau-runtime`: 88 passed
  - `tau-onboarding`: 270 passed
  - `tau-gateway`: 52 passed
  - `tau-deployment`: 36 passed
  - `tau-orchestrator`: 25 passed
  - `tau-browser-automation`: 15 passed
  - `tau-custom-command`: 13 passed
  - `tau-voice`: 13 passed
