### PR TITLE
Audit wave 2: remove orchestrator too_many_arguments allowances

### DIFF
--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -150,6 +150,10 @@ pub(crate) use crate::orchestrator_bridge::run_plan_first_prompt_with_policy_con
 #[cfg(test)]
 pub(crate) use crate::orchestrator_bridge::run_plan_first_prompt_with_policy_context_and_routing;
 #[cfg(test)]
+pub(crate) use crate::orchestrator_bridge::{
+    PlanFirstPromptPolicyRequest, PlanFirstPromptRequest, PlanFirstPromptRoutingRequest,
+};
+#[cfg(test)]
 pub(crate) use crate::package_manifest::execute_package_activate_on_startup;
 #[cfg(test)]
 pub(crate) use crate::package_manifest::{

--- a/crates/tau-coding-agent/src/orchestrator_bridge.rs
+++ b/crates/tau-coding-agent/src/orchestrator_bridge.rs
@@ -6,6 +6,9 @@ use tau_agent_core::Agent;
 use tau_ai::MessageRole;
 use tau_orchestrator::{
     OrchestratorPromptRunStatus, OrchestratorRenderOptions, OrchestratorRuntime,
+    PlanFirstPromptPolicyRequest as OrchestratorPlanFirstPromptPolicyRequest,
+    PlanFirstPromptRequest as OrchestratorPlanFirstPromptRequest,
+    PlanFirstPromptRoutingRequest as OrchestratorPlanFirstPromptRoutingRequest,
 };
 use tau_session::SessionRuntime;
 
@@ -16,6 +19,56 @@ use crate::runtime_types::RenderOptions;
 struct OrchestratorRuntimeAdapter<'a> {
     agent: &'a mut Agent,
     session_runtime: &'a mut Option<SessionRuntime>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlanFirstPromptRequest<'a> {
+    pub user_prompt: &'a str,
+    pub turn_timeout_ms: u64,
+    pub render_options: RenderOptions,
+    pub max_plan_steps: usize,
+    pub max_delegated_steps: usize,
+    pub max_executor_response_chars: usize,
+    pub max_delegated_step_response_chars: usize,
+    pub max_delegated_total_response_chars: usize,
+    pub delegate_steps: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlanFirstPromptPolicyRequest<'a> {
+    pub user_prompt: &'a str,
+    pub turn_timeout_ms: u64,
+    pub render_options: RenderOptions,
+    pub max_plan_steps: usize,
+    pub max_delegated_steps: usize,
+    pub max_executor_response_chars: usize,
+    pub max_delegated_step_response_chars: usize,
+    pub max_delegated_total_response_chars: usize,
+    pub delegate_steps: bool,
+    pub delegated_policy_context: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlanFirstPromptRoutingRequest<'a> {
+    pub user_prompt: &'a str,
+    pub turn_timeout_ms: u64,
+    pub render_options: RenderOptions,
+    pub max_plan_steps: usize,
+    pub max_delegated_steps: usize,
+    pub max_executor_response_chars: usize,
+    pub max_delegated_step_response_chars: usize,
+    pub max_delegated_total_response_chars: usize,
+    pub delegate_steps: bool,
+    pub delegated_policy_context: Option<&'a str>,
+    pub route_table: &'a MultiAgentRouteTable,
+    pub route_trace_log_path: Option<&'a Path>,
+}
+
+fn map_render_options(render_options: RenderOptions) -> OrchestratorRenderOptions {
+    OrchestratorRenderOptions {
+        stream_output: render_options.stream_output,
+        stream_delay_ms: render_options.stream_delay_ms,
+    }
 }
 
 #[async_trait(?Send)]
@@ -67,20 +120,10 @@ impl OrchestratorRuntime for OrchestratorRuntimeAdapter<'_> {
     }
 }
 
-// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt(
     agent: &mut Agent,
     session_runtime: &mut Option<SessionRuntime>,
