### PR TITLE
feat: fail-closed sandbox policy mode

### DIFF
--- a/crates/tau-cli/src/cli_args/gateway_daemon_flags.rs
+++ b/crates/tau-cli/src/cli_args/gateway_daemon_flags.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use clap::{ArgAction, Args};
 
 use crate::{
-    CliBashProfile, CliDaemonProfile, CliOsSandboxMode, CliSessionImportMode, CliToolPolicyPreset,
+    CliBashProfile, CliDaemonProfile, CliOsSandboxMode, CliOsSandboxPolicyMode,
+    CliSessionImportMode, CliToolPolicyPreset,
 };
 
 /// Gateway/daemon, Slack bridge, session, and tool-policy flags flattened into `Cli`.
@@ -567,6 +568,14 @@ pub struct CliGatewayDaemonFlags {
         help = "Optional sandbox launcher command template tokens. Supports placeholders: {shell}, {command}, {cwd}"
     )]
     pub os_sandbox_command: Vec<String>,
+
+    #[arg(
+        long = "os-sandbox-policy-mode",
+        env = "TAU_OS_SANDBOX_POLICY_MODE",
+        value_enum,
+        help = "Sandbox policy mode for bash tool: best-effort (allow unsandboxed fallback) or required (fail closed)"
+    )]
+    pub os_sandbox_policy_mode: Option<CliOsSandboxPolicyMode>,
 
     #[arg(
         long,

