### PR TITLE
Persist browser automation live-run health/state artifacts

### DIFF
--- a/scripts/demo/browser-automation-live.sh
+++ b/scripts/demo/browser-automation-live.sh
@@ -16,15 +16,25 @@ fi
 
 fixture_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json"
 playwright_cli_path="${TAU_DEMO_REPO_ROOT}/crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py"
+demo_state_dir=".tau/demo-browser-automation-live"
 
 tau_demo_common_require_file "${fixture_path}"
 tau_demo_common_require_file "${playwright_cli_path}"
 tau_demo_common_prepare_binary
 
+rm -rf "${TAU_DEMO_REPO_ROOT}/${demo_state_dir}"
+
 tau_demo_common_run_step \
   "browser-automation-live-runner" \
   --browser-automation-live-runner \
   --browser-automation-live-fixture ./crates/tau-coding-agent/testdata/browser-automation-live/live-sequence.json \
+  --browser-automation-state-dir "${demo_state_dir}" \
   --browser-automation-playwright-cli ./crates/tau-coding-agent/testdata/browser-automation-live/mock-playwright-cli.py
+
+tau_demo_common_run_step \
+  "transport-health-inspect-browser-automation-live" \
+  --browser-automation-state-dir "${demo_state_dir}" \
+  --transport-health-inspect browser-automation \
+  --transport-health-json
 
 tau_demo_common_finish


### PR DESCRIPTION
## Summary
- persist browser-automation live-runner state to `<state-dir>/state.json` with a transport-health-compatible `health` snapshot
- append deterministic live diagnostics to `<state-dir>/runtime-events.jsonl` (summary + reason codes)
- wire `BrowserAutomationLiveRunnerConfig` to honor `--browser-automation-state-dir`
- extend onboarding tests to validate persisted state and runtime events for live mode
- extend `scripts/demo/browser-automation-live.sh` to prove `--transport-health-inspect browser-automation` works immediately after a live run

## Risks and Compatibility
- low risk: only affects `--browser-automation-live-runner` execution path and live demo wrapper
- compatibility preserved: existing `--transport-health-inspect browser-automation` path is reused with no new inspect command
- state file writes are additive and localized to the caller-provided browser automation state directory

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-browser-automation --all-targets -- -D warnings`
- `cargo clippy -p tau-onboarding --all-targets -- -D warnings`
- `cargo clippy -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-onboarding browser_automation_live_runner -- --nocapture`
- `scripts/demo/browser-automation-live.sh --timeout-seconds 120`

Closes #1418