### PR TITLE
Add missing module docs in split runtime/admin files

### DIFF
--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/artifact_workflows.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/artifact_workflows.rs
@@ -1,3 +1,5 @@
+//! Artifact list/read workflow coverage for GitHub Issues runtime tests.
+
 use super::*;
 
 /// Confirms artifact listing and retrieval behavior across run and TTL states.

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/chat_and_controls.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/chat_and_controls.rs
@@ -1,3 +1,5 @@
+//! Chat/session lifecycle and control-command coverage for runtime tests.
+
 use super::*;
 
 /// Validates control command responses and chat session lifecycle operations.

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/command_workflows.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/command_workflows.rs
@@ -1,3 +1,5 @@
+//! Command workflow and report wiring coverage for runtime tests.
+
 use super::*;
 
 /// Verifies demo-index command rendering and run/report wiring in bridge flows.

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/core_and_parsing.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/core_and_parsing.rs
@@ -1,3 +1,5 @@
+//! Core parsing and helper coverage for GitHub Issues runtime tests.
+
 use super::*;
 
 /// Covers baseline parsing and filtering helpers for issue event ingestion.

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/polling_and_replay.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime/tests/polling_and_replay.rs
@@ -1,3 +1,5 @@
+//! Polling retry, replay safety, and update path coverage for runtime tests.
+
 use super::*;
 
 /// Exercises polling retry and replay-safe comment update behavior.

--- a/crates/tau-session/src/session_commands.rs
+++ b/crates/tau-session/src/session_commands.rs
@@ -1,3 +1,5 @@
+//! Session search and analysis command parsing/execution helpers.
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::{anyhow, bail, Context, Result};

--- a/crates/tau-session/src/session_graph_commands.rs
+++ b/crates/tau-session/src/session_graph_commands.rs
@@ -1,3 +1,5 @@
+//! Session graph rendering and export helpers for runtime commands.
+
 use std::path::{Path, PathBuf};
 
 use tau_core::write_text_atomic;

--- a/crates/tau-session/src/session_navigation_commands.rs
+++ b/crates/tau-session/src/session_navigation_commands.rs
@@ -1,3 +1,5 @@
+//! Branch alias parsing and navigation command helpers for session runtime.
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/tau-session/src/session_runtime_commands.rs
+++ b/crates/tau-session/src/session_runtime_commands.rs
@@ -1,3 +1,5 @@
+//! Runtime-facing session command dispatcher and outcome formatting helpers.
+
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Result};

--- a/crates/tau-session/src/session_runtime_helpers.rs
+++ b/crates/tau-session/src/session_runtime_helpers.rs
@@ -1,3 +1,5 @@
+//! Session initialization and validation helpers shared by runtime entrypoints.
+
 use std::path::Path;
 
 use anyhow::{bail, Result};


### PR DESCRIPTION
## Summary of behavior changes
- Adds top-level module docs (`//! ...`) to split runtime/admin files lacking module headers.
- Covers `tau-session` split command/helper modules and GitHub Issues runtime split test modules.
- Documentation-only change; no runtime behavior updates.

## Risks and compatibility notes
- Low risk: comments only.
- No API, data model, or runtime logic changes.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-github-issues-runtime --all-targets -- -D warnings`
- `cargo clippy -p tau-slack-runtime --all-targets -- -D warnings`
- `cargo clippy -p tau-session --all-targets -- -D warnings`
- Verification scan confirms module-doc-prefixed first non-empty line for `.rs` files in:
  - `crates/tau-github-issues-runtime/src`
  - `crates/tau-slack-runtime/src`
  - `crates/tau-session/src`

Closes #1411
