### PR TITLE
feat: add browser automation live runner mode

### DIFF
--- a/crates/tau-cli/src/cli_args.rs
+++ b/crates/tau-cli/src/cli_args.rs
@@ -3004,10 +3004,31 @@ pub struct Cli {
         long = "browser-automation-contract-runner",
         env = "TAU_BROWSER_AUTOMATION_CONTRACT_RUNNER",
         default_value_t = false,
-        conflicts_with = "browser_automation_preflight",
+        conflicts_with_all = ["browser_automation_live_runner", "browser_automation_preflight"],
         help = "Run fixture-driven browser automation runtime contract scenarios"
     )]
     pub browser_automation_contract_runner: bool,
+
+    #[arg(
+        long = "browser-automation-live-runner",
+        env = "TAU_BROWSER_AUTOMATION_LIVE_RUNNER",
+        default_value_t = false,
+        conflicts_with_all = [
+            "browser_automation_contract_runner",
+            "browser_automation_preflight"
+        ],
+        help = "Run browser automation fixtures against a live Playwright CLI executor"
+    )]
+    pub browser_automation_live_runner: bool,
+
+    #[arg(
+        long = "browser-automation-live-fixture",
+        env = "TAU_BROWSER_AUTOMATION_LIVE_FIXTURE",
+        default_value = "crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json",
+        requires = "browser_automation_live_runner",
+        help = "Path to browser automation live fixture JSON"
+    )]
+    pub browser_automation_live_fixture: PathBuf,
 
     #[arg(
         long = "browser-automation-fixture",
@@ -3097,7 +3118,7 @@ pub struct Cli {
         long = "browser-automation-playwright-cli",
         env = "TAU_BROWSER_AUTOMATION_PLAYWRIGHT_CLI",
         default_value = "playwright-cli",
-        help = "Playwright CLI executable used for browser automation preflight and doctor checks"
+        help = "Playwright CLI executable used for browser automation preflight, live runner, and doctor checks"
     )]
     pub browser_automation_playwright_cli: String,
 
@@ -3105,7 +3126,10 @@ pub struct Cli {
         long = "browser-automation-preflight",
         env = "TAU_BROWSER_AUTOMATION_PREFLIGHT",
         default_value_t = false,
-        conflicts_with = "browser_automation_contract_runner",
+        conflicts_with_all = [
+            "browser_automation_contract_runner",
+            "browser_automation_live_runner"
+        ],
         help = "Run browser automation prerequisite checks and exit"
     )]
     pub browser_automation_preflight: bool,

--- a/crates/tau-cli/src/validation.rs
+++ b/crates/tau-cli/src/validation.rs
@@ -923,6 +923,7 @@ pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> 
         || cli.multi_channel_contract_runner
         || cli.multi_channel_live_runner
         || cli.multi_agent_contract_runner
+        || cli.browser_automation_live_runner
         || cli.browser_automation_preflight
         || cli.memory_contract_runner
         || cli.dashboard_contract_runner
@@ -933,7 +934,7 @@ pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> 
         || cli.voice_live_runner
     {
         bail!(
-            "--browser-automation-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-channel-live-runner, --multi-agent-contract-runner, --browser-automation-preflight, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --deployment-contract-runner, --custom-command-contract-runner, --voice-contract-runner, or --voice-live-runner"
+            "--browser-automation-contract-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-channel-live-runner, --multi-agent-contract-runner, --browser-automation-live-runner, --browser-automation-preflight, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --deployment-contract-runner, --custom-command-contract-runner, --voice-contract-runner, or --voice-live-runner"
         );
     }
     if cli.browser_automation_queue_limit == 0 {
@@ -967,6 +968,56 @@ pub fn validate_browser_automation_contract_runner_cli(cli: &Cli) -> Result<()> 
     Ok(())
 }
 
