### PR TITLE
Story 1.7: enforce reserved built-in tool name registry

### DIFF
--- a/crates/tau-coding-agent/src/startup_local_runtime.rs
+++ b/crates/tau-coding-agent/src/startup_local_runtime.rs
@@ -154,7 +154,13 @@ pub(crate) async fn run_local_runtime(config: LocalRuntimeConfig<'_>) -> Result<
     } = build_onboarding_local_runtime_extension_startup(
         cli,
         load_multi_agent_route_table,
-        |root| discover_extension_runtime_registrations(root, crate::commands::COMMAND_NAMES),
+        |root| {
+            discover_extension_runtime_registrations(
+                root,
+                tools::builtin_agent_tool_names(),
+                crate::commands::COMMAND_NAMES,
+            )
+        },
         |root| ExtensionRuntimeRegistrationSummary {
             root: root.to_path_buf(),
             discovered: 0,

--- a/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
@@ -917,8 +917,11 @@ async fn integration_extension_registered_tool_executes_in_prompt_loop() {
     )
     .expect("write extension manifest");
 
-    let registrations =
-        discover_extension_runtime_registrations(&extension_root, crate::commands::COMMAND_NAMES);
+    let registrations = discover_extension_runtime_registrations(
+        &extension_root,
+        crate::tools::builtin_agent_tool_names(),
+        crate::commands::COMMAND_NAMES,
+    );
     assert_eq!(registrations.registered_tools.len(), 1);
 
     let responses = VecDeque::from(vec![
@@ -1015,8 +1018,11 @@ fn integration_handle_command_dispatches_extension_registered_command() {
 }"#,
     )
     .expect("write extension manifest");
-    let registrations =
-        discover_extension_runtime_registrations(&extension_root, crate::commands::COMMAND_NAMES);
+    let registrations = discover_extension_runtime_registrations(
+        &extension_root,
+        crate::tools::builtin_agent_tool_names(),
+        crate::commands::COMMAND_NAMES,
+    );
     assert_eq!(registrations.registered_commands.len(), 1);
 
     let mut agent = Agent::new(Arc::new(NoopClient), AgentConfig::default());
@@ -1087,8 +1093,11 @@ fn regression_handle_command_extension_failure_is_fail_isolated() {
 }"#,
     )
     .expect("write extension manifest");
-    let registrations =
-        discover_extension_runtime_registrations(&extension_root, crate::commands::COMMAND_NAMES);
+    let registrations = discover_extension_runtime_registrations(
+        &extension_root,
+        crate::tools::builtin_agent_tool_names(),
+        crate::commands::COMMAND_NAMES,
+    );
     assert_eq!(registrations.registered_commands.len(), 1);
 
     let mut agent = Agent::new(Arc::new(NoopClient), AgentConfig::default());

--- a/crates/tau-extensions/src/lib.rs
+++ b/crates/tau-extensions/src/lib.rs
@@ -28,7 +28,6 @@ const EXTENSION_TIMEOUT_MS_MAX: u64 = 300_000;
 const EXTENSION_HOOK_PAYLOAD_SCHEMA_VERSION: u32 = 1;
 const EXTENSION_COMMAND_RESPONSE_ACTION_CONTINUE: &str = "continue";
 const EXTENSION_COMMAND_RESPONSE_ACTION_EXIT: &str = "exit";
-const BUILTIN_TOOL_NAMES: &[&str] = &["read", "write", "edit", "bash"];
 
 pub fn execute_extension_list_command(cli: &Cli) -> Result<()> {
     if !cli.extension_list {
@@ -964,6 +963,7 @@ pub fn evaluate_extension_policy_override(
 
 pub fn discover_extension_runtime_registrations(
     root: &Path,
+    reserved_tool_names: &[&str],
     builtin_command_names: &[&str],
 ) -> ExtensionRuntimeRegistrationSummary {
     let mut summary = ExtensionRuntimeRegistrationSummary {
@@ -1041,13 +1041,14 @@ pub fn discover_extension_runtime_registrations(
                 ));
                 continue;
             }
-            if BUILTIN_TOOL_NAMES.contains(&tool_name.as_str()) {
+            if reserved_tool_names.contains(&tool_name.as_str()) {
                 summary.skipped_name_conflict += 1;
                 summary.diagnostics.push(format!(
-                    "extension runtime: tool={} id={} manifest={} denied: name conflicts with built-in tool",
+                    "extension runtime: tool={} id={} manifest={} denied: name conflicts with reserved built-in tool '{}'",
                     tool_name,
                     loaded_manifest.summary.id,
-                    loaded_manifest.summary.manifest_path.display()
+                    loaded_manifest.summary.manifest_path.display(),
+                    tool_name
                 ));
                 continue;
             }

--- a/crates/tau-tools/src/tools.rs
+++ b/crates/tau-tools/src/tools.rs
@@ -59,6 +59,17 @@ const TOOL_RATE_LIMIT_MAX_REQUESTS_PERMISSIVE: u32 = 240;
 const TOOL_RATE_LIMIT_MAX_REQUESTS_BALANCED: u32 = 120;
 const TOOL_RATE_LIMIT_MAX_REQUESTS_STRICT: u32 = 60;
 const TOOL_RATE_LIMIT_MAX_REQUESTS_HARDENED: u32 = 30;
+const BUILTIN_AGENT_TOOL_NAMES: &[&str] = &[
+    "read",
+    "write",
+    "edit",
+    "sessions_list",
+    "sessions_history",
+    "sessions_search",
+    "sessions_stats",
+    "sessions_send",
+    "bash",
+];
 
 #[derive(Debug, Clone, Serialize)]
 struct SessionInventoryEntry {
@@ -424,6 +435,11 @@ pub fn register_builtin_tools(agent: &mut Agent, policy: ToolPolicy) {
     agent.register_tool(SessionsStatsTool::new(policy.clone()));
     agent.register_tool(SessionsSendTool::new(policy.clone()));
     agent.register_tool(BashTool::new(policy));
+}
+
+/// Returns the reserved registry of built-in agent tool names.
+pub fn builtin_agent_tool_names() -> &'static [&'static str] {
+    BUILTIN_AGENT_TOOL_NAMES
 }
 
 pub fn register_extension_tools(agent: &mut Agent, tools: &[ExtensionRegisteredTool]) {

--- a/crates/tau-tools/src/tools/tests.rs
+++ b/crates/tau-tools/src/tools/tests.rs
@@ -6,13 +6,14 @@ use proptest::prelude::*;
 use tempfile::tempdir;
 
 use super::{
-    bash_profile_name, build_spec_from_command_template, canonicalize_best_effort,
-    command_available, evaluate_tool_approval_gate, evaluate_tool_rate_limit_gate,
-    evaluate_tool_rbac_gate, is_command_allowed, is_session_candidate_path, leading_executable,
-    os_sandbox_mode_name, redact_secrets, resolve_sandbox_spec, truncate_bytes, AgentTool,
-    BashCommandProfile, BashTool, EditTool, OsSandboxMode, SessionsHistoryTool, SessionsListTool,
-    SessionsSearchTool, SessionsSendTool, SessionsStatsTool, ToolExecutionResult, ToolPolicy,
-    ToolPolicyPreset, ToolRateLimitExceededBehavior, WriteTool,
+    bash_profile_name, build_spec_from_command_template, builtin_agent_tool_names,
+    canonicalize_best_effort, command_available, evaluate_tool_approval_gate,
+    evaluate_tool_rate_limit_gate, evaluate_tool_rbac_gate, is_command_allowed,
+    is_session_candidate_path, leading_executable, os_sandbox_mode_name, redact_secrets,
+    resolve_sandbox_spec, truncate_bytes, AgentTool, BashCommandProfile, BashTool, EditTool,
+    OsSandboxMode, SessionsHistoryTool, SessionsListTool, SessionsSearchTool, SessionsSendTool,
+    SessionsStatsTool, ToolExecutionResult, ToolPolicy, ToolPolicyPreset,
+    ToolRateLimitExceededBehavior, WriteTool,
 };
 use tau_access::ApprovalAction;
 use tau_ai::Message;
@@ -54,6 +55,20 @@ fn unit_tool_policy_hardened_preset_applies_expected_configuration() {
         policy.tool_rate_limit_exceeded_behavior,
         ToolRateLimitExceededBehavior::Reject
     );
+}
+
+#[test]
+fn unit_builtin_agent_tool_name_registry_includes_session_tools() {
+    let names = builtin_agent_tool_names();
+    assert!(names.contains(&"read"));
+    assert!(names.contains(&"write"));
+    assert!(names.contains(&"edit"));
+    assert!(names.contains(&"sessions_list"));
+    assert!(names.contains(&"sessions_history"));
+    assert!(names.contains(&"sessions_search"));
+    assert!(names.contains(&"sessions_stats"));
+    assert!(names.contains(&"sessions_send"));
+    assert!(names.contains(&"bash"));
 }
 
 #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This index maps Tau documentation by audience and task.
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
 | Runtime contributor | [Startup DI Pipeline](guides/startup-di-pipeline.md) | 3-stage startup resolution: preflight gate, dependency/context composition, mode dispatch |
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
+| Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |
 | Multi-channel contributor | [Multi-channel Event Pipeline](guides/multi-channel-event-pipeline.md) | Inbound normalization, policy/pairing, routing, persistence, outbound retry paths |
 | Runtime maintainer | [Doc Density Scorecard](guides/doc-density-scorecard.md) | Baseline/targets for public API docs coverage and CI regression guard policy |
 | Roadmap operator | [Roadmap Execution Index](guides/roadmap-execution-index.md) | End-to-end mapping from `tasks/todo.md` items to milestones/issues and execution wave ordering |

--- a/docs/guides/tool-name-registry.md
+++ b/docs/guides/tool-name-registry.md
@@ -1,0 +1,45 @@
+# Tool Name Registry
+
+Date: 2026-02-14  
+Story: #1442  
+Task: #1443
+
+## Scope
+
+Tau reserves built-in tool names so dynamic registrations cannot shadow runtime behavior.
+
+Reserved agent tool names:
+
+- `read`
+- `write`
+- `edit`
+- `sessions_list`
+- `sessions_history`
+- `sessions_search`
+- `sessions_stats`
+- `sessions_send`
+- `bash`
+
+Reserved MCP tool names:
+
+- `tau.read`
+- `tau.write`
+- `tau.edit`
+- `tau.bash`
+- `tau.context.session`
+- `tau.context.skills`
+- `tau.context.channel-store`
+
+## Runtime behavior
+
+- Extension runtime registration denies any extension tool whose name is in the reserved agent tool registry.
+- MCP external tool discovery denies any tool whose raw external name matches a reserved MCP tool name.
+- MCP external tool discovery also denies duplicate fully-qualified external registrations (for example `external.mock.echo` reported twice).
+
+## Deterministic diagnostics
+
+Conflict errors/diagnostics include the exact reserved name so operators can remediate manifests/config quickly.
+
+- Extension diagnostics: `name conflicts with reserved built-in tool '<name>'`
+- MCP external discovery errors: `returned reserved built-in tool name '<name>'`
+

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -116,6 +116,7 @@ Use this area when adding a new integration channel or adjusting bridge behavior
 ### Tool policy and observability
 
 - `tools.rs`: built-in tool registration and tool policy primitives.
+- `tools.rs` reserved built-in tool registry is reused by extension runtime startup (`discover_extension_runtime_registrations`) to deny name-shadow conflicts.
 - `tool_policy_config.rs`: CLI/preset/env policy assembly.
 - `observability_loggers.rs`: telemetry and tool audit log subscribers.
 - `startup_policy.rs`: startup policy packaging and optional policy printing.


### PR DESCRIPTION
Closes #1442
Closes #1443

## Summary of behavior changes
- Added a canonical reserved built-in agent tool registry in `tau-tools` (`builtin_agent_tool_names`) including session tools (`sessions_*`) and core tools (`read/write/edit/bash`).
- Wired startup extension registration discovery to consume the reserved registry instead of relying on a partial hardcoded list in `tau-extensions`.
- Updated extension registration conflicts to emit deterministic diagnostics naming the reserved tool (for example: `reserved built-in tool 'read'`).
- Added reserved MCP built-in tool registry (`tau.*` + context provider tools) and fail-closed external MCP discovery checks for:
  - reserved built-in name collisions
  - duplicate fully-qualified external registrations
- Added/updated test coverage across `tau-tools`, `tau-extensions`, and `tau-coding-agent` startup/runtime wiring.
- Added operator docs for this behavior in `docs/guides/tool-name-registry.md` and indexed it in `docs/README.md`.

## Risks and compatibility notes
- Extension manifests that previously registered names colliding with built-in session tools (for example `sessions_list`) now fail registration deterministically.
- External MCP servers that report reserved built-in MCP names (for example `tau.read`) now fail discovery at startup.
- No behavior changes for valid non-conflicting extension and external MCP tool names.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-tools -p tau-extensions -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-tools unit_builtin_agent_tool_name_registry_includes_session_tools -- --test-threads=1`
- `cargo test -p tau-tools unit_reserved_builtin_mcp_tool_names_contains_catalog_entries -- --test-threads=1`
- `cargo test -p tau-tools regression_external_discovery_rejects_reserved_builtin_name -- --test-threads=1`
- `cargo test -p tau-tools regression_external_discovery_rejects_duplicate_qualified_names -- --test-threads=1`
- `cargo test -p tau-tools integration_external_discovery_and_call_via_line_jsonrpc_server -- --test-threads=1`
- `cargo test -p tau-extensions functional_discover_extension_runtime_registrations_collects_tools_and_commands -- --test-threads=1`
- `cargo test -p tau-extensions regression_discover_extension_runtime_registrations_blocks_builtin_name_conflicts -- --test-threads=1`
- `cargo test -p tau-extensions regression_discover_extension_runtime_registrations_blocks_sessions_builtin_conflicts -- --test-threads=1`
- `cargo test -p tau-coding-agent integration_extension_registered_tool_executes_in_prompt_loop -- --test-threads=1`
- Live run proof:
  - `cargo run -p tau-coding-agent -- --mcp-server --mcp-external-server-config <temp-config>` with external tool `tau.read`
  - observed deterministic failure: `Error: external mcp server 'mock' returned reserved built-in tool name 'tau.read'`
