### PR TITLE
ci(live-smoke): add per-surface matrix jobs and merge gate policy

### DIFF
--- a/.github/scripts/live_smoke_matrix.py
+++ b/.github/scripts/live_smoke_matrix.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SurfacePlan:
+    surface: str
+    primary_wrapper: str
+    fallback_wrapper: str
+    artifact_dirs: tuple[str, ...]
+    timeout_seconds: int
+
+
+SURFACE_PLANS: dict[str, SurfacePlan] = {
+    "voice": SurfacePlan(
+        surface="voice",
+        primary_wrapper="scripts/demo/voice.sh",
+        fallback_wrapper="",
+        artifact_dirs=(".tau/demo-voice",),
+        timeout_seconds=180,
+    ),
+    "browser": SurfacePlan(
+        surface="browser",
+        primary_wrapper="scripts/demo/browser-automation-live.sh",
+        fallback_wrapper="scripts/demo/browser-automation.sh",
+        artifact_dirs=(".tau/demo-browser-automation-live", ".tau/demo-browser-automation"),
+        timeout_seconds=180,
+    ),
+    "dashboard": SurfacePlan(
+        surface="dashboard",
+        primary_wrapper="scripts/demo/dashboard.sh",
+        fallback_wrapper="",
+        artifact_dirs=(".tau/demo-dashboard",),
+        timeout_seconds=180,
+    ),
+    "custom-command": SurfacePlan(
+        surface="custom-command",
+        primary_wrapper="scripts/demo/custom-command.sh",
+        fallback_wrapper="",
+        artifact_dirs=(".tau/demo-custom-command",),
+        timeout_seconds=180,
+    ),
+    "memory": SurfacePlan(
+        surface="memory",
+        primary_wrapper="scripts/demo/memory.sh",
+        fallback_wrapper="",
+        artifact_dirs=(".tau/demo-memory",),
+        timeout_seconds=180,
+    ),
+}
+
+
+def resolve_surface_plan(surface: str) -> SurfacePlan:
+    key = surface.strip().lower()
+    if key not in SURFACE_PLANS:
+        supported = ", ".join(sorted(SURFACE_PLANS.keys()))
+        raise ValueError(f"unsupported live-smoke surface '{surface}' (supported: {supported})")
+    return SURFACE_PLANS[key]
+
+
+def emit_outputs(path: Path, plan: SurfacePlan) -> None:
+    payload = {
+        "surface": plan.surface,
+        "primary_wrapper": plan.primary_wrapper,
+        "fallback_wrapper": plan.fallback_wrapper,
+        "artifact_dirs": list(plan.artifact_dirs),
+        "timeout_seconds": plan.timeout_seconds,
+    }
+    lines = [
+        f"surface={plan.surface}",
+        f"primary_wrapper={plan.primary_wrapper}",
+        f"fallback_wrapper={plan.fallback_wrapper}",
+        f"artifact_dirs_json={json.dumps(payload['artifact_dirs'])}",
+        f"timeout_seconds={plan.timeout_seconds}",
+        f"plan_json={json.dumps(payload)}",
+    ]
+    with path.open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(f"{line}\n")
+
+
+def append_summary(path: Path, plan: SurfacePlan) -> None:
+    lines = [
+        "### Live Smoke Surface Plan",
+        f"- Surface: {plan.surface}",
+        f"- Primary wrapper: `{plan.primary_wrapper}`",
+        (
+            f"- Fallback wrapper: `{plan.fallback_wrapper}`"
+            if plan.fallback_wrapper
+            else "- Fallback wrapper: none"
+        ),
+        f"- Timeout seconds: {plan.timeout_seconds}",
+        "- Artifact roots:",
+    ]
+    lines.extend([f"  - `{root}`" for root in plan.artifact_dirs])
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Resolve CI live-smoke matrix surface plans.")
+    parser.add_argument("--surface", required=True, help="Surface key to resolve")
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Optional GitHub output file path to write key=value fields",
+    )
+    parser.add_argument(
+        "--summary",
+        default="",
+        help="Optional markdown summary file path append target",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print resolved plan JSON to stdout",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    plan = resolve_surface_plan(args.surface)
+
+    if args.output.strip():
+        emit_outputs(Path(args.output), plan)
+    if args.summary.strip():
+        append_summary(Path(args.summary), plan)
+    if args.json or not args.output.strip():
+        print(
+            json.dumps(
+                {
+                    "surface": plan.surface,
+                    "primary_wrapper": plan.primary_wrapper,
+                    "fallback_wrapper": plan.fallback_wrapper,
+                    "artifact_dirs": list(plan.artifact_dirs),
+                    "timeout_seconds": plan.timeout_seconds,
+                }
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_live_smoke_matrix.py
+++ b/.github/scripts/test_live_smoke_matrix.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNNER_SCRIPT = SCRIPT_DIR / "live_smoke_matrix.py"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import live_smoke_matrix  # noqa: E402
+
+
+class LiveSmokeMatrixTests(unittest.TestCase):
+    def test_unit_resolve_surface_plan_returns_expected_browser_fallback(self) -> None:
+        plan = live_smoke_matrix.resolve_surface_plan("browser")
+        self.assertEqual(plan.surface, "browser")
+        self.assertEqual(plan.primary_wrapper, "scripts/demo/browser-automation-live.sh")
+        self.assertEqual(plan.fallback_wrapper, "scripts/demo/browser-automation.sh")
+        self.assertIn(".tau/demo-browser-automation-live", plan.artifact_dirs)
+
+    def test_functional_cli_json_output_includes_surface_plan_fields(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(RUNNER_SCRIPT), "--surface", "voice", "--json"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["surface"], "voice")
+        self.assertEqual(payload["primary_wrapper"], "scripts/demo/voice.sh")
+        self.assertEqual(payload["fallback_wrapper"], "")
+        self.assertEqual(payload["timeout_seconds"], 180)
+
+    def test_integration_cli_writes_output_and_summary_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            output_path = root / "gh-output.txt"
+            summary_path = root / "summary.md"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER_SCRIPT),
+                    "--surface",
+                    "memory",
+                    "--output",
+                    str(output_path),
+                    "--summary",
+                    str(summary_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+            output_text = output_path.read_text(encoding="utf-8")
+            self.assertIn("surface=memory", output_text)
+            self.assertIn("primary_wrapper=scripts/demo/memory.sh", output_text)
+            self.assertIn("artifact_dirs_json=[\".tau/demo-memory\"]", output_text)
+            summary_text = summary_path.read_text(encoding="utf-8")
+            self.assertIn("### Live Smoke Surface Plan", summary_text)
+            self.assertIn("Surface: memory", summary_text)
+
+    def test_regression_cli_rejects_unknown_surface(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(RUNNER_SCRIPT), "--surface", "unknown"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("unsupported live-smoke surface", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       run_coverage: ${{ steps.quality_mode.outputs.run_coverage }}
       run_cross_platform: ${{ steps.quality_mode.outputs.run_cross_platform }}
       heavy_reason: ${{ steps.quality_mode.outputs.heavy_reason }}
+      rust_changed: ${{ steps.rust_scope.outputs.rust_changed }}
     steps:
       - name: Checkout (attempt 1)
         id: checkout_attempt_1
@@ -282,6 +283,218 @@ jobs:
         env:
           RUST_MIN_STACK: "8388608"
         run: cargo test --workspace
+
+  live-smoke-matrix:
+    name: Live smoke (${{ matrix.surface }})
+    needs: [quality-linux]
+    if: needs.quality-linux.outputs.rust_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        surface:
+          - voice
+          - browser
+          - dashboard
+          - custom-command
+          - memory
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve live-smoke surface plan
+        id: surface_plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/live_smoke_matrix.py \
+            --surface "${{ matrix.surface }}" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build required binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p tau-coding-agent
+          if [[ "${{ matrix.surface }}" == "browser" ]]; then
+            cargo build -p tau-browser-automation --bin browser_automation_live_harness
+          fi
+
+      - name: Run live-smoke wrapper with fallback
+        id: run_live_smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          surface="${{ matrix.surface }}"
+          artifact_dir="ci-artifacts/live-smoke/${surface}"
+          mkdir -p "${artifact_dir}"
+
+          primary_wrapper="${{ steps.surface_plan.outputs.primary_wrapper }}"
+          fallback_wrapper="${{ steps.surface_plan.outputs.fallback_wrapper }}"
+          timeout_seconds="${{ steps.surface_plan.outputs.timeout_seconds }}"
+
+          primary_stdout="${artifact_dir}/primary.stdout.log"
+          primary_stderr="${artifact_dir}/primary.stderr.log"
+
+          set +e
+          "${primary_wrapper}" \
+            --repo-root . \
+            --binary target/debug/tau-coding-agent \
+            --skip-build \
+            --timeout-seconds "${timeout_seconds}" >"${primary_stdout}" 2>"${primary_stderr}"
+          primary_rc=$?
+          set -e
+
+          final_rc="${primary_rc}"
+          execution_mode="primary"
+
+          if [[ "${primary_rc}" -ne 0 && -n "${fallback_wrapper}" ]]; then
+            echo "::warning::live-smoke primary wrapper failed for '${surface}' (exit=${primary_rc}); attempting fallback wrapper '${fallback_wrapper}'"
+            fallback_stdout="${artifact_dir}/fallback.stdout.log"
+            fallback_stderr="${artifact_dir}/fallback.stderr.log"
+            set +e
+            "${fallback_wrapper}" \
+              --repo-root . \
+              --binary target/debug/tau-coding-agent \
+              --skip-build \
+              --timeout-seconds "${timeout_seconds}" >"${fallback_stdout}" 2>"${fallback_stderr}"
+            fallback_rc=$?
+            set -e
+            final_rc="${fallback_rc}"
+            execution_mode="fallback"
+          fi
+
+          echo "execution_mode=${execution_mode}" >> "$GITHUB_OUTPUT"
+          echo "surface_exit_code=${final_rc}" >> "$GITHUB_OUTPUT"
+          echo "artifact_dir=${artifact_dir}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${final_rc}" -ne 0 ]]; then
+            echo "::error::live-smoke wrapper failed for '${surface}' mode='${execution_mode}' exit='${final_rc}'"
+            exit "${final_rc}"
+          fi
+
+      - name: Copy surface artifact roots into normalized CI layout
+        if: always()
+        shell: bash
+        env:
+          ARTIFACT_DIRS_JSON: ${{ steps.surface_plan.outputs.artifact_dirs_json }}
+          TARGET_ROOT: ${{ steps.run_live_smoke.outputs.artifact_dir }}/copied-artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p "${TARGET_ROOT}"
+          python3 - <<'PY'
+          import json
+          import os
+          import shutil
+          from pathlib import Path
+
+          artifact_dirs = json.loads(os.environ["ARTIFACT_DIRS_JSON"])
+          target_root = Path(os.environ["TARGET_ROOT"]).resolve()
+          repo_root = Path(".").resolve()
+
+          for raw in artifact_dirs:
+              source = Path(raw)
+              if not source.is_absolute():
+                  source = (repo_root / source).resolve()
+              if not source.exists():
+                  continue
+              destination = target_root / raw.lstrip("./")
+              destination.parent.mkdir(parents=True, exist_ok=True)
+              if source.is_dir():
+                  if destination.exists():
+                      shutil.rmtree(destination)
+                  shutil.copytree(source, destination)
+              else:
+                  shutil.copy2(source, destination)
+          PY
+
+      - name: Publish live-smoke surface summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          surface="${{ matrix.surface }}"
+          execution_mode="${{ steps.run_live_smoke.outputs.execution_mode }}"
+          surface_exit_code="${{ steps.run_live_smoke.outputs.surface_exit_code }}"
+          artifact_dir="${{ steps.run_live_smoke.outputs.artifact_dir }}"
+          if [[ -z "${execution_mode}" ]]; then
+            execution_mode="unavailable"
+          fi
+          if [[ -z "${surface_exit_code}" ]]; then
+            surface_exit_code="unknown"
+          fi
+          if [[ -z "${artifact_dir}" ]]; then
+            artifact_dir="ci-artifacts/live-smoke/${surface}"
+          fi
+
+          echo "### Live Smoke Surface: ${surface}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Execution mode: ${execution_mode}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Exit code: ${surface_exit_code}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact dir: \`${artifact_dir}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "${artifact_dir}/primary.stdout.log" ]]; then
+            summary_line=$(grep -E 'summary: total=' "${artifact_dir}/primary.stdout.log" | tail -n 1 || true)
+            if [[ -n "${summary_line}" ]]; then
+              echo "- Primary summary: \`${summary_line}\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          if [[ -f "${artifact_dir}/fallback.stdout.log" ]]; then
+            summary_line=$(grep -E 'summary: total=' "${artifact_dir}/fallback.stdout.log" | tail -n 1 || true)
+            if [[ -n "${summary_line}" ]]; then
+              echo "- Fallback summary: \`${summary_line}\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+      - name: Upload live-smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-smoke-${{ matrix.surface }}
+          path: ci-artifacts/live-smoke/${{ matrix.surface }}
+          if-no-files-found: ignore
+
+  live-smoke-gate:
+    name: Live smoke gate
+    needs: [quality-linux, live-smoke-matrix]
+    if: always() && needs.quality-linux.outputs.rust_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download live-smoke artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ci-artifacts/live-smoke
+          pattern: live-smoke-*
+          merge-multiple: false
+
+      - name: Summarize live-smoke gate outcome
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "### Live Smoke Gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Matrix result: ${{ needs.live-smoke-matrix.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Required surfaces: voice, browser, dashboard, custom-command, memory" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -d "ci-artifacts/live-smoke" ]]; then
+            echo "- Downloaded artifacts:" >> "$GITHUB_STEP_SUMMARY"
+            find ci-artifacts/live-smoke -maxdepth 2 -type d | sort | sed 's/^/  - /' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Downloaded artifacts: none" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Enforce merge gate on live-smoke failures
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ needs.live-smoke-matrix.result }}" != "success" ]]; then
+            echo "::error::required live-smoke matrix failed; merge gate is blocking"
+            exit 1
+          fi
 
   cross-platform-smoke:
     name: Cross-platform compile smoke (${{ matrix.os }})

