### PR TITLE
fix: unblock browser/custom-command live contract demos

### DIFF
--- a/crates/tau-cli/src/validation.rs
+++ b/crates/tau-cli/src/validation.rs
@@ -923,7 +923,6 @@ pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> 
         || cli.multi_channel_contract_runner
         || cli.multi_channel_live_runner
         || cli.multi_agent_contract_runner
-        || cli.browser_automation_contract_runner
         || cli.browser_automation_preflight
         || cli.memory_contract_runner
         || cli.dashboard_contract_runner
@@ -933,7 +932,9 @@ pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> 
         || cli.voice_contract_runner
         || cli.voice_live_runner
     {
-        bail!("--browser-automation-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-channel-live-runner, --multi-agent-contract-runner, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --deployment-contract-runner, --custom-command-contract-runner, or --voice-contract-runner");
+        bail!(
+            "--browser-automation-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-channel-live-runner, --multi-agent-contract-runner, --browser-automation-preflight, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --deployment-contract-runner, --custom-command-contract-runner, --voice-contract-runner, or --voice-live-runner"
+        );
     }
     if cli.browser_automation_queue_limit == 0 {
         bail!("--browser-automation-queue-limit must be greater than 0");

--- a/crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json
+++ b/crates/tau-coding-agent/testdata/custom-command-contract/rollout-pass.json
@@ -8,7 +8,7 @@
       "case_id": "custom-command-create-pass",
       "operation": "create",
       "command_name": "deploy_release",
-      "template": "deploy {{env}}",
+      "template": "echo deploy {{env}}",
       "arguments": {
         "env": "staging"
       },
@@ -28,7 +28,7 @@
       "case_id": "custom-command-update-pass",
       "operation": "update",
       "command_name": "deploy_release",
-      "template": "deploy {{env}} --safe",
+      "template": "echo deploy {{env}} --safe",
       "arguments": {
         "env": "staging"
       },

--- a/crates/tau-custom-command/testdata/custom-command-contract/rollout-pass.json
+++ b/crates/tau-custom-command/testdata/custom-command-contract/rollout-pass.json
@@ -8,7 +8,7 @@
       "case_id": "custom-command-create-pass",
       "operation": "create",
       "command_name": "deploy_release",
-      "template": "deploy {{env}}",
+      "template": "echo deploy {{env}}",
       "arguments": {
         "env": "staging"
       },
@@ -28,7 +28,7 @@
       "case_id": "custom-command-update-pass",
       "operation": "update",
       "command_name": "deploy_release",
-      "template": "deploy {{env}} --safe",
+      "template": "echo deploy {{env}} --safe",
       "arguments": {
         "env": "staging"
       },


### PR DESCRIPTION
## Summary
- fixes browser automation contract-runner CLI validation so `--browser-automation-contract-runner` no longer conflicts with itself
- expands browser automation conflict messaging to include real conflicting flags (`--browser-automation-preflight`, `--voice-live-runner`)
- adds tau-coding-agent regression tests for browser automation validator acceptance and conflict rejection
- updates custom-command `rollout-pass` fixtures to use deterministic executable templates (`echo deploy ...`) in both fixture copies
- adds tau-custom-command runtime integration regression covering successful execution of all `rollout-pass` cases

## Behavior Changes
- Browser automation contract-runner mode can now start with valid minimal config.
- Custom-command rollout-pass live demo now passes in clean environments without a `deploy` binary.

## Risks and Compatibility
- Low risk: validator change only removes an invalid self-conflict branch and clarifies message text.
- Fixture behavior changes are limited to contract testdata used by deterministic demo/runtime verification.
- Added test coverage protects both regression surfaces.

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-cli --all-targets -- -D warnings`
- `cargo clippy -p tau-custom-command --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-coding-agent browser_automation_contract_runner_cli -- --nocapture`
- `cargo test -p tau-custom-command integration_runner_rollout_pass_fixture_executes_all_cases_successfully -- --nocapture`
- `scripts/demo/browser-automation.sh --timeout-seconds 120`
- `scripts/demo/dashboard.sh --timeout-seconds 120`
- `scripts/demo/custom-command.sh --timeout-seconds 120`
- `scripts/demo/memory.sh --timeout-seconds 120`
- `scripts/demo/voice-live.sh --timeout-seconds 120`

Closes #1414
