### PR TITLE
docs: add module-level rustdoc headers for split-created modules

### DIFF
--- a/crates/tau-coding-agent/src/tests/auth_provider/auth_and_provider.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/auth_and_provider.rs
@@ -1,3 +1,5 @@
+//! Auth/provider command tests covering mode handling, client wiring, and fallback routing.
+
 use super::super::{
     auth_availability_counts, auth_mode_counts, auth_provider_counts, auth_revoked_counts,
     auth_source_kind, auth_source_kind_counts, auth_state_counts, auth_status_row_for_provider,

--- a/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
@@ -1,3 +1,5 @@
+//! Command/package validation tests covering skills, bridges, and runtime command surfaces.
+
 use super::super::{
     branch_alias_path_for_session, build_multi_channel_incident_timeline_report,
     build_multi_channel_route_inspect_report, command_file_error_mode_label,

--- a/crates/tau-coding-agent/src/tests/auth_provider/mod.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/mod.rs
@@ -1,3 +1,5 @@
+//! Auth/provider test module grouping for command, runtime, and doctor/session coverage.
+
 use std::path::Path;
 
 mod auth_and_provider;

--- a/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
@@ -1,3 +1,5 @@
+//! Runtime/startup auth-provider tests for dispatch, policy guards, and startup preflight behavior.
+
 use super::super::{
     apply_trust_root_mutations, build_tool_policy, default_skills_lock_path,
     discover_extension_runtime_registrations, execute_rpc_capabilities_command,

--- a/crates/tau-coding-agent/src/tests/auth_provider/session_and_doctor.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/session_and_doctor.rs
@@ -1,3 +1,5 @@
+//! Session and doctor command tests for auth/provider diagnostics and report rendering.
+
 use super::super::{
     build_doctor_command_config, compute_session_entry_depths, compute_session_stats,
     current_unix_timestamp, default_skills_lock_path, ensure_non_empty_text, escape_graph_label,

--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -1,3 +1,5 @@
+//! CLI validation tests for transport/runtime mode flag compatibility and guardrails.
+
 use std::path::{Path, PathBuf};
 
 use tau_cli::validation::validate_project_index_cli;

--- a/crates/tau-coding-agent/src/tests/extensions_rpc.rs
+++ b/crates/tau-coding-agent/src/tests/extensions_rpc.rs
@@ -1,3 +1,5 @@
+//! Extension and RPC CLI parsing tests for flag normalization and invalid combinations.
+
 use std::path::PathBuf;
 
 use tau_cli::CliDeploymentWasmRuntimeProfile;

--- a/crates/tau-coding-agent/src/tests/misc.rs
+++ b/crates/tau-coding-agent/src/tests/misc.rs
@@ -1,3 +1,5 @@
+//! Miscellaneous unit tests for shared argument normalization helpers.
+
 use crate::normalize_daemon_subcommand_args;
 
 #[test]

--- a/crates/tau-coding-agent/src/tests/runtime_agent.rs
+++ b/crates/tau-coding-agent/src/tests/runtime_agent.rs
@@ -1,3 +1,5 @@
+//! Runtime agent CLI tests covering model resolution, routing, and execution-mode flags.
+
 use std::path::Path;
 
 use tau_cli::CliOrchestratorMode;

--- a/crates/tau-coding-agent/tests/cli_integration/auth_provider.rs
+++ b/crates/tau-coding-agent/tests/cli_integration/auth_provider.rs
@@ -1,3 +1,5 @@
+//! CLI integration coverage for auth/provider workflows and models/status commands.
+
 use super::*;
 
 #[test]

--- a/crates/tau-coding-agent/tests/cli_integration/bridge_transports.rs
+++ b/crates/tau-coding-agent/tests/cli_integration/bridge_transports.rs
@@ -1,3 +1,5 @@
+//! CLI integration tests for bridge transport startup requirements and failure modes.
+
 use super::*;
 
 #[test]

--- a/crates/tau-coding-agent/tests/cli_integration/session_runtime.rs
+++ b/crates/tau-coding-agent/tests/cli_integration/session_runtime.rs
@@ -1,3 +1,5 @@
+//! CLI integration tests for session runtime persistence, restore, and help behavior.
+
 use super::*;
 
 #[test]

--- a/crates/tau-coding-agent/tests/cli_integration/tooling_skills.rs
+++ b/crates/tau-coding-agent/tests/cli_integration/tooling_skills.rs
@@ -1,3 +1,5 @@
+//! CLI integration tests for tooling/skills commands, lockfiles, and package operations.
+
 use super::*;
 
 #[test]

--- a/crates/tau-gateway/src/gateway_openresponses/request_translation.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/request_translation.rs
@@ -1,3 +1,5 @@
+//! Request translation helpers converting OpenResponses payloads into Tau runtime requests.
+
 use serde_json::Value;
 
 use super::{

--- a/crates/tau-gateway/src/gateway_openresponses/session_runtime.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/session_runtime.rs
@@ -1,3 +1,5 @@
+//! Session runtime orchestration for OpenResponses requests, response streaming, and persistence.
+
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};

--- a/crates/tau-gateway/src/gateway_openresponses/types.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/types.rs
@@ -1,3 +1,5 @@
+//! Core OpenResponses gateway request/response/error types used across handlers and translation.
+
 use std::collections::BTreeMap;
 
 use axum::http::StatusCode;

--- a/crates/tau-multi-channel/src/multi_channel_incident.rs
+++ b/crates/tau-multi-channel/src/multi_channel_incident.rs
@@ -1,3 +1,5 @@
+//! Incident timeline execution and reporting helpers for multi-channel runtime artifacts.
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/tau-multi-channel/src/multi_channel_route_inspect.rs
+++ b/crates/tau-multi-channel/src/multi_channel_route_inspect.rs
@@ -1,3 +1,5 @@
+//! Route-inspection execution and report builders for multi-channel transport/runtime state.
+
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};

--- a/crates/tau-multi-channel/src/multi_channel_runtime/tests.rs
+++ b/crates/tau-multi-channel/src/multi_channel_runtime/tests.rs
@@ -1,3 +1,5 @@
+//! Multi-channel runtime integration-style tests for contracts, live ingress, and routing behavior.
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;


### PR DESCRIPTION
Closes #1393

## Summary of behavior changes
- Added concise module-level `//!` rustdoc headers to 19 split-created modules across:
  - `crates/tau-coding-agent` test modules
  - `crates/tau-gateway/src/gateway_openresponses` runtime modules
  - `crates/tau-multi-channel` runtime and tests modules
- No runtime logic changes.

## Risks and compatibility notes
- Low risk and documentation-only change set.
- No API behavior, command parsing, transport behavior, or persistence logic changed.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo clippy -p tau-gateway -- -D warnings`
- `cargo clippy -p tau-multi-channel -- -D warnings`
- `cargo test -p tau-coding-agent dashboard_gateway_daemon:: -- --nocapture` (17 passed)
- `cargo test -p tau-coding-agent unit_cli_provider_retry_flags_accept_explicit_baseline_values -- --nocapture` (1 passed)
- `cargo test -p tau-coding-agent unit_normalize_daemon_subcommand_args_maps_action_and_alias_flags -- --nocapture` (1 passed)
- `cargo test -p tau-coding-agent integration_models_list_command_filters_catalog_entries -- --nocapture` (1 passed)
- `cargo test -p tau-multi-channel retry_delay_ms_scales_with_attempt_number -- --nocapture` (1 passed)

## Validation note
- `cargo clippy -p tau-gateway --all-targets -- -D warnings` currently fails due a pre-existing upstream test compile mismatch in `crates/tau-gateway/src/gateway_openresponses/tests.rs` (`ClientWsMessage::Ping` now expects `Bytes`). This PR does not change that test logic.
