### PR TITLE
fix(training): remove production expect/unwrap panic paths

### DIFF
--- a/crates/tau-training-tracer/src/lib.rs
+++ b/crates/tau-training-tracer/src/lib.rs
@@ -229,7 +229,7 @@ impl TrainingTracer {
     /// Flushes completed spans to the backing store.
     pub async fn flush(&self, store: &(dyn TrainingStore + Send + Sync)) -> StoreResult<usize> {
         let spans = {
-            let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+            let mut inner = self.lock_inner();
             let now = Utc::now();
 
             let open_ids: Vec<String> = inner.open_spans.keys().cloned().collect();
@@ -270,7 +270,7 @@ impl TrainingTracer {
 
     /// Returns an in-memory snapshot of completed spans.
     pub fn completed_spans(&self) -> Vec<TrainingSpan> {
-        let inner = self.inner.lock().expect("training tracer mutex poisoned");
+        let inner = self.lock_inner();
         let mut spans = inner.completed_spans.clone();
         spans.sort_by_key(|span| span.sequence_id);
         spans
@@ -278,13 +278,13 @@ impl TrainingTracer {
 
     fn start_managed_span(&self, key: String, name: String, attributes: HashMap<String, Value>) {
         let span_id = self.start_span(name, None, attributes);
-        let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+        let mut inner = self.lock_inner();
         inner.managed_keys.insert(key, span_id);
     }
 
     fn end_managed_span(&self, key: &str, extra_attributes: HashMap<String, Value>) {
         let span_id = {
-            let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+            let mut inner = self.lock_inner();
             inner.managed_keys.remove(key)
         };
         if let Some(span_id) = span_id {
@@ -300,7 +300,7 @@ impl TrainingTracer {
         parent_id: Option<String>,
         attributes: HashMap<String, Value>,
     ) -> String {
-        let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+        let mut inner = self.lock_inner();
         inner.next_sequence_id += 1;
         let sequence_id = inner.next_sequence_id;
         let span_id = next_id("span");
@@ -319,7 +319,7 @@ impl TrainingTracer {
     }
 
     fn end_span(&self, span_id: &str, extra_attributes: HashMap<String, Value>) {
-        let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+        let mut inner = self.lock_inner();
         let Some(mut open) = inner.open_spans.remove(span_id) else {
             return;
         };
@@ -345,7 +345,7 @@ impl TrainingTracer {
     }
 
     fn instant_span(&self, name: String, attributes: HashMap<String, Value>) {
-        let mut inner = self.inner.lock().expect("training tracer mutex poisoned");
+        let mut inner = self.lock_inner();
         inner.next_sequence_id += 1;
         let sequence_id = inner.next_sequence_id;
         let now = Utc::now();
@@ -363,6 +363,13 @@ impl TrainingTracer {
             start_time: now,
             end_time: Some(now),
         });
+    }
+
+    fn lock_inner(&self) -> std::sync::MutexGuard<'_, TrainingTracerInner> {
+        match self.inner.lock() {
+            Ok(inner) => inner,
+            Err(poisoned) => poisoned.into_inner(),
+        }
     }
 }
 
@@ -404,6 +411,25 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].name, "reward.emit");
         assert_eq!(spans[0].attributes.get("reward_value"), Some(&json!(1.0)));
+    }
+
+    #[test]
+    fn regression_poisoned_mutex_does_not_panic_or_drop_spans() {
+        let tracer = TrainingTracer::new("r-1", "a-1");
+        let poisoned = tracer.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoned
+                .inner
+                .lock()
+                .unwrap_or_else(|inner| inner.into_inner());
+            panic!("intentional poison");
+        })
+        .join();
+
+        tracer.emit_reward(Reward::new("recovered", 1.0));
+        let spans = tracer.completed_spans();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].name, "reward.emit");
     }
 
     #[tokio::test]

