### PR TITLE
docs(rollout): add canary/rollback runbooks and release sign-off checklist (#1329)

### DIFF
--- a/.github/scripts/test_docs_link_check.py
+++ b/.github/scripts/test_docs_link_check.py
@@ -63,6 +63,7 @@ class DocsLinkCheckTests(unittest.TestCase):
         docs_index = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
         self.assertIn("guides/quickstart.md", docs_index)
         self.assertIn("guides/transports.md", docs_index)
+        self.assertIn("guides/release-signoff-checklist.md", docs_index)
         self.assertIn("guides/packages.md", docs_index)
         self.assertIn("guides/events.md", docs_index)
 

--- a/.github/scripts/test_release_rollout_docs.py
+++ b/.github/scripts/test_release_rollout_docs.py
@@ -1,0 +1,65 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+RELEASE_CHANNEL_OPS = REPO_ROOT / "docs" / "guides" / "release-channel-ops.md"
+SIGNOFF_CHECKLIST = REPO_ROOT / "docs" / "guides" / "release-signoff-checklist.md"
+SURFACE_RUNBOOKS = [
+    REPO_ROOT / "docs" / "guides" / "voice-ops.md",
+    REPO_ROOT / "docs" / "guides" / "browser-automation-live-ops.md",
+    REPO_ROOT / "docs" / "guides" / "dashboard-ops.md",
+    REPO_ROOT / "docs" / "guides" / "custom-command-ops.md",
+    REPO_ROOT / "docs" / "guides" / "memory-ops.md",
+]
+
+
+class ReleaseRolloutDocsTests(unittest.TestCase):
+    def test_unit_release_channel_runbook_defines_expected_canary_percentages(self):
+        content = RELEASE_CHANNEL_OPS.read_text(encoding="utf-8")
+        phase_percentages = re.findall(r"\|\s*canary-\d+\s*\|\s*(\d+)%\s*\|", content)
+        self.assertEqual(phase_percentages, ["5", "25", "50"])
+        self.assertIn("| general-availability | 100% |", content)
+
+    def test_functional_surface_runbooks_include_canary_profile_and_global_contract_link(self):
+        for runbook in SURFACE_RUNBOOKS:
+            content = runbook.read_text(encoding="utf-8")
+            self.assertIn("## Canary rollout profile", content, msg=str(runbook))
+            self.assertIn(
+                "release-channel-ops.md#cross-surface-rollout-contract",
+                content,
+                msg=str(runbook),
+            )
+
+    def test_integration_signoff_checklist_covers_all_surfaces_and_evidence_contract(self):
+        content = SIGNOFF_CHECKLIST.read_text(encoding="utf-8")
+        required_links = [
+            "release-channel-ops.md",
+            "live-run-unified-ops.md",
+            "voice-ops.md",
+            "browser-automation-live-ops.md",
+            "dashboard-ops.md",
+            "custom-command-ops.md",
+            "memory-ops.md",
+        ]
+        for link in required_links:
+            self.assertIn(link, content)
+        self.assertIn("Mandatory Evidence Contract", content)
+        self.assertIn("CI URL", content)
+        self.assertIn("repository artifact path", content)
+
+    def test_regression_release_channel_runbook_includes_rollback_trigger_matrix(self):
+        content = RELEASE_CHANNEL_OPS.read_text(encoding="utf-8")
+        self.assertIn("## Rollback Trigger Matrix", content)
+        self.assertIn("failure_streak>=3", content)
+        self.assertIn("case_processing_failed", content)
+        self.assertIn("malformed_inputs_observed", content)
+        self.assertIn("live-smoke-matrix", content)
+        self.assertIn("## Rollback Execution Steps", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This index maps Tau documentation by audience and task.
 | New user / operator | [Quickstart Guide](guides/quickstart.md) | Onboarding, auth modes, first prompt, first TUI run |
 | Fresh-clone validator / demo operator | [Demo Index Guide](guides/demo-index.md) | Deterministic onboarding, gateway auth, multi-channel live ingest, and deployment WASM demos |
 | Release validator / rollout operator | [Unified Live-Run Harness Guide](guides/live-run-unified-ops.md) | Single command cross-surface live validation manifest for voice/browser/dashboard/custom-command/memory |
+| Release manager / canary operator | [Release Sign-Off Checklist](guides/release-signoff-checklist.md) | Mandatory evidence checklist covering preflight, 5/25/50 canaries, rollback readiness, and 100% promotion sign-off |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |

--- a/docs/guides/browser-automation-live-ops.md
+++ b/docs/guides/browser-automation-live-ops.md
@@ -57,6 +57,19 @@ Common failure signals:
 - Playwright wrapper issue: validate executable path passed to `--playwright-cli`.
 - Policy denials: inspect `reason_codes` and timeline `error_code` fields.
 
+## Canary rollout profile
+
+Apply the global rollout contract in [Release Channel Ops](release-channel-ops.md#cross-surface-rollout-contract).
+
+| Phase | Canary % | Browser-specific gates |
+| --- | --- | --- |
+| canary-1 | 5% | `health_state=healthy`; no timeline item has non-`ok` `status`; all `error_code` fields are empty. |
+| canary-2 | 25% | canary-1 gates hold for 60 minutes; `artifact_records` count grows with executed cases. |
+| canary-3 | 50% | canary-2 gates hold for 120 minutes; `reason_codes` has no new hard-failure entries. |
+| general-availability | 100% | 24-hour monitor window passes and release sign-off checklist is complete. |
+
+If any rollback trigger from [Rollback Trigger Matrix](release-channel-ops.md#rollback-trigger-matrix) fires, stop promotion immediately and execute [Rollback Execution Steps](release-channel-ops.md#rollback-execution-steps).
+
 ## CI Attachment Pattern
 
 Publish these files as CI artifacts for merge evidence:

--- a/docs/guides/custom-command-ops.md
+++ b/docs/guides/custom-command-ops.md
@@ -71,6 +71,17 @@ Guardrail interpretation:
    `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
    `reason_code_counts`.
 
+## Canary rollout profile
+
+Apply the global rollout contract in [Release Channel Ops](release-channel-ops.md#cross-surface-rollout-contract).
+
+| Phase | Canary % | Custom-command-specific gates |
+| --- | --- | --- |
+| canary-1 | 5% | `rollout_gate=pass`, `health_state=healthy`, `failure_streak=0`, `queue_depth<=1`, no new `case_processing_failed`. |
+| canary-2 | 25% | canary-1 gates hold for 60 minutes; `command_runs_recorded` continues to advance. |
+| canary-3 | 50% | canary-2 gates hold for 120 minutes; `command_registry_mutated` is present when registry changes are expected. |
+| general-availability | 100% | 24-hour monitor window passes and release sign-off checklist is complete. |
+
 ## Rollback plan
 
 1. Stop invoking `--custom-command-contract-runner`.
@@ -78,6 +89,7 @@ Guardrail interpretation:
 3. Revert to last known-good revision:
    `git revert <commit>`
 4. Re-run validation matrix before re-enable.
+5. If any rollback trigger from [Rollback Trigger Matrix](release-channel-ops.md#rollback-trigger-matrix) fires, stop promotion immediately and execute [Rollback Execution Steps](release-channel-ops.md#rollback-execution-steps).
 
 ## Troubleshooting
 

--- a/docs/guides/dashboard-ops.md
+++ b/docs/guides/dashboard-ops.md
@@ -69,6 +69,17 @@ Guardrail interpretation:
 5. Promote by increasing fixture complexity gradually while monitoring:
    `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`.
 
+## Canary rollout profile
+
+Apply the global rollout contract in [Release Channel Ops](release-channel-ops.md#cross-surface-rollout-contract).
+
+| Phase | Canary % | Dashboard-specific gates |
+| --- | --- | --- |
+| canary-1 | 5% | `rollout_gate=pass`, `health_state=healthy`, `failure_streak=0`, `queue_depth<=1`, no new `case_processing_failed`. |
+| canary-2 | 25% | canary-1 gates hold for 60 minutes; `widget_views_updated` and `control_actions_applied` continue to advance. |
+| canary-3 | 50% | canary-2 gates hold for 120 minutes; retry-related reason codes remain flat. |
+| general-availability | 100% | 24-hour monitor window passes and release sign-off checklist is complete. |
+
 ## Rollback plan
 
 1. Stop invoking `--dashboard-contract-runner`.
@@ -76,6 +87,7 @@ Guardrail interpretation:
 3. Revert to last known-good revision:
    `git revert <commit>`
 4. Re-run validation matrix before re-enable.
+5. If any rollback trigger from [Rollback Trigger Matrix](release-channel-ops.md#rollback-trigger-matrix) fires, stop promotion immediately and execute [Rollback Execution Steps](release-channel-ops.md#rollback-execution-steps).
 
 ## Troubleshooting
 

--- a/docs/guides/live-run-unified-ops.md
+++ b/docs/guides/live-run-unified-ops.md
@@ -99,3 +99,9 @@ Merge gate blocks when:
 
 - any required surface fails both primary and fallback mode, or
 - matrix job exits non-success.
+
+## Release Sign-Off Usage
+
+Use unified harness outputs as mandatory evidence in:
+
+- [Release Sign-Off Checklist](release-signoff-checklist.md)

--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -52,6 +52,17 @@ Primary state files:
 5. Promote by increasing fixture complexity gradually while monitoring:
    `failure_streak`, `last_cycle_failed`, `queue_depth`.
 
+## Canary rollout profile
+
+Apply the global rollout contract in [Release Channel Ops](release-channel-ops.md#cross-surface-rollout-contract).
+
+| Phase | Canary % | Memory-specific gates |
+| --- | --- | --- |
+| canary-1 | 5% | `health_state=healthy`, `failure_streak=0`, `last_cycle_failed=false`, `queue_depth<=1`, no new `case_processing_failed`. |
+| canary-2 | 25% | canary-1 gates hold for 60 minutes; duplicate and malformed counts remain flat. |
+| canary-3 | 50% | canary-2 gates hold for 120 minutes; retry-related reason codes remain flat. |
+| general-availability | 100% | 24-hour monitor window passes and release sign-off checklist is complete. |
+
 ## Rollback plan
 
 1. Stop invoking `--memory-contract-runner`.
@@ -59,6 +70,7 @@ Primary state files:
 3. Revert to last known-good revision:
    `git revert <commit>`
 4. Re-run validation matrix before re-enable.
+5. If any rollback trigger from [Rollback Trigger Matrix](release-channel-ops.md#rollback-trigger-matrix) fires, stop promotion immediately and execute [Rollback Execution Steps](release-channel-ops.md#rollback-execution-steps).
 
 ## Troubleshooting
 

--- a/docs/guides/release-channel-ops.md
+++ b/docs/guides/release-channel-ops.md
@@ -2,6 +2,97 @@
 
 Run commands from repository root.
 
+## Cross-Surface Rollout Contract
+
+Use this rollout profile for all live surfaces:
+
+- voice
+- browser automation
+- dashboard
+- custom command
+- memory
+
+| Phase | Canary % | Minimum Soak | Promotion Gates (all required) |
+| --- | --- | --- | --- |
+| preflight | 0% | 1 full run | `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180` reports `total=5 passed=5 failed=0`; CI `live-smoke-matrix` is green; rollback target is recorded via `/release-channel show`. |
+| canary-1 | 5% | 30 minutes | Every surface is `health_state=healthy`; `failure_streak=0`; `last_cycle_failed=false`; `queue_depth<=1`; no new `case_processing_failed` or `malformed_inputs_observed`. |
+| canary-2 | 25% | 60 minutes | canary-1 gates continue to hold; browser timeline has no non-`ok` step and no `error_code`; no rollback trigger fired. |
+| canary-3 | 50% | 120 minutes | canary-2 gates continue to hold; retry pressure is stable (`retry_attempted` and `retryable_failures_observed` are flat). |
+| general-availability | 100% | 24 hours | canary-3 gates hold for full window; release sign-off checklist is complete with evidence links. |
+
+### Health Threshold Collection Commands
+
+Run these checks at each phase boundary:
+
+```bash
+# voice
+cargo run -p tau-coding-agent -- \
+  --voice-state-dir .tau/voice \
+  --voice-status-inspect \
+  --voice-status-json
+
+# dashboard
+cargo run -p tau-coding-agent -- \
+  --dashboard-state-dir .tau/dashboard \
+  --dashboard-status-inspect \
+  --dashboard-status-json
+
+# custom command
+cargo run -p tau-coding-agent -- \
+  --custom-command-state-dir .tau/custom-command \
+  --custom-command-status-inspect \
+  --custom-command-status-json
+
+# memory
+cargo run -p tau-coding-agent -- \
+  --memory-state-dir .tau/memory \
+  --transport-health-inspect memory \
+  --transport-health-json
+
+# browser live summary
+cat .tau/demo-browser-automation-live/browser-live-summary.json
+```
+
+## Rollback Trigger Matrix
+
+| Trigger | Threshold | Immediate Action |
+| --- | --- | --- |
+| Health regression | Any surface reports `health_state=degraded` or `health_state=failing` for 2 consecutive checks | Freeze promotion at current phase and start rollback workflow. |
+| Failure streak breach | Any surface reaches `failure_streak>=3` | Trigger rollback immediately, do not continue canary. |
+| Hard runtime errors | New `case_processing_failed` or `malformed_inputs_observed` appears during canary windows | Trigger rollback, capture runtime events and artifacts for incident review. |
+| Browser execution failure | Browser timeline step is non-`ok` or has non-empty `error_code` | Trigger rollback and switch to previous known-good browser lane. |
+| Validation gate failure | Unified harness or CI `live-smoke-matrix` fails | Trigger rollback and block merge/release sign-off. |
+
+## Rollback Execution Steps
+
+1. Freeze promotion and record incident timestamp.
+2. Capture evidence before cleanup:
+   - `.tau/live-run-unified/report.json`
+   - `.tau/live-run-unified/manifest.json`
+   - per-surface logs under `.tau/live-run-unified/surfaces/`
+3. Inspect rollback target metadata:
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel show
+/quit
+EOF
+```
+
+4. Apply rollback plan to target version metadata:
+
+```bash
+cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
+/release-channel apply --target <rollback_version>
+/quit
+EOF
+```
+
+5. Revert/redeploy to the last known-good revision:
+   `git revert <release_commit_sha>`
+6. Re-run unified validation before reopening rollout:
+   `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180`
+
 ## Inspect channel and rollback metadata
 
 ```bash
@@ -75,3 +166,9 @@ cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini <<'EOF'
 /quit
 EOF
 ```
+
+## Release Sign-Off Checklist Template
+
+Use the checklist guide before any 100% rollout:
+
+- [Release Sign-Off Checklist](release-signoff-checklist.md)

--- a/docs/guides/release-signoff-checklist.md
+++ b/docs/guides/release-signoff-checklist.md
@@ -1,0 +1,98 @@
+# Release Sign-Off Checklist
+
+Run commands from repository root.
+
+Use this checklist for every release touching live surfaces:
+
+- voice
+- browser automation
+- dashboard
+- custom command
+- memory
+
+Related runbooks:
+
+- [Release Channel Ops](release-channel-ops.md)
+- [Unified Live-Run Harness Guide](live-run-unified-ops.md)
+- [Voice Operations Runbook](voice-ops.md)
+- [Browser Automation Live Ops Guide](browser-automation-live-ops.md)
+- [Dashboard Operations Runbook](dashboard-ops.md)
+- [Custom Command Operations Runbook](custom-command-ops.md)
+- [Memory Operations Runbook](memory-ops.md)
+
+## Mandatory Evidence Contract
+
+Every checklist item must include at least one concrete evidence link:
+
+- CI URL (workflow run, job, artifact URL), or
+- repository artifact path (for example `.tau/live-run-unified/report.json`)
+
+`TBD`, blank links, or "see logs" are not acceptable for sign-off.
+
+## Checklist Template
+
+Copy and fill this template in your release issue or PR comment:
+
+```markdown
+## Release Sign-Off: <release-id>
+
+- Release date (UTC): <YYYY-MM-DD>
+- Release owner: <name>
+- Reviewer(s): <name(s)>
+- Target channel: <stable|beta|dev>
+
+### 1. Preflight (0%)
+- [ ] Unified harness passed
+  - Evidence: <link/path to .tau/live-run-unified/report.json>
+- [ ] CI live-smoke matrix passed (voice/browser/dashboard/custom-command/memory)
+  - Evidence: <workflow URL>
+- [ ] Rollback target captured from `/release-channel show`
+  - Evidence: <link/path/screenshot/log snippet>
+
+### 2. Canary Phases
+- [ ] 5% canary complete (30m) with healthy thresholds
+  - Evidence: <status snapshots + logs>
+- [ ] 25% canary complete (60m) with healthy thresholds
+  - Evidence: <status snapshots + logs>
+- [ ] 50% canary complete (120m) with healthy thresholds
+  - Evidence: <status snapshots + logs>
+
+### 3. Rollback Readiness
+- [ ] Rollback trigger matrix reviewed
+  - Evidence: <link to runbook section + ack>
+- [ ] Rollback command rehearsal executed
+  - Evidence: <command transcript path or CI URL>
+
+### 4. Surface Verification
+- [ ] Voice health/status checks
+  - Evidence: <link/path>
+- [ ] Browser live summary/timeline checks
+  - Evidence: <link/path>
+- [ ] Dashboard health/status checks
+  - Evidence: <link/path>
+- [ ] Custom command health/status checks
+  - Evidence: <link/path>
+- [ ] Memory health checks
+  - Evidence: <link/path>
+
+### 5. General Availability (100%)
+- [ ] 24h post-promotion monitor completed
+  - Evidence: <link/path>
+- [ ] No unresolved rollback triggers
+  - Evidence: <link/path>
+- [ ] Final approver sign-off
+  - Evidence: <review URL or comment permalink>
+```
+
+## Rehearsal Procedure (Dry Run)
+
+Run one rehearsal before first production use of a new release train:
+
+1. Execute unified harness:
+   `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180`
+2. Capture preflight evidence links from:
+   - `.tau/live-run-unified/report.json`
+   - `.tau/live-run-unified/manifest.json`
+3. Collect per-surface status evidence from each runbook's inspect commands.
+4. Fill the full checklist template with rehearsal evidence.
+5. Attach checklist to the release issue/PR and request reviewer acknowledgment.

--- a/docs/guides/voice-ops.md
+++ b/docs/guides/voice-ops.md
@@ -71,6 +71,17 @@ Guardrail interpretation:
    `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
    `wake_word_detected`, and `turns_handled`.
 
+## Canary rollout profile
+
+Apply the global rollout contract in [Release Channel Ops](release-channel-ops.md#cross-surface-rollout-contract).
+
+| Phase | Canary % | Voice-specific gates |
+| --- | --- | --- |
+| canary-1 | 5% | `rollout_gate=pass`, `health_state=healthy`, `failure_streak=0`, `queue_depth<=1`, no new `case_processing_failed`. |
+| canary-2 | 25% | canary-1 gates hold for 60 minutes; `wake_word_detected` and `turns_handled` continue to advance. |
+| canary-3 | 50% | canary-2 gates hold for 120 minutes; `retryable_failures_observed` remains flat. |
+| general-availability | 100% | 24-hour monitor window passes and release sign-off checklist is complete. |
+
 ## Rollback plan
 
 1. Stop invoking `--voice-contract-runner`.
@@ -78,6 +89,7 @@ Guardrail interpretation:
 3. Revert to last known-good revision:
    `git revert <commit>`
 4. Re-run validation matrix before re-enable.
+5. If any rollback trigger from [Rollback Trigger Matrix](release-channel-ops.md#rollback-trigger-matrix) fires, stop promotion immediately and execute [Rollback Execution Steps](release-channel-ops.md#rollback-execution-steps).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #1329

## Summary of behavior changes
- Added explicit cross-surface rollout contract in `docs/guides/release-channel-ops.md` with 0/5/25/50/100 canary phases and hard promotion thresholds.
- Added rollback trigger matrix and rollback execution procedure in `docs/guides/release-channel-ops.md`.
- Added `docs/guides/release-signoff-checklist.md` with mandatory evidence-link requirements and a copy/paste sign-off template.
- Updated per-surface ops runbooks (`voice`, `browser`, `dashboard`, `custom-command`, `memory`) to include canary profile gates and rollback trigger linkage.
- Linked sign-off flow from `docs/guides/live-run-unified-ops.md` and `docs/README.md`.
- Added doc regression test suite `.github/scripts/test_release_rollout_docs.py` and extended link-check coverage in `.github/scripts/test_docs_link_check.py`.

## Risks and compatibility notes
- Documentation and Python tests only; no Rust production code paths changed.
- Rollout thresholds are now explicit and stricter; operators should align existing release playbooks with the documented gates.

## Validation evidence
- `python3 .github/scripts/test_release_rollout_docs.py`
- `python3 .github/scripts/test_docs_link_check.py`
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`
- `python3 .github/scripts/docs_link_check.py --repo-root . --file docs/README.md --file docs/guides/release-channel-ops.md --file docs/guides/release-signoff-checklist.md --file docs/guides/live-run-unified-ops.md`
- `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180 --keep-going` (rehearsal live run)
- `cargo fmt --all -- --check` not run (docs/test-only change)
- `cargo clippy --workspace --all-targets -- -D warnings` not run (docs/test-only change)