### PR TITLE
feat(custom-command): add live proof harness + policy deny runtime

### DIFF
--- a/.github/scripts/live_smoke_matrix.py
+++ b/.github/scripts/live_smoke_matrix.py
@@ -41,9 +41,9 @@ SURFACE_PLANS: dict[str, SurfacePlan] = {
     ),
     "custom-command": SurfacePlan(
         surface="custom-command",
-        primary_wrapper="scripts/demo/custom-command.sh",
-        fallback_wrapper="",
-        artifact_dirs=(".tau/demo-custom-command",),
+        primary_wrapper="scripts/demo/custom-command-live.sh",
+        fallback_wrapper="scripts/demo/custom-command.sh",
+        artifact_dirs=(".tau/demo-custom-command-live", ".tau/demo-custom-command"),
         timeout_seconds=180,
     ),
     "memory": SurfacePlan(

--- a/.github/scripts/test_custom_command_live_demo.py
+++ b/.github/scripts/test_custom_command_live_demo.py
@@ -1,0 +1,212 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts" / "demo"
+
+
+def write_mock_custom_command_binary(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+
+if "--custom-command-contract-runner" in args:
+    state_dir = Path(args[args.index("--custom-command-state-dir") + 1])
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "processed_case_keys": ["a", "b", "c", "d", "e", "f"],
+                "commands": [],
+                "health": {
+                    "health_state": "degraded",
+                    "failure_streak": 1,
+                    "queue_depth": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "runtime-events.jsonl").write_text(
+        '{"reason_codes":["command_runs_recorded","case_processing_failed"],"health_reason":"retry pending"}\\n',
+        encoding="utf-8",
+    )
+
+    base = state_dir / "channel-store" / "channels" / "custom-command"
+    deploy = base / "deploy_release"
+    deploy.mkdir(parents=True, exist_ok=True)
+    deploy_event = {
+        "payload": {
+            "outcome": "success",
+            "operation": "run",
+            "command_name": "deploy_release",
+            "status_code": 200,
+            "error_code": "",
+        }
+    }
+    (deploy / "log.jsonl").write_text(json.dumps(deploy_event) + "\\n", encoding="utf-8")
+
+    if os.environ.get("TAU_MOCK_SKIP_POLICY_DENY") != "1":
+        admin = base / "admin_shutdown"
+        admin.mkdir(parents=True, exist_ok=True)
+        admin_event = {
+            "payload": {
+                "outcome": "malformed_input",
+                "operation": "run",
+                "command_name": "admin_shutdown",
+                "status_code": 403,
+                "error_code": "custom_command_policy_denied",
+            }
+        }
+        (admin / "log.jsonl").write_text(json.dumps(admin_event) + "\\n", encoding="utf-8")
+
+    triage = base / "triage_alerts"
+    triage.mkdir(parents=True, exist_ok=True)
+    triage_event = {
+        "payload": {
+            "outcome": "retryable_failure",
+            "operation": "run",
+            "command_name": "triage_alerts",
+            "status_code": 503,
+            "error_code": "custom_command_backend_unavailable",
+        }
+    }
+    (triage / "log.jsonl").write_text(json.dumps(triage_event) + "\\n", encoding="utf-8")
+    print("custom-command-runner-ok")
+    raise SystemExit(0)
+
+if "--transport-health-inspect" in args:
+    print(json.dumps({"health_state": "degraded", "failure_streak": 1, "queue_depth": 0}))
+    raise SystemExit(0)
+
+if "--custom-command-status-inspect" in args:
+    print(json.dumps({"health_state": "degraded", "rollout_gate": "hold"}))
+    raise SystemExit(0)
+
+if "--channel-store-inspect" in args:
+    print(json.dumps({"status": "ok", "channel": args[args.index("--channel-store-inspect") + 1]}))
+    raise SystemExit(0)
+
+print("mock-ok " + " ".join(args))
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def prepare_fixture_tree(repo_root: Path) -> None:
+    fixture = (
+        repo_root
+        / "crates"
+        / "tau-coding-agent"
+        / "testdata"
+        / "custom-command-contract"
+        / "live-execution-matrix.json"
+    )
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.write_text('{"schema_version":1,"cases":[]}', encoding="utf-8")
+
+
+def run_custom_command_live_script(
+    repo_root: Path,
+    binary_path: Path,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [
+            str(SCRIPTS_DIR / "custom-command-live.sh"),
+            "--skip-build",
+            "--repo-root",
+            str(repo_root),
+            "--binary",
+            str(binary_path),
+            "--timeout-seconds",
+            "30",
+        ],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class CustomCommandLiveDemoTests(unittest.TestCase):
+    def test_unit_custom_command_live_rejects_unknown_argument(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPTS_DIR / "custom-command-live.sh"), "--definitely-unknown"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("unknown argument: --definitely-unknown", completed.stderr)
+
+    def test_functional_custom_command_live_runs_with_mock_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            prepare_fixture_tree(root)
+            binary_path = root / "bin" / "tau-coding-agent"
+            write_mock_custom_command_binary(binary_path)
+
+            completed = run_custom_command_live_script(root, binary_path)
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+            self.assertIn("[demo:custom-command-live] summary: total=", completed.stdout)
+            self.assertIn("failed=0", completed.stdout)
+
+            summary_path = root / ".tau" / "demo-custom-command-live" / "custom-command-live-summary.json"
+            report_path = root / ".tau" / "demo-custom-command-live" / "custom-command-live-report.json"
+            self.assertTrue(summary_path.exists())
+            self.assertTrue(report_path.exists())
+
+    def test_integration_custom_command_live_report_includes_policy_and_retry_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            prepare_fixture_tree(root)
+            binary_path = root / "bin" / "tau-coding-agent"
+            write_mock_custom_command_binary(binary_path)
+
+            completed = run_custom_command_live_script(root, binary_path)
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+
+            summary_path = root / ".tau" / "demo-custom-command-live" / "custom-command-live-summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(summary["health_state"], "degraded")
+            self.assertEqual(summary["rollout_gate"], "hold")
+            self.assertEqual(summary["deploy_event_count"], 1)
+            self.assertEqual(summary["policy_deny_event_count"], 1)
+            self.assertEqual(summary["retryable_failure_event_count"], 1)
+
+    def test_regression_custom_command_live_fails_closed_when_policy_deny_events_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            prepare_fixture_tree(root)
+            binary_path = root / "bin" / "tau-coding-agent"
+            write_mock_custom_command_binary(binary_path)
+
+            completed = run_custom_command_live_script(
+                root,
+                binary_path,
+                env_overrides={"TAU_MOCK_SKIP_POLICY_DENY": "1"},
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            combined = completed.stdout + "\n" + completed.stderr
+            self.assertIn("policy deny events were not captured", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_live_smoke_matrix.py
+++ b/.github/scripts/test_live_smoke_matrix.py
@@ -29,6 +29,14 @@ class LiveSmokeMatrixTests(unittest.TestCase):
         self.assertIn(".tau/demo-dashboard-live", plan.artifact_dirs)
         self.assertIn(".tau/demo-dashboard", plan.artifact_dirs)
 
+    def test_unit_resolve_surface_plan_returns_expected_custom_command_primary_and_fallback(self) -> None:
+        plan = live_smoke_matrix.resolve_surface_plan("custom-command")
+        self.assertEqual(plan.surface, "custom-command")
+        self.assertEqual(plan.primary_wrapper, "scripts/demo/custom-command-live.sh")
+        self.assertEqual(plan.fallback_wrapper, "scripts/demo/custom-command.sh")
+        self.assertIn(".tau/demo-custom-command-live", plan.artifact_dirs)
+        self.assertIn(".tau/demo-custom-command", plan.artifact_dirs)
+
     def test_functional_cli_json_output_includes_surface_plan_fields(self) -> None:
         completed = subprocess.run(
             [sys.executable, str(RUNNER_SCRIPT), "--surface", "voice", "--json"],

--- a/crates/tau-coding-agent/testdata/custom-command-contract/README.md
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/README.md
@@ -7,6 +7,7 @@ and lifecycle operations.
 
 - `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
 - `rollout-pass.json`: all-success fixture for deterministic demo and rollout checks.
+- `live-execution-matrix.json`: success + policy deny + retryable failure matrix for live-proof workflows.
 - `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
 - `invalid-error-code.json`: regression fixture for unsupported `error_code`.
 
@@ -20,3 +21,4 @@ and lifecycle operations.
   - `custom_command_invalid_name`
   - `custom_command_invalid_template`
   - `custom_command_backend_unavailable`
+  - `custom_command_policy_denied`

--- a/crates/tau-coding-agent/testdata/custom-command-contract/live-execution-matrix.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/live-execution-matrix.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-live-execution-matrix",
+  "description": "Live-mode custom command execution matrix covering success, policy deny, and retryable failure outcomes.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-01-create-success",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "operation": "create",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-02-update-success",
+      "operation": "update",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}} --safe",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "update",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-03-run-success",
+      "operation": "run",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {
+        "env": "staging",
+        "plan": "canary"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "run",
+          "command_name": "deploy_release",
+          "arguments": {
+            "env": "staging",
+            "plan": "canary"
+          }
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-04-list-success",
+      "operation": "list",
+      "command_name": "",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "list",
+          "commands": [
+            "deploy_release",
+            "triage_alerts"
+          ]
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-05-delete-success",
+      "operation": "delete",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "delete",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-06-policy-deny-admin-run",
+      "operation": "run",
+      "command_name": "admin_shutdown",
+      "template": "",
+      "arguments": {
+        "scope": "global"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 403,
+        "error_code": "custom_command_policy_denied",
+        "response_body": {
+          "status": "denied",
+          "reason": "policy_denied",
+          "command_name": "admin_shutdown"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-07-retryable-run-backend",
+      "operation": "run",
+      "command_name": "triage_alerts",
+      "template": "",
+      "arguments": {
+        "severity": "high"
+      },
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "custom_command_backend_unavailable",
+        "response_body": {
+          "status": "retryable",
+          "reason": "backend_unavailable"
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-custom-command/testdata/custom-command-contract/README.md
+++ b/crates/tau-custom-command/testdata/custom-command-contract/README.md
@@ -7,6 +7,7 @@ and lifecycle operations.
 
 - `mixed-outcomes.json`: success + malformed_input + retryable_failure matrix.
 - `rollout-pass.json`: all-success fixture for deterministic demo and rollout checks.
+- `live-execution-matrix.json`: success + policy deny + retryable failure matrix for live-proof workflows.
 - `invalid-duplicate-case-id.json`: regression fixture for duplicate `case_id`.
 - `invalid-error-code.json`: regression fixture for unsupported `error_code`.
 
@@ -20,3 +21,4 @@ and lifecycle operations.
   - `custom_command_invalid_name`
   - `custom_command_invalid_template`
   - `custom_command_backend_unavailable`
+  - `custom_command_policy_denied`

--- a/crates/tau-custom-command/testdata/custom-command-contract/live-execution-matrix.json
+++ b/crates/tau-custom-command/testdata/custom-command-contract/live-execution-matrix.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "name": "custom-command-live-execution-matrix",
+  "description": "Live-mode custom command execution matrix covering success, policy deny, and retryable failure outcomes.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-01-create-success",
+      "operation": "create",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}}",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 201,
+        "response_body": {
+          "status": "accepted",
+          "operation": "create",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-02-update-success",
+      "operation": "update",
+      "command_name": "deploy_release",
+      "template": "deploy {{env}} --safe",
+      "arguments": {
+        "env": "staging"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "update",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-03-run-success",
+      "operation": "run",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {
+        "env": "staging",
+        "plan": "canary"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "run",
+          "command_name": "deploy_release",
+          "arguments": {
+            "env": "staging",
+            "plan": "canary"
+          }
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-04-list-success",
+      "operation": "list",
+      "command_name": "",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "list",
+          "commands": [
+            "deploy_release",
+            "triage_alerts"
+          ]
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-05-delete-success",
+      "operation": "delete",
+      "command_name": "deploy_release",
+      "template": "",
+      "arguments": {},
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "accepted",
+          "operation": "delete",
+          "command_name": "deploy_release"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-06-policy-deny-admin-run",
+      "operation": "run",
+      "command_name": "admin_shutdown",
+      "template": "",
+      "arguments": {
+        "scope": "global"
+      },
+      "simulate_retryable_failure": false,
+      "expected": {
+        "outcome": "malformed_input",
+        "status_code": 403,
+        "error_code": "custom_command_policy_denied",
+        "response_body": {
+          "status": "denied",
+          "reason": "policy_denied",
+          "command_name": "admin_shutdown"
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "custom-command-07-retryable-run-backend",
+      "operation": "run",
+      "command_name": "triage_alerts",
+      "template": "",
+      "arguments": {
+        "severity": "high"
+      },
+      "simulate_retryable_failure": true,
+      "expected": {
+        "outcome": "retryable_failure",
+        "status_code": 503,
+        "error_code": "custom_command_backend_unavailable",
+        "response_body": {
+          "status": "retryable",
+          "reason": "backend_unavailable"
+        }
+      }
+    }
+  ]
+}

--- a/docs/guides/custom-command-ops.md
+++ b/docs/guides/custom-command-ops.md
@@ -6,6 +6,7 @@ Run all commands from repository root.
 
 This runbook covers the fixture-driven no-code custom command runtime
 (`--custom-command-contract-runner`).
+It also covers the live proof harness for create/update/delete/list/run execution validation.
 
 ## Health and observability signals
 
@@ -56,6 +57,26 @@ Guardrail interpretation:
 ./scripts/demo/custom-command.sh
 ```
 
+## Live proof harness
+
+```bash
+./scripts/demo/custom-command-live.sh
+```
+
+Primary proof artifacts:
+
+- `.tau/demo-custom-command-live/custom-command-live-summary.json`
+- `.tau/demo-custom-command-live/custom-command-live-report.json`
+- `.tau/demo-custom-command-live/custom-command-live-transcript.log`
+- `.tau/demo-custom-command-live/state/state.json`
+- `.tau/demo-custom-command-live/state/channel-store/channels/custom-command/**/log.jsonl`
+
+Live harness coverage includes:
+
+- real execution flow for `create`, `update`, `run`, `list`, and `delete`
+- policy deny handling (`custom_command_policy_denied`)
+- retryable failure handling (`custom_command_backend_unavailable`)
+
 ## Rollout plan with guardrails
 
 1. Validate contract fixtures and compatibility:
@@ -64,10 +85,12 @@ Guardrail interpretation:
    `cargo test -p tau-coding-agent custom_command_runtime -- --test-threads=1`
 3. Run deterministic demo:
    `./scripts/demo/custom-command.sh`
-4. Verify transport health and status gate:
+4. Run live proof harness:
+   `./scripts/demo/custom-command-live.sh`
+5. Verify transport health and status gate:
    `--transport-health-inspect custom-command --transport-health-json`
    `--custom-command-status-inspect --custom-command-status-json`
-5. Promote by increasing fixture complexity while monitoring:
+6. Promote by increasing fixture complexity while monitoring:
    `failure_streak`, `last_cycle_failed`, `queue_depth`, `rollout_gate`,
    `reason_code_counts`.
 

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -108,6 +108,20 @@ Primary outputs:
 - `.tau/demo-dashboard-live/dashboard-action-audit.json`
 - `.tau/demo-dashboard-live/webchat-fallback-check.json`
 
+`custom-command-live` is a standalone wrapper (not part of `index.sh` scenario allowlist)
+used for live custom-command execution proof (create/update/run/list/delete + policy deny/retry paths):
+
+```bash
+./scripts/demo/custom-command-live.sh
+```
+
+Primary outputs:
+
+- `.tau/demo-custom-command-live/custom-command-live-summary.json`
+- `.tau/demo-custom-command-live/custom-command-live-report.json`
+- `.tau/demo-custom-command-live/custom-command-live-transcript.log`
+- `.tau/demo-custom-command-live/state/channel-store/channels/custom-command/**/log.jsonl`
+
 ## Unified Live-Run Harness
 
 Cross-surface validation wrapper (voice/browser/dashboard/custom-command/memory):

--- a/docs/guides/live-run-unified-ops.md
+++ b/docs/guides/live-run-unified-ops.md
@@ -100,6 +100,11 @@ Dashboard matrix lane includes fallback behavior:
 - primary: `scripts/demo/dashboard-live.sh`
 - fallback: `scripts/demo/dashboard.sh`
 
+Custom-command matrix lane includes fallback behavior:
+
+- primary: `scripts/demo/custom-command-live.sh`
+- fallback: `scripts/demo/custom-command.sh`
+
 Merge gate blocks when:
 
 - any required surface fails both primary and fallback mode, or

--- a/scripts/demo/custom-command-live.sh
+++ b/scripts/demo/custom-command-live.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+binary_path="${repo_root}/target/debug/tau-coding-agent"
+skip_build="false"
+timeout_seconds=""
+step_total=0
+step_passed=0
+
+print_usage() {
+  cat <<EOF
+Usage: custom-command-live.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--timeout-seconds N] [--help]
+
+Run deterministic custom-command live proof flow with summary/report artifact generation.
+
+Options:
+  --repo-root PATH      Repository root (defaults to caller-derived root)
+  --binary PATH         tau-coding-agent binary path
+  --skip-build          Skip cargo build and require binary to exist
+  --timeout-seconds N   Positive integer timeout per command step
+  --help                Show this usage message
+EOF
+}
+
+log_info() {
+  echo "[demo:custom-command-live] $1"
+}
+
+run_step() {
+  local label="$1"
+  shift
+  step_total=$((step_total + 1))
+  log_info "[${step_total}] ${label}"
+  if "$@"; then
+    step_passed=$((step_passed + 1))
+    log_info "PASS ${label}"
+  else
+    local rc=$?
+    log_info "FAIL ${label} exit=${rc}"
+    return "${rc}"
+  fi
+}
+
+run_with_timeout() {
+  local -a command=("$@")
+  if [[ -n "${timeout_seconds}" ]]; then
+    python3 - "${timeout_seconds}" "${command[@]}" <<'PY'
+import subprocess
+import sys
+
+timeout_seconds = int(sys.argv[1])
+command = sys.argv[2:]
+try:
+    completed = subprocess.run(command, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+sys.exit(completed.returncode)
+PY
+  else
+    "${command[@]}"
+  fi
+}
+
+run_logged_command() {
+  local stdout_log="$1"
+  local stderr_log="$2"
+  shift 2
+  set +e
+  run_with_timeout "$@" >"${stdout_log}" 2>"${stderr_log}"
+  local rc=$?
+  set -e
+  return "${rc}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --repo-root" >&2
+        print_usage >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --binary)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --binary" >&2
+        print_usage >&2
+        exit 2
+      fi
+      binary_path="$2"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build="true"
+      shift
+      ;;
+    --timeout-seconds)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --timeout-seconds" >&2
+        print_usage >&2
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+        echo "invalid value for --timeout-seconds (expected positive integer): $2" >&2
+        print_usage >&2
+        exit 2
+      fi
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "${repo_root}" ]]; then
+  echo "invalid --repo-root path (directory not found): ${repo_root}" >&2
+  exit 2
+fi
+repo_root="$(cd "${repo_root}" && pwd)"
+
+if [[ "${binary_path}" != /* ]]; then
+  binary_path="${repo_root}/${binary_path}"
+fi
+
+fixture_path="${repo_root}/crates/tau-coding-agent/testdata/custom-command-contract/live-execution-matrix.json"
+if [[ ! -f "${fixture_path}" ]]; then
+  echo "missing required custom-command fixture: ${fixture_path}" >&2
+  exit 1
+fi
+
+work_root="${repo_root}/.tau/demo-custom-command-live"
+state_dir="${work_root}/state"
+summary_json="${work_root}/custom-command-live-summary.json"
+report_json="${work_root}/custom-command-live-report.json"
+transcript_log="${work_root}/custom-command-live-transcript.log"
+
+rm -rf "${work_root}"
+mkdir -p "${state_dir}"
+
+if [[ "${skip_build}" != "true" ]]; then
+  run_step "build-tau-coding-agent" \
+    bash -lc "cd '${repo_root}' && cargo build -p tau-coding-agent >/dev/null"
+fi
+
+if [[ ! -x "${binary_path}" ]]; then
+  echo "missing tau-coding-agent binary: ${binary_path}" >&2
+  exit 1
+fi
+
+run_step "custom-command-live-runner" \
+  run_logged_command \
+  "${work_root}/runner.stdout.log" \
+  "${work_root}/runner.stderr.log" \
+  "${binary_path}" \
+  --custom-command-contract-runner \
+  --custom-command-fixture "${fixture_path}" \
+  --custom-command-state-dir "${state_dir}" \
+  --custom-command-queue-limit 64 \
+  --custom-command-processed-case-cap 10000 \
+  --custom-command-retry-max-attempts 2 \
+  --custom-command-retry-base-delay-ms 0
+
+run_step "transport-health-inspect-custom-command" \
+  run_logged_command \
+  "${work_root}/health.stdout.log" \
+  "${work_root}/health.stderr.log" \
+  "${binary_path}" \
+  --custom-command-state-dir "${state_dir}" \
+  --transport-health-inspect custom-command \
+  --transport-health-json
+
+run_step "custom-command-status-inspect" \
+  run_logged_command \
+  "${work_root}/status.stdout.log" \
+  "${work_root}/status.stderr.log" \
+  "${binary_path}" \
+  --custom-command-state-dir "${state_dir}" \
+  --custom-command-status-inspect \
+  --custom-command-status-json
+
+run_step "channel-store-inspect-custom-command-deploy-release" \
+  run_logged_command \
+  "${work_root}/deploy-release.stdout.log" \
+  "${work_root}/deploy-release.stderr.log" \
+  "${binary_path}" \
+  --channel-store-root "${state_dir}/channel-store" \
+  --channel-store-inspect custom-command/deploy_release
+
+run_step "channel-store-inspect-custom-command-admin-shutdown" \
+  run_logged_command \
+  "${work_root}/admin-shutdown.stdout.log" \
+  "${work_root}/admin-shutdown.stderr.log" \
+  "${binary_path}" \
+  --channel-store-root "${state_dir}/channel-store" \
+  --channel-store-inspect custom-command/admin_shutdown
+
+run_step "channel-store-inspect-custom-command-triage-alerts" \
+  run_logged_command \
+  "${work_root}/triage-alerts.stdout.log" \
+  "${work_root}/triage-alerts.stderr.log" \
+  "${binary_path}" \
+  --channel-store-root "${state_dir}/channel-store" \
+  --channel-store-inspect custom-command/triage_alerts
+
+validate_outputs() {
+  python3 - \
+    "${state_dir}" \
+    "${work_root}" \
+    "${summary_json}" \
+    "${report_json}" \
+    "${transcript_log}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_dir = Path(sys.argv[1])
+work_root = Path(sys.argv[2])
+summary_path = Path(sys.argv[3])
+report_path = Path(sys.argv[4])
+transcript_path = Path(sys.argv[5])
+
+state_path = state_dir / "state.json"
+if not state_path.exists():
+    raise SystemExit(f"custom-command state missing: {state_path}")
+state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+
+health_stdout = work_root / "health.stdout.log"
+status_stdout = work_root / "status.stdout.log"
+if not health_stdout.exists() or not status_stdout.exists():
+    raise SystemExit("health/status inspection logs are missing")
+
+raw_health_payload = json.loads(health_stdout.read_text(encoding="utf-8"))
+status_payload = json.loads(status_stdout.read_text(encoding="utf-8"))
+if not isinstance(status_payload, dict):
+    raise SystemExit("custom-command status inspect payload must be an object")
+
+if isinstance(raw_health_payload, list):
+    first_entry = raw_health_payload[0] if raw_health_payload else {}
+    if not isinstance(first_entry, dict):
+        raise SystemExit("transport health inspect list payload must contain objects")
+    health_payload = first_entry.get("health", {})
+    if not isinstance(health_payload, dict):
+        raise SystemExit("transport health inspect entry has invalid health payload")
+    health_state = status_payload.get("health_state", "")
+elif isinstance(raw_health_payload, dict):
+    if isinstance(raw_health_payload.get("health"), dict):
+        health_payload = raw_health_payload.get("health", {})
+    else:
+        health_payload = raw_health_payload
+    health_state = raw_health_payload.get(
+        "health_state",
+        status_payload.get("health_state", ""),
+    )
+else:
+    raise SystemExit("transport health inspect payload must be an object or array")
+
+channel_logs = sorted((state_dir / "channel-store" / "channels" / "custom-command").glob("*/log.jsonl"))
+if not channel_logs:
+    raise SystemExit("custom-command channel-store logs are missing")
+
+deploy_events = []
+policy_deny_events = []
+retryable_failure_events = []
+
+for log_file in channel_logs:
+    lines = [line for line in log_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+    for line in lines:
+        event = json.loads(line)
+        payload = event.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("command_name") == "deploy_release":
+            deploy_events.append(event)
+        if payload.get("error_code") == "custom_command_policy_denied":
+            policy_deny_events.append(event)
+        if payload.get("error_code") == "custom_command_backend_unavailable":
+            retryable_failure_events.append(event)
+
+if not deploy_events:
+    raise SystemExit("deploy_release execution events were not captured")
+if not policy_deny_events:
+    raise SystemExit("policy deny events were not captured")
+if not retryable_failure_events:
+    raise SystemExit("retryable failure events were not captured")
+
+runner_stdout = work_root / "runner.stdout.log"
+runner_stderr = work_root / "runner.stderr.log"
+segments = []
+for log_path in (
+    runner_stdout,
+    runner_stderr,
+    health_stdout,
+    work_root / "health.stderr.log",
+    status_stdout,
+    work_root / "status.stderr.log",
+    work_root / "deploy-release.stdout.log",
+    work_root / "deploy-release.stderr.log",
+    work_root / "admin-shutdown.stdout.log",
+    work_root / "admin-shutdown.stderr.log",
+    work_root / "triage-alerts.stdout.log",
+    work_root / "triage-alerts.stderr.log",
+):
+    if log_path.exists():
+        segments.append(f"### {log_path.name}")
+        segments.append(log_path.read_text(encoding="utf-8"))
+transcript_path.write_text("\n".join(segments), encoding="utf-8")
+
+summary = {
+    "schema_version": 1,
+    "health_state": health_state,
+    "rollout_gate": status_payload.get("rollout_gate", ""),
+    "failure_streak": int(health_payload.get("failure_streak", 0)),
+    "queue_depth": int(health_payload.get("queue_depth", 0)),
+    "commands_remaining": len(state_payload.get("commands", [])),
+    "deploy_event_count": len(deploy_events),
+    "policy_deny_event_count": len(policy_deny_events),
+    "retryable_failure_event_count": len(retryable_failure_events),
+}
+summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+report = {
+    "schema_version": 1,
+    "summary_path": str(summary_path),
+    "transcript_path": str(transcript_path),
+    "state_path": str(state_path),
+    "health_inspect_path": str(health_stdout),
+    "status_inspect_path": str(status_stdout),
+    "channel_log_paths": [str(path) for path in channel_logs],
+    "summary": summary,
+}
+report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+print(f"report_json={report_path}")
+PY
+}
+
+run_step "validate-custom-command-live-artifacts-and-write-report" validate_outputs
+
+log_info "summary_json=${summary_json}"
+log_info "report_json=${report_json}"
+log_info "transcript_log=${transcript_log}"
+log_info "summary: total=${step_total} passed=${step_passed} failed=$((step_total - step_passed))"


### PR DESCRIPTION
Closes #1323

## Summary of behavior changes
- add `custom_command_policy_denied` handling to the custom-command contract evaluator for `RUN` operations targeting `admin_*` commands
- extend runtime integration coverage with a live execution matrix fixture (create/update/run/list/delete + policy deny + retryable failure)
- add `scripts/demo/custom-command-live.sh` to execute a deterministic live proof flow and emit summary/report/transcript artifacts
- switch CI live-smoke custom-command surface to a primary live harness with fallback wrapper and expanded matrix assertions
- update custom-command docs and demo index/live-run docs for the new live proof pathway

## Risks and compatibility notes
- runtime behavior now explicitly denies `RUN admin_*` with HTTP `403` and `custom_command_policy_denied`; this is a behavioral tightening and is covered by regression tests/fixtures
- live harness report parsing now supports both list-based and object-based transport-health JSON payload shapes
- CI uses the new live wrapper first and only falls back to the previous wrapper if needed

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-custom-command --all-targets -- -D warnings`
- `cargo test -p tau-custom-command -- --test-threads=1`
- `python3 .github/scripts/test_custom_command_live_demo.py`
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`
- `./scripts/demo/custom-command-live.sh --timeout-seconds 180`