### PR TITLE
feat(voice): add live proof harness and contract compatibility matrix

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -157,6 +157,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/deployment.sh
 ./scripts/demo/custom-command.sh
 ./scripts/demo/voice.sh
+./scripts/demo/voice-live.sh
 ```
 
 `all.sh --json` and report-file payloads include `duration_ms` per wrapper entry.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -698,6 +698,48 @@ cargo run -p tau-coding-agent -- \
 
 Operational rollout and rollback guidance: `docs/guides/voice-ops.md`.
 
+## Voice live session replay runner
+
+Use this fixture-driven live mode to validate wake-word routing, live turn handling, and
+fallback behavior (invalid audio/provider outages).
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --model openai/gpt-4o-mini \
+  --voice-live-runner \
+  --voice-live-input crates/tau-coding-agent/testdata/voice-live/single-turn.json \
+  --voice-live-wake-word tau \
+  --voice-live-max-turns 64 \
+  --voice-live-tts-output \
+  --voice-state-dir .tau/voice-live
+```
+
+The runner writes state and observability output under:
+
+- `.tau/voice-live/state.json`
+- `.tau/voice-live/runtime-events.jsonl`
+- `.tau/voice-live/channel-store/voice/<speaker_id>/...`
+
+Inspect live voice transport health snapshot:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice-live \
+  --transport-health-inspect voice \
+  --transport-health-json
+```
+
+Inspect live voice rollout guardrail/status report:
+
+```bash
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice-live \
+  --voice-status-inspect \
+  --voice-status-json
+```
+
+Operational rollout and rollback guidance: `docs/guides/voice-ops.md`.
+
 ## ChannelStore inspection and repair
 
 Inspect one channel:

--- a/docs/guides/voice-ops.md
+++ b/docs/guides/voice-ops.md
@@ -4,8 +4,12 @@ Run all commands from repository root.
 
 ## Scope
 
-This runbook covers the fixture-driven voice runtime (`--voice-contract-runner`) for wake-word
-detection and turn handling.
+This runbook covers both voice runtime modes:
+
+- Fixture-driven contract replay (`--voice-contract-runner`) for deterministic wake-word/turn
+  contract validation.
+- Fixture-driven live session replay (`--voice-live-runner`) for end-to-end live session proof,
+  fallback handling, and artifact capture.
 
 ## Health and observability signals
 
@@ -33,6 +37,13 @@ Primary state files:
 - `.tau/voice/runtime-events.jsonl`
 - `.tau/voice/channel-store/voice/<speaker_id>/...`
 
+Live demo proof artifacts:
+
+- `.tau/demo-voice-live/state.json`
+- `.tau/demo-voice-live/runtime-events.jsonl`
+- `.tau/demo-voice-live/channel-store/voice/<speaker_id>/...`
+- `.tau/demo-voice-live/artifact-manifest.json`
+
 `runtime-events.jsonl` reason codes:
 
 - `healthy_cycle`
@@ -44,6 +55,10 @@ Primary state files:
 - `case_processing_failed`
 - `wake_word_detected`
 - `turns_handled`
+- `frames_ignored_no_wake_word`
+- `invalid_audio_frames_observed`
+- `provider_outage_observed`
+- `tts_output_emitted`
 
 Guardrail interpretation:
 
@@ -54,7 +69,12 @@ Guardrail interpretation:
 
 ```bash
 ./scripts/demo/voice.sh
+./scripts/demo/voice-live.sh
 ```
+
+`voice-live.sh` writes a machine-readable proof manifest at
+`.tau/demo-voice-live/artifact-manifest.json` that records artifact paths and latest
+health/reason-code snapshot.
 
 ## Rollout plan with guardrails
 
@@ -62,18 +82,25 @@ Guardrail interpretation:
    `cargo test -p tau-coding-agent voice_contract -- --test-threads=1`
 2. Validate runtime behavior coverage:
    `cargo test -p tau-coding-agent voice_runtime -- --test-threads=1`
-3. Run deterministic demo:
+3. Validate onboarding dispatch paths:
+   `cargo test -p tau-onboarding integration_run_voice_contract_runner_if_requested_executes_runtime -- --test-threads=1`
+   `cargo test -p tau-onboarding integration_run_voice_live_runner_if_requested_executes_runtime -- --test-threads=1`
+4. Run deterministic demos:
    `./scripts/demo/voice.sh`
-4. Verify health and status gate:
+   `./scripts/demo/voice-live.sh`
+5. Verify health and status gate:
    `--transport-health-inspect voice --transport-health-json`
    `--voice-status-inspect --voice-status-json`
-5. Promote by increasing fixture complexity gradually while monitoring:
+6. Verify live-run proof manifest:
+   `.tau/demo-voice-live/artifact-manifest.json`
+7. Promote by increasing fixture complexity gradually while monitoring:
    `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
