### PR TITLE
feat(validation): add unified live-run harness and consolidated artifact manifest

### DIFF
--- a/.github/live-run-unified-manifest.json
+++ b/.github/live-run-unified-manifest.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "surfaces": [
+    {
+      "id": "voice",
+      "script": "scripts/demo/voice.sh",
+      "artifact_roots": [
+        ".tau/demo-voice"
+      ]
+    },
+    {
+      "id": "browser",
+      "script": "scripts/demo/browser-automation-live.sh",
+      "artifact_roots": [
+        ".tau/demo-browser-automation-live"
+      ]
+    },
+    {
+      "id": "dashboard",
+      "script": "scripts/demo/dashboard.sh",
+      "artifact_roots": [
+        ".tau/demo-dashboard"
+      ]
+    },
+    {
+      "id": "custom-command",
+      "script": "scripts/demo/custom-command.sh",
+      "artifact_roots": [
+        ".tau/demo-custom-command"
+      ]
+    },
+    {
+      "id": "memory",
+      "script": "scripts/demo/memory.sh",
+      "artifact_roots": [
+        ".tau/demo-memory"
+      ]
+    }
+  ]
+}

--- a/.github/scripts/live_run_unified_runner.py
+++ b/.github/scripts/live_run_unified_runner.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SURFACE_MANIFEST_SCHEMA_VERSION = 1
+UNIFIED_RUN_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SurfaceSpec:
+    surface_id: str
+    script: str
+    artifact_roots: list[str]
+
+
+@dataclass(frozen=True)
+class SurfaceRunResult:
+    surface_id: str
+    script: str
+    command: list[str]
+    status: str
+    exit_code: int
+    duration_ms: int
+    stdout_log: Path
+    stderr_log: Path
+    artifacts_dir: Path
+    artifacts: list[dict[str, object]]
+    missing_artifact_roots: list[str]
+    summary_line: str
+    diagnostics: list[str]
+
+
+def load_surface_manifest(path: Path) -> list[SurfaceSpec]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("surface manifest must be a JSON object")
+
+    schema_version = raw.get("schema_version")
+    if schema_version != SURFACE_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported live-run surface manifest schema_version: "
+            f"expected {SURFACE_MANIFEST_SCHEMA_VERSION}, found {schema_version}"
+        )
+
+    surfaces = raw.get("surfaces")
+    if not isinstance(surfaces, list) or not surfaces:
+        raise ValueError("surface manifest 'surfaces' must be a non-empty array")
+
+    parsed: list[SurfaceSpec] = []
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(surfaces):
+        if not isinstance(entry, dict):
+            raise ValueError(f"surfaces[{index}] must be an object")
+
+        surface_id = entry.get("id")
+        if not isinstance(surface_id, str) or not surface_id.strip():
+            raise ValueError(f"surfaces[{index}].id must be a non-empty string")
+        normalized_id = surface_id.strip()
+        if normalized_id in seen_ids:
+            raise ValueError(f"surface manifest contains duplicate id '{normalized_id}'")
+        seen_ids.add(normalized_id)
+
+        script = entry.get("script")
+        if not isinstance(script, str) or not script.strip():
+            raise ValueError(f"surfaces[{index}].script must be a non-empty string")
+
+        artifact_roots = entry.get("artifact_roots")
+        if not isinstance(artifact_roots, list) or not artifact_roots:
+            raise ValueError(
+                f"surfaces[{index}].artifact_roots must be a non-empty array"
+            )
+        parsed_roots: list[str] = []
+        for root_index, root in enumerate(artifact_roots):
+            if not isinstance(root, str) or not root.strip():
+                raise ValueError(
+                    f"surfaces[{index}].artifact_roots[{root_index}] must be a non-empty string"
+                )
+            parsed_roots.append(root.strip())
+
+        parsed.append(
+            SurfaceSpec(
+                surface_id=normalized_id,
+                script=script.strip(),
+                artifact_roots=parsed_roots,
+            )
+        )
+    return parsed
+
+
+def resolve_path(root: Path, raw: str) -> Path:
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (root / candidate).resolve()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def clean_relative_label(raw: str) -> str:
+    label = raw.strip().replace("\\", "/")
+    if label.startswith("./"):
+        label = label[2:]
+    label = label.strip("/")
+    return label or "root"
+
+
+def copy_surface_artifacts(
+    repo_root: Path,
+    surface_output_dir: Path,
+    artifact_roots: list[str],
+) -> tuple[list[dict[str, object]], list[str]]:
+    artifacts_dir = surface_output_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    missing_roots: list[str] = []
+    for root in artifact_roots:
+        source = resolve_path(repo_root, root)
+        if not source.exists():
+            missing_roots.append(root)
+            continue
+
+        destination = artifacts_dir / clean_relative_label(root)
+        if source.is_file():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            continue
+
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(source, destination)
+
+    artifacts: list[dict[str, object]] = []
+    if artifacts_dir.exists():
+        for path in sorted(artifacts_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(surface_output_dir).as_posix()
+            artifacts.append(
+                {
+                    "relative_path": relative,
+                    "bytes": path.stat().st_size,
+                    "sha256": file_sha256(path),
+                }
+            )
+    return artifacts, missing_roots
+
+
+def extract_summary_line(stdout: str) -> str:
+    for line in reversed(stdout.splitlines()):
+        if "summary:" in line:
+            return line.strip()
+    return ""
+
+
+def run_surface(
+    spec: SurfaceSpec,
+    repo_root: Path,
+    output_dir: Path,
+    binary: Path,
+    skip_build: bool,
+    timeout_seconds: int | None,
+) -> SurfaceRunResult:
+    script_path = resolve_path(repo_root, spec.script)
+    if not script_path.exists():
+        raise FileNotFoundError(f"surface script does not exist: {script_path}")
+
+    surface_dir = output_dir / "surfaces" / spec.surface_id
+    surface_dir.mkdir(parents=True, exist_ok=True)
+    stdout_log = surface_dir / "stdout.log"
+    stderr_log = surface_dir / "stderr.log"
+
+    command = [
+        str(script_path),
+        "--repo-root",
+        str(repo_root),
+        "--binary",
+        str(binary),
+    ]
+    if skip_build:
+        command.append("--skip-build")
+    if timeout_seconds is not None:
+        command.extend(["--timeout-seconds", str(timeout_seconds)])
+
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    duration_ms = int((time.perf_counter() - started) * 1000)
+
+    stdout_log.write_text(completed.stdout, encoding="utf-8")
+    stderr_log.write_text(completed.stderr, encoding="utf-8")
+
+    artifacts, missing_roots = copy_surface_artifacts(
+        repo_root=repo_root,
+        surface_output_dir=surface_dir,
+        artifact_roots=spec.artifact_roots,
+    )
+
+    diagnostics: list[str] = []
+    if completed.returncode != 0:
+        diagnostics.append(f"surface script exited with code {completed.returncode}")
+    if missing_roots:
+        diagnostics.append(
+            "missing expected artifact roots: " + ", ".join(sorted(missing_roots))
+        )
+    if completed.returncode == 0 and not artifacts:
+        diagnostics.append("surface run produced no copied artifacts")
+
+    status = "passed" if completed.returncode == 0 else "failed"
+    return SurfaceRunResult(
+        surface_id=spec.surface_id,
+        script=spec.script,
+        command=command,
+        status=status,
+        exit_code=completed.returncode,
+        duration_ms=duration_ms,
+        stdout_log=stdout_log,
+        stderr_log=stderr_log,
+        artifacts_dir=surface_dir / "artifacts",
+        artifacts=artifacts,
+        missing_artifact_roots=missing_roots,
+        summary_line=extract_summary_line(completed.stdout),
+        diagnostics=diagnostics,
+    )
+
+
+def build_binaries(repo_root: Path) -> None:
+    subprocess.run(
+        ["cargo", "build", "-p", "tau-coding-agent"],
+        cwd=repo_root,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "cargo",
+            "build",
+            "-p",
+            "tau-browser-automation",
+            "--bin",
+            "browser_automation_live_harness",
+        ],
+        cwd=repo_root,
+        check=True,
+    )
+
+
+def print_surface_list(specs: list[SurfaceSpec], as_json: bool) -> None:
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "schema_version": SURFACE_MANIFEST_SCHEMA_VERSION,
+                    "surfaces": [
+                        {
+                            "id": spec.surface_id,
+                            "script": spec.script,
+                            "artifact_roots": spec.artifact_roots,
+                        }
+                        for spec in specs
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    for spec in specs:
+        print(spec.surface_id)
+        print(f"  script: {spec.script}")
+        for root in spec.artifact_roots:
+            print(f"  artifact_root: {root}")
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run unified live validation harness across voice/browser/dashboard/custom-command/memory."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used to resolve scripts and artifact roots",
+    )
+    parser.add_argument(
+        "--surfaces-manifest",
+        default=".github/live-run-unified-manifest.json",
+        help="Path to unified live-run surfaces manifest JSON",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".tau/live-run-unified",
+        help="Directory where unified logs/manifests are written",
+    )
+    parser.add_argument(
+        "--binary",
+        default="target/debug/tau-coding-agent",
+        help="tau-coding-agent binary path forwarded to demo wrappers",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Skip cargo build and require binaries to already exist",
+    )
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue running remaining surfaces after one fails",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=0,
+        help="Optional timeout in seconds forwarded to wrappers (0 disables timeout forwarding)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print available surfaces from the surfaces manifest and exit",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output for --list mode",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    manifest_path = resolve_path(repo_root, args.surfaces_manifest)
+    output_dir = resolve_path(repo_root, args.output_dir)
+    binary_path = resolve_path(repo_root, args.binary)
+
+    specs = load_surface_manifest(manifest_path)
+    if args.list:
+        print_surface_list(specs, as_json=args.json)
+        return 0
+
+    timeout_seconds: int | None = None
+    if args.timeout_seconds < 0:
+        raise ValueError("--timeout-seconds must be >= 0")
+    if args.timeout_seconds > 0:
+        timeout_seconds = args.timeout_seconds
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_build:
+        print("[live-run-unified] building tau-coding-agent and browser live harness binaries")
+        build_binaries(repo_root)
+    elif not binary_path.exists():
+        raise FileNotFoundError(
+            f"--skip-build requested but binary does not exist: {binary_path}"
+        )
+
+    started_unix_ms = int(time.time() * 1000)
+    started_monotonic = time.perf_counter()
+
+    results: list[SurfaceRunResult] = []
+    for index, spec in enumerate(specs, start=1):
+        print(f"[live-run-unified] [{index}/{len(specs)}] {spec.surface_id}")
+        print(
+            "[live-run-unified] command: "
+            + shlex.join(
+                [
+                    spec.script,
+                    "--repo-root",
+                    str(repo_root),
+                    "--binary",
+                    str(binary_path),
+                    "--skip-build" if args.skip_build else "",
+                ]
+            ).replace(" ''", "")
+        )
+        result = run_surface(
+            spec=spec,
+            repo_root=repo_root,
+            output_dir=output_dir,
+            binary=binary_path,
+            skip_build=args.skip_build,
+            timeout_seconds=timeout_seconds,
+        )
+        results.append(result)
+
+        print(
+            f"[live-run-unified] {result.status.upper()} {result.surface_id} "
+            f"exit={result.exit_code} duration_ms={result.duration_ms} "
+            f"artifacts={len(result.artifacts)}"
+        )
+        if result.summary_line:
+            print(f"[live-run-unified] summary-line: {result.summary_line}")
+        if result.status == "failed" and not args.keep_going:
+            print("[live-run-unified] stopping after first failure (use --keep-going to continue)")
+            break
+
+    duration_ms = int((time.perf_counter() - started_monotonic) * 1000)
+    passed = sum(1 for result in results if result.status == "passed")
+    failed = len(results) - passed
+    overall_status = "passed" if failed == 0 else "failed"
+
+    manifest = {
+        "schema_version": UNIFIED_RUN_SCHEMA_VERSION,
+        "started_unix_ms": started_unix_ms,
+        "duration_ms": duration_ms,
+        "repo_root": str(repo_root),
+        "binary": str(binary_path),
+        "surfaces_manifest": str(manifest_path),
+        "output_dir": str(output_dir),
+        "overall": {
+            "status": overall_status,
+            "total_surfaces": len(results),
+            "passed_surfaces": passed,
+            "failed_surfaces": failed,
+        },
+        "surfaces": [
+            {
+                "surface_id": result.surface_id,
+                "script": result.script,
+                "command": result.command,
+                "status": result.status,
+                "exit_code": result.exit_code,
+                "duration_ms": result.duration_ms,
+                "stdout_log": result.stdout_log.relative_to(output_dir).as_posix(),
+                "stderr_log": result.stderr_log.relative_to(output_dir).as_posix(),
+                "artifacts_dir": result.artifacts_dir.relative_to(output_dir).as_posix(),
+                "artifact_count": len(result.artifacts),
+                "artifacts": result.artifacts,
+                "missing_artifact_roots": result.missing_artifact_roots,
+                "summary_line": result.summary_line,
+                "diagnostics": result.diagnostics,
+            }
+            for result in results
+        ],
+    }
+
+    report = {
+        "schema_version": UNIFIED_RUN_SCHEMA_VERSION,
+        "overall": manifest["overall"],
+        "duration_ms": duration_ms,
+        "surface_status": {
+            result.surface_id: {
+                "status": result.status,
+                "exit_code": result.exit_code,
+                "artifact_count": len(result.artifacts),
+                "summary_line": result.summary_line,
+            }
+            for result in results
+        },
+        "failed_surfaces": [result.surface_id for result in results if result.status == "failed"],
+    }
+
+    manifest_path_out = output_dir / "manifest.json"
+    report_path_out = output_dir / "report.json"
+    write_json(manifest_path_out, manifest)
+    write_json(report_path_out, report)
+
+    print(
+        f"[live-run-unified] summary: total={len(results)} passed={passed} failed={failed} "
+        f"duration_ms={duration_ms}"
+    )
+    print(f"[live-run-unified] manifest={manifest_path_out}")
+    print(f"[live-run-unified] report={report_path_out}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_live_run_unified_runner.py
+++ b/.github/scripts/test_live_run_unified_runner.py
@@ -1,0 +1,198 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+RUNNER_SCRIPT = SCRIPT_DIR / "live_run_unified_runner.py"
+WRAPPER_SCRIPT = REPO_ROOT / "scripts" / "demo" / "live-run-unified.sh"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import live_run_unified_runner  # noqa: E402
+
+
+def write_file(path: Path, content: str, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if executable:
+        path.chmod(0o755)
+
+
+def write_pass_surface_script(path: Path, state_dir: str, summary_tag: str) -> None:
+    write_file(
+        path,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "{state_dir}"
+echo "{{\\"surface\\":\\"ok\\"}}" > "{state_dir}/state.json"
+echo "[demo:{summary_tag}] summary: total=1 passed=1 failed=0"
+""",
+        executable=True,
+    )
+
+
+def write_fail_surface_script(path: Path, state_dir: str, summary_tag: str) -> None:
+    write_file(
+        path,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "{state_dir}"
+echo "{{\\"surface\\":\\"failed\\"}}" > "{state_dir}/state.json"
+echo "[demo:{summary_tag}] summary: total=1 passed=0 failed=1" >&2
+exit 7
+""",
+        executable=True,
+    )
+
+
+class LiveRunUnifiedRunnerTests(unittest.TestCase):
+    def test_unit_load_surface_manifest_rejects_duplicate_surface_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "manifest.json"
+            write_file(
+                manifest_path,
+                """{
+  "schema_version": 1,
+  "surfaces": [
+    {"id":"voice","script":"scripts/demo/voice.sh","artifact_roots":[".tau/demo-voice"]},
+    {"id":"voice","script":"scripts/demo/voice-2.sh","artifact_roots":[".tau/demo-voice-2"]}
+  ]
+}
+""",
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate id"):
+                live_run_unified_runner.load_surface_manifest(manifest_path)
+
+    def test_functional_run_writes_manifest_report_and_surface_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            binary_path = repo_root / "target" / "debug" / "tau-coding-agent"
+            write_file(binary_path, "#!/usr/bin/env bash\nexit 0\n", executable=True)
+            voice_script = repo_root / "scripts" / "demo" / "voice.sh"
+            browser_script = repo_root / "scripts" / "demo" / "browser-automation-live.sh"
+            write_pass_surface_script(voice_script, ".tau/demo-voice", "voice")
+            write_pass_surface_script(
+                browser_script, ".tau/demo-browser-automation-live", "browser-automation-live"
+            )
+            manifest_path = repo_root / ".github" / "live-manifest.json"
+            write_file(
+                manifest_path,
+                """{
+  "schema_version": 1,
+  "surfaces": [
+    {"id":"voice","script":"scripts/demo/voice.sh","artifact_roots":[".tau/demo-voice"]},
+    {"id":"browser","script":"scripts/demo/browser-automation-live.sh","artifact_roots":[".tau/demo-browser-automation-live"]}
+  ]
+}
+""",
+            )
+            output_dir = repo_root / ".tau" / "live-run-unified"
+            exit_code = live_run_unified_runner.main(
+                [
+                    "--repo-root",
+                    str(repo_root),
+                    "--surfaces-manifest",
+                    str(manifest_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--binary",
+                    str(binary_path),
+                    "--skip-build",
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+            manifest_out = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+            report_out = json.loads((output_dir / "report.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest_out["overall"]["status"], "passed")
+            self.assertEqual(manifest_out["overall"]["total_surfaces"], 2)
+            self.assertEqual(report_out["overall"]["failed_surfaces"], 0)
+            self.assertEqual(len(manifest_out["surfaces"]), 2)
+            voice_surface = manifest_out["surfaces"][0]
+            self.assertEqual(voice_surface["surface_id"], "voice")
+            self.assertGreaterEqual(voice_surface["artifact_count"], 1)
+            copied_artifact = (
+                output_dir
+                / "surfaces"
+                / "voice"
+                / "artifacts"
+                / ".tau"
+                / "demo-voice"
+                / "state.json"
+            )
+            self.assertTrue(copied_artifact.exists())
+
+    def test_integration_wrapper_lists_default_surfaces_with_json(self) -> None:
+        completed = subprocess.run(
+            [str(WRAPPER_SCRIPT), "--list", "--json"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        payload = json.loads(completed.stdout)
+        surface_ids = [entry["id"] for entry in payload["surfaces"]]
+        self.assertEqual(
+            surface_ids,
+            ["voice", "browser", "dashboard", "custom-command", "memory"],
+        )
+
+    def test_regression_failure_surface_sets_nonzero_exit_and_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            binary_path = repo_root / "target" / "debug" / "tau-coding-agent"
+            write_file(binary_path, "#!/usr/bin/env bash\nexit 0\n", executable=True)
+            pass_script = repo_root / "scripts" / "demo" / "voice.sh"
+            fail_script = repo_root / "scripts" / "demo" / "dashboard.sh"
+            write_pass_surface_script(pass_script, ".tau/demo-voice", "voice")
+            write_fail_surface_script(fail_script, ".tau/demo-dashboard", "dashboard")
+            manifest_path = repo_root / ".github" / "live-manifest.json"
+            write_file(
+                manifest_path,
+                """{
+  "schema_version": 1,
+  "surfaces": [
+    {"id":"voice","script":"scripts/demo/voice.sh","artifact_roots":[".tau/demo-voice"]},
+    {"id":"dashboard","script":"scripts/demo/dashboard.sh","artifact_roots":[".tau/demo-dashboard"]}
+  ]
+}
+""",
+            )
+            output_dir = repo_root / ".tau" / "live-run-unified"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER_SCRIPT),
+                    "--repo-root",
+                    str(repo_root),
+                    "--surfaces-manifest",
+                    str(manifest_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--binary",
+                    str(binary_path),
+                    "--skip-build",
+                    "--keep-going",
+                ],
+                cwd=repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 1)
+            self.assertIn("[live-run-unified] FAILED dashboard", completed.stdout)
+            manifest_out = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest_out["overall"]["status"], "failed")
+            self.assertEqual(manifest_out["overall"]["failed_surfaces"], 1)
+            dashboard = manifest_out["surfaces"][1]
+            self.assertEqual(dashboard["surface_id"], "dashboard")
+            self.assertEqual(dashboard["status"], "failed")
+            self.assertIn("surface script exited with code 7", dashboard["diagnostics"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This index maps Tau documentation by audience and task.
 | --- | --- | --- |
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
 | Fresh-clone validator / demo operator | [Demo Index Guide](guides/demo-index.md) | Deterministic onboarding, gateway auth, multi-channel live ingest, and deployment WASM demos |
+| Release validator / rollout operator | [Unified Live-Run Harness Guide](guides/live-run-unified-ops.md) | Single command cross-surface live validation manifest for voice/browser/dashboard/custom-command/memory |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -93,6 +93,28 @@ Primary outputs:
 - `.tau/demo-browser-automation-live/browser-live-report.json`
 - `.tau/demo-browser-automation-live/browser-live-transcript.log`
 
+## Unified Live-Run Harness
+
+Cross-surface validation wrapper (voice/browser/dashboard/custom-command/memory):
+
+```bash
+./scripts/demo/live-run-unified.sh
+```
+
+Deterministic inventory mode:
+
+```bash
+./scripts/demo/live-run-unified.sh --list
+./scripts/demo/live-run-unified.sh --list --json
+```
+
+Primary outputs:
+
+- `.tau/live-run-unified/manifest.json`
+- `.tau/live-run-unified/report.json`
+- `.tau/live-run-unified/surfaces/<surface>/stdout.log`
+- `.tau/live-run-unified/surfaces/<surface>/stderr.log`
+
 ## CI-light smoke notes
 
 The repository smoke manifest (`.github/demo-smoke-manifest.json`) includes lightweight

--- a/docs/guides/live-run-unified-ops.md
+++ b/docs/guides/live-run-unified-ops.md
@@ -1,0 +1,84 @@
+# Unified Live-Run Harness Guide
+
+Run all commands from repository root.
+
+This harness executes live validation flows across:
+
+- voice
+- browser automation
+- dashboard
+- custom commands
+- memory
+
+## Run Unified Harness
+
+```bash
+./scripts/demo/live-run-unified.sh
+```
+
+Fast inventory check without execution:
+
+```bash
+./scripts/demo/live-run-unified.sh --list
+./scripts/demo/live-run-unified.sh --list --json
+```
+
+Run with bounded wrapper timeout and continue after one surface fails:
+
+```bash
+./scripts/demo/live-run-unified.sh --timeout-seconds 120 --keep-going
+```
+
+## Manifest + Report Contract
+
+Outputs are written under:
+
+- `.tau/live-run-unified/manifest.json`
+- `.tau/live-run-unified/report.json`
+- `.tau/live-run-unified/surfaces/<surface-id>/stdout.log`
+- `.tau/live-run-unified/surfaces/<surface-id>/stderr.log`
+- `.tau/live-run-unified/surfaces/<surface-id>/artifacts/...`
+
+`manifest.json` includes:
+
+- `schema_version`
+- `overall` (`status`, `total_surfaces`, `passed_surfaces`, `failed_surfaces`)
+- per-surface run records (`status`, `exit_code`, `duration_ms`, logs, copied artifact inventory, diagnostics)
+
+`report.json` includes:
+
+- aggregated overall summary
+- per-surface status map
+- failed surface IDs
+
+## Surface Manifest
+
+The default surface orchestration file is:
+
+- `.github/live-run-unified-manifest.json`
+
+Each entry defines:
+
+- `id`
+- `script`
+- `artifact_roots`
+
+## Triage Workflow
+
+1. Inspect aggregate result:
+   - `cat .tau/live-run-unified/report.json`
+2. Inspect detailed contract:
+   - `cat .tau/live-run-unified/manifest.json`
+3. For a failed surface, inspect:
+   - `cat .tau/live-run-unified/surfaces/<surface-id>/stdout.log`
+   - `cat .tau/live-run-unified/surfaces/<surface-id>/stderr.log`
+4. Validate copied artifact inventory and checksums in `manifest.json`.
+
+## CI Artifact Set
+
+Attach these files for rollout-signoff evidence:
+
+- `.tau/live-run-unified/manifest.json`
+- `.tau/live-run-unified/report.json`
+- `.tau/live-run-unified/surfaces/**/stdout.log`
+- `.tau/live-run-unified/surfaces/**/stderr.log`

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -150,6 +150,7 @@ cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
 ./scripts/demo/multi-agent.sh
 ./scripts/demo/browser-automation.sh
 ./scripts/demo/browser-automation-live.sh
+./scripts/demo/live-run-unified.sh
 ./scripts/demo/memory.sh
 ./scripts/demo/dashboard.sh
 ./scripts/demo/gateway.sh

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -386,6 +386,15 @@ Live harness outputs:
 
 Operational runbook and triage playbook: `docs/guides/browser-automation-live-ops.md`.
 
+Cross-surface unified live-run harness:
+
+```bash
+./scripts/demo/live-run-unified.sh
+./scripts/demo/live-run-unified.sh --list --json
+```
+
+Unified manifest/report runbook: `docs/guides/live-run-unified-ops.md`.
+
 Troubleshooting:
 
 - `browser_automation.npx` not ready: install Node.js/npm and ensure `npx` is on `PATH`.

--- a/scripts/demo/live-run-unified.sh
+++ b/scripts/demo/live-run-unified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+(
+  cd "${repo_root}"
+  python3 ".github/scripts/live_run_unified_runner.py" \
+    --repo-root "${repo_root}" \
+    --surfaces-manifest "${repo_root}/.github/live-run-unified-manifest.json" \
+    "$@"
+)


### PR DESCRIPTION
Closes #1327

Depends on #1336

## Summary of behavior changes
- Added unified surface manifest contract:
  - `.github/live-run-unified-manifest.json`
  - defines surface id, wrapper script path, and artifact roots for voice/browser/dashboard/custom-command/memory.
- Added unified runner implementation:
  - `.github/scripts/live_run_unified_runner.py`
  - orchestrates all configured surfaces in one command
  - captures per-surface stdout/stderr logs
  - copies surface artifacts into standardized layout
  - emits machine-readable consolidated outputs:
    - `.tau/live-run-unified/manifest.json`
    - `.tau/live-run-unified/report.json`
- Added public wrapper entrypoint:
  - `scripts/demo/live-run-unified.sh`
- Added explicit test matrix for runner contract and failure surfacing:
  - `.github/scripts/test_live_run_unified_runner.py`
- Added runbook/documentation links:
  - `docs/guides/live-run-unified-ops.md`
  - updated `docs/guides/transports.md`, `docs/guides/demo-index.md`, `docs/guides/quickstart.md`, and `docs/README.md`.

## Risks and compatibility notes
- Stacked PR: merge after #1336.
- Unified runner deletes/recreates `--output-dir` each run (default `.tau/live-run-unified`) to keep artifacts deterministic.
- `--skip-build` requires `target/debug/tau-coding-agent` and browser live harness binary to already exist.

## Validation evidence
- `python3 .github/scripts/test_live_run_unified_runner.py`
- `python3 .github/scripts/test_demo_index.py`
- `python3 .github/scripts/test_demo_scripts.py`
- `./scripts/demo/live-run-unified.sh --list --json`
- `./scripts/demo/live-run-unified.sh --timeout-seconds 180`
- `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180`

Live unified run proof:
- `summary: total=5 passed=5 failed=0`
- `manifest=/Users/n/RustroverProjects/rust_pi_issue1327/.tau/live-run-unified/manifest.json`
- `report=/Users/n/RustroverProjects/rust_pi_issue1327/.tau/live-run-unified/report.json`
