### PR TITLE
Story 1.6: enforce protected identity/system paths in tool policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This index maps Tau documentation by audience and task.
 | Runtime contributor | [Startup DI Pipeline](guides/startup-di-pipeline.md) | 3-stage startup resolution: preflight gate, dependency/context composition, mode dispatch |
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
 | Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |
+| Runtime contributor | [Tool Policy Protected Paths](guides/tool-policy-protected-paths.md) | Protected identity/system file deny policy for write/edit with override controls and diagnostics |
 | Multi-channel contributor | [Multi-channel Event Pipeline](guides/multi-channel-event-pipeline.md) | Inbound normalization, policy/pairing, routing, persistence, outbound retry paths |
 | Runtime maintainer | [Doc Density Scorecard](guides/doc-density-scorecard.md) | Baseline/targets for public API docs coverage and CI regression guard policy |
 | Roadmap operator | [Roadmap Execution Index](guides/roadmap-execution-index.md) | End-to-end mapping from `tasks/todo.md` items to milestones/issues and execution wave ordering |

--- a/docs/guides/tool-policy-protected-paths.md
+++ b/docs/guides/tool-policy-protected-paths.md
@@ -1,0 +1,52 @@
+## Tool Policy Protected Paths
+
+Date: 2026-02-14  
+Story: #1440  
+Task: #1441
+
+### Scope
+
+Tool policy now enforces protected identity/system paths for file mutation tools (`write`, `edit`).
+
+Default protected paths (per allowed root):
+
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `.tau/rbac-policy.json`
+- `.tau/trust-roots.json`
+- `.tau/channel-policy.json`
+
+### Deny Contract
+
+Protected path mutation attempts fail with deterministic policy diagnostics:
+
+- `policy_rule: "protected_path"`
+- `decision: "deny"`
+- `reason_code: "protected_path_denied"`
+- `action: "tool:write"` or `action: "tool:edit"`
+- `path` and matched `protected_path`
+
+### Override Flow
+
+For controlled maintenance windows, operators can allow protected mutations:
+
+```bash
+export TAU_ALLOW_PROTECTED_PATH_MUTATIONS=1
+```
+
+Additional protected paths can be appended:
+
+```bash
+export TAU_PROTECTED_PATHS=\"/abs/path/one,/abs/path/two\"
+```
+
+### Operator Diagnostics
+
+`tool_policy_to_json` now includes:
+
+- `protected_paths`
+- `allow_protected_path_mutations`
+
+Use existing `--print-tool-policy` workflow to verify effective configuration.
+


### PR DESCRIPTION
Closes #1440
Closes #1441

## Summary of behavior changes
- Added protected path controls to `ToolPolicy`:
  - `protected_paths`
  - `allow_protected_path_mutations`
- Seeded default protected identity/system files (per allowed root):
  - `AGENTS.md`, `SOUL.md`, `USER.md`
  - `.tau/rbac-policy.json`, `.tau/trust-roots.json`, `.tau/channel-policy.json`
- Enforced fail-closed protected path denials in `write` and `edit` execution paths.
- Added deterministic denial payload contract:
  - `policy_rule=protected_path`
  - `reason_code=protected_path_denied`
  - includes `action`, `path`, `protected_path`, and operator hint.
- Extended tool policy JSON output to expose protected-path controls and values.
- Added operator override/config env controls in policy build flow:
  - `TAU_ALLOW_PROTECTED_PATH_MUTATIONS`
  - `TAU_PROTECTED_PATHS`
- Added MCP integration coverage proving protected-path denial through real `tools/call` flow.
- Added documentation:
  - `docs/guides/tool-policy-protected-paths.md`
  - docs index update in `docs/README.md`

## Risks and compatibility notes
- `write`/`edit` now deny mutations of protected identity/system files by default.
- Existing automation that writes to these files must explicitly opt into the override control.
- Non-protected file mutation behavior remains unchanged.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-tools --all-targets -- -D warnings`
- `cargo test -p tau-tools protected_path -- --test-threads=1`
- `cargo test -p tau-tools write_tool_creates_parent_directory -- --test-threads=1`
- `cargo test -p tau-tools edit_tool_replaces_single_match -- --test-threads=1`
- Live run proof:
  - launched MCP server entrypoint and submitted `tau.write` call targeting `AGENTS.md`
  - observed deny payload including `policy_rule=protected_path` and `reason_code=protected_path_denied`
