### PR TITLE
Runtime hygiene audit: remove dead allows, add split-module docs

### DIFF
--- a/crates/tau-coding-agent/src/browser_automation_contract.rs
+++ b/crates/tau-coding-agent/src/browser_automation_contract.rs
@@ -1,3 +1,0 @@
-// Intentionally kept as a compatibility re-export for contract tooling wiring.
-#[allow(unused_imports)]
-pub use tau_browser_automation::browser_automation_contract::*;

--- a/crates/tau-coding-agent/src/channel_store_admin.rs
+++ b/crates/tau-coding-agent/src/channel_store_admin.rs
@@ -1,1 +1,3 @@
+//! Compatibility re-export for channel-store admin operations from `tau-ops`.
+
 pub use tau_ops::*;

--- a/crates/tau-coding-agent/src/custom_command_contract.rs
+++ b/crates/tau-coding-agent/src/custom_command_contract.rs
@@ -1,3 +1,0 @@
-// Intentionally kept as a compatibility re-export for contract tooling wiring.
-#[allow(unused_imports)]
-pub use tau_custom_command::custom_command_contract::*;

--- a/crates/tau-coding-agent/src/dashboard_contract.rs
+++ b/crates/tau-coding-agent/src/dashboard_contract.rs
@@ -1,3 +1,0 @@
-// Intentionally kept as a compatibility re-export for contract tooling wiring.
-#[allow(unused_imports)]
-pub use tau_dashboard::dashboard_contract::*;

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -2,7 +2,6 @@
 
 mod auth_commands;
 mod bootstrap_helpers;
-mod browser_automation_contract;
 mod canvas;
 mod channel_adapters;
 mod channel_lifecycle;
@@ -10,13 +9,10 @@ mod channel_send;
 mod channel_store;
 mod channel_store_admin;
 mod commands;
-mod custom_command_contract;
-mod dashboard_contract;
 mod deployment_wasm;
 mod events;
 mod macro_profile_commands;
 mod mcp_server;
-mod memory_contract;
 mod model_catalog;
 mod multi_agent_router;
 mod observability_loggers;
@@ -29,12 +25,12 @@ mod rpc_protocol;
 mod runtime_loop;
 mod runtime_output;
 mod runtime_types;
-mod slack_helpers;
 mod startup_dispatch;
 mod startup_local_runtime;
 mod startup_model_catalog;
 mod startup_preflight;
 mod startup_transport_modes;
+#[cfg(test)]
 mod tool_policy_config;
 mod tools;
 mod training_proxy_runtime;
@@ -43,7 +39,6 @@ mod training_runtime;
 mod transport_conformance;
 #[cfg(test)]
 mod transport_health;
-mod voice_contract;
 
 #[cfg(test)]
 use std::path::{Path, PathBuf};

--- a/crates/tau-coding-agent/src/memory_contract.rs
+++ b/crates/tau-coding-agent/src/memory_contract.rs
@@ -1,3 +1,0 @@
-// Intentionally kept as a compatibility re-export for contract tooling wiring.
-#[allow(unused_imports)]
-pub use tau_memory::memory_contract::*;

--- a/crates/tau-coding-agent/src/slack_helpers.rs
+++ b/crates/tau-coding-agent/src/slack_helpers.rs
@@ -1,3 +1,0 @@
-// Re-export retained for runtime helper parity with other transport modules.
-#[allow(unused_imports)]
-pub(crate) use tau_runtime::slack_helpers_runtime::*;

--- a/crates/tau-coding-agent/src/tool_policy_config.rs
+++ b/crates/tau-coding-agent/src/tool_policy_config.rs
@@ -1,3 +1,4 @@
-// Re-export retained for test harness access through `crate::tool_policy_config`.
-#[allow(unused_imports)]
-pub use tau_tools::tool_policy_config::*;
+// Re-export retained for startup/runtime tests through `crate::tool_policy_config`.
+pub(crate) use tau_tools::tool_policy_config::{
+    build_tool_policy, parse_sandbox_command_tokens, tool_policy_to_json,
+};

