### PR TITLE
refactor: extract live memory backend boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tau-ai",
+ "tau-memory-backend",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3079,10 +3080,20 @@ dependencies = [
  "serde_json",
  "tau-contract",
  "tau-core",
+ "tau-memory-backend",
  "tau-runtime",
  "tau-session",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "tau-memory-backend"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/tau-contract",
   "crates/tau-ops",
   "crates/tau-memory",
+  "crates/tau-memory-backend",
   "crates/tau-github-issues",
   "crates/tau-github-issues-runtime",
   "crates/tau-dashboard",

--- a/crates/tau-agent-core/Cargo.toml
+++ b/crates/tau-agent-core/Cargo.toml
@@ -13,6 +13,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tau-ai = { path = "../tau-ai" }
+tau-memory-backend = { path = "../tau-memory-backend" }
 
 [dev-dependencies]
 httpmock = "0.8"

--- a/crates/tau-memory-backend/Cargo.toml
+++ b/crates/tau-memory-backend/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tau-memory-backend"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/crates/tau-memory-backend/src/lib.rs
+++ b/crates/tau-memory-backend/src/lib.rs
@@ -1,0 +1,321 @@
+//! Shared live-memory backend abstraction and default JSONL implementation.
+//!
+//! This crate intentionally focuses on production memory persistence concerns so
+//! contract replay crates can stay deterministic and runtime crates can share a
+//! single backend implementation.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+const LIVE_MEMORY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+/// Enumerates supported `LiveMemoryRole` values.
+pub enum LiveMemoryRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Public struct `LiveMemoryMessage` used across Tau components.
+pub struct LiveMemoryMessage {
+    pub role: LiveMemoryRole,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedLiveMemoryEntry {
+    schema_version: u32,
+    entry_id: String,
+    workspace_id: String,
+    role: LiveMemoryRole,
+    text: String,
+    created_unix_ms: u64,
+}
+
+/// Trait contract for `LiveMemoryBackend` behavior.
+pub trait LiveMemoryBackend: Send + Sync {
+    fn state_file(&self, workspace_id: &str) -> PathBuf;
+
+    fn load_messages(&self, workspace_id: &str) -> Result<Vec<LiveMemoryMessage>, String>;
+
+    fn append_messages(
+        &self,
+        workspace_id: &str,
+        messages: &[LiveMemoryMessage],
+        max_entries: usize,
+    ) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone)]
+/// Public struct `JsonlLiveMemoryBackend` used across Tau components.
+pub struct JsonlLiveMemoryBackend {
+    backend_dir: PathBuf,
+}
+
+impl JsonlLiveMemoryBackend {
+    pub fn from_state_dir(state_dir: &Path) -> Option<Self> {
+        if state_dir.as_os_str().is_empty() {
+            return None;
+        }
+        let backend_dir = state_dir.join("live-backend");
+        fs::create_dir_all(&backend_dir).ok()?;
+        Some(Self { backend_dir })
+    }
+
+    fn load_entries(&self, workspace_id: &str) -> Result<Vec<PersistedLiveMemoryEntry>, String> {
+        let state_file = self.state_file(workspace_id);
+        if !state_file.exists() {
+            return Ok(Vec::new());
+        }
+
+        let raw = fs::read_to_string(&state_file).map_err(|error| {
+            format!(
+                "failed to read memory backend state '{}': {error}",
+                state_file.display()
+            )
+        })?;
+        let normalized_workspace_id = normalize_workspace_id(workspace_id);
+        let mut entries = Vec::new();
+        for line in raw.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let Ok(entry) = serde_json::from_str::<PersistedLiveMemoryEntry>(line) else {
+                continue;
+            };
+            if entry.schema_version != LIVE_MEMORY_SCHEMA_VERSION {
+                continue;
+            }
+            if entry.workspace_id.trim() != normalized_workspace_id {
+                continue;
+            }
+            if entry.text.trim().is_empty() {
+                continue;
+            }
+            entries.push(entry);
+        }
+        entries.sort_by(|left, right| left.created_unix_ms.cmp(&right.created_unix_ms));
+        Ok(entries)
+    }
+}
+
+impl LiveMemoryBackend for JsonlLiveMemoryBackend {
+    fn state_file(&self, workspace_id: &str) -> PathBuf {
+        let normalized = normalize_workspace_id(workspace_id);
+        self.backend_dir.join(format!("{normalized}.jsonl"))
+    }
+
+    fn load_messages(&self, workspace_id: &str) -> Result<Vec<LiveMemoryMessage>, String> {
+        let entries = self.load_entries(workspace_id)?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| LiveMemoryMessage {
+                role: entry.role,
+                text: entry.text,
+            })
+            .collect())
+    }
+
+    fn append_messages(
+        &self,
+        workspace_id: &str,
+        messages: &[LiveMemoryMessage],
+        max_entries: usize,
+    ) -> Result<(), String> {
+        if max_entries == 0 {
+            return Ok(());
+        }
+
+        let normalized_workspace_id = normalize_workspace_id(workspace_id);
+        let state_file = self.state_file(normalized_workspace_id.as_str());
+        let mut entries = self
+            .load_entries(normalized_workspace_id.as_str())
+            .unwrap_or_default();
+        let now_unix_ms = current_unix_timestamp_ms();
+        let mut appended = 0usize;
+        for message in messages {
+            let text = collapse_whitespace(message.text.as_str());
+            if text.trim().is_empty() {
+                continue;
+            }
+            let created_unix_ms = now_unix_ms.saturating_add(appended as u64);
+            let hash_input = format!(
+                "{}:{}:{}:{}",
+                normalized_workspace_id,
+                role_label(message.role),
+                created_unix_ms,
+                text
+            );
+            let entry_id = format!("mem_{:016x}", fnv1a_hash(hash_input.as_bytes()));
+            entries.push(PersistedLiveMemoryEntry {
+                schema_version: LIVE_MEMORY_SCHEMA_VERSION,
+                entry_id,
+                workspace_id: normalized_workspace_id.clone(),
+                role: message.role,
+                text,
+                created_unix_ms,
+            });
+            appended = appended.saturating_add(1);
+        }
+        if appended == 0 {
+            return Ok(());
+        }
+
+        if entries.len() > max_entries {
+            let drop_count = entries.len().saturating_sub(max_entries);
+            entries.drain(0..drop_count);
+        }
+
+        let mut payload = String::new();
+        for entry in entries {
+            let line = serde_json::to_string(&entry)
+                .map_err(|error| format!("failed to serialize memory backend entry: {error}"))?;
+            payload.push_str(line.as_str());
+            payload.push('\n');
+        }
+        fs::write(&state_file, payload).map_err(|error| {
+            format!(
+                "failed to write memory backend state '{}': {error}",
+                state_file.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+pub fn normalize_workspace_id(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "default".to_string();
+    }
+    let mut normalized = String::with_capacity(trimmed.len());
+    for character in trimmed.chars() {
+        if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+            normalized.push(character.to_ascii_lowercase());
+        } else {
+            normalized.push('-');
+        }
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    if normalized.is_empty() {
+        "default".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn current_unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn role_label(role: LiveMemoryRole) -> &'static str {
+    match role {
+        LiveMemoryRole::User => "user",
+        LiveMemoryRole::Assistant => "assistant",
+    }
+}
+
+fn fnv1a_hash(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JsonlLiveMemoryBackend, LiveMemoryBackend, LiveMemoryMessage, LiveMemoryRole};
+
+    #[test]
+    fn unit_normalize_workspace_id_rewrites_unsupported_chars() {
+        assert_eq!(
+            super::normalize_workspace_id("  Ops / Team  "),
+            "ops---team"
+        );
+        assert_eq!(super::normalize_workspace_id(""), "default");
+        assert_eq!(super::normalize_workspace_id("___"), "___");
+    }
+
+    #[test]
+    fn functional_jsonl_backend_roundtrips_messages() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let backend = JsonlLiveMemoryBackend::from_state_dir(temp.path()).expect("backend");
+        backend
+            .append_messages(
+                "workspace-a",
+                &[
+                    LiveMemoryMessage {
+                        role: LiveMemoryRole::User,
+                        text: "postgres failover checklist".to_string(),
+                    },
+                    LiveMemoryMessage {
+                        role: LiveMemoryRole::Assistant,
+                        text: "promote replica and verify lag".to_string(),
+                    },
+                ],
+                32,
+            )
+            .expect("append");
+        let loaded = backend.load_messages("workspace-a").expect("load");
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded[0].text.contains("postgres failover"));
+        assert!(loaded[1].text.contains("verify lag"));
+    }
+
+    #[test]
+    fn regression_jsonl_backend_respects_entry_cap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let backend = JsonlLiveMemoryBackend::from_state_dir(temp.path()).expect("backend");
+        backend
+            .append_messages(
+                "workspace-cap",
+                &[
+                    LiveMemoryMessage {
+                        role: LiveMemoryRole::User,
+                        text: "entry-one".to_string(),
+                    },
+                    LiveMemoryMessage {
+                        role: LiveMemoryRole::Assistant,
+                        text: "entry-two".to_string(),
+                    },
+                    LiveMemoryMessage {
+                        role: LiveMemoryRole::User,
+                        text: "entry-three".to_string(),
+                    },
+                ],
+                2,
+            )
+            .expect("append");
+        let loaded = backend.load_messages("workspace-cap").expect("load");
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].text, "entry-two");
+        assert_eq!(loaded[1].text, "entry-three");
+    }
+
+    #[test]
+    fn integration_from_state_dir_returns_none_when_unusable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let blocked = temp.path().join("blocked");
+        std::fs::write(&blocked, "file").expect("write blocked path");
+        let backend = JsonlLiveMemoryBackend::from_state_dir(blocked.as_path());
+        assert!(backend.is_none());
+    }
+}