--- a/docs/guides/live-run-unified-ops.md
+++ b/docs/guides/live-run-unified-ops.md
@@ -82,3 +82,20 @@ Attach these files for rollout-signoff evidence:
 - `.tau/live-run-unified/report.json`
 - `.tau/live-run-unified/surfaces/**/stdout.log`
 - `.tau/live-run-unified/surfaces/**/stderr.log`
+
+## CI Gate Policy
+
+CI workflow `CI` includes:
+
+- `live-smoke-matrix` (surface matrix: voice/browser/dashboard/custom-command/memory)
+- `live-smoke-gate` (fails merge gate when required surface smoke fails)
+
+Browser matrix lane includes fallback behavior:
+
+- primary: `scripts/demo/browser-automation-live.sh`
+- fallback: `scripts/demo/browser-automation.sh`
+
+Merge gate blocks when:
+
+- any required surface fails both primary and fallback mode, or
+- matrix job exits non-success.


### PR DESCRIPTION
Closes #1328

Depends on #1337

## Summary of behavior changes
- Added CI decision helper for live-smoke matrix surface planning:
  - `.github/scripts/live_smoke_matrix.py`
  - resolves primary wrapper, fallback wrapper, artifact roots, and timeout by surface.
- Added tests for live-smoke decision logic:
  - `.github/scripts/test_live_smoke_matrix.py` (unit/functional/integration/regression)
- Updated `CI` workflow (`.github/workflows/ci.yml`):
  - `quality-linux` now exports `rust_changed` output.
  - New `live-smoke-matrix` job (voice/browser/dashboard/custom-command/memory):
    - builds required binaries
    - runs per-surface wrappers
    - supports browser fallback (`browser-automation-live.sh` -> `browser-automation.sh`)
    - uploads per-surface artifacts/logs
    - appends per-surface summaries to job summary.
  - New `live-smoke-gate` job:
    - aggregates matrix outcome
    - enforces merge gate failure when required live-smoke matrix fails.
- Updated unified harness runbook with CI gate policy details.

## Risks and compatibility notes
- Stacked PR: merge after #1337.
- CI runtime/cost increases due live-smoke matrix builds and executions.
- Gate enforcement only applies when `quality-linux` reports Rust/Cargo change scope.

## Validation evidence
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY` (workflow parse check)
- `python3 .github/scripts/live_smoke_matrix.py --surface browser --json`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `./scripts/demo/live-run-unified.sh --list --json`

Gating behavior encoded in workflow:
- Required surface matrix: `voice`, `browser`, `dashboard`, `custom-command`, `memory`
- Merge gate failure condition: `needs.live-smoke-matrix.result != 'success'`