-    user_prompt: &str,
-    turn_timeout_ms: u64,
-    render_options: RenderOptions,
-    max_plan_steps: usize,
-    max_delegated_steps: usize,
-    max_executor_response_chars: usize,
-    max_delegated_step_response_chars: usize,
-    max_delegated_total_response_chars: usize,
-    delegate_steps: bool,
+    request: PlanFirstPromptRequest<'_>,
 ) -> Result<()> {
     let mut adapter = OrchestratorRuntimeAdapter {
         agent,
@@ -88,37 +131,25 @@ pub(crate) async fn run_plan_first_prompt(
     };
     tau_orchestrator::run_plan_first_prompt(
         &mut adapter,
-        user_prompt,
-        turn_timeout_ms,
-        OrchestratorRenderOptions {
-            stream_output: render_options.stream_output,
-            stream_delay_ms: render_options.stream_delay_ms,
+        OrchestratorPlanFirstPromptRequest {
+            user_prompt: request.user_prompt,
+            turn_timeout_ms: request.turn_timeout_ms,
+            render_options: map_render_options(request.render_options),
+            max_plan_steps: request.max_plan_steps,
+            max_delegated_steps: request.max_delegated_steps,
+            max_executor_response_chars: request.max_executor_response_chars,
+            max_delegated_step_response_chars: request.max_delegated_step_response_chars,
+            max_delegated_total_response_chars: request.max_delegated_total_response_chars,
+            delegate_steps: request.delegate_steps,
         },
-        max_plan_steps,
-        max_delegated_steps,
-        max_executor_response_chars,
-        max_delegated_step_response_chars,
-        max_delegated_total_response_chars,
-        delegate_steps,
     )
     .await
 }
 
-// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context(
     agent: &mut Agent,
     session_runtime: &mut Option<SessionRuntime>,
-    user_prompt: &str,
-    turn_timeout_ms: u64,
-    render_options: RenderOptions,
-    max_plan_steps: usize,
-    max_delegated_steps: usize,
-    max_executor_response_chars: usize,
-    max_delegated_step_response_chars: usize,
-    max_delegated_total_response_chars: usize,
-    delegate_steps: bool,
-    delegated_policy_context: Option<&str>,
+    request: PlanFirstPromptPolicyRequest<'_>,
 ) -> Result<()> {
     let mut adapter = OrchestratorRuntimeAdapter {
         agent,
@@ -126,40 +157,26 @@ pub(crate) async fn run_plan_first_prompt_with_policy_context(
     };
     tau_orchestrator::run_plan_first_prompt_with_policy_context(
         &mut adapter,
-        user_prompt,
-        turn_timeout_ms,
-        OrchestratorRenderOptions {
-            stream_output: render_options.stream_output,
-            stream_delay_ms: render_options.stream_delay_ms,
+        OrchestratorPlanFirstPromptPolicyRequest {
+            user_prompt: request.user_prompt,
+            turn_timeout_ms: request.turn_timeout_ms,
+            render_options: map_render_options(request.render_options),
+            max_plan_steps: request.max_plan_steps,
+            max_delegated_steps: request.max_delegated_steps,
+            max_executor_response_chars: request.max_executor_response_chars,
+            max_delegated_step_response_chars: request.max_delegated_step_response_chars,
+            max_delegated_total_response_chars: request.max_delegated_total_response_chars,
+            delegate_steps: request.delegate_steps,
+            delegated_policy_context: request.delegated_policy_context,
         },
-        max_plan_steps,
-        max_delegated_steps,
-        max_executor_response_chars,
-        max_delegated_step_response_chars,
-        max_delegated_total_response_chars,
-        delegate_steps,
-        delegated_policy_context,
     )
     .await
 }
 
-// Intentional pass-through of all orchestrator knobs to preserve explicit runtime wiring.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_plan_first_prompt_with_policy_context_and_routing(
     agent: &mut Agent,
     session_runtime: &mut Option<SessionRuntime>,
-    user_prompt: &str,
-    turn_timeout_ms: u64,
-    render_options: RenderOptions,
-    max_plan_steps: usize,
-    max_delegated_steps: usize,
-    max_executor_response_chars: usize,
-    max_delegated_step_response_chars: usize,
-    max_delegated_total_response_chars: usize,
-    delegate_steps: bool,
-    delegated_policy_context: Option<&str>,
-    route_table: &MultiAgentRouteTable,
-    route_trace_log_path: Option<&Path>,
+    request: PlanFirstPromptRoutingRequest<'_>,
 ) -> Result<()> {
     let mut adapter = OrchestratorRuntimeAdapter {
         agent,
@@ -167,21 +184,20 @@ pub(crate) async fn run_plan_first_prompt_with_policy_context_and_routing(
     };
     tau_orchestrator::run_plan_first_prompt_with_policy_context_and_routing(
         &mut adapter,
-        user_prompt,
-        turn_timeout_ms,
-        OrchestratorRenderOptions {
-            stream_output: render_options.stream_output,
-            stream_delay_ms: render_options.stream_delay_ms,
+        OrchestratorPlanFirstPromptRoutingRequest {
+            user_prompt: request.user_prompt,
+            turn_timeout_ms: request.turn_timeout_ms,
+            render_options: map_render_options(request.render_options),
+            max_plan_steps: request.max_plan_steps,
+            max_delegated_steps: request.max_delegated_steps,
+            max_executor_response_chars: request.max_executor_response_chars,
+            max_delegated_step_response_chars: request.max_delegated_step_response_chars,
+            max_delegated_total_response_chars: request.max_delegated_total_response_chars,
+            delegate_steps: request.delegate_steps,
+            delegated_policy_context: request.delegated_policy_context,
+            route_table: request.route_table,
+            route_trace_log_path: request.route_trace_log_path,
         },
-        max_plan_steps,
-        max_delegated_steps,
-        max_executor_response_chars,
-        max_delegated_step_response_chars,
-        max_delegated_total_response_chars,
-        delegate_steps,
-        delegated_policy_context,
-        route_table,
-        route_trace_log_path,
     )
     .await
 }

--- a/crates/tau-coding-agent/src/runtime_loop.rs
+++ b/crates/tau-coding-agent/src/runtime_loop.rs
@@ -34,7 +34,8 @@ use crate::commands::{handle_command_with_session_import_mode, CommandAction, CO
 use crate::multi_agent_router::MultiAgentRouteTable;
 use crate::orchestrator_bridge::{
     run_plan_first_prompt, run_plan_first_prompt_with_policy_context,
-    run_plan_first_prompt_with_policy_context_and_routing,
+    run_plan_first_prompt_with_policy_context_and_routing, PlanFirstPromptPolicyRequest,
+    PlanFirstPromptRequest, PlanFirstPromptRoutingRequest,
 };
 use crate::runtime_output::{persist_messages, print_assistant_messages};
 use crate::runtime_types::{CommandExecutionContext, RenderOptions};
@@ -551,31 +552,39 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
             run_plan_first_prompt_with_policy_context(
                 agent,
                 session_runtime,
-                &effective_prompt,
-                turn_timeout_ms,
-                render_options,
-                orchestrator_max_plan_steps,
-                orchestrator_max_delegated_steps,
-                orchestrator_max_executor_response_chars,
-                orchestrator_max_delegated_step_response_chars,
-                orchestrator_max_delegated_total_response_chars,
-                orchestrator_delegate_steps,
-                Some(policy_context),
+                PlanFirstPromptPolicyRequest {
+                    user_prompt: &effective_prompt,
+                    turn_timeout_ms,
+                    render_options,
+                    max_plan_steps: orchestrator_max_plan_steps,
+                    max_delegated_steps: orchestrator_max_delegated_steps,
+                    max_executor_response_chars: orchestrator_max_executor_response_chars,
+                    max_delegated_step_response_chars:
+                        orchestrator_max_delegated_step_response_chars,
+                    max_delegated_total_response_chars:
+                        orchestrator_max_delegated_total_response_chars,
+                    delegate_steps: orchestrator_delegate_steps,
+                    delegated_policy_context: Some(policy_context),
+                },
             )
             .await
         } else {
             run_plan_first_prompt(
                 agent,
                 session_runtime,
-                &effective_prompt,
-                turn_timeout_ms,
-                render_options,
-                orchestrator_max_plan_steps,
-                orchestrator_max_delegated_steps,
-                orchestrator_max_executor_response_chars,
-                orchestrator_max_delegated_step_response_chars,
-                orchestrator_max_delegated_total_response_chars,
-                orchestrator_delegate_steps,
+                PlanFirstPromptRequest {
+                    user_prompt: &effective_prompt,
+                    turn_timeout_ms,
+                    render_options,
+                    max_plan_steps: orchestrator_max_plan_steps,
+                    max_delegated_steps: orchestrator_max_delegated_steps,
+                    max_executor_response_chars: orchestrator_max_executor_response_chars,
+                    max_delegated_step_response_chars:
+                        orchestrator_max_delegated_step_response_chars,
+                    max_delegated_total_response_chars:
+                        orchestrator_max_delegated_total_response_chars,
+                    delegate_steps: orchestrator_delegate_steps,
+                },
             )
             .await
         }
@@ -583,18 +592,20 @@ pub(crate) async fn run_plan_first_prompt_with_runtime_hooks(
         run_plan_first_prompt_with_policy_context_and_routing(
             agent,
             session_runtime,
-            &effective_prompt,
-            turn_timeout_ms,
-            render_options,
-            orchestrator_max_plan_steps,
-            orchestrator_max_delegated_steps,
-            orchestrator_max_executor_response_chars,
-            orchestrator_max_delegated_step_response_chars,
-            orchestrator_max_delegated_total_response_chars,
-            orchestrator_delegate_steps,
-            policy_context.as_deref(),
-            orchestrator_route_table,
-            orchestrator_route_trace_log,
+            PlanFirstPromptRoutingRequest {
+                user_prompt: &effective_prompt,
+                turn_timeout_ms,
+                render_options,
+                max_plan_steps: orchestrator_max_plan_steps,
+                max_delegated_steps: orchestrator_max_delegated_steps,
+                max_executor_response_chars: orchestrator_max_executor_response_chars,
+                max_delegated_step_response_chars: orchestrator_max_delegated_step_response_chars,
+                max_delegated_total_response_chars: orchestrator_max_delegated_total_response_chars,
+                delegate_steps: orchestrator_delegate_steps,
+                delegated_policy_context: policy_context.as_deref(),
+                route_table: orchestrator_route_table,
+                route_trace_log_path: orchestrator_route_trace_log,
+            },
         )
         .await
     };

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -108,6 +108,7 @@ use super::{
     DoctorCommandConfig, DoctorCommandOutputFormat, DoctorMultiChannelReadinessConfig,
     DoctorProviderKeyStatus, DoctorStatus, FallbackRoutingClient, IntegrationAuthCommand,
     IntegrationCredentialStoreRecord, MacroCommand, MacroFile, MultiAgentRouteTable,
+    PlanFirstPromptPolicyRequest, PlanFirstPromptRequest, PlanFirstPromptRoutingRequest,
     ProfileCommand, ProfileDefaults, ProfileStoreFile, PromptRunStatus, PromptTelemetryLogger,
     ProviderAuthMethod, ProviderCredentialStoreRecord, RenderOptions, RuntimeExtensionHooksConfig,
     SessionBookmarkCommand, SessionBookmarkFile, SessionDiffEntry, SessionDiffReport,


### PR DESCRIPTION
Closes #1405

## Summary of behavior changes
- Replaced wide plan-first orchestrator argument lists with typed request payloads in:
  - `crates/tau-orchestrator/src/orchestrator.rs`
  - `crates/tau-coding-agent/src/orchestrator_bridge.rs`
- Updated runtime call sites to request-based API:
  - `crates/tau-coding-agent/src/runtime_loop.rs`
- Updated affected test call sites and test re-exports:
  - `crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs`
  - `crates/tau-coding-agent/src/main.rs`
  - `crates/tau-coding-agent/src/tests.rs`
- Removed all `#[allow(clippy::too_many_arguments)]` entries from the two scoped files.

## Risks and compatibility notes
- Medium refactor risk: signature migration across runtime/test call sites.
- Behavioral intent unchanged: orchestration logic, budgets, routing, and policy-context handling remain equivalent.
- Remaining global allows are outside this issue’s scope.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-orchestrator --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-orchestrator -- --nocapture`
  - Result: `25 passed; 0 failed`
- `cargo test -p tau-coding-agent run_plan_first_prompt -- --nocapture`
  - Result: `12 passed; 0 failed`