--- a/crates/tau-memory/Cargo.toml
+++ b/crates/tau-memory/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.43", features = ["time"] }
 
 tau-core = { path = "../tau-core" }
 tau-contract = { path = "../tau-contract" }
+tau-memory-backend = { path = "../tau-memory-backend" }
 tau-runtime = { path = "../tau-runtime" }
 tau-session = { path = "../tau-session" }
 

--- a/crates/tau-memory/src/lib.rs
+++ b/crates/tau-memory/src/lib.rs
@@ -5,3 +5,8 @@
 
 pub mod memory_contract;
 pub mod memory_runtime;
+
+pub use tau_memory_backend::{
+    normalize_workspace_id, JsonlLiveMemoryBackend, LiveMemoryBackend, LiveMemoryMessage,
+    LiveMemoryRole,
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This index maps Tau documentation by audience and task.
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
+| Memory platform contributor | [Memory Architecture Boundary](guides/memory-architecture.md) | Responsibilities and migration boundary for replay vs live backend memory paths |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |
 | Scheduler / automation operator | [Events Guide](guides/events.md) | Events inspect/validate/simulate, runner, webhook ingest |
 | Contributor to `tau-coding-agent` internals | [Code Map](tau-coding-agent/code-map.md) | Module ownership and architecture navigation |

--- a/docs/guides/memory-architecture.md
+++ b/docs/guides/memory-architecture.md
@@ -1,0 +1,56 @@
+# Memory Architecture Boundary
+
+Run all commands from repository root.
+
+## Goal
+
+Define a strict boundary between:
+
+- deterministic contract replay/runtime behavior
+- production live-memory persistence used by agent runtime recall
+
+## Crate responsibilities
+
+### `tau-memory`
+
+- Owns fixture schema/contracts (`memory_contract.rs`)
+- Owns deterministic runtime replay for contract validation (`memory_runtime.rs`)
+- Re-exports the live backend abstraction for consumers that need both surfaces
+
+### `tau-memory-backend`
+
+- Owns shared live backend abstraction (`LiveMemoryBackend`)
+- Owns default JSONL backend implementation (`JsonlLiveMemoryBackend`)
+- Owns workspace normalization and persisted message read/append lifecycle
+- Contains no fixture replay/runtime orchestration logic
+
+### `tau-agent-core`
+
+- Owns runtime retrieval/scoring/recall injection behavior
+- Consumes `LiveMemoryBackend` for persisted cross-session memory
+- Does not own backend file-format/storage implementation details
+
+## Public boundary contract
+
+Live runtime consumers should depend on:
+
+- `tau_memory_backend::LiveMemoryBackend`
+- `tau_memory_backend::JsonlLiveMemoryBackend`
+- `tau_memory_backend::LiveMemoryMessage`
+- `tau_memory_backend::LiveMemoryRole`
+- `tau_memory_backend::normalize_workspace_id`
+
+Fixture replay consumers should depend on:
+
+- `tau_memory::memory_contract::*`
+- `tau_memory::memory_runtime::*`
+
+## Migration notes
+
+1. Replace direct JSONL helper logic in runtime crates with `LiveMemoryBackend`.
+2. Keep fixture replay behavior in `tau-memory`; avoid importing replay driver logic into `tau-agent-core`.
+3. Preserve on-disk compatibility for existing backend files (`live-backend/<workspace>.jsonl`).
+4. Add/maintain boundary tests in both crates:
+   - `tau-memory-backend`: storage/normalization/cap behavior
+   - `tau-agent-core`: integration with persisted retrieval and fallback behavior
+


### PR DESCRIPTION
Closes #1324

## Summary of behavior changes
- Added new `tau-memory-backend` crate that owns the shared live-memory persistence boundary:
  - `LiveMemoryBackend` trait
  - `JsonlLiveMemoryBackend` default JSONL implementation
  - `LiveMemoryMessage` / `LiveMemoryRole` model types
  - `normalize_workspace_id` utility
- Updated workspace wiring so `tau-memory` depends on and re-exports `tau-memory-backend` public backend surface.
- Refactored `tau-agent-core` to consume `LiveMemoryBackend` instead of owning JSONL file-format helpers inline.
- Added architecture documentation at `docs/guides/memory-architecture.md` and linked it from `docs/README.md`.

## Risks and compatibility notes
- On-disk live backend compatibility is preserved (`live-backend/<workspace>.jsonl` remains the storage layout).
- Runtime retrieval/ranking behavior remains in `tau-agent-core`; only persistence ownership moved behind the shared backend crate boundary.
- This PR is stacked on `codex/issue-1326-memory-live-proof` and should merge after its base stack.

## Validation evidence
- `cargo fmt --all -- --check`
- `python3 .github/scripts/test_docs_link_check.py`
- `python3 .github/scripts/test_demo_index.py`
- `cargo test -p tau-memory-backend -- --test-threads=1`
- `cargo test -p tau-memory -- --test-threads=1`
- `cargo test -p tau-agent-core -- --test-threads=1`
- `cargo clippy -p tau-memory-backend --all-targets -- -D warnings`
- `cargo clippy -p tau-memory --all-targets -- -D warnings`
- `cargo clippy -p tau-agent-core --all-targets -- -D warnings`
- `./scripts/demo/memory-live.sh --timeout-seconds 180`