--- a/docs/guides/expect-unwrap-audit-wave1.md
+++ b/docs/guides/expect-unwrap-audit-wave1.md
@@ -1,0 +1,76 @@
+## `expect()/unwrap()` Audit - Wave 1
+
+Date: 2026-02-14  
+Issue: #1514
+
+### Scope
+
+- Inventory `expect()/unwrap()` usage by crate/path.
+- Classify each hit as `production`, `debug-only`, or `test-only`.
+- Remove production panic paths in Cleanup 3 scope crates.
+
+### Inventory Method
+
+Commands used:
+
+```bash
+rg -n "\b(expect|unwrap)\(" crates --glob '*.rs'
+```
+
+```bash
+python3 - <<'PY'
+import pathlib,re,collections
+root=pathlib.Path('crates')
+pat=re.compile(r'\b(expect|unwrap)\s*\(')
+results=collections.defaultdict(lambda: {'production':0,'test_only':0})
+for path in root.rglob('*.rs'):
+    text=path.read_text(encoding='utf-8')
+    lines=text.splitlines()
+    cfg_test_line=next((i for i,l in enumerate(lines,1) if '#[cfg(test)]' in l),None)
+    path_test=('/tests/' in str(path) or str(path).endswith('/tests.rs'))
+    for i,l in enumerate(lines,1):
+        if not pat.search(l):
+            continue
+        if path_test or (cfg_test_line is not None and i>cfg_test_line):
+            results[str(path)]['test_only'] += 1
+        else:
+            results[str(path)]['production'] += 1
+for p,v in sorted(results.items()):
+    if v['production'] or v['test_only']:
+        print(p, v)
+PY
+```
+
+### Classification Summary
+
+- Production runtime panic paths in this wave: `8` (fixed)
+  - `crates/tau-training-tracer/src/lib.rs`: `7`
+  - `crates/tau-training-store/src/sqlite.rs`: `1`
+- Production/doc-example-only (non-runtime) hits: `2`
+  - `crates/tau-agent-core/src/lib.rs` Rustdoc examples
+- Debug-only panic paths (`#[cfg(debug_assertions)]` scoped): `0`
+- Test-only hits in modified files after remediation: `16`
+  - `crates/tau-training-store/src/sqlite.rs`: `14`
+  - `crates/tau-training-tracer/src/lib.rs`: `2`
+
+### Remediation Completed
+
+1. `crates/tau-training-tracer/src/lib.rs`
+   - Replaced mutex lock panics with poison recovery via `lock_inner()`.
+   - Removed all production `expect()` usage from tracer runtime paths.
+   - Added regression test `regression_poisoned_mutex_does_not_panic_or_drop_spans`.
+
+2. `crates/tau-training-store/src/sqlite.rs`
+   - Removed `attempt_id.expect("checked above")` in `query_spans(...)`.
+   - Switched to explicit `if let Some(attempt_id)` binding for query params.
+   - Preserved behavior while removing panic-only control flow.
+
+### Validation
+
+- `cargo fmt --all --check`
+- `cargo test -p tau-training-tracer -p tau-training-store --all-targets`
+- `cargo clippy -p tau-training-tracer -p tau-training-store --all-targets -- -D warnings`
+
+### Follow-up
+
+- Keep Rustdoc `expect()` usage in `crates/tau-agent-core/src/lib.rs` under review; these are illustrative examples and not runtime panic paths.


### PR DESCRIPTION
## Summary
- remove production panic-path `expect()` in `SqliteTrainingStore::query_spans` by binding `attempt_id` explicitly instead of `expect("checked above")`
- replace training tracer runtime mutex `expect()` calls with poison-recovery helper `lock_inner()`
- add regression coverage for poisoned tracer mutex to ensure span emission still works
- add `docs/guides/expect-unwrap-audit-wave1.md` with inventory method, risk classification, and remediation notes for issue scope

## Risks and compatibility
- behavior-compatible for successful paths; no API signature changes
- poisoned tracer mutex now recovers and continues rather than panicking, which changes failure behavior in favor of availability
- sqlite span query behavior is unchanged; only panic-only control flow was removed

## Validation evidence
- `cargo fmt --all --check`
- `cargo test -p tau-training-tracer -p tau-training-store --all-targets`
- `cargo clippy -p tau-training-tracer -p tau-training-store --all-targets -- -D warnings`

Closes #1514