-   `wake_word_detected`, and `turns_handled`.
+   `wake_word_detected`, `turns_handled`, `invalid_audio_frames_observed`,
+   and `provider_outage_observed`.
 
 ## Rollback plan
 
-1. Stop invoking `--voice-contract-runner`.
+1. Stop invoking `--voice-contract-runner` and `--voice-live-runner`.
 2. Preserve `.tau/voice/` for incident analysis.
 3. Revert to last known-good revision:
    `git revert <commit>`
@@ -93,3 +120,6 @@ Guardrail interpretation:
   Action: run deterministic demo and re-check `voice-status-inspect` freshness fields.
 - Symptom: non-zero `queue_depth`.
   Action: reduce per-cycle fixture volume or increase `--voice-queue-limit`.
+- Symptom: live manifest missing expected artifacts.
+  Action: rerun `./scripts/demo/voice-live.sh`, then verify `.tau/demo-voice-live/state.json` and
+  `.tau/demo-voice-live/runtime-events.jsonl` exist before triaging runner output.

--- a/scripts/demo/voice-live.sh
+++ b/scripts/demo/voice-live.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "voice-live" "Run deterministic live voice runtime commands against checked-in fixtures and emit an artifact manifest." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+single_turn_fixture="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/voice-live/single-turn.json"
+multi_turn_fixture="${TAU_DEMO_REPO_ROOT}/crates/tau-voice/testdata/voice-live/multi-turn.json"
+fallback_fixture="${TAU_DEMO_REPO_ROOT}/crates/tau-voice/testdata/voice-live/fallbacks.json"
+demo_state_dir="${TAU_DEMO_VOICE_LIVE_STATE_DIR:-.tau/demo-voice-live}"
+
+if [[ "${demo_state_dir}" = /* ]]; then
+  demo_state_path="${demo_state_dir}"
+else
+  demo_state_path="${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+fi
+artifact_manifest_path="${demo_state_path}/artifact-manifest.json"
+
+tau_demo_common_require_file "${single_turn_fixture}"
+tau_demo_common_require_file "${multi_turn_fixture}"
+tau_demo_common_require_file "${fallback_fixture}"
+tau_demo_common_require_command python3
+tau_demo_common_prepare_binary
+
+rm -rf "${demo_state_path}"
+
+tau_demo_common_run_step \
+  "voice-live-runner-single-turn" \
+  --voice-live-runner \
+  --voice-live-input ./crates/tau-coding-agent/testdata/voice-live/single-turn.json \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-live-wake-word tau \
+  --voice-live-max-turns 64 \
+  --voice-live-tts-output
+
+tau_demo_common_run_step \
+  "voice-live-runner-multi-turn" \
+  --voice-live-runner \
+  --voice-live-input ./crates/tau-voice/testdata/voice-live/multi-turn.json \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-live-wake-word tau \
+  --voice-live-max-turns 64 \
+  --voice-live-tts-output=false
+
+tau_demo_common_run_step \
+  "voice-live-runner-fallbacks" \
+  --voice-live-runner \
+  --voice-live-input ./crates/tau-voice/testdata/voice-live/fallbacks.json \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-live-wake-word tau \
+  --voice-live-max-turns 64 \
+  --voice-live-tts-output
+
+tau_demo_common_run_step \
+  "transport-health-inspect-voice-live" \
+  --voice-state-dir "${demo_state_dir}" \
+  --transport-health-inspect voice \
+  --transport-health-json
+
+tau_demo_common_run_step \
+  "voice-status-inspect-live" \
+  --voice-state-dir "${demo_state_dir}" \
+  --voice-status-inspect \
+  --voice-status-json
+
+tau_demo_common_run_step \
+  "channel-store-inspect-voice-live-ops-live" \
+  --channel-store-root "${demo_state_dir}/channel-store" \
+  --channel-store-inspect voice/ops-live
+
+python3 - "${demo_state_path}" "${artifact_manifest_path}" "${demo_state_dir}" <<'PY'
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+state_dir = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+state_dir_label = sys.argv[3]
+
+def artifact(name: str, path: Path) -> dict:
+    return {
+        "name": name,
+        "path": str(path),
+        "exists": path.exists(),
+        "size_bytes": path.stat().st_size if path.exists() else 0,
+    }
+
+state_path = state_dir / "state.json"
+events_path = state_dir / "runtime-events.jsonl"
+channel_store_path = state_dir / "channel-store"
+
+artifacts = [
+    artifact("state", state_path),
+    artifact("runtime_events", events_path),
+    artifact("channel_store_root", channel_store_path),
+]
+
+trace_log = os.environ.get("TAU_DEMO_TRACE_LOG", "").strip()
+if trace_log:
+    trace_path = Path(trace_log)
+    artifacts.append(artifact("trace_log", trace_path))
+
+health_snapshot = {}
+if state_path.exists():
+    try:
+        parsed_state = json.loads(state_path.read_text(encoding="utf-8"))
+        health_snapshot = parsed_state.get("health", {})
+    except json.JSONDecodeError:
+        health_snapshot = {"parse_error": "invalid_state_json"}
+
+last_reason_codes = []
+last_health_state = ""
+if events_path.exists():
+    lines = [line for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if lines:
+        try:
+            last_event = json.loads(lines[-1])
+            codes = last_event.get("reason_codes", [])
+            if isinstance(codes, list):
+                last_reason_codes = [str(code) for code in codes]
+            last_health_state = str(last_event.get("health_state", ""))
+        except json.JSONDecodeError:
+            last_reason_codes = ["invalid_runtime_events_json"]
+
+payload = {
+    "schema_version": 1,
+    "demo": "voice-live",
+    "generated_unix_ms": int(time.time() * 1000),
+    "state_dir": state_dir_label,
+    "artifacts": artifacts,
+    "last_health_state": last_health_state,
+    "last_reason_codes": last_reason_codes,
+    "health_snapshot": health_snapshot,
+}
+
+manifest_path.parent.mkdir(parents=True, exist_ok=True)
+manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"[demo:voice-live] artifact-manifest: {manifest_path}")
+PY
+
+tau_demo_common_require_file "${artifact_manifest_path}"
+tau_demo_common_finish


### PR DESCRIPTION
Closes #1314

## Summary of behavior changes
- Added `scripts/demo/voice-live.sh` to run deterministic live voice replay across single-turn, multi-turn, and fallback fixtures.
- Added machine-readable proof output at `.tau/demo-voice-live/artifact-manifest.json` with artifact paths plus latest health and reason-code snapshot.
- Added demo test coverage in `.github/scripts/test_demo_scripts.py`:
  - unit parser coverage for `voice-live.sh`
  - functional/integration coverage for manifest creation and live diagnostic step ordering
  - regression coverage confirming `scripts/demo/voice.sh` remains contract-runner-only
- Added onboarding runtime coverage in `crates/tau-onboarding/src/startup_transport_modes.rs`:
  - integration test for `run_voice_contract_runner_if_requested`
  - regression test proving contract runner remains stable even when live-only fixture path is set while live mode is disabled
- Updated operator docs for voice live mode and proof workflow:
  - `docs/guides/voice-ops.md`
  - `docs/guides/transports.md`
  - `docs/guides/quickstart.md`

## Risks and compatibility notes
- `scripts/demo/voice-live.sh` is additive and does not alter existing wrapper behavior.
- Existing `scripts/demo/voice.sh` flow remains unchanged; regression tests explicitly verify no accidental migration to live flags.
- Live demo defaults to `.tau/demo-voice-live`; an absolute/relative override is available via `TAU_DEMO_VOICE_LIVE_STATE_DIR`.

## Validation evidence
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 cargo test -p tau-onboarding integration_run_voice_contract_runner_if_requested_executes_runtime -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test -p tau-onboarding integration_run_voice_live_runner_if_requested_executes_runtime -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test -p tau-onboarding regression_run_voice_contract_runner_if_requested_ignores_live_fixture_when_disabled -- --test-threads=1`
- `python3 -m unittest discover -s .github/scripts -p 'test_demo_scripts.py' -k voice_live`
- `python3 -m unittest discover -s .github/scripts -p 'test_demo_scripts.py' -k voice_contract_demo_remains_contract_runner_only`
- `CARGO_INCREMENTAL=0 cargo build -p tau-coding-agent`
- `./scripts/demo/voice-live.sh --skip-build --binary ./target/debug/tau-coding-agent --timeout-seconds 30`
- `CARGO_INCREMENTAL=0 cargo clippy -p tau-onboarding --all-targets -- -D warnings`
