### PR TITLE
feat(memory): add live recall quality harness and proof artifacts

### DIFF
--- a/.github/scripts/test_memory_live_demo.py
+++ b/.github/scripts/test_memory_live_demo.py
@@ -1,0 +1,194 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts" / "demo"
+
+
+def write_mock_memory_harness(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+
+def value(flag: str, default: str) -> str:
+    if flag not in args:
+        return default
+    return args[args.index(flag) + 1]
+
+output_dir = Path(value("--output-dir", ".tau/demo-memory-live"))
+state_dir = Path(value("--state-dir", str(output_dir / "state")))
+summary_path = Path(value("--summary-json-out", str(output_dir / "memory-live-summary.json")))
+quality_path = Path(
+    value("--quality-report-json-out", str(output_dir / "memory-live-quality-report.json"))
+)
+manifest_path = Path(
+    value("--artifact-manifest-json-out", str(output_dir / "memory-live-artifact-manifest.json"))
+)
+workspace_id = value("--workspace-id", "demo-workspace")
+
+output_dir.mkdir(parents=True, exist_ok=True)
+state_dir.mkdir(parents=True, exist_ok=True)
+(state_dir / "live-backend").mkdir(parents=True, exist_ok=True)
+backend_path = state_dir / "live-backend" / f"{workspace_id}.jsonl"
+backend_path.write_text('{"entry":"ok"}\\n', encoding="utf-8")
+
+quality_gate_passed = os.environ.get("TAU_MOCK_MEMORY_LIVE_FAIL_QUALITY") != "1"
+
+summary_path.write_text(
+    json.dumps(
+        {
+            "schema_version": 1,
+            "workspace_id": workspace_id,
+            "total_cases": 3,
+            "persisted_entry_count": 6,
+            "top1_hits": 3 if quality_gate_passed else 1,
+            "topk_hits": 3,
+            "top1_relevance_rate": 1.0 if quality_gate_passed else 0.33,
+            "topk_relevance_rate": 1.0,
+            "quality_gate_passed": quality_gate_passed,
+            "request_captures_path": str(output_dir / "memory-live-request-captures.json"),
+        }
+    ),
+    encoding="utf-8",
+)
+quality_path.write_text(
+    json.dumps(
+        {
+            "schema_version": 1,
+            "workspace_id": workspace_id,
+            "thresholds": {
+                "top1_relevance_min": 0.66,
+                "topk_relevance_min": 1.0,
+            },
+            "metrics": {
+                "total_cases": 3,
+                "top1_hits": 3 if quality_gate_passed else 1,
+                "topk_hits": 3,
+                "top1_relevance_rate": 1.0 if quality_gate_passed else 0.33,
+                "topk_relevance_rate": 1.0,
+                "quality_gate_passed": quality_gate_passed,
+            },
+            "cases": [],
+        }
+    ),
+    encoding="utf-8",
+)
+manifest_path.write_text(
+    json.dumps(
+        {
+            "schema_version": 1,
+            "artifacts": [
+                {"label": "summary", "path": str(summary_path), "bytes": summary_path.stat().st_size},
+                {"label": "quality_report", "path": str(quality_path), "bytes": quality_path.stat().st_size},
+                {"label": "backend_state", "path": str(backend_path), "bytes": backend_path.stat().st_size},
+            ],
+            "missing_artifacts": [],
+        }
+    ),
+    encoding="utf-8",
+)
+
+print("mock-memory-live-harness-ok")
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def run_memory_live_script(
+    repo_root: Path, harness_path: Path, env_overrides: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [
+            str(SCRIPTS_DIR / "memory-live.sh"),
+            "--skip-build",
+            "--repo-root",
+            str(repo_root),
+            "--harness-bin",
+            str(harness_path),
+            "--timeout-seconds",
+            "30",
+        ],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class MemoryLiveDemoTests(unittest.TestCase):
+    def test_unit_memory_live_rejects_unknown_argument(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPTS_DIR / "memory-live.sh"), "--definitely-unknown"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("unknown argument: --definitely-unknown", completed.stderr)
+
+    def test_functional_memory_live_runs_with_mock_harness(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness_path = root / "bin" / "memory_live_harness"
+            write_mock_memory_harness(harness_path)
+
+            completed = run_memory_live_script(root, harness_path)
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+            self.assertIn("[demo:memory-live] summary: total=", completed.stdout)
+            self.assertIn("failed=0", completed.stdout)
+
+            summary_path = root / ".tau" / "demo-memory-live" / "memory-live-summary.json"
+            report_path = root / ".tau" / "demo-memory-live" / "memory-live-report.json"
+            self.assertTrue(summary_path.exists())
+            self.assertTrue(report_path.exists())
+
+    def test_integration_memory_live_report_contains_quality_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness_path = root / "bin" / "memory_live_harness"
+            write_mock_memory_harness(harness_path)
+
+            completed = run_memory_live_script(root, harness_path)
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+
+            report_path = root / ".tau" / "demo-memory-live" / "memory-live-report.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertTrue(report["quality_gate_passed"])
+            self.assertEqual(report["total_cases"], 3)
+            self.assertGreaterEqual(report["artifact_manifest_entries"], 3)
+            self.assertEqual(report["top1_relevance_rate"], 1.0)
+            self.assertEqual(report["topk_relevance_rate"], 1.0)
+
+    def test_regression_memory_live_fails_closed_when_quality_gate_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness_path = root / "bin" / "memory_live_harness"
+            write_mock_memory_harness(harness_path)
+
+            completed = run_memory_live_script(
+                root,
+                harness_path,
+                env_overrides={"TAU_MOCK_MEMORY_LIVE_FAIL_QUALITY": "1"},
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            combined = completed.stdout + "\n" + completed.stderr
+            self.assertIn("memory live quality gate failed", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/tau-agent-core/src/bin/memory_live_harness.rs
+++ b/crates/tau-agent-core/src/bin/memory_live_harness.rs
@@ -1,0 +1,624 @@
+use std::{
+    collections::VecDeque,
+    env, fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use serde::Serialize;
+use tau_agent_core::{Agent, AgentConfig};
+use tau_ai::{ChatRequest, ChatResponse, ChatUsage, LlmClient, Message, MessageRole, TauAiError};
+use tokio::sync::Mutex as AsyncMutex;
+
+const HARNESS_SCHEMA_VERSION: u32 = 1;
+const MEMORY_RECALL_PREFIX: &str = "[Tau memory recall]";
+
+#[derive(Debug, Clone)]
+struct CliArgs {
+    output_dir: PathBuf,
+    state_dir: PathBuf,
+    summary_json_out: PathBuf,
+    quality_report_json_out: PathBuf,
+    artifact_manifest_json_out: PathBuf,
+    workspace_id: String,
+}
+
+impl CliArgs {
+    fn parse() -> Result<Self, String> {
+        let mut output_dir = PathBuf::from(".tau/demo-memory-live");
+        let mut state_dir: Option<PathBuf> = None;
+        let mut summary_json_out: Option<PathBuf> = None;
+        let mut quality_report_json_out: Option<PathBuf> = None;
+        let mut artifact_manifest_json_out: Option<PathBuf> = None;
+        let mut workspace_id = "demo-workspace".to_string();
+
+        let args = env::args().skip(1).collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index < args.len() {
+            match args[index].as_str() {
+                "--output-dir" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "missing value for --output-dir".to_string())?;
+                    output_dir = PathBuf::from(value);
+                    index += 2;
+                }
+                "--state-dir" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "missing value for --state-dir".to_string())?;
+                    state_dir = Some(PathBuf::from(value));
+                    index += 2;
+                }
+                "--summary-json-out" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "missing value for --summary-json-out".to_string())?;
+                    summary_json_out = Some(PathBuf::from(value));
+                    index += 2;
+                }
+                "--quality-report-json-out" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "missing value for --quality-report-json-out".to_string())?;
+                    quality_report_json_out = Some(PathBuf::from(value));
+                    index += 2;
+                }
+                "--artifact-manifest-json-out" => {
+                    let value = args.get(index + 1).ok_or_else(|| {
+                        "missing value for --artifact-manifest-json-out".to_string()
+                    })?;
+                    artifact_manifest_json_out = Some(PathBuf::from(value));
+                    index += 2;
+                }
+                "--workspace-id" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| "missing value for --workspace-id".to_string())?;
+                    workspace_id = value.to_string();
+                    index += 2;
+                }
+                "--help" => {
+                    print_usage();
+                    std::process::exit(0);
+                }
+                unknown => {
+                    return Err(format!("unknown argument: {unknown}"));
+                }
+            }
+        }
+
+        let state_dir = state_dir.unwrap_or_else(|| output_dir.join("state"));
+        let summary_json_out =
+            summary_json_out.unwrap_or_else(|| output_dir.join("memory-live-summary.json"));
+        let quality_report_json_out = quality_report_json_out
+            .unwrap_or_else(|| output_dir.join("memory-live-quality-report.json"));
+        let artifact_manifest_json_out = artifact_manifest_json_out
+            .unwrap_or_else(|| output_dir.join("memory-live-artifact-manifest.json"));
+
+        Ok(Self {
+            output_dir,
+            state_dir,
+            summary_json_out,
+            quality_report_json_out,
+            artifact_manifest_json_out,
+            workspace_id,
+        })
+    }
+}
+
+fn print_usage() {
+    println!(
+        "Usage: memory_live_harness [--output-dir PATH] [--state-dir PATH] [--summary-json-out PATH] [--quality-report-json-out PATH] [--artifact-manifest-json-out PATH] [--workspace-id VALUE]"
+    );
+}
+
+#[derive(Clone)]
+struct CapturingMockClient {
+    responses: Arc<AsyncMutex<VecDeque<ChatResponse>>>,
+    requests: Arc<AsyncMutex<Vec<ChatRequest>>>,
+}
+
+impl CapturingMockClient {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Arc::new(AsyncMutex::new(VecDeque::from(responses))),
+            requests: Arc::new(AsyncMutex::new(Vec::new())),
+        }
+    }
+
+    async fn requests(&self) -> Vec<ChatRequest> {
+        self.requests.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl LlmClient for CapturingMockClient {
+    async fn complete(&self, request: ChatRequest) -> Result<ChatResponse, TauAiError> {
+        self.requests.lock().await.push(request);
+        self.responses
+            .lock()
+            .await
+            .pop_front()
+            .ok_or_else(|| TauAiError::InvalidResponse("mock response queue exhausted".to_string()))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EvaluationCase {
+    case_id: &'static str,
+    query: &'static str,
+    expected_keywords: &'static [&'static str],
+}
+
+#[derive(Debug, Serialize)]
+struct RequestCaptureMessage {
+    role: String,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RequestCapture {
+    case_id: String,
+    query: String,
+    request_messages: Vec<RequestCaptureMessage>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvaluationCaseResult {
+    case_id: String,
+    query: String,
+    expected_keywords: Vec<String>,
+    recall_count: usize,
+    top1_score: Option<f32>,
+    top1_text: Option<String>,
+    top1_hit: bool,
+    topk_hit: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct QualityThresholds {
+    top1_relevance_min: f64,
+    topk_relevance_min: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct QualityMetrics {
+    total_cases: usize,
+    top1_hits: usize,
+    topk_hits: usize,
+    top1_relevance_rate: f64,
+    topk_relevance_rate: f64,
+    quality_gate_passed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct QualityReport {
+    schema_version: u32,
+    generated_unix_ms: u64,
+    workspace_id: String,
+    backend_state_file: String,
+    thresholds: QualityThresholds,
+    metrics: QualityMetrics,
+    cases: Vec<EvaluationCaseResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct SummaryReport {
+    schema_version: u32,
+    generated_unix_ms: u64,
+    workspace_id: String,
+    total_cases: usize,
+    persisted_entry_count: usize,
+    top1_hits: usize,
+    topk_hits: usize,
+    top1_relevance_rate: f64,
+    topk_relevance_rate: f64,
+    quality_gate_passed: bool,
+    request_captures_path: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ArtifactRecord {
+    label: String,
+    path: String,
+    bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ArtifactManifest {
+    schema_version: u32,
+    generated_unix_ms: u64,
+    artifacts: Vec<ArtifactRecord>,
+    missing_artifacts: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("[memory-live-harness] {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let args = CliArgs::parse()?;
+    fs::create_dir_all(&args.output_dir).map_err(|error| {
+        format!(
+            "failed to create output directory '{}': {error}",
+            args.output_dir.display()
+        )
+    })?;
+    fs::create_dir_all(&args.state_dir).map_err(|error| {
+        format!(
+            "failed to create state directory '{}': {error}",
+            args.state_dir.display()
+        )
+    })?;
+
+    let normalized_workspace_id = normalize_workspace_id(&args.workspace_id);
+    let request_captures_path = args.output_dir.join("memory-live-request-captures.json");
+    let backend_state_file = args
+        .state_dir
+        .join("live-backend")
+        .join(format!("{normalized_workspace_id}.jsonl"));
+
+    seed_persisted_backend(args.state_dir.as_path(), normalized_workspace_id.as_str()).await?;
+
+    let evaluation_cases = vec![
+        EvaluationCase {
+            case_id: "postgres-failover",
+            query: "What is the postgres failover lag checklist?",
+            expected_keywords: &["postgres", "failover"],
+        },
+        EvaluationCase {
+            case_id: "redis-warmup",
+            query: "How do we run redis cache warmup before cutover?",
+            expected_keywords: &["redis", "warmup"],
+        },
+        EvaluationCase {
+            case_id: "kafka-lag",
+            query: "Remind me of the kafka lag remediation steps.",
+            expected_keywords: &["kafka", "lag"],
+        },
+    ];
+
+    let mut case_results = Vec::new();
+    let mut request_captures = Vec::new();
+    for case in &evaluation_cases {
+        let request_response = ChatResponse {
+            message: Message::assistant_text("ack"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        };
+        let reader_client = Arc::new(CapturingMockClient::new(vec![request_response]));
+        let mut reader = Agent::new(
+            reader_client.clone(),
+            AgentConfig {
+                max_context_messages: Some(2),
+                memory_retrieval_limit: 3,
+                memory_min_similarity: 0.0,
+                memory_backend_state_dir: Some(args.state_dir.clone()),
+                memory_backend_workspace_id: normalized_workspace_id.clone(),
+                ..AgentConfig::default()
+            },
+        );
+        reader
+            .prompt(case.query)
+            .await
+            .map_err(|error| format!("reader prompt failed for '{}': {error}", case.case_id))?;
+
+        let requests = reader_client.requests().await;
+        let request = requests
+            .first()
+            .ok_or_else(|| format!("missing captured request for '{}'", case.case_id))?;
+        let recall_block = request
+            .messages
+            .iter()
+            .find(|message| {
+                message.role == MessageRole::System
+                    && message.text_content().starts_with(MEMORY_RECALL_PREFIX)
+            })
+            .map(|message| message.text_content())
+            .unwrap_or_default();
+        let recall_entries = parse_recall_entries(recall_block.as_str());
+
+        let top1_text = recall_entries.first().map(|(_, text)| text.clone());
+        let top1_score = recall_entries.first().map(|(score, _)| *score);
+        let top1_hit = top1_text
+            .as_deref()
+            .map(|text| keywords_match(text, case.expected_keywords))
+            .unwrap_or(false);
+        let topk_hit = recall_entries
+            .iter()
+            .any(|(_, text)| keywords_match(text, case.expected_keywords));
+
+        case_results.push(EvaluationCaseResult {
+            case_id: case.case_id.to_string(),
+            query: case.query.to_string(),
+            expected_keywords: case
+                .expected_keywords
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            recall_count: recall_entries.len(),
+            top1_score,
+            top1_text,
+            top1_hit,
+            topk_hit,
+        });
+
+        request_captures.push(RequestCapture {
+            case_id: case.case_id.to_string(),
+            query: case.query.to_string(),
+            request_messages: request
+                .messages
+                .iter()
+                .map(|message| RequestCaptureMessage {
+                    role: role_label(message.role).to_string(),
+                    text: message.text_content(),
+                })
+                .collect(),
+        });
+    }
+
+    write_json(request_captures_path.as_path(), &request_captures)?;
+
+    let total_cases = case_results.len();
+    let top1_hits = case_results.iter().filter(|result| result.top1_hit).count();
+    let topk_hits = case_results.iter().filter(|result| result.topk_hit).count();
+    let top1_relevance_rate = ratio(top1_hits, total_cases);
+    let topk_relevance_rate = ratio(topk_hits, total_cases);
+    let thresholds = QualityThresholds {
+        top1_relevance_min: 0.66,
+        topk_relevance_min: 1.0,
+    };
+    let quality_gate_passed = top1_relevance_rate >= thresholds.top1_relevance_min
+        && topk_relevance_rate >= thresholds.topk_relevance_min
+        && case_results.iter().all(|case| case.recall_count > 0);
+
+    let persisted_entry_count = read_nonempty_lines(backend_state_file.as_path())?.len();
+    let quality_report = QualityReport {
+        schema_version: HARNESS_SCHEMA_VERSION,
+        generated_unix_ms: current_unix_timestamp_ms(),
+        workspace_id: normalized_workspace_id.clone(),
+        backend_state_file: backend_state_file.display().to_string(),
+        thresholds,
+        metrics: QualityMetrics {
+            total_cases,
+            top1_hits,
+            topk_hits,
+            top1_relevance_rate,
+            topk_relevance_rate,
+            quality_gate_passed,
+        },
+        cases: case_results,
+    };
+    write_json(args.quality_report_json_out.as_path(), &quality_report)?;
+
+    let summary_report = SummaryReport {
+        schema_version: HARNESS_SCHEMA_VERSION,
+        generated_unix_ms: current_unix_timestamp_ms(),
+        workspace_id: normalized_workspace_id.clone(),
+        total_cases,
+        persisted_entry_count,
+        top1_hits,
+        topk_hits,
+        top1_relevance_rate,
+        topk_relevance_rate,
+        quality_gate_passed,
+        request_captures_path: request_captures_path.display().to_string(),
+    };
+    write_json(args.summary_json_out.as_path(), &summary_report)?;
+
+    let artifact_manifest = build_artifact_manifest(
+        vec![
+            ("summary", args.summary_json_out.as_path()),
+            ("quality_report", args.quality_report_json_out.as_path()),
+            ("request_captures", request_captures_path.as_path()),
+            ("backend_state", backend_state_file.as_path()),
+        ],
+        current_unix_timestamp_ms(),
+    );
+    write_json(
+        args.artifact_manifest_json_out.as_path(),
+        &artifact_manifest,
+    )?;
+
+    if !quality_gate_passed {
+        return Err(format!(
+            "quality gate failed: top1={:.3} topk={:.3}",
+            top1_relevance_rate, topk_relevance_rate
+        ));
+    }
+
+    println!(
+        "[memory-live-harness] quality_gate_passed=true total_cases={} top1_rate={:.3} topk_rate={:.3}",
+        total_cases, top1_relevance_rate, topk_relevance_rate
+    );
+    Ok(())
+}
+
+async fn seed_persisted_backend(state_dir: &Path, workspace_id: &str) -> Result<(), String> {
+    let seed_prompts = vec![
+        (
+            "postgres-failover-seed",
+            "Postgres failover checklist: promote the replica and verify replication lag metrics.",
+            "Postgres failover requires promotion, lag checks, and write verification.",
+        ),
+        (
+            "redis-warmup-seed",
+            "Redis warmup runbook: preload hot keys before serving production traffic.",
+            "Redis warmup includes preload, cache hit validation, and staged traffic ramp.",
+        ),
+        (
+            "kafka-lag-seed",
+            "Kafka lag remediation: inspect partitions and trigger consumer-group rebalance.",
+            "Kafka lag response includes partition inspection, rebalance, and backlog drain.",
+        ),
+    ];
+
+    let responses = seed_prompts
+        .iter()
+        .map(|(_, _, response)| ChatResponse {
+            message: Message::assistant_text(*response),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        })
+        .collect::<Vec<_>>();
+    let writer_client = Arc::new(CapturingMockClient::new(responses));
+    let mut writer = Agent::new(
+        writer_client,
+        AgentConfig {
+            max_context_messages: Some(2),
+            memory_retrieval_limit: 3,
+            memory_min_similarity: 0.0,
+            memory_backend_state_dir: Some(state_dir.to_path_buf()),
+            memory_backend_workspace_id: workspace_id.to_string(),
+            memory_backend_max_entries: 512,
+            ..AgentConfig::default()
+        },
+    );
+
+    for (_, prompt, _) in &seed_prompts {
+        writer
+            .prompt(*prompt)
+            .await
+            .map_err(|error| format!("seed prompt failed: {error}"))?;
+    }
+
+    Ok(())
+}
+
+fn build_artifact_manifest(
+    artifacts: Vec<(&'static str, &Path)>,
+    generated_unix_ms: u64,
+) -> ArtifactManifest {
+    let mut records = Vec::new();
+    let mut missing = Vec::new();
+    for (label, path) in artifacts {
+        if let Ok(metadata) = fs::metadata(path) {
+            records.push(ArtifactRecord {
+                label: label.to_string(),
+                path: path.display().to_string(),
+                bytes: metadata.len(),
+            });
+        } else {
+            missing.push(path.display().to_string());
+        }
+    }
+    ArtifactManifest {
+        schema_version: HARNESS_SCHEMA_VERSION,
+        generated_unix_ms,
+        artifacts: records,
+        missing_artifacts: missing,
+    }
+}
+
+fn write_json<T: Serialize>(path: &Path, payload: &T) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create parent directory for '{}': {error}",
+                path.display()
+            )
+        })?;
+    }
+    let body = serde_json::to_string_pretty(payload)
+        .map_err(|error| format!("failed to serialize JSON for '{}': {error}", path.display()))?;
+    fs::write(path, body)
+        .map_err(|error| format!("failed to write JSON file '{}': {error}", path.display()))
+}
+
+fn current_unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn parse_recall_entries(block: &str) -> Vec<(f32, String)> {
+    block
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let score = trimmed
+                .split_whitespace()
+                .find_map(|part| part.strip_prefix("score="))
+                .and_then(|raw| raw.parse::<f32>().ok())
+                .unwrap_or(0.0);
+            let text = trimmed
+                .split("text=")
+                .nth(1)
+                .map(str::trim)
+                .unwrap_or("")
+                .to_string();
+            if text.is_empty() {
+                None
+            } else {
+                Some((score, text))
+            }
+        })
+        .collect()
+}
+
+fn keywords_match(text: &str, expected_keywords: &[&str]) -> bool {
+    let lowered = text.to_ascii_lowercase();
+    expected_keywords
+        .iter()
+        .all(|keyword| lowered.contains(keyword.to_ascii_lowercase().as_str()))
+}
+
+fn role_label(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => "system",
+        MessageRole::Tool => "tool",
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        return 0.0;
+    }
+    numerator as f64 / denominator as f64
+}
+
+fn read_nonempty_lines(path: &Path) -> Result<Vec<String>, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+    Ok(raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+fn normalize_workspace_id(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "default".to_string();
+    }
+    let mut normalized = String::with_capacity(trimmed.len());
+    for character in trimmed.chars() {
+        if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+            normalized.push(character.to_ascii_lowercase());
+        } else {
+            normalized.push('-');
+        }
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    if normalized.is_empty() {
+        "default".to_string()
+    } else {
+        normalized
+    }
+}

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -108,6 +108,21 @@ Primary outputs:
 - `.tau/demo-dashboard-live/dashboard-action-audit.json`
 - `.tau/demo-dashboard-live/webchat-fallback-check.json`
 
+`memory-live` is a standalone wrapper (not part of `index.sh` scenario allowlist)
+used for live memory backend recall quality proof with persisted snapshot artifacts:
+
+```bash
+./scripts/demo/memory-live.sh
+```
+
+Primary outputs:
+
+- `.tau/demo-memory-live/memory-live-summary.json`
+- `.tau/demo-memory-live/memory-live-quality-report.json`
+- `.tau/demo-memory-live/memory-live-artifact-manifest.json`
+- `.tau/demo-memory-live/memory-live-report.json`
+- `.tau/demo-memory-live/memory-live-request-captures.json`
+
 ## Unified Live-Run Harness
 
 Cross-surface validation wrapper (voice/browser/dashboard/custom-command/memory):

--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -4,7 +4,10 @@ Run all commands from repository root.
 
 ## Scope
 
-This runbook covers the fixture-driven semantic memory runtime (`--memory-contract-runner`).
+This runbook covers:
+
+- fixture-driven semantic memory runtime (`--memory-contract-runner`)
+- live backend recall quality proof (`scripts/demo/memory-live.sh`)
 
 ## Health and observability signals
 
@@ -39,17 +42,34 @@ Primary state files:
 ./scripts/demo/memory.sh
 ```
 
+## Live backend quality proof
+
+```bash
+./scripts/demo/memory-live.sh
+```
+
+Primary proof artifacts:
+
+- `.tau/demo-memory-live/memory-live-summary.json`
+- `.tau/demo-memory-live/memory-live-quality-report.json`
+- `.tau/demo-memory-live/memory-live-artifact-manifest.json`
+- `.tau/demo-memory-live/memory-live-report.json`
+- `.tau/demo-memory-live/memory-live-request-captures.json`
+- `.tau/demo-memory-live/state/live-backend/<workspace>.jsonl`
+
 ## Rollout plan with guardrails
 
 1. Validate fixture contract and runtime locally:
    `cargo test -p tau-coding-agent memory_contract -- --test-threads=1`
 2. Validate runtime coverage:
    `cargo test -p tau-coding-agent memory_runtime -- --test-threads=1`
-3. Run deterministic demo:
+3. Validate live memory backend retrieval quality and artifact manifest generation:
+   `./scripts/demo/memory-live.sh --skip-build --timeout-seconds 120`
+4. Run deterministic fixture demo:
    `./scripts/demo/memory.sh`
-4. Confirm health snapshot is `healthy` before promotion:
+5. Confirm health snapshot is `healthy` before promotion:
    `--transport-health-inspect memory --transport-health-json`
-5. Promote by increasing fixture complexity gradually while monitoring:
+6. Promote by increasing fixture complexity gradually while monitoring:
    `failure_streak`, `last_cycle_failed`, `queue_depth`.
 
 ## Canary rollout profile
@@ -82,3 +102,5 @@ Apply the global rollout contract in [Release Channel Ops](release-channel-ops.m
   Action: treat as rollout gate failure; pause promotion and investigate repeated runtime failures.
 - Symptom: non-zero `queue_depth`.
   Action: increase `--memory-queue-limit` or reduce per-cycle fixture volume.
+- Symptom: `memory-live` report fails quality gate.
+  Action: inspect `.tau/demo-memory-live/memory-live-quality-report.json` and request captures to verify recall ordering drift.

--- a/scripts/demo/memory-live.sh
+++ b/scripts/demo/memory-live.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+skip_build="false"
+timeout_seconds=""
+unused_binary=""
+harness_bin=""
+workspace_id="demo-workspace"
+step_total=0
+step_passed=0
+
+print_usage() {
+  cat <<EOF
+Usage: memory-live.sh [--repo-root PATH] [--binary PATH] [--harness-bin PATH] [--workspace-id VALUE] [--skip-build] [--timeout-seconds N] [--help]
+
+Run deterministic live memory backend proof and emit summary/quality/artifact-manifest JSON outputs.
+
+Options:
+  --repo-root PATH      Repository root (defaults to caller-derived root)
+  --binary PATH         Accepted for wrapper compatibility; unused by this script
+  --harness-bin PATH    memory_live_harness binary path
+  --workspace-id VALUE  Workspace id used for persisted memory partitioning
+  --skip-build          Skip cargo build and use existing harness binary
+  --timeout-seconds N   Positive integer timeout for harness execution
+  --help                Show this usage message
+EOF
+}
+
+log_info() {
+  echo "[demo:memory-live] $1"
+}
+
+run_step() {
+  local label="$1"
+  shift
+  step_total=$((step_total + 1))
+  log_info "[${step_total}] ${label}"
+  if "$@"; then
+    step_passed=$((step_passed + 1))
+    log_info "PASS ${label}"
+  else
+    local rc=$?
+    log_info "FAIL ${label} exit=${rc}"
+    return "${rc}"
+  fi
+}
+
+run_with_timeout() {
+  local -a command=("$@")
+  if [[ -n "${timeout_seconds}" ]]; then
+    python3 - "${timeout_seconds}" "${command[@]}" <<'PY'
+import subprocess
+import sys
+
+timeout_seconds = int(sys.argv[1])
+command = sys.argv[2:]
+try:
+    completed = subprocess.run(command, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+sys.exit(completed.returncode)
+PY
+  else
+    "${command[@]}"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --repo-root" >&2
+        print_usage >&2
+        exit 2
+      fi
+      repo_root="$2"
+      shift 2
+      ;;
+    --binary)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --binary" >&2
+        print_usage >&2
+        exit 2
+      fi
+      unused_binary="$2"
+      shift 2
+      ;;
+    --harness-bin)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --harness-bin" >&2
+        print_usage >&2
+        exit 2
+      fi
+      harness_bin="$2"
+      shift 2
+      ;;
+    --workspace-id)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --workspace-id" >&2
+        print_usage >&2
+        exit 2
+      fi
+      workspace_id="$2"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build="true"
+      shift
+      ;;
+    --timeout-seconds)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --timeout-seconds" >&2
+        print_usage >&2
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+        echo "invalid value for --timeout-seconds (expected positive integer): $2" >&2
+        print_usage >&2
+        exit 2
+      fi
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "${repo_root}" ]]; then
+  echo "invalid --repo-root path (directory not found): ${repo_root}" >&2
+  exit 2
+fi
+repo_root="$(cd "${repo_root}" && pwd)"
+
+if [[ -z "${harness_bin}" ]]; then
+  harness_bin="${repo_root}/target/debug/memory_live_harness"
+elif [[ "${harness_bin}" != /* ]]; then
+  harness_bin="${repo_root}/${harness_bin}"
+fi
+
+work_root="${repo_root}/.tau/demo-memory-live"
+state_dir="${work_root}/state"
+summary_json="${work_root}/memory-live-summary.json"
+quality_json="${work_root}/memory-live-quality-report.json"
+manifest_json="${work_root}/memory-live-artifact-manifest.json"
+report_json="${work_root}/memory-live-report.json"
+transcript_log="${work_root}/memory-live-transcript.log"
+
+rm -rf "${work_root}"
+mkdir -p "${work_root}" "${state_dir}"
+
+if [[ "${skip_build}" != "true" ]]; then
+  run_step "build-memory-live-harness" \
+    bash -lc "cd '${repo_root}' && cargo build -p tau-agent-core --bin memory_live_harness >/dev/null"
+fi
+
+if [[ ! -x "${harness_bin}" ]]; then
+  echo "missing harness binary: ${harness_bin}" >&2
+  exit 1
+fi
+
+run_harness() {
+  local -a command=(
+    "${harness_bin}"
+    "--output-dir" "${work_root}"
+    "--state-dir" "${state_dir}"
+    "--summary-json-out" "${summary_json}"
+    "--quality-report-json-out" "${quality_json}"
+    "--artifact-manifest-json-out" "${manifest_json}"
+    "--workspace-id" "${workspace_id}"
+  )
+
+  set +e
+  run_with_timeout "${command[@]}" 2>&1 | tee "${transcript_log}"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  return "${rc}"
+}
+
+run_step "run-memory-live-harness" run_harness
+
+for required_file in "${summary_json}" "${quality_json}" "${manifest_json}" "${transcript_log}"; do
+  if [[ ! -f "${required_file}" ]]; then
+    echo "missing expected output artifact: ${required_file}" >&2
+    exit 1
+  fi
+done
+
+run_step "synthesize-memory-live-report" \
+  python3 - "${summary_json}" "${quality_json}" "${manifest_json}" "${report_json}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary_path = Path(sys.argv[1])
+quality_path = Path(sys.argv[2])
+manifest_path = Path(sys.argv[3])
+report_path = Path(sys.argv[4])
+
+summary = json.loads(summary_path.read_text(encoding="utf-8"))
+quality = json.loads(quality_path.read_text(encoding="utf-8"))
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+quality_gate_passed = bool(summary.get("quality_gate_passed")) and bool(
+    quality.get("metrics", {}).get("quality_gate_passed")
+)
+if not quality_gate_passed:
+    print("memory live quality gate failed", file=sys.stderr)
+    sys.exit(1)
+
+report = {
+    "schema_version": 1,
+    "quality_gate_passed": quality_gate_passed,
+    "workspace_id": summary.get("workspace_id"),
+    "total_cases": summary.get("total_cases"),
+    "top1_relevance_rate": summary.get("top1_relevance_rate"),
+    "topk_relevance_rate": summary.get("topk_relevance_rate"),
+    "persisted_entry_count": summary.get("persisted_entry_count"),
+    "quality_thresholds": quality.get("thresholds", {}),
+    "quality_metrics": quality.get("metrics", {}),
+    "artifact_manifest_entries": len(manifest.get("artifacts", [])),
+    "summary_path": str(summary_path),
+    "quality_report_path": str(quality_path),
+    "artifact_manifest_path": str(manifest_path),
+}
+
+report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+print(
+    f"report quality gate passed with top1={report['top1_relevance_rate']} topk={report['topk_relevance_rate']}"
+)
+PY
+
+run_step "print-memory-live-report" \
+  python3 - "${report_json}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(json.dumps(report, indent=2))
+PY
+
+failed=$((step_total - step_passed))
+log_info "summary: total=${step_total} passed=${step_passed} failed=${failed}"
+


### PR DESCRIPTION
Closes #1326

## Summary
- add deterministic live proof harness binary: `crates/tau-agent-core/src/bin/memory_live_harness.rs`
- add standalone live wrapper: `scripts/demo/memory-live.sh`
- emit machine-readable proof artifacts:
  - `memory-live-summary.json`
  - `memory-live-quality-report.json`
  - `memory-live-artifact-manifest.json`
  - `memory-live-report.json`
  - `memory-live-request-captures.json`
- add new runtime quality coverage in `tau-agent-core` for multi-turn persisted-memory ranking and backend entry cap behavior
- add CI-facing wrapper tests for the live memory demo workflow
- document live backend proof and validation workflow in memory runbooks/docs

## Behavior Changes
- new `memory_live_harness` executable validates persisted recall relevance across representative conversation topics and produces structured artifacts.
- new `memory-live.sh` wrapper builds/runs the harness, enforces quality gates fail-closed, and synthesizes a final report.
- memory tests now include persisted-backend ordering validation and max-entry cap regression coverage.

## Risks and Compatibility
- additive-only: existing memory contract runner (`scripts/demo/memory.sh`) is unchanged.
- harness/report output paths are isolated under `.tau/demo-memory-live`.
- quality gate thresholds are explicit in JSON outputs and can be tuned in follow-up without API breakage.

## Validation Evidence
- `cargo fmt --all -- --check`
- `cargo clippy -p tau-agent-core --all-targets -- -D warnings`
- `cargo test -p tau-agent-core -- --test-threads=1`
- `python3 .github/scripts/test_memory_live_demo.py`
- `python3 .github/scripts/test_docs_link_check.py`
- `python3 .github/scripts/test_demo_index.py`
- `./scripts/demo/memory-live.sh --timeout-seconds 180`

Live-run proof snapshot (local run):
- `quality_gate_passed=true`
- `total_cases=3`
- `top1_relevance_rate=1.0`
- `topk_relevance_rate=1.0`
- artifacts at `.tau/demo-memory-live/`

## Test Matrix Coverage
- Unit: `test_unit_memory_live_rejects_unknown_argument`
- Functional: `test_functional_memory_live_runs_with_mock_harness`
- Integration: `integration_memory_backend_recall_orders_relevant_entries_for_multiturn_topics`
- Regression: `regression_memory_backend_respects_max_entries_cap`
