### PR TITLE
feat(memory): add live backend persistence + cross-session recall wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,8 +2778,10 @@ dependencies = [
  "httpmock",
  "jsonschema",
  "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "tau-ai",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/tau-agent-core/Cargo.toml
+++ b/crates/tau-agent-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 async-trait.workspace = true
 jsonschema.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -15,3 +16,4 @@ tau-ai = { path = "../tau-ai" }
 
 [dev-dependencies]
 httpmock = "0.8"
+tempfile = "3.10"

--- a/crates/tau-agent-core/src/tests/streaming_and_budgets.rs
+++ b/crates/tau-agent-core/src/tests/streaming_and_budgets.rs
@@ -18,6 +18,9 @@ fn unit_agent_config_defaults_include_request_and_tool_timeouts() {
     assert_eq!(config.memory_embedding_model, None);
     assert_eq!(config.memory_embedding_api_base, None);
     assert_eq!(config.memory_embedding_api_key, None);
+    assert_eq!(config.memory_backend_state_dir, None);
+    assert_eq!(config.memory_backend_workspace_id, "default");
+    assert_eq!(config.memory_backend_max_entries, 10_000);
     assert!(config.response_cache_enabled);
     assert_eq!(config.response_cache_max_entries, 128);
     assert!(config.tool_result_cache_enabled);

--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -89,6 +89,15 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
                 .and_then(|entry| entry.output_cost_per_million),
             cost_budget_usd: cli.agent_cost_budget_usd,
             cost_alert_thresholds_percent: cli.agent_cost_alert_threshold_percent.clone(),
+            memory_backend_state_dir: Some(cli.memory_state_dir.clone()),
+            memory_backend_workspace_id: cli
+                .session
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("default")
+                .to_string(),
         },
         tool_policy,
     );

--- a/crates/tau-onboarding/src/startup_local_runtime.rs
+++ b/crates/tau-onboarding/src/startup_local_runtime.rs
@@ -31,6 +31,8 @@ pub struct LocalRuntimeAgentSettings {
     pub model_output_cost_per_million: Option<f64>,
     pub cost_budget_usd: Option<f64>,
     pub cost_alert_thresholds_percent: Vec<u8>,
+    pub memory_backend_state_dir: Option<PathBuf>,
+    pub memory_backend_workspace_id: String,
 }
 
 pub fn build_local_runtime_agent(
@@ -59,6 +61,8 @@ pub fn build_local_runtime_agent(
             model_output_cost_per_million: settings.model_output_cost_per_million,
             cost_budget_usd: settings.cost_budget_usd,
             cost_alert_thresholds_percent: settings.cost_alert_thresholds_percent,
+            memory_backend_state_dir: settings.memory_backend_state_dir,
+            memory_backend_workspace_id: settings.memory_backend_workspace_id,
             ..AgentConfig::default()
         },
     );
@@ -1041,6 +1045,8 @@ mod tests {
                 model_output_cost_per_million: None,
                 cost_budget_usd: None,
                 cost_alert_thresholds_percent: vec![80, 100],
+                memory_backend_state_dir: None,
+                memory_backend_workspace_id: "default".to_string(),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1079,6 +1085,8 @@ mod tests {
                 model_output_cost_per_million: Some(0.0),
                 cost_budget_usd: Some(1.0),
                 cost_alert_thresholds_percent: vec![80, 100],
+                memory_backend_state_dir: None,
+                memory_backend_workspace_id: "default".to_string(),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1118,6 +1126,8 @@ mod tests {
                 model_output_cost_per_million: None,
                 cost_budget_usd: None,
                 cost_alert_thresholds_percent: vec![80, 100],
+                memory_backend_state_dir: None,
+                memory_backend_workspace_id: "default".to_string(),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1157,6 +1167,8 @@ mod tests {
                 model_output_cost_per_million: None,
                 cost_budget_usd: None,
                 cost_alert_thresholds_percent: vec![80, 100],
+                memory_backend_state_dir: None,
+                memory_backend_workspace_id: "default".to_string(),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );
@@ -1190,6 +1202,8 @@ mod tests {
                 model_output_cost_per_million: None,
                 cost_budget_usd: None,
                 cost_alert_thresholds_percent: vec![80, 100],
+                memory_backend_state_dir: None,
+                memory_backend_workspace_id: "default".to_string(),
             },
             ToolPolicy::new(vec![std::env::temp_dir()]),
         );


### PR DESCRIPTION
Closes #1325

## Summary
- add persisted live memory backend support in `tau-agent-core` with JSONL storage (`.tau/.../live-backend/<workspace>.jsonl`)
- wire persisted memory retrieval into request-time memory recall flow before dropped-context fallback
- persist user/assistant messages from successful prompt runs into the backend with workspace scoping + max-entry cap
- normalize/resolve memory backend workspace/path handling inside `Agent::new`
- wire runtime settings through onboarding + coding agent startup so local runtime sessions use the memory backend automatically
- extend tests for defaults and live backend behavior (functional/integration/regression)

## Behavior Changes
- `AgentConfig` now includes:
  - `memory_backend_state_dir: Option<PathBuf>`
  - `memory_backend_workspace_id: String`
  - `memory_backend_max_entries: usize`
- when configured, memory recall can come from persisted backend entries across process/session boundaries
- if persisted backend path is unavailable or embedding API fails, runtime falls back to existing in-memory/hash retrieval behavior

## Risks and Compatibility
- additive config fields only; defaults preserve existing behavior when backend is unset
- backend writes are best-effort and intentionally fail-open (runtime continues if persistence fails)
- persisted file format includes schema version guard for forward compatibility

## Validation Evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p tau-agent-core --all-targets -- -D warnings`
- `cargo clippy -p tau-onboarding --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-agent-core -- --test-threads=1`
- `cargo test -p tau-onboarding startup_local_runtime -- --test-threads=1`
- `cargo test -p tau-coding-agent startup_local_runtime -- --test-threads=1`

## Test Matrix Coverage
- Unit: `unit_agent_config_defaults_include_request_and_tool_timeouts` updated with new memory backend defaults
- Functional: `functional_memory_backend_persists_entries_and_recalls_across_sessions`
- Integration: `integration_memory_backend_unavailable_falls_back_to_context_history_recall`
- Regression: `regression_memory_backend_recall_falls_back_to_hash_when_embedding_api_fails`