--- a/crates/tau-cli/src/cli_types.rs
+++ b/crates/tau-cli/src/cli_types.rs
@@ -22,6 +22,13 @@ pub enum CliOsSandboxMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Enumerates supported `CliOsSandboxPolicyMode` values.
+pub enum CliOsSandboxPolicyMode {
+    BestEffort,
+    Required,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 /// Enumerates supported `CliSessionImportMode` values.
 pub enum CliSessionImportMode {
     Merge,

--- a/crates/tau-coding-agent/src/runtime_loop.rs
+++ b/crates/tau-coding-agent/src/runtime_loop.rs
@@ -694,6 +694,10 @@ fn render_orchestrator_policy_inheritance_context(
         .get("os_sandbox_mode")
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| anyhow!("tool policy JSON missing string field 'os_sandbox_mode'"))?;
+    let os_sandbox_policy_mode = object
+        .get("os_sandbox_policy_mode")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("tool policy JSON missing string field 'os_sandbox_policy_mode'"))?;
     let bash_dry_run = object
         .get("bash_dry_run")
         .and_then(serde_json::Value::as_bool)
@@ -722,7 +726,7 @@ fn render_orchestrator_policy_inheritance_context(
         .ok_or_else(|| anyhow!("tool policy JSON missing array field 'allowed_commands'"))?;
 
     Ok(format!(
-        "schema_version={schema_version};preset={preset};bash_profile={bash_profile};os_sandbox_mode={os_sandbox_mode};bash_dry_run={bash_dry_run};enforce_regular_files={enforce_regular_files};max_command_length={max_command_length};max_command_output_bytes={max_command_output_bytes};allowed_roots={};allowed_commands={};extension_runtime_hooks_enabled={}",
+        "schema_version={schema_version};preset={preset};bash_profile={bash_profile};os_sandbox_mode={os_sandbox_mode};os_sandbox_policy_mode={os_sandbox_policy_mode};bash_dry_run={bash_dry_run};enforce_regular_files={enforce_regular_files};max_command_length={max_command_length};max_command_output_bytes={max_command_output_bytes};allowed_roots={};allowed_commands={};extension_runtime_hooks_enabled={}",
         allowed_roots.len(),
         allowed_commands.len(),
         extension_runtime_hooks.enabled,
@@ -1092,6 +1096,7 @@ mod tests {
             "preset": "balanced",
             "bash_profile": "balanced",
             "os_sandbox_mode": "off",
+            "os_sandbox_policy_mode": "best-effort",
             "bash_dry_run": false,
             "enforce_regular_files": true,
             "max_command_length": 4096,
@@ -1103,7 +1108,7 @@ mod tests {
             .expect("policy context should render");
         assert_eq!(
             context,
-            "schema_version=1;preset=balanced;bash_profile=balanced;os_sandbox_mode=off;bash_dry_run=false;enforce_regular_files=true;max_command_length=4096;max_command_output_bytes=16000;allowed_roots=1;allowed_commands=2;extension_runtime_hooks_enabled=true"
+            "schema_version=1;preset=balanced;bash_profile=balanced;os_sandbox_mode=off;os_sandbox_policy_mode=best-effort;bash_dry_run=false;enforce_regular_files=true;max_command_length=4096;max_command_output_bytes=16000;allowed_roots=1;allowed_commands=2;extension_runtime_hooks_enabled=true"
         );
     }
 

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -496,6 +496,7 @@ pub(crate) fn test_cli() -> Cli {
             telemetry_log: None,
             os_sandbox_mode: CliOsSandboxMode::Off,
             os_sandbox_command: vec![],
+            os_sandbox_policy_mode: None,
             enforce_regular_files: true,
         },
         deployment_status_inspect: false,

--- a/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup/startup_preflight_and_policy.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup/startup_preflight_and_policy.rs
@@ -1547,6 +1547,10 @@ fn build_tool_policy_includes_cwd_and_custom_root() {
     assert_eq!(policy.max_command_length, 4096);
     assert!(policy.allow_command_newlines);
     assert_eq!(policy.os_sandbox_mode, OsSandboxMode::Off);
+    assert_eq!(
+        tool_policy_to_json(&policy)["os_sandbox_policy_mode"],
+        "best-effort"
+    );
     assert!(policy.os_sandbox_command.is_empty());
     assert!(policy.enforce_regular_files);
     assert_eq!(policy.policy_preset, ToolPolicyPreset::Balanced);
@@ -1566,10 +1570,11 @@ fn unit_tool_policy_to_json_includes_key_limits_and_modes() {
 
     let policy = build_tool_policy(&cli).expect("policy should build");
     let payload = tool_policy_to_json(&policy);
-    assert_eq!(payload["schema_version"], 3);
+    assert_eq!(payload["schema_version"], 5);
     assert_eq!(payload["preset"], "balanced");
     assert_eq!(payload["bash_profile"], "strict");
     assert_eq!(payload["os_sandbox_mode"], "auto");
+    assert_eq!(payload["os_sandbox_policy_mode"], "best-effort");
     assert_eq!(payload["max_file_write_bytes"], 4096);
     assert_eq!(payload["enforce_regular_files"], true);
     assert_eq!(payload["bash_dry_run"], false);
@@ -1603,6 +1608,10 @@ fn functional_build_tool_policy_hardened_preset_applies_hardened_defaults() {
     assert_eq!(policy.max_command_length, 1_024);
     assert_eq!(policy.max_command_output_bytes, 4_000);
     assert_eq!(policy.os_sandbox_mode, OsSandboxMode::Force);
+    assert_eq!(
+        tool_policy_to_json(&policy)["os_sandbox_policy_mode"],
+        "required"
+    );
     assert_eq!(policy.tool_rate_limit_max_requests, 30);
     assert_eq!(policy.tool_rate_limit_window_ms, 60_000);
 }

--- a/crates/tau-coding-agent/src/tests/cli_validation.rs
+++ b/crates/tau-coding-agent/src/tests/cli_validation.rs
@@ -6,7 +6,8 @@ use tau_cli::validation::validate_project_index_cli;
 use tau_cli::{
     CliCredentialStoreEncryptionMode, CliDaemonProfile, CliDeploymentWasmRuntimeProfile,
     CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile, CliMultiChannelLiveConnectorMode,
-    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliProviderAuthMode,
+    CliMultiChannelOutboundMode, CliMultiChannelTransport, CliOsSandboxPolicyMode,
+    CliProviderAuthMode,
 };
 
 use super::{parse_cli_with_stack, try_parse_cli_with_stack};
@@ -147,6 +148,21 @@ fn unit_cli_provider_subscription_strict_defaults_to_disabled() {
 fn functional_cli_provider_subscription_strict_accepts_overrides() {
     let cli = parse_cli_with_stack(["tau-rs", "--provider-subscription-strict=true"]);
     assert!(cli.provider_subscription_strict);
+}
+
+#[test]
+fn unit_cli_os_sandbox_policy_mode_defaults_to_none() {
+    let cli = parse_cli_with_stack(["tau-rs"]);
+    assert_eq!(cli.os_sandbox_policy_mode, None);
+}
+
+#[test]
+fn functional_cli_os_sandbox_policy_mode_accepts_required_override() {
+    let cli = parse_cli_with_stack(["tau-rs", "--os-sandbox-policy-mode", "required"]);
+    assert_eq!(
+        cli.os_sandbox_policy_mode,
+        Some(CliOsSandboxPolicyMode::Required)
+    );
 }
 
 #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This index maps Tau documentation by audience and task.
 | Runtime contributor | [Startup DI Pipeline](guides/startup-di-pipeline.md) | 3-stage startup resolution: preflight gate, dependency/context composition, mode dispatch |
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
 | Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |
+| Runtime contributor | [Tool Policy Sandbox Mode](guides/tool-policy-sandbox-mode.md) | Fail-closed sandbox posture (`best-effort` vs `required`), preset defaults, and operator diagnostics |
 | Runtime contributor | [Tool Policy Protected Paths](guides/tool-policy-protected-paths.md) | Protected identity/system file deny policy for write/edit with override controls and diagnostics |
 | Multi-channel contributor | [Multi-channel Event Pipeline](guides/multi-channel-event-pipeline.md) | Inbound normalization, policy/pairing, routing, persistence, outbound retry paths |
 | Runtime maintainer | [Doc Density Scorecard](guides/doc-density-scorecard.md) | Baseline/targets for public API docs coverage and CI regression guard policy |

--- a/docs/guides/tool-policy-sandbox-mode.md
+++ b/docs/guides/tool-policy-sandbox-mode.md
@@ -1,0 +1,73 @@
+## Tool Policy Sandbox Mode
+
+Date: 2026-02-14  
+Story: #1436  
+Task: #1437
+
+### Scope
+
+Tool policy now supports explicit sandbox fallback posture for bash execution:
+
+- `best-effort`: allow unsandboxed fallback when no launcher/template is available.
+- `required`: fail closed if execution would run unsandboxed.
+
+This mode is independent from sandbox launcher selection (`off`, `auto`, `force`).
+
+### Preset Defaults
+
+| Preset      | `os_sandbox_mode` | `os_sandbox_policy_mode` |
+|-------------|-------------------|--------------------------|
+| permissive  | off               | best-effort              |
+| balanced    | off               | best-effort              |
+| strict      | auto              | required                 |
+| hardened    | force             | required                 |
+
+### CLI and JSON Surfaces
+
+Set sandbox posture explicitly:
+
+```bash
+--os-sandbox-policy-mode best-effort|required
+```
+
+Environment override:
+
+```bash
+TAU_OS_SANDBOX_POLICY_MODE=best-effort|required
+```
+
+`--print-tool-policy` output now includes:
+
+- `os_sandbox_policy_mode`
+
+Runtime/orchestrator policy context now includes:
+
+- `os_sandbox_policy_mode=<value>`
+
+### Fail-Closed Error Contract
+
+When sandbox execution is denied, bash tool payloads include deterministic diagnostics:
+
+- `policy_rule: "os_sandbox_mode"`
+- `reason_code`
+  - `sandbox_policy_required` when `required` mode would fall back unsandboxed
+  - `sandbox_launcher_unavailable` when `force` mode cannot resolve launcher
+- `sandbox_mode`
+- `sandbox_policy_mode`
+- `error`
+
+### Runbook
+
+1. Verify effective posture:
+
+```bash
+cargo run -p tau-coding-agent -- --print-tool-policy --tool-policy-preset strict
+```
+
+2. Force fail-closed behavior on hosts without an OS sandbox launcher/template:
+
+```bash
+cargo run -p tau-coding-agent -- --print-tool-policy --os-sandbox-mode off --os-sandbox-policy-mode required
+```
+
+3. If rollout safety requires strict isolation guarantees, use `strict` or `hardened` preset and keep `os_sandbox_policy_mode=required`.


### PR DESCRIPTION
## Summary
- add explicit sandbox fallback posture to tool policy (`best-effort` vs `required`)
- expose new CLI/env control: `--os-sandbox-policy-mode` / `TAU_OS_SANDBOX_POLICY_MODE`
- make `strict` and `hardened` presets fail closed by default (`os_sandbox_policy_mode=required`)
- update Bash execution deny payloads with deterministic sandbox reason-codes and policy mode fields
- export `os_sandbox_policy_mode` through policy JSON and orchestrator inheritance diagnostics
- add coverage for CLI parse/defaults, policy mapping, runtime execution payloads, and regression invariants
- document operational runbook in `docs/guides/tool-policy-sandbox-mode.md`

## Behavior Changes
- `ToolPolicy` now includes `os_sandbox_policy_mode`.
- Bash tool denies execution when mode is `required` and no sandbox launcher/template resolves (`reason_code=sandbox_policy_required`).
- Force mode launcher failures report deterministic `reason_code=sandbox_launcher_unavailable`.
- Policy payloads now include `sandbox_policy_mode` and policy JSON includes `os_sandbox_policy_mode`.

## Risks and Compatibility
- tool policy JSON schema version increments from `4` to `5` due new field addition
- strict/hardened runtime posture is now explicitly fail-closed by default, which can block previously allowed unsandboxed fallback on hosts missing launchers
- compatibility preserved for permissive/balanced defaults (`best-effort`)

## Validation
- `cargo fmt --all`
- `cargo clippy -p tau-cli -p tau-tools -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-tools`
- `cargo test -p tau-coding-agent startup_preflight_and_policy`
- `cargo test -p tau-coding-agent runtime_loop::tests::unit_render_orchestrator_policy_inheritance_context_is_deterministic`
- `cargo test -p tau-coding-agent os_sandbox_policy_mode`
- live scripted proof: `cargo test -p tau-tools regression_bash_tool_required_policy_mode_fails_closed_with_reason_code -- --nocapture`

Closes #1436
Closes #1437
