### PR TITLE
docs(ci): require live-run evidence in PR template and final validation package (#1340)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,72 @@
+## Linked Issue
+
+Closes #<issue-id>
+
+## Summary of behavior changes
+
+- <change 1>
+- <change 2>
+
+## Risks and compatibility notes
+
+- <risk or compatibility impact>
+
+## Impacted live surfaces
+
+Select every impacted surface:
+
+- [ ] voice
+- [ ] browser automation
+- [ ] dashboard
+- [ ] custom command
+- [ ] memory
+- [ ] none (no live-surface impact)
+
+## Mandatory live-run evidence (required when any surface above is checked)
+
+For each impacted surface, include at least one concrete evidence link:
+
+- CI workflow/job/artifact URL, or
+- repository artifact path (for example `.tau/live-run-unified/report.json`)
+
+| Surface | Evidence link(s) | Result summary |
+| --- | --- | --- |
+| voice | <link/path> | <pass/fail + key numbers> |
+| browser automation | <link/path> | <pass/fail + key numbers> |
+| dashboard | <link/path> | <pass/fail + key numbers> |
+| custom command | <link/path> | <pass/fail + key numbers> |
+| memory | <link/path> | <pass/fail + key numbers> |
+
+If a surface is not impacted, write `n/a`.
+
+## Validation matrix evidence (required)
+
+- Unit:
+  - `<command>`
+  - `<result>`
+- Functional:
+  - `<command>`
+  - `<result>`
+- Integration:
+  - `<command>`
+  - `<result>`
+- Regression:
+  - `<command>`
+  - `<result>`
+- Formatting:
+  - `cargo fmt --all -- --check`
+  - `<result or reason not run>`
+- Lint:
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+  - `<result or reason not run>`
+
+## Final validation package + sign-off
+
+- [ ] Attached final validation package or linked package artifact location.
+- [ ] Included go/no-go summary with approver name and timestamp.
+- [ ] If rollout-sensitive, completed release sign-off checklist.
+
+References:
+
+- `docs/guides/release-signoff-checklist.md`
+- `docs/guides/final-validation-package.md`

--- a/.github/scripts/test_docs_link_check.py
+++ b/.github/scripts/test_docs_link_check.py
@@ -64,6 +64,7 @@ class DocsLinkCheckTests(unittest.TestCase):
         self.assertIn("guides/quickstart.md", docs_index)
         self.assertIn("guides/transports.md", docs_index)
         self.assertIn("guides/release-signoff-checklist.md", docs_index)
+        self.assertIn("guides/final-validation-package.md", docs_index)
         self.assertIn("guides/packages.md", docs_index)
         self.assertIn("guides/events.md", docs_index)
 

--- a/.github/scripts/test_pr_template_validation_package.py
+++ b/.github/scripts/test_pr_template_validation_package.py
@@ -1,0 +1,56 @@
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+PR_TEMPLATE = REPO_ROOT / ".github" / "pull_request_template.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
+SIGNOFF_GUIDE = REPO_ROOT / "docs" / "guides" / "release-signoff-checklist.md"
+VALIDATION_GUIDE = REPO_ROOT / "docs" / "guides" / "final-validation-package.md"
+DRY_RUN_GUIDE = REPO_ROOT / "docs" / "guides" / "final-validation-package-dry-run.md"
+
+
+class PrTemplateValidationPackageTests(unittest.TestCase):
+    def test_unit_pr_template_contains_required_surface_and_validation_sections(self):
+        content = PR_TEMPLATE.read_text(encoding="utf-8")
+        self.assertIn("## Mandatory live-run evidence", content)
+        self.assertIn("## Validation matrix evidence", content)
+        self.assertIn("voice", content)
+        self.assertIn("browser automation", content)
+        self.assertIn("dashboard", content)
+        self.assertIn("custom command", content)
+        self.assertIn("memory", content)
+
+    def test_functional_validation_guide_defines_required_package_contents(self):
+        content = VALIDATION_GUIDE.read_text(encoding="utf-8")
+        self.assertIn("## Required package contents", content)
+        self.assertIn("Execution transcripts", content)
+        self.assertIn("Logs/traces/screenshots/audio", content)
+        self.assertIn("Artifact manifest", content)
+        self.assertIn("Go/no-go summary", content)
+        self.assertIn(".tau/live-run-unified/manifest.json", content)
+        self.assertIn(".tau/live-run-unified/report.json", content)
+
+    def test_integration_docs_index_and_signoff_guide_link_validation_package(self):
+        docs_index = DOCS_INDEX.read_text(encoding="utf-8")
+        self.assertIn("guides/final-validation-package.md", docs_index)
+
+        signoff = SIGNOFF_GUIDE.read_text(encoding="utf-8")
+        self.assertIn("final-validation-package.md", signoff)
+
+    def test_regression_dry_run_includes_real_command_and_artifact_evidence(self):
+        content = DRY_RUN_GUIDE.read_text(encoding="utf-8")
+        self.assertIn("rehearsal-2026-02-14", content)
+        self.assertIn(
+            "./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180 --keep-going",
+            content,
+        )
+        self.assertIn("total=5 passed=5 failed=0", content)
+        self.assertIn(".tau/live-run-unified/manifest.json", content)
+        self.assertIn(".tau/live-run-unified/report.json", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This index maps Tau documentation by audience and task.
 | Fresh-clone validator / demo operator | [Demo Index Guide](guides/demo-index.md) | Deterministic onboarding, gateway auth, multi-channel live ingest, and deployment WASM demos |
 | Release validator / rollout operator | [Unified Live-Run Harness Guide](guides/live-run-unified-ops.md) | Single command cross-surface live validation manifest for voice/browser/dashboard/custom-command/memory |
 | Release manager / canary operator | [Release Sign-Off Checklist](guides/release-signoff-checklist.md) | Mandatory evidence checklist covering preflight, 5/25/50 canaries, rollback readiness, and 100% promotion sign-off |
+| Release approver / go-no-go owner | [Final Validation Package Guide](guides/final-validation-package.md) | Required package contract for transcripts, logs/traces, artifact manifest, and explicit go/no-go summary |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |

--- a/docs/guides/final-validation-package-dry-run.md
+++ b/docs/guides/final-validation-package-dry-run.md
@@ -1,0 +1,36 @@
+# Final Validation Package Dry Run
+
+This file records one rehearsal fill of the package template using live-run evidence.
+
+## Final Validation Package: rehearsal-2026-02-14
+
+- Decision owner: Codex automation
+- Reviewer(s): pending human reviewer
+- Decision timestamp (UTC): 2026-02-14T00:00:00Z
+- Decision: GO (rehearsal only)
+
+### 1) Execution transcripts
+
+- Command: `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180 --keep-going`
+  - Evidence: `.tau/live-run-unified/report.json`
+  - Result summary: `total=5 passed=5 failed=0 duration_ms=8275`
+
+### 2) Logs/traces/screenshots/audio
+
+- Voice: `.tau/live-run-unified/surfaces/voice/stdout.log`
+- Browser: `.tau/live-run-unified/surfaces/browser/stdout.log`
+- Dashboard: `.tau/live-run-unified/surfaces/dashboard/stdout.log`
+- Custom command: `.tau/live-run-unified/surfaces/custom-command/stdout.log`
+- Memory: `.tau/live-run-unified/surfaces/memory/stdout.log`
+
+### 3) Artifact manifest
+
+- Manifest: `.tau/live-run-unified/manifest.json`
+- Report: `.tau/live-run-unified/report.json`
+
+### 4) Rollback readiness + go/no-go summary
+
+- Rollback trigger matrix review evidence:
+  `docs/guides/release-channel-ops.md#rollback-trigger-matrix`
+- Current trigger status: none active
+- Final decision rationale: rehearsal run passed all five surfaces and produced complete artifact set.

--- a/docs/guides/final-validation-package.md
+++ b/docs/guides/final-validation-package.md
@@ -1,0 +1,92 @@
+# Final Validation Package Guide
+
+Run commands from repository root.
+
+Use this guide to assemble the go/no-go package for rollout-sensitive changes.
+
+Related guides:
+
+- [Release Sign-Off Checklist](release-signoff-checklist.md)
+- [Release Channel Ops](release-channel-ops.md)
+- [Unified Live-Run Harness Guide](live-run-unified-ops.md)
+- [Final Validation Package Dry Run](final-validation-package-dry-run.md)
+
+## Required package contents
+
+Every package must include these sections:
+
+1. Execution transcripts:
+   - exact commands used
+   - timestamped summary lines
+2. Logs/traces/screenshots/audio (as applicable):
+   - per-surface output logs
+   - runtime traces or summaries
+   - screenshot/audio links only for surfaces that produce them
+3. Artifact manifest:
+   - machine-readable manifest (for example `.tau/live-run-unified/manifest.json`)
+   - machine-readable report (for example `.tau/live-run-unified/report.json`)
+4. Go/no-go summary:
+   - explicit `GO` or `NO-GO`
+   - owner + reviewer names
+   - decision timestamp (UTC)
+   - rollback trigger status
+
+## Minimal package layout
+
+Store package evidence in a deterministic path (or CI artifact bundle):
+
+```text
+.tau/validation-package/<release-id>/
+  checklist.md
+  command-transcript.log
+  go-no-go-summary.md
+  live-run-unified/
+    manifest.json
+    report.json
+    surfaces/<surface>/stdout.log
+    surfaces/<surface>/stderr.log
+```
+
+## Checklist template
+
+Copy this into a release issue/PR comment or package file:
+
+```markdown
+## Final Validation Package: <release-id>
+
+- Decision owner: <name>
+- Reviewer(s): <name(s)>
+- Decision timestamp (UTC): <YYYY-MM-DDTHH:MM:SSZ>
+- Decision: <GO|NO-GO>
+
+### 1) Execution transcripts
+- Command: <exact command>
+  - Evidence: <link/path>
+- Command: <exact command>
+  - Evidence: <link/path>
+
+### 2) Logs/traces/screenshots/audio
+- Voice: <link/path or n/a>
+- Browser: <link/path or n/a>
+- Dashboard: <link/path or n/a>
+- Custom command: <link/path or n/a>
+- Memory: <link/path or n/a>
+
+### 3) Artifact manifest
+- Manifest: <link/path>
+- Report: <link/path>
+
+### 4) Rollback readiness + go/no-go summary
+- Rollback trigger matrix review evidence: <link/path>
+- Current trigger status: <none active | list active triggers>
+- Final decision rationale: <short rationale>
+```
+
+## Assembly workflow
+
+1. Run unified harness:
+   `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180 --keep-going`
+2. Save transcript output to package evidence.
+3. Attach `manifest.json`, `report.json`, and per-surface logs.
+4. Complete release sign-off checklist.
+5. Fill final validation package template and record explicit decision.

--- a/docs/guides/live-run-unified-ops.md
+++ b/docs/guides/live-run-unified-ops.md
@@ -105,3 +105,4 @@ Merge gate blocks when:
 Use unified harness outputs as mandatory evidence in:
 
 - [Release Sign-Off Checklist](release-signoff-checklist.md)
+- [Final Validation Package Guide](final-validation-package.md)

--- a/docs/guides/release-signoff-checklist.md
+++ b/docs/guides/release-signoff-checklist.md
@@ -19,6 +19,7 @@ Related runbooks:
 - [Dashboard Operations Runbook](dashboard-ops.md)
 - [Custom Command Operations Runbook](custom-command-ops.md)
 - [Memory Operations Runbook](memory-ops.md)
+- [Final Validation Package Guide](final-validation-package.md)
 
 ## Mandatory Evidence Contract
 
@@ -96,3 +97,5 @@ Run one rehearsal before first production use of a new release train:
 3. Collect per-surface status evidence from each runbook's inspect commands.
 4. Fill the full checklist template with rehearsal evidence.
 5. Attach checklist to the release issue/PR and request reviewer acknowledgment.
+6. Assemble and attach the final package using:
+   `docs/guides/final-validation-package.md`


### PR DESCRIPTION
Closes #1340

## Summary of behavior changes
- Added `.github/pull_request_template.md` with required linked issue, impacted surface matrix, mandatory live-run evidence table, validation matrix evidence, and final sign-off fields.
- Added `docs/guides/final-validation-package.md` defining required package contents (transcripts, logs/traces/screenshots/audio as applicable, artifact manifest, go/no-go summary).
- Added `docs/guides/final-validation-package-dry-run.md` as a completed rehearsal example using real live-run evidence.
- Wired final validation package guidance into:
  - `docs/README.md`
  - `docs/guides/release-signoff-checklist.md`
  - `docs/guides/live-run-unified-ops.md`
- Added regression tests in `.github/scripts/test_pr_template_validation_package.py` and expanded docs index assertions in `.github/scripts/test_docs_link_check.py`.

## Risks and compatibility notes
- Documentation and Python tests only; no Rust runtime behavior changed.
- PR submissions now have stricter required evidence sections; contributors must provide explicit links or `n/a` entries.

## Validation evidence
- `./scripts/demo/live-run-unified.sh --skip-build --timeout-seconds 180 --keep-going`
  - Result: `total=5 passed=5 failed=0`
- `python3 .github/scripts/test_pr_template_validation_package.py`
- `python3 .github/scripts/test_docs_link_check.py`
- `python3 .github/scripts/test_release_rollout_docs.py`
- `python3 .github/scripts/docs_link_check.py --repo-root . --file docs/README.md --file docs/guides/release-signoff-checklist.md --file docs/guides/final-validation-package.md --file docs/guides/final-validation-package-dry-run.md`
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`
- `cargo fmt --all -- --check` not run (docs/test-only change)
- `cargo clippy --workspace --all-targets -- -D warnings` not run (docs/test-only change)