--- a/crates/tau-coding-agent/src/voice_contract.rs
+++ b/crates/tau-coding-agent/src/voice_contract.rs
@@ -1,3 +1,0 @@
-// Intentionally kept as a compatibility re-export for contract tooling wiring.
-#[allow(unused_imports)]
-pub use tau_voice::voice_contract::*;

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
@@ -1,3 +1,5 @@
+//! GitHub Issues bridge runtime and command execution orchestration.
+
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/github_api_client.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/github_api_client.rs
@@ -1,3 +1,5 @@
+//! GitHub REST client helpers used by bridge polling and command workflows.
+
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_command_helpers.rs
@@ -1,3 +1,5 @@
+//! Command parsing and normalization helpers for issue bridge slash commands.
+
 use std::path::{Path, PathBuf};
 
 use tau_github_issues::issue_artifacts_command::{

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_rbac_helpers.rs
@@ -1,3 +1,5 @@
+//! RBAC action mapping helpers for parsed GitHub issue events.
+
 use super::{EventAction, TauIssueAuthCommandKind, TauIssueCommand};
 
 /// Maps parsed issue events to RBAC action identifiers used by policy checks.

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_render_helpers.rs
@@ -1,3 +1,5 @@
+//! Rendering helpers for issue comments, run summaries, and status output.
+
 use tau_diagnostics::DoctorStatus;
 use tau_github_issues::issue_comment::{
     render_issue_comment_chunks_with_footer,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_run_task.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_run_task.rs
@@ -1,3 +1,5 @@
+//! Run-task execution flow that wires command handling to issue updates.
+
 use std::{path::PathBuf, time::Instant};
 
 use tokio::sync::watch;

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_session_runtime.rs
@@ -1,3 +1,5 @@
+//! Session runtime helpers for persisted issue conversation state.
+
 use std::path::Path;
 
 use anyhow::{Context, Result};

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_state_store.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/issue_state_store.rs
@@ -1,3 +1,5 @@
+//! State-file persistence for issue bridge checkpoints and run metadata.
+
 use std::{
     collections::{BTreeMap, HashSet},
     io::Write,

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/prompt_execution.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/prompt_execution.rs
@@ -1,3 +1,5 @@
+//! Prompt execution helpers for issue-driven agent runs and bookkeeping.
+
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},

--- a/crates/tau-ops/src/channel_store_admin.rs
+++ b/crates/tau-ops/src/channel_store_admin.rs
@@ -1,3 +1,5 @@
+//! Channel-store admin command handling and transport-health reporting.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 

--- a/crates/tau-ops/src/channel_store_admin/command_parsing_helpers.rs
+++ b/crates/tau-ops/src/channel_store_admin/command_parsing_helpers.rs
@@ -1,3 +1,5 @@
+//! Parsing helpers for channel-store admin command arguments.
+
 use anyhow::{anyhow, bail, Result};
 
 use super::TransportHealthInspectTarget;

--- a/crates/tau-ops/src/channel_store_admin/render_helpers.rs
+++ b/crates/tau-ops/src/channel_store_admin/render_helpers.rs
@@ -1,3 +1,5 @@
+//! Output rendering helpers for channel-store admin status surfaces.
+
 use std::collections::BTreeMap;
 
 use tau_core::current_unix_timestamp_ms;

--- a/crates/tau-ops/src/channel_store_admin/transport_health_helpers.rs
+++ b/crates/tau-ops/src/channel_store_admin/transport_health_helpers.rs
@@ -1,3 +1,5 @@
+//! Transport-health snapshot collection helpers for admin inspection commands.
+
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};

--- a/crates/tau-slack-runtime/src/slack_runtime/slack_api_client.rs
+++ b/crates/tau-slack-runtime/src/slack_runtime/slack_api_client.rs
@@ -1,3 +1,5 @@
+//! Slack Web API client helpers used by bridge polling and posting flows.
+
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};

--- a/crates/tau-slack-runtime/src/slack_runtime/slack_state_store.rs
+++ b/crates/tau-slack-runtime/src/slack_runtime/slack_state_store.rs
@@ -1,3 +1,5 @@
+//! File-backed state persistence for Slack bridge cursors and run metadata.
+
 use std::{
     collections::HashSet,
     io::Write,


### PR DESCRIPTION
Closes #1359

## Summary of behavior changes
- Removed six dead compatibility shim modules from `tau-coding-agent` that only re-exported other crates and required `#[allow(unused_imports)]`.
- Updated `tau-coding-agent/src/main.rs` module wiring accordingly and gated `tool_policy_config` as test-only.
- Added concise module-level rustdoc to split runtime/admin modules in:
  - `tau-github-issues-runtime`
  - `tau-slack-runtime`
  - `tau-ops/channel_store_admin`
  - `tau-coding-agent/src/channel_store_admin.rs`
- Fixed `tau-slack-runtime` websocket message type conversions for tungstenite 0.28 (`Utf8Bytes`/`Bytes`) to restore strict lint/test compatibility.

## Risks and compatibility notes
- Low risk: shim module removals were dead/unreferenced in `tau-coding-agent`; behavior paths were unaffected.
- Medium-low risk: tungstenite conversion fixes touch socket envelope handling and related tests; changes are type-level conversions only.
- Documentation additions are non-functional.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent -p tau-github-issues-runtime -p tau-slack-runtime -p tau-ops --all-targets -- -D warnings`
- `cargo test -p tau-slack-runtime unit_parse_socket_envelope_handles_text_binary_and_ping`
- `cargo test -p tau-github-issues-runtime unit_normalize_artifact_retention_days_maps_zero_to_none`
- `cargo test -p tau-ops parse_transport_health_inspect_target`
