### PR TITLE
feat(browser): add live harness matrix and machine-readable reports

### DIFF
--- a/crates/tau-browser-automation/src/bin/browser_automation_live_harness.rs
+++ b/crates/tau-browser-automation/src/bin/browser_automation_live_harness.rs
@@ -1,0 +1,242 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tau_browser_automation::browser_automation_contract::load_browser_automation_contract_fixture;
+use tau_browser_automation::browser_automation_live::{
+    run_browser_automation_live_fixture_with_persistence, BrowserAutomationLivePersistenceConfig,
+    BrowserAutomationLivePolicy, BrowserAutomationLiveRunSummary, BrowserSessionManager,
+    PlaywrightCliActionExecutor,
+};
+
+#[derive(Debug, Clone)]
+struct HarnessCli {
+    fixture: PathBuf,
+    state_dir: PathBuf,
+    playwright_cli: String,
+    summary_json_out: PathBuf,
+    artifact_retention_days: Option<u64>,
+    action_timeout_ms: u64,
+    max_actions_per_case: usize,
+    allow_unsafe_actions: bool,
+}
+
+impl HarnessCli {
+    fn parse() -> Result<Self> {
+        let mut fixture: Option<PathBuf> = None;
+        let mut state_dir: Option<PathBuf> = None;
+        let mut playwright_cli: Option<String> = None;
+        let mut summary_json_out: Option<PathBuf> = None;
+        let mut artifact_retention_days: Option<u64> = Some(7);
+        let mut action_timeout_ms: u64 = 5_000;
+        let mut max_actions_per_case: usize = 8;
+        let mut allow_unsafe_actions = false;
+
+        let mut args = std::env::args().skip(1);
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--help" | "-h" => {
+                    print_usage();
+                    std::process::exit(0);
+                }
+                "--fixture" => fixture = Some(PathBuf::from(require_arg_value(&mut args, &flag)?)),
+                "--state-dir" => {
+                    state_dir = Some(PathBuf::from(require_arg_value(&mut args, &flag)?))
+                }
+                "--playwright-cli" => {
+                    playwright_cli = Some(require_arg_value(&mut args, &flag)?);
+                }
+                "--summary-json-out" => {
+                    summary_json_out = Some(PathBuf::from(require_arg_value(&mut args, &flag)?));
+                }
+                "--artifact-retention-days" => {
+                    let raw = require_arg_value(&mut args, &flag)?;
+                    artifact_retention_days = if raw.trim().eq_ignore_ascii_case("none") {
+                        None
+                    } else {
+                        Some(parse_positive_u64(&raw, &flag)?)
+                    };
+                }
+                "--action-timeout-ms" => {
+                    action_timeout_ms =
+                        parse_positive_u64(&require_arg_value(&mut args, &flag)?, &flag)?;
+                }
+                "--max-actions-per-case" => {
+                    max_actions_per_case =
+                        parse_positive_usize(&require_arg_value(&mut args, &flag)?, &flag)?;
+                }
+                "--allow-unsafe-actions" => {
+                    allow_unsafe_actions = true;
+                }
+                other => {
+                    bail!("unknown argument '{other}'");
+                }
+            }
+        }
+
+        let fixture = fixture.context("--fixture is required")?;
+        let state_dir = state_dir.context("--state-dir is required")?;
+        let playwright_cli = playwright_cli.context("--playwright-cli is required")?;
+        if playwright_cli.trim().is_empty() {
+            bail!("--playwright-cli cannot be empty");
+        }
+
+        let summary_json_out =
+            summary_json_out.unwrap_or_else(|| state_dir.join("browser-live-summary.json"));
+
+        Ok(Self {
+            fixture,
+            state_dir,
+            playwright_cli,
+            summary_json_out,
+            artifact_retention_days,
+            action_timeout_ms,
+            max_actions_per_case,
+            allow_unsafe_actions,
+        })
+    }
+}
+
+fn require_arg_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    args.next()
+        .with_context(|| format!("missing value for {flag}"))
+}
+
+fn parse_positive_u64(raw: &str, flag: &str) -> Result<u64> {
+    let parsed = raw
+        .parse::<u64>()
+        .with_context(|| format!("invalid numeric value for {flag}: '{raw}'"))?;
+    if parsed == 0 {
+        bail!("{flag} must be greater than 0");
+    }
+    Ok(parsed)
+}
+
+fn parse_positive_usize(raw: &str, flag: &str) -> Result<usize> {
+    let parsed = raw
+        .parse::<usize>()
+        .with_context(|| format!("invalid numeric value for {flag}: '{raw}'"))?;
+    if parsed == 0 {
+        bail!("{flag} must be greater than 0");
+    }
+    Ok(parsed)
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_summary_json(path: &Path, summary: &BrowserAutomationLiveRunSummary) -> Result<()> {
+    ensure_parent_dir(path)?;
+    let rendered = serde_json::to_string_pretty(summary).context("serialize live summary json")?;
+    std::fs::write(path, rendered).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn print_usage() {
+    println!(
+        "Usage: browser_automation_live_harness \
+--fixture <path> \
+--state-dir <path> \
+--playwright-cli <path> \
+[--summary-json-out <path>] \
+[--artifact-retention-days <n|none>] \
+[--action-timeout-ms <n>] \
+[--max-actions-per-case <n>] \
+[--allow-unsafe-actions]"
+    );
+}
+
+fn run() -> Result<()> {
+    let cli = HarnessCli::parse()?;
+    if !cli.fixture.exists() {
+        bail!("fixture '{}' does not exist", cli.fixture.display());
+    }
+    if !cli.fixture.is_file() {
+        bail!("fixture '{}' must point to a file", cli.fixture.display());
+    }
+    std::fs::create_dir_all(&cli.state_dir)
+        .with_context(|| format!("failed to create {}", cli.state_dir.display()))?;
+
+    let fixture = load_browser_automation_contract_fixture(&cli.fixture)
+        .with_context(|| format!("failed to load fixture '{}'", cli.fixture.display()))?;
+    let persistence = BrowserAutomationLivePersistenceConfig {
+        state_dir: cli.state_dir.clone(),
+        artifact_retention_days: cli.artifact_retention_days,
+    };
+    let policy = BrowserAutomationLivePolicy {
+        action_timeout_ms: cli.action_timeout_ms,
+        max_actions_per_case: cli.max_actions_per_case,
+        allow_unsafe_actions: cli.allow_unsafe_actions,
+    };
+
+    let executor = PlaywrightCliActionExecutor::new(cli.playwright_cli.clone())
+        .context("failed to initialize playwright action executor")?;
+    let mut manager = BrowserSessionManager::new(executor);
+    let summary = run_browser_automation_live_fixture_with_persistence(
+        &fixture,
+        &mut manager,
+        &policy,
+        Some(&persistence),
+    )?;
+    write_summary_json(&cli.summary_json_out, &summary)?;
+
+    println!(
+        "browser automation live harness summary: discovered={} success={} malformed={} retryable_failures={} timeout_failures={} denied_unsafe_actions={} denied_action_limit={} artifact_records={} health_state={}",
+        summary.discovered_cases,
+        summary.success_cases,
+        summary.malformed_cases,
+        summary.retryable_failures,
+        summary.timeout_failures,
+        summary.denied_unsafe_actions,
+        summary.denied_action_limit,
+        summary.artifact_records,
+        summary.health_state,
+    );
+    for (index, entry) in summary.timeline.iter().enumerate() {
+        println!(
+            "timeline[{index}] case_id={} operation={} action={} replay_step={} status_code={} error_code={} artifact_types={}",
+            entry.case_id,
+            entry.operation,
+            entry.action,
+            entry.replay_step,
+            entry.status_code,
+            if entry.error_code.trim().is_empty() {
+                "none"
+            } else {
+                entry.error_code.as_str()
+            },
+            if entry.artifact_types.is_empty() {
+                "none".to_string()
+            } else {
+                entry.artifact_types.join(",")
+            },
+        );
+    }
+    println!("summary_json={}", cli.summary_json_out.display());
+    println!(
+        "channel_artifact_index={}",
+        cli.state_dir
+            .join("channel-store/channels/browser-automation/live/artifacts/index.jsonl")
+            .display()
+    );
+    println!(
+        "channel_log={}",
+        cli.state_dir
+            .join("channel-store/channels/browser-automation/live/log.jsonl")
+            .display()
+    );
+
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("browser automation live harness failed: {error:#}");
+        std::process::exit(1);
+    }
+}

--- a/docs/guides/browser-automation-live-ops.md
+++ b/docs/guides/browser-automation-live-ops.md
@@ -1,0 +1,66 @@
+# Browser Automation Live Ops Guide
+
+Run all commands from repository root.
+
+This guide covers the deterministic live browser harness used for local and CI proof runs.
+
+## Run Live Harness
+
+```bash
+./scripts/demo/browser-automation-live.sh
+```
+
+Optional bounded execution:
+
+```bash
+./scripts/demo/browser-automation-live.sh --timeout-seconds 120
+```
+
+Use an external Playwright CLI wrapper instead of the deterministic mock fallback:
+
+```bash
+./scripts/demo/browser-automation-live.sh --playwright-cli /path/to/playwright-wrapper
+```
+
+## Output Artifacts
+
+The harness writes:
+
+- `.tau/demo-browser-automation-live/browser-live-summary.json`
+- `.tau/demo-browser-automation-live/browser-live-report.json`
+- `.tau/demo-browser-automation-live/browser-live-transcript.log`
+- `.tau/demo-browser-automation-live/state/channel-store/channels/browser-automation/live/log.jsonl`
+- `.tau/demo-browser-automation-live/state/channel-store/channels/browser-automation/live/artifacts/index.jsonl`
+
+`browser-live-summary.json` contains health counters and per-case timeline entries:
+
+- `health_state`
+- `reason_codes`
+- `artifact_records`
+- `timeline` (case order, replay step, status, error code, artifact types)
+
+## Triage Workflow
+
+1. Check summary health:
+   - `cat .tau/demo-browser-automation-live/browser-live-summary.json`
+2. Check transcript for failing step:
+   - `cat .tau/demo-browser-automation-live/browser-live-transcript.log`
+3. Inspect channel-store event log:
+   - `cat .tau/demo-browser-automation-live/state/channel-store/channels/browser-automation/live/log.jsonl`
+4. Inspect artifact index:
+   - `cat .tau/demo-browser-automation-live/state/channel-store/channels/browser-automation/live/artifacts/index.jsonl`
+
+Common failure signals:
+
+- Harness binary missing: run without `--skip-build` so `cargo build` compiles it.
+- Timeout: increase `--timeout-seconds`.
+- Playwright wrapper issue: validate executable path passed to `--playwright-cli`.
+- Policy denials: inspect `reason_codes` and timeline `error_code` fields.
+
+## CI Attachment Pattern
+
+Publish these files as CI artifacts for merge evidence:
+
+- `.tau/demo-browser-automation-live/browser-live-summary.json`
+- `.tau/demo-browser-automation-live/browser-live-report.json`
+- `.tau/demo-browser-automation-live/browser-live-transcript.log`

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -78,6 +78,21 @@ Write deterministic JSON summary:
 - Troubleshooting checkpoint:
   - verify deployment fixture paths and WASM module file in `testdata/deployment-wasm`.
 
+## Standalone Live Harness
+
+`browser-automation-live` is a standalone wrapper (not part of `index.sh` scenario allowlist)
+used for live browser timeline/artifact proof runs:
+
+```bash
+./scripts/demo/browser-automation-live.sh
+```
+
+Primary outputs:
+
+- `.tau/demo-browser-automation-live/browser-live-summary.json`
+- `.tau/demo-browser-automation-live/browser-live-report.json`
+- `.tau/demo-browser-automation-live/browser-live-transcript.log`
+
 ## CI-light smoke notes
 
 The repository smoke manifest (`.github/demo-smoke-manifest.json`) includes lightweight

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -149,6 +149,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/multi-channel.sh
 ./scripts/demo/multi-agent.sh
 ./scripts/demo/browser-automation.sh
+./scripts/demo/browser-automation-live.sh
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -371,6 +371,21 @@ cargo run -p tau-coding-agent -- \
   --browser-automation-preflight-json
 ```
 
+Run deterministic live harness proof (timeline + artifact summary + machine-readable report):
+
+```bash
+./scripts/demo/browser-automation-live.sh
+./scripts/demo/browser-automation-live.sh --timeout-seconds 120
+```
+
+Live harness outputs:
+
+- `.tau/demo-browser-automation-live/browser-live-summary.json`
+- `.tau/demo-browser-automation-live/browser-live-report.json`
+- `.tau/demo-browser-automation-live/browser-live-transcript.log`
+
+Operational runbook and triage playbook: `docs/guides/browser-automation-live-ops.md`.
+
 Troubleshooting:
 
 - `browser_automation.npx` not ready: install Node.js/npm and ensure `npx` is on `PATH`.
@@ -381,6 +396,7 @@ Troubleshooting:
 Demo command path:
 
 - `./scripts/demo/browser-automation.sh`
+- `./scripts/demo/browser-automation-live.sh`
 - `./scripts/demo/all.sh --only browser-automation --fail-fast`
 
 ## Dashboard contract runner

--- a/scripts/demo/browser-automation-live.sh
+++ b/scripts/demo/browser-automation-live.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+skip_build="false"
+timeout_seconds=""
+playwright_cli_override=""
+unused_binary=""
+step_total=0
+step_passed=0
+
+print_usage() {
+  cat <<EOF
+Usage: browser-automation-live.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--timeout-seconds N] [--playwright-cli PATH] [--help]
+
+Run deterministic browser live-harness validation and emit machine-readable summary/report artifacts.
+
+Options:
+  --repo-root PATH      Repository root (defaults to caller-derived root)
+  --binary PATH         Accepted for wrapper compatibility; unused by this script
+  --skip-build          Skip cargo build and use existing harness binary
+  --timeout-seconds N   Positive integer timeout for the live harness execution step
+  --playwright-cli PATH Use this Playwright CLI path instead of the deterministic mock fallback
+  --help                Show this usage message
+EOF
+}
+
+log_info() {
+  echo "[demo:browser-automation-live] $1"
+}
+
+run_step() {
+  local label="$1"
+  shift
+  step_total=$((step_total + 1))
+  log_info "[${step_total}] ${label}"
+  if "$@"; then
+    step_passed=$((step_passed + 1))
+    log_info "PASS ${label}"
+  else
+    local rc=$?
+    log_info "FAIL ${label} exit=${rc}"
+    return "${rc}"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --repo-root" >&2
+        print_usage >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --binary)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --binary" >&2
+        print_usage >&2
+        exit 2
+      fi
+      unused_binary="$2"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build="true"
+      shift
+      ;;
+    --timeout-seconds)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --timeout-seconds" >&2
+        print_usage >&2
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+        echo "invalid value for --timeout-seconds (expected positive integer): $2" >&2
+        print_usage >&2
+        exit 2
+      fi
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --playwright-cli)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --playwright-cli" >&2
+        print_usage >&2
+        exit 2
+      fi
+      playwright_cli_override="$2"
+      shift 2
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "${repo_root}" ]]; then
+  echo "invalid --repo-root path (directory not found): ${repo_root}" >&2
+  exit 2
+fi
+repo_root="$(cd "${repo_root}" && pwd)"
+
+work_root="${repo_root}/.tau/demo-browser-automation-live"
+work_dir="${work_root}/work"
+state_dir="${work_root}/state"
+fixture_path="${work_dir}/browser-live-fixture.json"
+page_path="${work_dir}/browser-live-page.html"
+summary_json="${work_root}/browser-live-summary.json"
+report_json="${work_root}/browser-live-report.json"
+transcript_log="${work_root}/browser-live-transcript.log"
+mock_cli_path="${work_dir}/mock-playwright-cli.py"
+harness_bin="${repo_root}/target/debug/browser_automation_live_harness"
+
+rm -rf "${work_root}"
+mkdir -p "${work_dir}" "${state_dir}"
+
+cat >"${page_path}" <<'EOF'
+<html><head><title>Demo Live Page</title></head><body><button id='run'>Run</button></body></html>
+EOF
+
+cat >"${fixture_path}" <<EOF
+{
+  "schema_version": 1,
+  "name": "demo-browser-live",
+  "description": "Deterministic live browser harness fixture for CI/local proof runs",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "navigate-demo",
+      "operation": "navigate",
+      "url": "file://${page_path}",
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "ok",
+          "operation": "navigate",
+          "url": "file://${page_path}",
+          "title": "Demo Live Page",
+          "dom_nodes": 10
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "snapshot-demo",
+      "operation": "snapshot",
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "ok",
+          "operation": "snapshot",
+          "snapshot_id": "snapshot-live",
+          "elements": [{"id": "e1", "role": "button", "name": "Run"}]
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "action-demo",
+      "operation": "action",
+      "action": "click",
+      "selector": "#run",
+      "text": "go",
+      "timeout_ms": 1000,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "ok",
+          "operation": "action",
+          "action": "click",
+          "selector": "#run",
+          "repeat_count": 1,
+          "text": "go",
+          "timeout_ms": 1000
+        }
+      }
+    }
+  ]
+}
+EOF
+
+if [[ -n "${playwright_cli_override}" ]]; then
+  playwright_cli="${playwright_cli_override}"
+  if [[ ! -x "${playwright_cli}" ]]; then
+    echo "provided --playwright-cli is not executable: ${playwright_cli}" >&2
+    exit 2
+  fi
+else
+  cat >"${mock_cli_path}" <<'EOF'
+#!/usr/bin/env python3
+import json
+import pathlib
+import re
+import sys
+
+session_file = pathlib.Path(__file__).with_suffix(".session")
+command = sys.argv[1] if len(sys.argv) > 1 else ""
+
+if command == "start-session":
+    session_file.write_text("active", encoding="utf-8")
+    print(json.dumps({"status": "ok"}))
+    raise SystemExit(0)
+
+if command == "shutdown-session":
+    if session_file.exists():
+        session_file.unlink()
+    print(json.dumps({"status": "ok"}))
+    raise SystemExit(0)
+
+if command != "execute-action":
+    print("unsupported command", file=sys.stderr)
+    raise SystemExit(2)
+
+payload = json.loads(sys.argv[2]) if len(sys.argv) > 2 else {}
+operation = payload.get("operation", "")
+
+if operation == "navigate":
+    url = payload.get("url", "")
+    html_path = pathlib.Path(url[7:])
+    html = html_path.read_text(encoding="utf-8")
+    match = re.search(r"<title>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+    title = match.group(1).strip() if match else "Untitled"
+    print(json.dumps({
+        "status_code": 200,
+        "response_body": {
+            "status": "ok",
+            "operation": "navigate",
+            "url": url,
+            "title": title,
+            "dom_nodes": html.count("<")
+        },
+        "artifacts": {
+            "dom_snapshot_html": html,
+            "screenshot_svg": "<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>",
+            "trace_json": json.dumps({"events": ["navigate"], "url": url})
+        }
+    }))
+    raise SystemExit(0)
+
+if operation == "snapshot":
+    print(json.dumps({
+        "status_code": 200,
+        "response_body": {
+            "status": "ok",
+            "operation": "snapshot",
+            "snapshot_id": "snapshot-live",
+            "elements": [{"id": "e1", "role": "button", "name": "Run"}]
+        },
+        "artifacts": {
+            "dom_snapshot_html": "<html><body><button id='run'>Run</button></body></html>",
+            "screenshot_svg": "<svg xmlns='http://www.w3.org/2000/svg'><circle cx='5' cy='5' r='5'/></svg>",
+            "trace_json": "{\"events\":[\"snapshot\"]}"
+        }
+    }))
+    raise SystemExit(0)
+
+if operation == "action":
+    print(json.dumps({
+        "status_code": 200,
+        "response_body": {
+            "status": "ok",
+            "operation": "action",
+            "action": payload.get("action", ""),
+            "selector": payload.get("selector", ""),
+            "repeat_count": payload.get("action_repeat_count", 1),
+            "text": payload.get("text", ""),
+            "timeout_ms": payload.get("timeout_ms", 0)
+        },
+        "artifacts": {
+            "dom_snapshot_html": "",
+            "screenshot_svg": "<svg xmlns='http://www.w3.org/2000/svg'><line x1='0' y1='0' x2='10' y2='10'/></svg>",
+            "trace_json": "{\"events\":[\"action\"]}"
+        }
+    }))
+    raise SystemExit(0)
+
+print(json.dumps({
+    "status_code": 400,
+    "error_code": "browser_automation_invalid_operation",
+    "response_body": {"status": "rejected", "reason": "invalid_operation"}
+}))
+EOF
+  chmod +x "${mock_cli_path}"
+  playwright_cli="${mock_cli_path}"
+fi
+
+if [[ "${skip_build}" != "true" ]]; then
+  run_step "build-browser-live-harness" \
+    bash -lc "cd '${repo_root}' && cargo build -p tau-browser-automation --bin browser_automation_live_harness >/dev/null"
+fi
+
+if [[ ! -x "${harness_bin}" ]]; then
+  echo "missing harness binary: ${harness_bin}" >&2
+  exit 1
+fi
+
+run_harness() {
+  local -a command=(
+    "${harness_bin}"
+    "--fixture" "${fixture_path}"
+    "--state-dir" "${state_dir}"
+    "--playwright-cli" "${playwright_cli}"
+    "--summary-json-out" "${summary_json}"
+    "--artifact-retention-days" "7"
+    "--action-timeout-ms" "4000"
+    "--max-actions-per-case" "4"
+  )
+
+  set +e
+  if [[ -n "${timeout_seconds}" ]]; then
+    python3 - "${timeout_seconds}" "${command[@]}" <<'PY' 2>&1 | tee "${transcript_log}"
+import subprocess
+import sys
+
+timeout_seconds = int(sys.argv[1])
+command = sys.argv[2:]
+try:
+    completed = subprocess.run(command, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+sys.exit(completed.returncode)
+PY
+  else
+    "${command[@]}" 2>&1 | tee "${transcript_log}"
+  fi
+  local rc=${PIPESTATUS[0]}
+  set -e
+  return "${rc}"
+}
+
+run_step "run-browser-live-harness" run_harness
+
+validate_summary() {
+  python3 - "${summary_json}" "${report_json}" "${transcript_log}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary_path = Path(sys.argv[1])
+report_path = Path(sys.argv[2])
+transcript_path = Path(sys.argv[3])
+
+if not summary_path.exists():
+    raise SystemExit(f"summary JSON missing: {summary_path}")
+
+summary = json.loads(summary_path.read_text(encoding="utf-8"))
+if summary.get("discovered_cases") != 3:
+    raise SystemExit("unexpected discovered_cases in live summary")
+if summary.get("success_cases") != 3:
+    raise SystemExit("unexpected success_cases in live summary")
+if summary.get("health_state") != "healthy":
+    raise SystemExit("live summary health_state is not healthy")
+timeline = summary.get("timeline", [])
+if len(timeline) != 3:
+    raise SystemExit("timeline does not contain all expected cases")
+
+report = {
+    "schema_version": 1,
+    "summary_path": str(summary_path),
+    "transcript_path": str(transcript_path),
+    "health_state": summary.get("health_state"),
+    "reason_codes": summary.get("reason_codes", []),
+    "discovered_cases": summary.get("discovered_cases"),
+    "success_cases": summary.get("success_cases"),
+    "artifact_records": summary.get("artifact_records"),
+    "timeline": timeline,
+}
+report_path.parent.mkdir(parents=True, exist_ok=True)
+report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+print(f"report_json={report_path}")
+PY
+}
+
+run_step "validate-live-summary-and-write-report" validate_summary
+
+log_info "summary_json=${summary_json}"
+log_info "report_json=${report_json}"
+log_info "transcript_log=${transcript_log}"
+log_info "summary: total=${step_total} passed=${step_passed} failed=$((step_total - step_passed))"


### PR DESCRIPTION
Closes #1317

Depends on #1335

## Summary of behavior changes
- Added machine-readable timeline support to browser live summaries:
  - `BrowserAutomationLiveTimelineEntry`
  - serde-enabled `BrowserAutomationLiveRunSummary` with per-case `timeline`
- Added dedicated browser live harness binary:
  - `browser_automation_live_harness`
  - runs live fixture + persistence with `PlaywrightCliActionExecutor`
  - writes JSON summary artifact (`--summary-json-out`)
  - prints deterministic timeline transcript lines for CI evidence
- Added deterministic live-run demo wrapper:
  - `scripts/demo/browser-automation-live.sh`
  - creates local fixture page + fixture JSON
  - uses provided Playwright CLI or deterministic mock fallback
  - emits:
    - `.tau/demo-browser-automation-live/browser-live-summary.json`
    - `.tau/demo-browser-automation-live/browser-live-report.json`
    - `.tau/demo-browser-automation-live/browser-live-transcript.log`
- Expanded browser live validation coverage:
  - functional live sequence now covers navigate + snapshot + action
  - integration checks include timeline/artifact assertions
  - regression test asserts fixture-order timeline compatibility
- Added runbook and docs references:
  - `docs/guides/browser-automation-live-ops.md`
  - transport/demo/quickstart guide links updated

## Risks and compatibility notes
- Stacked PR: merge after #1335.
- `BrowserAutomationLiveRunSummary` now includes timeline + serde derives; consumers deserializing with strict schemas should allow new fields.
- Demo wrapper builds/uses a dedicated harness binary; `--skip-build` requires that binary to already exist.

## Validation evidence
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 cargo test -p tau-browser-automation`
- `CARGO_INCREMENTAL=0 cargo clippy -p tau-browser-automation --all-targets -- -D warnings`
- `./scripts/demo/browser-automation-live.sh`
- `./scripts/demo/browser-automation-live.sh --skip-build --timeout-seconds 120`

Live run transcript excerpt (successful):
- `browser automation live harness summary: discovered=3 success=3 ... health_state=healthy`
- `timeline[0] case_id=navigate-demo ... artifact_types=dom_snapshot,screenshot,trace`
- `timeline[1] case_id=snapshot-demo ... artifact_types=dom_snapshot,screenshot,trace`
- `timeline[2] case_id=action-demo ... artifact_types=screenshot,trace`
