### PR TITLE
Audit remaining too_many_arguments allowances with explicit rationale

### DIFF
--- a/crates/tau-coding-agent/src/commands.rs
+++ b/crates/tau-coding-agent/src/commands.rs
@@ -200,7 +200,7 @@ pub(crate) fn handle_command(
     )
 }
 
-// Command execution keeps dependencies explicit to avoid hidden global state.
+// Intentional explicit dependency list keeps command execution deterministic in tests/runtime.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_command_with_session_import_mode(
     command: &str,

--- a/crates/tau-coding-agent/src/orchestrator_bridge.rs
+++ b/crates/tau-coding-agent/src/orchestrator_bridge.rs
@@ -67,7 +67,7 @@ impl OrchestratorRuntime for OrchestratorRuntimeAdapter<'_> {
     }
 }
 
-// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
+// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt(
     agent: &mut Agent,
@@ -104,7 +104,7 @@ pub(crate) async fn run_plan_first_prompt(
     .await
 }
 
-// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
+// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context(
     agent: &mut Agent,
@@ -143,7 +143,7 @@ pub(crate) async fn run_plan_first_prompt_with_policy_context(
     .await
 }
 
-// Mirrors the orchestrator runtime API to keep call sites explicit and stable.
+// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context_and_routing(
     agent: &mut Agent,

--- a/crates/tau-coding-agent/src/runtime_loop.rs
+++ b/crates/tau-coding-agent/src/runtime_loop.rs
@@ -505,7 +505,7 @@ where
     }
 }
 
-// Startup/runtime wiring intentionally threads explicit knobs rather than hidden config.
+// Intentional explicit startup/runtime knobs keep policy inheritance and hooks testable.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
     agent: &mut Agent,

--- a/crates/tau-onboarding/src/startup_dispatch.rs
+++ b/crates/tau-onboarding/src/startup_dispatch.rs
@@ -157,7 +157,7 @@ where
     })
 }
 
-// Generic startup resolver keeps each injected dependency explicit for testing.
+// Generic resolver intentionally keeps injected dependencies explicit for deterministic tests.
 #[allow(clippy::too_many_arguments)]
 pub async fn resolve_startup_runtime_from_cli<
     TModelRef,
@@ -223,7 +223,7 @@ where
     })
 }
 
-// Generic startup resolver keeps each injected dependency explicit for testing.
+// Generic resolver intentionally keeps injected dependencies explicit for deterministic tests.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_startup_runtime_from_cli_with_modes<
     TModelRef,

--- a/crates/tau-orchestrator/src/orchestrator.rs
+++ b/crates/tau-orchestrator/src/orchestrator.rs
@@ -48,7 +48,7 @@ enum RoutedPromptRunState {
     Interrupted,
 }
 
-// Public orchestration entrypoint keeps policy and budget controls explicit.
+// Intentional broad signature: callers set all policy/budget knobs explicitly per run.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -79,7 +79,7 @@ pub async fn run_plan_first_prompt<R: OrchestratorRuntime>(
     .await
 }
 
-// Public orchestration entrypoint keeps policy and budget controls explicit.
+// Intentional broad signature: callers set all policy/budget knobs explicitly per run.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt_with_policy_context<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -113,7 +113,7 @@ pub async fn run_plan_first_prompt_with_policy_context<R: OrchestratorRuntime>(
     .await
 }
 
-// Public orchestration entrypoint keeps policy and budget controls explicit.
+// Intentional broad signature: callers set all policy/budget knobs explicitly per run.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan_first_prompt_with_policy_context_and_routing<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -371,7 +371,7 @@ pub async fn run_plan_first_prompt_with_policy_context_and_routing<R: Orchestrat
     Ok(())
 }
 
-// Route tracing accepts granular optional fields to keep call sites straightforward.
+// Route execution needs explicit trace metadata and runtime controls at each call site.
 #[allow(clippy::too_many_arguments)]
 async fn run_routed_prompt_with_fallback<R: OrchestratorRuntime>(
     runtime: &mut R,
@@ -524,7 +524,7 @@ async fn run_routed_prompt_with_fallback<R: OrchestratorRuntime>(
     );
 }
 
-// Route trace emission accepts many optional dimensions to keep logs structured.
+// Trace records carry many optional dimensions; keeping them explicit avoids hidden state.
 #[allow(clippy::too_many_arguments)]
 fn emit_route_trace(
     route_trace_log_path: Option<&Path>,


### PR DESCRIPTION
Closes #1365

## Summary of behavior changes
- Audited all remaining `#[allow(clippy::too_many_arguments)]` sites across orchestrator/startup/runtime surfaces.
- Kept all 12 sites because they represent intentional explicit API/dependency configuration surfaces.
- Updated rationale comments adjacent to each allow for explicit auditability.

## Risks and compatibility notes
- Very low risk: comment-only clarifications; no behavioral logic change.
- Function signatures and call paths remain unchanged.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-orchestrator -p tau-coding-agent -p tau-onboarding --all-targets -- -D warnings`
- `cargo test -p tau-orchestrator unit_parse_numbered_plan_steps_extracts_dot_and_paren_prefixes`
- `cargo test -p tau-onboarding unit_execute_startup_runtime_from_cli_with_modes_runs_local_when_transport_not_requested`
- `cargo test -p tau-coding-agent unit_render_orchestrator_policy_inheritance_context_is_deterministic`
- `cargo test -p tau-coding-agent functional_run_plan_first_prompt_executes_planner_then_executor`