+pub fn validate_browser_automation_live_runner_cli(cli: &Cli) -> Result<()> {
+    if !cli.browser_automation_live_runner {
+        return Ok(());
+    }
+
+    if has_prompt_or_command_input(cli) {
+        bail!("--browser-automation-live-runner cannot be combined with --prompt, --prompt-file, --prompt-template-file, or --command-file");
+    }
+    if cli.no_session {
+        bail!("--browser-automation-live-runner cannot be used together with --no-session");
+    }
+    if cli.github_issues_bridge
+        || cli.slack_bridge
+        || cli.events_runner
+        || cli.multi_channel_contract_runner
+        || cli.multi_channel_live_runner
+        || cli.multi_agent_contract_runner
+        || cli.browser_automation_contract_runner
+        || cli.browser_automation_preflight
+        || cli.memory_contract_runner
+        || cli.dashboard_contract_runner
+        || cli.gateway_contract_runner
+        || cli.deployment_contract_runner
+        || cli.custom_command_contract_runner
+        || cli.voice_contract_runner
+        || cli.voice_live_runner
+    {
+        bail!(
+            "--browser-automation-live-runner cannot be combined with --github-issues-bridge, --slack-bridge, --events-runner, --multi-channel-contract-runner, --multi-channel-live-runner, --multi-agent-contract-runner, --browser-automation-contract-runner, --browser-automation-preflight, --memory-contract-runner, --dashboard-contract-runner, --gateway-contract-runner, --deployment-contract-runner, --custom-command-contract-runner, --voice-contract-runner, or --voice-live-runner"
+        );
+    }
+    if cli.browser_automation_playwright_cli.trim().is_empty() {
+        bail!("--browser-automation-playwright-cli cannot be empty");
+    }
+    if !cli.browser_automation_live_fixture.exists() {
+        bail!(
+            "--browser-automation-live-fixture '{}' does not exist",
+            cli.browser_automation_live_fixture.display()
+        );
+    }
+    if !cli.browser_automation_live_fixture.is_file() {
+        bail!(
+            "--browser-automation-live-fixture '{}' must point to a file",
+            cli.browser_automation_live_fixture.display()
+        );
+    }
+
+    Ok(())
+}
+
 pub fn validate_browser_automation_preflight_cli(cli: &Cli) -> Result<()> {
     if !cli.browser_automation_preflight {
         return Ok(());
@@ -982,6 +1033,7 @@ pub fn validate_browser_automation_preflight_cli(cli: &Cli) -> Result<()> {
         || cli.multi_channel_live_runner
         || cli.multi_agent_contract_runner
         || cli.browser_automation_contract_runner
+        || cli.browser_automation_live_runner
         || cli.memory_contract_runner
         || cli.dashboard_contract_runner
         || cli.gateway_contract_runner

--- a/crates/tau-coding-agent/src/startup_transport_modes.rs
+++ b/crates/tau-coding-agent/src/startup_transport_modes.rs
@@ -11,6 +11,7 @@ use tau_onboarding::startup_transport_modes::{
     resolve_github_issues_bridge_repo_and_token_from_cli as resolve_onboarding_github_issues_bridge_repo_and_token_from_cli,
     resolve_slack_bridge_tokens_from_cli as resolve_onboarding_slack_bridge_tokens_from_cli,
     run_browser_automation_contract_runner_if_requested,
+    run_browser_automation_live_runner_if_requested,
     run_custom_command_contract_runner_if_requested, run_dashboard_contract_runner_if_requested,
     run_deployment_contract_runner_if_requested,
     run_events_runner_with_runtime_defaults_if_requested as run_onboarding_events_runner_with_runtime_defaults_if_requested,
@@ -234,6 +235,11 @@ impl TransportRuntimeExecutor for CodingAgentTransportRuntimeExecutor<'_> {
 
     async fn run_browser_automation_contract_runner(&self) -> Result<()> {
         run_browser_automation_contract_runner_if_requested(self.cli).await?;
+        Ok(())
+    }
+
+    async fn run_browser_automation_live_runner(&self) -> Result<()> {
+        run_browser_automation_live_runner_if_requested(self.cli).await?;
         Ok(())
     }
 

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -663,6 +663,10 @@ pub(crate) fn test_cli() -> Cli {
         multi_agent_retry_max_attempts: 4,
         multi_agent_retry_base_delay_ms: 0,
         browser_automation_contract_runner: false,
+        browser_automation_live_runner: false,
+        browser_automation_live_fixture: PathBuf::from(
+            "crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json",
+        ),
         browser_automation_fixture: PathBuf::from(
             "crates/tau-coding-agent/testdata/browser-automation-contract/mixed-outcomes.json",
         ),

--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -1260,6 +1260,65 @@ fn regression_cli_gateway_guardrail_flags_require_gateway_runner_flag() {
 }
 
 #[test]
+fn unit_cli_browser_automation_live_runner_flags_default_to_disabled() {
+    let cli = parse_cli_with_stack(["tau-rs"]);
+    assert!(!cli.browser_automation_contract_runner);
+    assert!(!cli.browser_automation_live_runner);
+    assert_eq!(
+        cli.browser_automation_live_fixture,
+        PathBuf::from(
+            "crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json"
+        )
+    );
+    assert_eq!(cli.browser_automation_playwright_cli, "playwright-cli");
+}
+
+#[test]
+fn functional_cli_browser_automation_live_runner_flags_accept_explicit_overrides() {
+    let cli = parse_cli_with_stack([
+        "tau-rs",
+        "--browser-automation-live-runner",
+        "--browser-automation-live-fixture",
+        "fixtures/browser-live.json",
+        "--browser-automation-playwright-cli",
+        "./bin/mock-playwright-cli",
+    ]);
+    assert!(cli.browser_automation_live_runner);
+    assert_eq!(
+        cli.browser_automation_live_fixture,
+        PathBuf::from("fixtures/browser-live.json")
+    );
+    assert_eq!(
+        cli.browser_automation_playwright_cli,
+        "./bin/mock-playwright-cli"
+    );
+}
+
+#[test]
+fn regression_cli_browser_automation_live_fixture_requires_live_runner_flag() {
+    let parse = try_parse_cli_with_stack([
+        "tau-rs",
+        "--browser-automation-live-fixture",
+        "fixtures/browser-live.json",
+    ]);
+    let error = parse.expect_err("fixture flag should require live runner mode");
+    assert!(error
+        .to_string()
+        .contains("required arguments were not provided"));
+}
+
+#[test]
+fn regression_cli_browser_automation_live_runner_conflicts_with_contract_runner() {
+    let parse = try_parse_cli_with_stack([
+        "tau-rs",
+        "--browser-automation-live-runner",
+        "--browser-automation-contract-runner",
+    ]);
+    let error = parse.expect_err("live runner should conflict with contract runner");
+    assert!(error.to_string().contains("cannot be used with"));
+}
+
+#[test]
 fn unit_cli_deployment_runner_flags_default_to_disabled() {
     let cli = parse_cli_with_stack(["tau-rs"]);
     assert!(!cli.deployment_contract_runner);

--- a/crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json
+++ b/crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "name": "live-sequence",
+  "description": "Deterministic browser automation live fixture for mock Playwright executor demos.",
+  "cases": [
+    {
+      "schema_version": 1,
+      "case_id": "snapshot-live",
+      "operation": "snapshot",
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "ok",
+          "operation": "snapshot",
+          "snapshot_id": "snapshot-live",
+          "elements": [
+            {
+              "id": "e1",
+              "role": "button",
+              "name": "Run"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "schema_version": 1,
+      "case_id": "action-click-live",
+      "operation": "action",
+      "action": "click",
+      "selector": "#run",
+      "timeout_ms": 1000,
+      "expected": {
+        "outcome": "success",
+        "status_code": 200,
+        "response_body": {
+          "status": "ok",
+          "operation": "action",
+          "action": "click",
+          "selector": "#run",
+          "repeat_count": 1,
+          "text": "",
+          "timeout_ms": 1000
+        }
+      }
+    }
+  ]
+}

--- a/crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py
+++ b/crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+
+def main() -> int:
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    if command == "start-session":
+        print(json.dumps({"status": "ok"}))
+        return 0
+
+    if command == "shutdown-session":
+        print(json.dumps({"status": "ok"}))
+        return 0
+
+    if command != "execute-action":
+        print("unsupported command", file=sys.stderr)
+        return 2
+
+    payload = json.loads(sys.argv[2]) if len(sys.argv) > 2 else {}
+    operation = str(payload.get("operation", "")).strip().lower()
+
+    if operation == "snapshot":
+        print(
+            json.dumps(
+                {
+                    "status_code": 200,
+                    "response_body": {
+                        "status": "ok",
+                        "operation": "snapshot",
+                        "snapshot_id": "snapshot-live",
+                        "elements": [{"id": "e1", "role": "button", "name": "Run"}],
+                    },
+                }
+            )
+        )
+        return 0
+
+    if operation == "action":
+        print(
+            json.dumps(
+                {
+                    "status_code": 200,
+                    "response_body": {
+                        "status": "ok",
+                        "operation": "action",
+                        "action": payload.get("action", ""),
+                        "selector": payload.get("selector", ""),
+                        "repeat_count": payload.get("action_repeat_count", 1),
+                        "text": payload.get("text", ""),
+                        "timeout_ms": payload.get("timeout_ms", 0),
+                    },
+                }
+            )
+        )
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "status_code": 400,
+                "error_code": "browser_automation_invalid_operation",
+                "response_body": {"status": "rejected", "reason": "invalid_operation"},
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo/all.sh
+++ b/scripts/demo/all.sh
@@ -20,6 +20,7 @@ demo_scripts=(
   "multi-channel.sh"
   "multi-agent.sh"
   "browser-automation.sh"
+  "browser-automation-live.sh"
   "memory.sh"
   "dashboard.sh"
   "gateway.sh"
@@ -91,6 +92,10 @@ normalize_demo_name() {
       ;;
     browser-automation|browserautomation|browser|browser-automation.sh|browserautomation.sh|browser.sh)
       echo "browser-automation.sh"
+      return 0
+      ;;
+    browser-automation-live|browserautomationlive|browser-live|browser-automation-live.sh|browserautomationlive.sh|browser-live.sh)
+      echo "browser-automation-live.sh"
       return 0
       ;;
     memory|memory.sh)
@@ -235,14 +240,14 @@ print_usage() {
   cat <<EOF
 Usage: all.sh [--repo-root PATH] [--binary PATH] [--skip-build] [--list] [--only DEMOS] [--json] [--report-file PATH] [--fail-fast] [--timeout-seconds N] [--help]
 
-Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/memory/dashboard/gateway/gateway-auth/gateway-remote-access/deployment/custom-command/voice) with deterministic summary output.
+Run checked-in Tau demo wrappers (local/rpc/events/package/multi-channel/multi-agent/browser-automation/browser-automation-live/memory/dashboard/gateway/gateway-auth/gateway-remote-access/deployment/custom-command/voice) with deterministic summary output.
 
 Options:
   --repo-root PATH  Repository root (defaults to caller-derived root)
   --binary PATH     tau-coding-agent binary path (default: <repo-root>/target/debug/tau-coding-agent)
   --skip-build      Skip cargo build and require --binary to exist
   --list            Print selected demos and exit without execution
-  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,memory,dashboard,gateway,gateway-auth,gateway-remote-access,deployment,custom-command,voice)
+  --only DEMOS      Comma-separated subset (names: local,rpc,events,package,multi-channel,multi-agent,browser-automation,browser-automation-live,memory,dashboard,gateway,gateway-auth,gateway-remote-access,deployment,custom-command,voice)
   --json            Emit deterministic JSON output for list/summary modes
   --report-file     Write deterministic JSON report artifact to path
   --fail-fast       Stop after first failed wrapper

--- a/scripts/demo/browser-automation-live.sh
+++ b/scripts/demo/browser-automation-live.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/common.sh"
+
+init_rc=0
+tau_demo_common_init "browser-automation-live" "Run deterministic browser automation live fixture execution through a mock Playwright CLI wrapper." "$@" || init_rc=$?
+if [[ "${init_rc}" -eq 64 ]]; then
+  exit 0
+fi
+if [[ "${init_rc}" -ne 0 ]]; then
+  exit "${init_rc}"
+fi
+
+fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json"
+playwright_cli_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py"
+
+tau_demo_common_require_file "${fixture_path}"
+tau_demo_common_require_file "${playwright_cli_path}"
+tau_demo_common_prepare_binary
+
+tau_demo_common_run_step \
+  "browser-automation-live-runner" \
+  --browser-automation-live-runner \
+  --browser-automation-live-fixture ./crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json \
+  --browser-automation-playwright-cli ./crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py
+
+tau_demo_common_finish


### PR DESCRIPTION
## Summary
- adds a first-class browser automation live runner mode to `tau-coding-agent` CLI
- wires live runner through onboarding transport-mode resolution/dispatch and coding-agent startup executor
- adds live-mode CLI validation for conflict, fixture, and Playwright CLI path requirements
- introduces deterministic live fixture + mock Playwright CLI assets for reproducible execution proof
- adds `scripts/demo/browser-automation-live.sh` and includes it in `scripts/demo/all.sh`

## Behavior Changes
- new CLI flags:
  - `--browser-automation-live-runner`
  - `--browser-automation-live-fixture`
- live mode executes browser automation fixtures through `tau-browser-automation::browser_automation_live` with `--browser-automation-playwright-cli`.
- transport-mode resolution now includes `BrowserAutomationLiveRunner` path.

## Risks and Compatibility
- low-to-moderate risk due transport-mode enum/dispatch extension; covered with targeted mode-resolution + dispatch tests.
- existing browser automation contract-runner and preflight modes remain unchanged; explicit regression checks run.
- new default fixture path is only used when the live runner mode is enabled.

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-cli --all-targets -- -D warnings`
- `cargo clippy -p tau-onboarding --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-onboarding browser_automation_live_runner -- --nocapture`
- `cargo test -p tau-coding-agent browser_automation_live_runner -- --nocapture`
- `cargo test -p tau-coding-agent browser_automation_contract_runner_cli -- --nocapture`
- `scripts/demo/browser-automation-live.sh --timeout-seconds 120`
- `scripts/demo/browser-automation.sh --timeout-seconds 120`

Closes #1416
