### PR TITLE
docs: enforce Rust doc density targets and uplift API docs

### DIFF
--- a/.github/scripts/rust_doc_density.py
+++ b/.github/scripts/rust_doc_density.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PUB_ITEM_PATTERN = re.compile(
+    r"^\s*pub\s+(?:async\s+)?(?P<kind>const|fn|struct|enum|trait|mod|type)\b"
+)
+LINE_DOC_PATTERN = re.compile(r"^\s*///")
+
+
+@dataclass(frozen=True)
+class PublicItem:
+    file_path: Path
+    line: int
+    kind: str
+    signature: str
+    documented: bool
+
+
+@dataclass(frozen=True)
+class CrateDensityReport:
+    crate: str
+    total_public_items: int
+    documented_public_items: int
+    percent: float
+
+
+@dataclass(frozen=True)
+class ThresholdIssue:
+    kind: str
+    detail: str
+
+
+def is_rust_source_file(path: Path) -> bool:
+    return path.is_file() and path.suffix == ".rs"
+
+
+def should_skip_file(path: Path) -> bool:
+    as_posix = path.as_posix()
+    return "/tests/" in as_posix or path.name == "tests.rs"
+
+
+def has_preceding_line_doc(lines: list[str], index: int) -> bool:
+    cursor = index - 1
+    while cursor >= 0 and lines[cursor].strip() == "":
+        cursor -= 1
+
+    if cursor < 0:
+        return False
+    return bool(LINE_DOC_PATTERN.match(lines[cursor]))
+
+
+def extract_public_items(path: Path) -> list[PublicItem]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    items: list[PublicItem] = []
+    for index, line in enumerate(lines):
+        match = PUB_ITEM_PATTERN.match(line)
+        if not match:
+            continue
+        kind = match.group("kind")
+        items.append(
+            PublicItem(
+                file_path=path,
+                line=index + 1,
+                kind=kind,
+                signature=line.strip(),
+                documented=has_preceding_line_doc(lines, index),
+            )
+        )
+    return items
+
+
+def discover_crate_dirs(crates_root: Path) -> list[Path]:
+    crate_dirs: list[Path] = []
+    if not crates_root.exists():
+        return crate_dirs
+
+    for candidate in sorted(crates_root.iterdir()):
+        if not candidate.is_dir():
+            continue
+        if not (candidate / "Cargo.toml").is_file():
+            continue
+        if not (candidate / "src").is_dir():
+            continue
+        crate_dirs.append(candidate)
+    return crate_dirs
+
+
+def compute_density_reports(repo_root: Path, crates_dir: str) -> tuple[list[CrateDensityReport], list[PublicItem]]:
+    crates_root = (repo_root / crates_dir).resolve()
+    reports: list[CrateDensityReport] = []
+    all_items: list[PublicItem] = []
+
+    for crate_dir in discover_crate_dirs(crates_root):
+        items: list[PublicItem] = []
+        for rust_file in sorted((crate_dir / "src").rglob("*.rs")):
+            if not is_rust_source_file(rust_file):
+                continue
+            if should_skip_file(rust_file):
+                continue
+            items.extend(extract_public_items(rust_file))
+
+        total = len(items)
+        documented = sum(1 for item in items if item.documented)
+        percent = (documented / total * 100.0) if total else 100.0
+
+        reports.append(
+            CrateDensityReport(
+                crate=crate_dir.name,
+                total_public_items=total,
+                documented_public_items=documented,
+                percent=percent,
+            )
+        )
+        all_items.extend(items)
+
+    reports.sort(key=lambda report: (report.percent, report.crate))
+    return reports, all_items
+
+
+def parse_crate_target_arg(raw: str) -> tuple[str, float]:
+    if "=" not in raw:
+        raise ValueError(f"invalid --crate-min '{raw}' (expected crate=percent)")
+    crate, raw_percent = raw.split("=", 1)
+    crate = crate.strip()
+    if not crate:
+        raise ValueError(f"invalid --crate-min '{raw}' (crate name cannot be empty)")
+    try:
+        percent = float(raw_percent.strip())
+    except ValueError as error:
+        raise ValueError(f"invalid --crate-min '{raw}' (percent must be numeric)") from error
+    if percent < 0.0 or percent > 100.0:
+        raise ValueError(f"invalid --crate-min '{raw}' (percent must be between 0 and 100)")
+    return crate, percent
+
+
+def load_targets_file(path: Path) -> tuple[float | None, dict[str, float]]:
+    if not path.is_file():
+        raise FileNotFoundError(f"targets file not found: {path}")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    global_min = payload.get("global_min_percent")
+    crate_targets_raw = payload.get("crate_min_percent", {})
+
+    if global_min is not None:
+        global_min = float(global_min)
+        if global_min < 0.0 or global_min > 100.0:
+            raise ValueError("global_min_percent must be between 0 and 100")
+
+    crate_targets: dict[str, float] = {}
+    if not isinstance(crate_targets_raw, dict):
+        raise ValueError("crate_min_percent must be an object mapping crate to percent")
+    for crate, value in crate_targets_raw.items():
+        crate_name = str(crate).strip()
+        percent = float(value)
+        if not crate_name:
+            raise ValueError("crate_min_percent contains an empty crate name")
+        if percent < 0.0 or percent > 100.0:
+            raise ValueError(f"crate target for '{crate_name}' must be between 0 and 100")
+        crate_targets[crate_name] = percent
+
+    return global_min, crate_targets
+
+
+def evaluate_thresholds(
+    reports: list[CrateDensityReport],
+    global_min_percent: float | None,
+    crate_min_percent: dict[str, float],
+) -> list[ThresholdIssue]:
+    issues: list[ThresholdIssue] = []
+    total_public = sum(report.total_public_items for report in reports)
+    total_documented = sum(report.documented_public_items for report in reports)
+    overall_percent = (total_documented / total_public * 100.0) if total_public else 100.0
+
+    if global_min_percent is not None and overall_percent < global_min_percent:
+        issues.append(
+            ThresholdIssue(
+                kind="global_min_failed",
+                detail=(
+                    f"overall density {overall_percent:.2f}% is below global minimum "
+                    f"{global_min_percent:.2f}%"
+                ),
+            )
+        )
+
+    by_crate = {report.crate: report for report in reports}
+    for crate, target in sorted(crate_min_percent.items()):
+        report = by_crate.get(crate)
+        if report is None:
+            issues.append(
+                ThresholdIssue(
+                    kind="missing_crate",
+                    detail=f"crate target configured for '{crate}' but crate was not discovered",
+                )
+            )
+            continue
+        if report.percent < target:
+            issues.append(
+                ThresholdIssue(
+                    kind="crate_min_failed",
+                    detail=(
+                        f"crate '{crate}' density {report.percent:.2f}% is below "
+                        f"configured minimum {target:.2f}%"
+                    ),
+                )
+            )
+
+    return issues
+
+
+def render_human_report(
+    repo_root: Path,
+    reports: list[CrateDensityReport],
+    global_min_percent: float | None,
+    crate_min_percent: dict[str, float],
+    issues: list[ThresholdIssue],
+) -> str:
+    total_public = sum(report.total_public_items for report in reports)
+    total_documented = sum(report.documented_public_items for report in reports)
+    overall_percent = (total_documented / total_public * 100.0) if total_public else 100.0
+
+    lines = [
+        "rust doc density check",
+        f"repo_root={repo_root}",
+        f"crate_count={len(reports)}",
+        f"overall_public_items={total_public}",
+        f"overall_documented_items={total_documented}",
+        f"overall_percent={overall_percent:.2f}",
+        f"global_min_percent={global_min_percent if global_min_percent is not None else 'none'}",
+        f"crate_targets={len(crate_min_percent)}",
+        f"issues={len(issues)}",
+    ]
+
+    for report in reports:
+        target = crate_min_percent.get(report.crate)
+        target_render = f"{target:.2f}" if target is not None else "-"
+        lines.append(
+            f"- {report.crate}: total={report.total_public_items} documented={report.documented_public_items} "
+            f"percent={report.percent:.2f} target={target_render}"
+        )
+
+    for issue in issues:
+        lines.append(f"! {issue.kind}: {issue.detail}")
+
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Measure rust public API doc density and validate configured thresholds."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root containing crates/",
+    )
+    parser.add_argument(
+        "--crates-dir",
+        default="crates",
+        help="Relative directory containing crate folders (default: crates)",
+    )
+    parser.add_argument(
+        "--targets-file",
+        help="Optional JSON file with global_min_percent and crate_min_percent targets",
+    )
+    parser.add_argument(
+        "--global-min-percent",
+        type=float,
+        help="Optional global minimum percent override",
+    )
+    parser.add_argument(
+        "--crate-min",
+        action="append",
+        default=[],
+        help="Per-crate minimum threshold in crate=percent format (repeatable)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON payload instead of human-readable text",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    reports, _ = compute_density_reports(repo_root, args.crates_dir)
+
+    global_min_percent: float | None = None
+    crate_min_percent: dict[str, float] = {}
+
+    if args.targets_file:
+        file_global_min, file_crate_targets = load_targets_file(
+            (repo_root / args.targets_file).resolve()
+        )
+        global_min_percent = file_global_min
+        crate_min_percent.update(file_crate_targets)
+
+    if args.global_min_percent is not None:
+        if args.global_min_percent < 0.0 or args.global_min_percent > 100.0:
+            raise ValueError("--global-min-percent must be between 0 and 100")
+        global_min_percent = float(args.global_min_percent)
+
+    for raw_target in args.crate_min:
+        crate, percent = parse_crate_target_arg(raw_target)
+        crate_min_percent[crate] = percent
+
+    issues = evaluate_thresholds(reports, global_min_percent, crate_min_percent)
+
+    if args.json:
+        total_public = sum(report.total_public_items for report in reports)
+        total_documented = sum(report.documented_public_items for report in reports)
+        overall_percent = (total_documented / total_public * 100.0) if total_public else 100.0
+        print(
+            json.dumps(
+                {
+                    "repo_root": str(repo_root),
+                    "crate_count": len(reports),
+                    "overall_public_items": total_public,
+                    "overall_documented_items": total_documented,
+                    "overall_percent": round(overall_percent, 2),
+                    "global_min_percent": global_min_percent,
+                    "crate_targets": crate_min_percent,
+                    "reports": [
+                        {
+                            "crate": report.crate,
+                            "total_public_items": report.total_public_items,
+                            "documented_public_items": report.documented_public_items,
+                            "percent": round(report.percent, 2),
+                        }
+                        for report in reports
+                    ],
+                    "issues": [
+                        {
+                            "kind": issue.kind,
+                            "detail": issue.detail,
+                        }
+                        for issue in issues
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(
+            render_human_report(
+                repo_root,
+                reports,
+                global_min_percent,
+                crate_min_percent,
+                issues,
+            )
+        )
+
+    return 0 if not issues else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_demo_scripts.py
+++ b/.github/scripts/test_demo_scripts.py
@@ -240,6 +240,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-channel.sh",
                 "multi-agent.sh",
                 "browser-automation.sh",
+                "browser-automation-live.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
@@ -317,6 +318,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-channel.sh",
                 "multi-agent.sh",
                 "browser-automation.sh",
+                "browser-automation-live.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
@@ -463,7 +465,7 @@ class DemoScriptsTests(unittest.TestCase):
                 0,
                 msg=f"all.sh failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
             )
-            self.assertIn("[demo:all] summary: total=15 passed=15 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=16 passed=16 failed=0", completed.stdout)
 
             rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
             self.assertGreaterEqual(len(rows), 30)
@@ -515,11 +517,11 @@ class DemoScriptsTests(unittest.TestCase):
 
             completed = run_demo_script("all.sh", binary_path, trace_path, extra_args=["--report-file", str(report_path)])
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-            self.assertIn("[demo:all] summary: total=15 passed=15 failed=0", completed.stdout)
+            self.assertIn("[demo:all] summary: total=16 passed=16 failed=0", completed.stdout)
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"], {"total": 15, "passed": 15, "failed": 0})
+            self.assertEqual(payload["summary"], {"total": 16, "passed": 16, "failed": 0})
             self.assertEqual(
                 [entry["name"] for entry in payload["demos"]],
                 [
@@ -530,6 +532,7 @@ class DemoScriptsTests(unittest.TestCase):
                     "multi-channel.sh",
                     "multi-agent.sh",
                     "browser-automation.sh",
+                    "browser-automation-live.sh",
                     "memory.sh",
                     "dashboard.sh",
                     "gateway.sh",
@@ -612,14 +615,15 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertIn("[demo:all] [5] multi-channel.sh", completed.stdout)
             self.assertIn("[demo:all] [6] multi-agent.sh", completed.stdout)
             self.assertIn("[demo:all] [7] browser-automation.sh", completed.stdout)
-            self.assertIn("[demo:all] [8] memory.sh", completed.stdout)
-            self.assertIn("[demo:all] [9] dashboard.sh", completed.stdout)
-            self.assertIn("[demo:all] [10] gateway.sh", completed.stdout)
-            self.assertIn("[demo:all] [11] gateway-auth.sh", completed.stdout)
-            self.assertIn("[demo:all] [12] gateway-remote-access.sh", completed.stdout)
-            self.assertIn("[demo:all] [13] deployment.sh", completed.stdout)
-            self.assertIn("[demo:all] [14] custom-command.sh", completed.stdout)
-            self.assertIn("[demo:all] [15] voice.sh", completed.stdout)
+            self.assertIn("[demo:all] [8] browser-automation-live.sh", completed.stdout)
+            self.assertIn("[demo:all] [9] memory.sh", completed.stdout)
+            self.assertIn("[demo:all] [10] dashboard.sh", completed.stdout)
+            self.assertIn("[demo:all] [11] gateway.sh", completed.stdout)
+            self.assertIn("[demo:all] [12] gateway-auth.sh", completed.stdout)
+            self.assertIn("[demo:all] [13] gateway-remote-access.sh", completed.stdout)
+            self.assertIn("[demo:all] [14] deployment.sh", completed.stdout)
+            self.assertIn("[demo:all] [15] custom-command.sh", completed.stdout)
+            self.assertIn("[demo:all] [16] voice.sh", completed.stdout)
 
     def test_integration_multi_channel_demo_includes_live_mode_diagnostics_steps(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -704,6 +708,7 @@ class DemoScriptsTests(unittest.TestCase):
                 "multi-channel.sh",
                 "multi-agent.sh",
                 "browser-automation.sh",
+                "browser-automation-live.sh",
                 "memory.sh",
                 "dashboard.sh",
                 "gateway.sh",
@@ -858,8 +863,8 @@ class DemoScriptsTests(unittest.TestCase):
             self.assertTrue(report_path.exists())
 
             payload = json.loads(report_path.read_text(encoding="utf-8"))
-            self.assertEqual(payload["summary"]["total"], 15)
-            self.assertEqual(payload["summary"]["failed"], 15)
+            self.assertEqual(payload["summary"]["total"], 16)
+            self.assertEqual(payload["summary"]["failed"], 16)
             self.assertEqual(payload["summary"]["passed"], 0)
             for entry in payload["demos"]:
                 assert_duration_ms_field(self, entry)

--- a/.github/scripts/test_docs_link_check.py
+++ b/.github/scripts/test_docs_link_check.py
@@ -43,13 +43,15 @@ class DocsLinkCheckTests(unittest.TestCase):
                 "docs/README.md",
                 "--file",
                 "docs/guides/quickstart.md",
+                "--file",
+                "docs/guides/doc-density-scorecard.md",
             ],
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertEqual(completed.returncode, 0, msg=completed.stderr)
-        self.assertIn("checked_files=3", completed.stdout)
+        self.assertIn("checked_files=4", completed.stdout)
         self.assertIn("issues=0", completed.stdout)
 
     def test_integration_docs_index_and_readme_links_stay_valid(self):
@@ -65,6 +67,10 @@ class DocsLinkCheckTests(unittest.TestCase):
         self.assertIn("guides/transports.md", docs_index)
         self.assertIn("guides/packages.md", docs_index)
         self.assertIn("guides/events.md", docs_index)
+        self.assertIn("guides/doc-density-scorecard.md", docs_index)
+
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("docs/guides/doc-density-scorecard.md", readme)
 
     def test_regression_cli_reports_missing_link_and_fails(self):
         script_path = SCRIPT_DIR / "docs_link_check.py"

--- a/.github/scripts/test_rust_doc_density.py
+++ b/.github/scripts/test_rust_doc_density.py
@@ -1,0 +1,107 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import rust_doc_density  # noqa: E402
+
+
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+
+class RustDocDensityTests(unittest.TestCase):
+    def test_unit_extract_public_items_reports_documented_and_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / "lib.rs"
+            file_path.write_text(
+                """
+/// documented struct
+pub struct Documented;
+
+pub enum Undocumented {
+    A,
+}
+""",
+                encoding="utf-8",
+            )
+            items = rust_doc_density.extract_public_items(file_path)
+            self.assertEqual(len(items), 2)
+            self.assertTrue(items[0].documented)
+            self.assertFalse(items[1].documented)
+
+    def test_functional_cli_reports_success_for_repository_targets(self):
+        script_path = SCRIPT_DIR / "rust_doc_density.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--repo-root",
+                str(REPO_ROOT),
+                "--targets-file",
+                "docs/guides/doc-density-targets.json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+        self.assertIn("rust doc density check", completed.stdout)
+        self.assertIn("issues=0", completed.stdout)
+
+    def test_integration_density_reports_include_anchor_crates(self):
+        reports, items = rust_doc_density.compute_density_reports(REPO_ROOT, "crates")
+        by_crate = {report.crate: report for report in reports}
+
+        self.assertIn("tau-core", by_crate)
+        self.assertIn("tau-startup", by_crate)
+        self.assertGreater(by_crate["tau-core"].total_public_items, 0)
+        self.assertGreater(len(items), 0)
+
+    def test_regression_cli_fails_when_crate_target_not_met(self):
+        script_path = SCRIPT_DIR / "rust_doc_density.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            src_dir = root / "crates" / "demo-crate" / "src"
+            src_dir.mkdir(parents=True, exist_ok=True)
+            (root / "crates" / "demo-crate" / "Cargo.toml").write_text(
+                "[package]\nname = \"demo-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+                encoding="utf-8",
+            )
+            (src_dir / "lib.rs").write_text("pub fn undoc() {}\n", encoding="utf-8")
+            targets_path = root / "targets.json"
+            targets_path.write_text(
+                json.dumps(
+                    {
+                        "crate_min_percent": {
+                            "demo-crate": 100.0,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script_path),
+                    "--repo-root",
+                    str(root),
+                    "--targets-file",
+                    str(targets_path.relative_to(root)),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("crate_min_failed", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,13 @@ jobs:
         if: steps.helper_scope.outputs.helper_tests_needed == 'true'
         run: python3 -m unittest discover -s .github/scripts -p "test_*.py"
 
+      - name: Check rust doc density thresholds
+        if: steps.rust_scope.outputs.rust_changed == 'true'
+        run: |
+          python3 .github/scripts/rust_doc_density.py \
+            --repo-root . \
+            --targets-file docs/guides/doc-density-targets.json
+
       - name: Determine fast-validate script scope
         id: fast_validate_scope
         shell: bash

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Focused guides:
 - Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Transports (GitHub/Slack/RPC): [`docs/guides/transports.md`](docs/guides/transports.md)
 - Operator control summary: [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md)
+- Doc density scorecard: [`docs/guides/doc-density-scorecard.md`](docs/guides/doc-density-scorecard.md)
 - Packages and extensions: [`docs/guides/packages.md`](docs/guides/packages.md)
 - Events and scheduler: [`docs/guides/events.md`](docs/guides/events.md)
 

--- a/crates/tau-core/src/atomic_io.rs
+++ b/crates/tau-core/src/atomic_io.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::time_utils::current_unix_timestamp;
 
+/// Writes text using a temp file + rename so readers never observe partial data.
 pub fn write_text_atomic(path: &Path, content: &str) -> Result<()> {
     if path.as_os_str().is_empty() {
         bail!("destination path cannot be empty");

--- a/crates/tau-core/src/lib.rs
+++ b/crates/tau-core/src/lib.rs
@@ -3,7 +3,9 @@
 //! Provides atomic file-write helpers and time utilities used by runtime state,
 //! cache persistence, and expiry calculations.
 
+/// Atomic file-write helpers for durable state updates.
 pub mod atomic_io;
+/// Unix timestamp utilities used across runtime policy/state logic.
 pub mod time_utils;
 
 pub use atomic_io::write_text_atomic;

--- a/crates/tau-core/src/time_utils.rs
+++ b/crates/tau-core/src/time_utils.rs
@@ -1,3 +1,4 @@
+/// Returns the current Unix timestamp in milliseconds.
 pub fn current_unix_timestamp_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -7,6 +8,7 @@ pub fn current_unix_timestamp_ms() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
+/// Returns the current Unix timestamp in seconds.
 pub fn current_unix_timestamp() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -14,6 +16,7 @@ pub fn current_unix_timestamp() -> u64 {
         .as_secs()
 }
 
+/// Returns true when `expires_unix` is present and no longer in the future.
 pub fn is_expired_unix(expires_unix: Option<u64>, now_unix: u64) -> bool {
     matches!(expires_unix, Some(value) if value <= now_unix)
 }

--- a/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
+++ b/crates/tau-github-issues-runtime/src/github_issues_runtime.rs
@@ -137,6 +137,7 @@ const DEMO_INDEX_SCENARIOS: [&str; 4] = [
 ];
 
 #[derive(Clone)]
+/// Runtime configuration for the GitHub Issues bridge transport loop.
 pub struct GithubIssuesBridgeRuntimeConfig {
     pub client: Arc<dyn LlmClient>,
     pub model: String,
@@ -380,6 +381,7 @@ pub(crate) struct PollCycleReport {
     pub failed_events: usize,
 }
 
+/// Runs the GitHub Issues bridge using polling + command/event processing.
 pub async fn run_github_issues_bridge(config: GithubIssuesBridgeRuntimeConfig) -> Result<()> {
     let mut runtime = GithubIssuesBridgeRuntime::new(config).await?;
     runtime.run().await

--- a/crates/tau-github-issues-runtime/src/lib.rs
+++ b/crates/tau-github-issues-runtime/src/lib.rs
@@ -19,6 +19,7 @@ use tau_ai::StreamDeltaHandler;
 use tau_session::SessionRuntime;
 use tokio::sync::mpsc;
 
+/// GitHub Issues bridge runtime internals and transport loop entrypoints.
 pub mod github_issues_runtime;
 
 pub use github_issues_runtime::{run_github_issues_bridge, GithubIssuesBridgeRuntimeConfig};
@@ -40,12 +41,14 @@ pub use tau_startup::runtime_types::RenderOptions;
 pub use tau_startup::runtime_types::{DoctorCommandConfig, DoctorMultiChannelReadinessConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Outcome reported by prompt execution with cancellation/timeout controls.
 pub enum PromptRunStatus {
     Completed,
     Cancelled,
     TimedOut,
 }
 
+/// Runs a prompt turn with cooperative cancellation and bounded timeout handling.
 pub async fn run_prompt_with_cancellation<F>(
     agent: &mut Agent,
     session_runtime: &mut Option<SessionRuntime>,

--- a/crates/tau-slack-runtime/src/lib.rs
+++ b/crates/tau-slack-runtime/src/lib.rs
@@ -19,6 +19,7 @@ use tau_ai::StreamDeltaHandler;
 use tau_session::SessionRuntime;
 use tokio::sync::mpsc;
 
+/// Slack bridge runtime internals and transport loop entrypoints.
 pub mod slack_runtime;
 
 pub use slack_runtime::{run_slack_bridge, SlackBridgeRuntimeConfig};
@@ -37,12 +38,14 @@ pub use tau_runtime::TransportHealthSnapshot;
 pub use tau_startup::runtime_types::RenderOptions;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Outcome reported by prompt execution with cancellation/timeout controls.
 pub enum PromptRunStatus {
     Completed,
     Cancelled,
     TimedOut,
 }
 
+/// Runs a prompt turn with cooperative cancellation and bounded timeout handling.
 pub async fn run_prompt_with_cancellation<F>(
     agent: &mut Agent,
     session_runtime: &mut Option<SessionRuntime>,

--- a/crates/tau-slack-runtime/src/slack_runtime.rs
+++ b/crates/tau-slack-runtime/src/slack_runtime.rs
@@ -37,6 +37,7 @@ const SLACK_METADATA_MARKER_PREFIX: &str = "<!-- tau-slack-event:";
 const SLACK_METADATA_MARKER_SUFFIX: &str = " -->";
 
 #[derive(Clone)]
+/// Runtime configuration for the Slack bridge transport loop.
 pub struct SlackBridgeRuntimeConfig {
     pub client: Arc<dyn LlmClient>,
     pub model: String,
@@ -212,6 +213,7 @@ pub(crate) struct PollCycleReport {
     pub failed_events: usize,
 }
 
+/// Runs the Slack bridge transport loop and processes incoming events.
 pub async fn run_slack_bridge(config: SlackBridgeRuntimeConfig) -> Result<()> {
     let mut runtime = SlackBridgeRuntime::new(config).await?;
     runtime.run().await

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -24,11 +24,17 @@ use tau_gateway::{
 };
 use tau_session::validate_session_file;
 
+/// Shared startup/runtime value objects used across CLI entrypoints.
 pub mod runtime_types;
+/// Command-file execution runtime helpers.
 pub mod startup_command_file_runtime;
+/// Model-catalog resolution and validation helpers for startup.
 pub mod startup_model_catalog;
+/// Multi-channel adapter factories used by startup command wiring.
 pub mod startup_multi_channel_adapters;
+/// Multi-channel command implementations executed during startup preflight.
 pub mod startup_multi_channel_commands;
+/// RPC capabilities command rendering and dispatch helpers.
 pub mod startup_rpc_capabilities_command;
 
 pub use runtime_types::*;
@@ -84,6 +90,7 @@ pub trait StartupPreflightActions {
     fn handle_daemon_commands(&self, cli: &Cli) -> Result<bool>;
 }
 
+/// Executes startup preflight commands and returns whether startup was handled.
 pub fn execute_startup_preflight(cli: &Cli, actions: &dyn StartupPreflightActions) -> Result<bool> {
     if cli.onboard {
         actions.execute_onboarding_command(cli)?;

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This index maps Tau documentation by audience and task.
 | Training integration operator | [Training Proxy Operations Guide](guides/training-proxy-ops.md) | OpenAI-compatible proxy mode with rollout/attempt attribution logs |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
+| Runtime maintainer | [Doc Density Scorecard](guides/doc-density-scorecard.md) | Baseline/targets for public API docs coverage and CI regression guard policy |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/memory/dashboard/gateway/deployment/custom-command/voice), RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/doc-density-scorecard.md
+++ b/docs/guides/doc-density-scorecard.md
@@ -1,0 +1,60 @@
+# Doc Density Scorecard
+
+This scorecard tracks public API documentation density across Tau crates and defines CI guard targets.
+
+## Method
+
+Measured by `.github/scripts/rust_doc_density.py`:
+
+- Scans `crates/*/src/**/*.rs`.
+- Counts public API items declared with `pub` (`fn`, `struct`, `enum`, `trait`, `mod`, `const`, `type`).
+- Marks an item documented when an immediate preceding line-doc comment (`///`) is present.
+- Excludes test modules (`tests.rs`, `src/**/tests/**`).
+
+## Baseline Snapshot (2026-02-14)
+
+Before this wave:
+
+- Overall: `648 / 1913` documented public items (`33.87%`).
+- `tau-core`: `0 / 6` (`0.00%`).
+- `tau-github-issues-runtime`: `0 / 5` (`0.00%`).
+- `tau-slack-runtime`: `0 / 5` (`0.00%`).
+- `tau-startup`: `3 / 21` (`14.29%`).
+
+After this wave:
+
+- Overall: `671 / 1913` documented public items (`35.08%`).
+- `tau-core`: `6 / 6` (`100.00%`).
+- `tau-github-issues-runtime`: `5 / 5` (`100.00%`).
+- `tau-slack-runtime`: `5 / 5` (`100.00%`).
+- `tau-startup`: `10 / 21` (`47.62%`).
+
+## CI Targets
+
+Targets are defined in `docs/guides/doc-density-targets.json` and enforced in CI:
+
+- Global minimum: `35.0%`.
+- Crate minima (anchor crates):
+- `tau-core >= 100.0%`
+- `tau-github-issues-runtime >= 100.0%`
+- `tau-slack-runtime >= 100.0%`
+- `tau-startup >= 45.0%`
+- `tau-onboarding >= 23.0%`
+- `tau-runtime >= 28.0%`
+- `tau-provider >= 27.0%`
+- `tau-tools >= 37.0%`
+- `tau-multi-channel >= 45.0%`
+- `tau-session >= 23.0%`
+
+## Recompute
+
+```bash
+python3 .github/scripts/rust_doc_density.py \
+  --repo-root . \
+  --targets-file docs/guides/doc-density-targets.json
+
+python3 .github/scripts/rust_doc_density.py \
+  --repo-root . \
+  --targets-file docs/guides/doc-density-targets.json \
+  --json
+```

--- a/docs/guides/doc-density-targets.json
+++ b/docs/guides/doc-density-targets.json
@@ -1,0 +1,15 @@
+{
+  "global_min_percent": 35.0,
+  "crate_min_percent": {
+    "tau-core": 100.0,
+    "tau-github-issues-runtime": 100.0,
+    "tau-slack-runtime": 100.0,
+    "tau-startup": 45.0,
+    "tau-onboarding": 23.0,
+    "tau-runtime": 28.0,
+    "tau-provider": 27.0,
+    "tau-tools": 37.0,
+    "tau-multi-channel": 45.0,
+    "tau-session": 23.0
+  }
+}


### PR DESCRIPTION
Closes #1481

## Summary
- add a new CI-checkable Rust API doc-density guardrail via `.github/scripts/rust_doc_density.py`
- add unit/functional/integration/regression coverage for the checker in `.github/scripts/test_rust_doc_density.py`
- add `docs/guides/doc-density-targets.json` to define global and per-crate minimum thresholds
- add `docs/guides/doc-density-scorecard.md` and wire links in `README.md` and `docs/README.md`
- wire doc-density enforcement into `quality-linux` in `.github/workflows/ci.yml`
- add `///` documentation to previously undocumented public APIs in:
  - `tau-core`
  - `tau-github-issues-runtime`
  - `tau-slack-runtime`
  - `tau-startup`
- update `test_demo_scripts.py` inventory/count expectations to include `browser-automation-live.sh` so script-suite tests remain deterministic

## Risks / Compatibility
- CI will now fail if global/per-crate doc-density thresholds regress below configured minima.
- thresholds are explicit and versioned in-repo, so tightening/relaxing is controlled and reviewable.
- no runtime behavior changes to production agent execution paths.

## Validation
- `python3 .github/scripts/docs_link_check.py --repo-root .`
- `python3 .github/scripts/rust_doc_density.py --repo-root . --targets-file docs/guides/doc-density-targets.json`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`
- `cargo fmt --all --check`
- `cargo test -p tau-core -p tau-github-issues-runtime -p tau-slack-runtime -p tau-startup --all-targets`
- `cargo clippy -p tau-core -p tau-github-issues-runtime -p tau-slack-runtime -p tau-startup --all-targets -- -D warnings`
