### PR TITLE
feat: add session undo/redo runtime commands and agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Implemented now:
 - Multi-provider model routing (`openai/*`, `anthropic/*`, `google/*`)
 - OAuth/session login backend routing for Codex, Claude Code, and Gemini CLI flows
 - Interactive prompt mode, one-shot mode, and plan-first orchestration mode
-- Persistent JSONL sessions with branch/resume/repair/export/import tooling
+- Persistent JSONL sessions with branch/undo/redo/resume/repair/export/import tooling
 - Deterministic project index build/query/inspect workflow for local code search
 - Built-in filesystem and shell tools
 - Transport bridges for GitHub Issues and Slack Socket Mode

--- a/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
@@ -1361,6 +1361,8 @@ fn functional_render_help_overview_lists_known_commands() {
     assert!(help.contains("/integration-auth <set|status|rotate|revoke> ..."));
     assert!(help.contains("/profile <save|load|list|show|delete> ..."));
     assert!(help.contains("/branch <id>"));
+    assert!(help.contains("/undo"));
+    assert!(help.contains("/redo"));
     assert!(help.contains("/branch-alias <set|list|use> ..."));
     assert!(help.contains("/session-bookmark <set|list|use|delete> ..."));
     assert!(help.contains("/quit"));
@@ -1372,6 +1374,14 @@ fn functional_render_command_help_supports_branch_topic_without_slash() {
     assert!(help.contains("command: /branch"));
     assert!(help.contains("usage: /branch <id>"));
     assert!(help.contains("example: /branch 12"));
+}
+
+#[test]
+fn functional_render_command_help_supports_undo_topic_without_slash() {
+    let help = render_command_help("undo").expect("render help");
+    assert!(help.contains("command: /undo"));
+    assert!(help.contains("usage: /undo"));
+    assert!(help.contains("example: /undo"));
 }
 
 #[test]

--- a/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs
@@ -2138,7 +2138,7 @@ async fn integration_agent_write_policy_blocks_oversized_content() {
 }
 
 #[test]
-fn branch_and_resume_commands_reload_agent_messages() {
+fn branch_undo_redo_and_resume_commands_reload_agent_messages() {
     let temp = tempdir().expect("tempdir");
     let path = temp.path().join("session.jsonl");
 
@@ -2180,6 +2180,24 @@ fn branch_and_resume_commands_reload_agent_messages() {
         &tool_policy_json,
     )
     .expect("branch command should succeed");
+    assert_eq!(action, CommandAction::Continue);
+    assert_eq!(
+        runtime.as_ref().and_then(|runtime| runtime.active_head),
+        Some(branch_target)
+    );
+    assert_eq!(agent.messages().len(), 3);
+
+    let action = handle_command("/undo", &mut agent, &mut runtime, &tool_policy_json)
+        .expect("undo command should succeed");
+    assert_eq!(action, CommandAction::Continue);
+    assert_eq!(
+        runtime.as_ref().and_then(|runtime| runtime.active_head),
+        Some(head)
+    );
+    assert_eq!(agent.messages().len(), 5);
+
+    let action = handle_command("/redo", &mut agent, &mut runtime, &tool_policy_json)
+        .expect("redo command should succeed");
     assert_eq!(action, CommandAction::Continue);
     assert_eq!(
         runtime.as_ref().and_then(|runtime| runtime.active_head),

--- a/crates/tau-ops/src/command_catalog.rs
+++ b/crates/tau-ops/src/command_catalog.rs
@@ -328,6 +328,22 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         example: "/branch 12",
     },
     CommandSpec {
+        name: "/undo",
+        usage: "/undo",
+        description: "Rewind active session head to previous navigation target",
+        details:
+            "Uses persisted navigation history and skips stale targets removed by repair/compact operations.",
+        example: "/undo",
+    },
+    CommandSpec {
+        name: "/redo",
+        usage: "/redo",
+        description: "Re-apply one previously undone session head navigation step",
+        details:
+            "Available after a successful undo. Uses persisted navigation history and reports empty-stack diagnostics when unavailable.",
+        example: "/redo",
+    },
+    CommandSpec {
         name: "/resume",
         usage: "/resume",
         description: "Jump back to the latest session head",
@@ -399,6 +415,8 @@ pub const COMMAND_NAMES: &[&str] = &[
     "/branch-alias",
     "/session-bookmark",
     "/branch",
+    "/undo",
+    "/redo",
     "/resume",
     "/session-repair",
     "/session-compact",
@@ -430,6 +448,8 @@ mod tests {
     fn unit_command_catalog_contains_expected_entries() {
         assert!(COMMAND_NAMES.contains(&"/help"));
         assert!(COMMAND_NAMES.contains(&"/canvas"));
+        assert!(COMMAND_NAMES.contains(&"/undo"));
+        assert!(COMMAND_NAMES.contains(&"/redo"));
         assert!(COMMAND_NAMES.contains(&"/exit"));
         assert_eq!(COMMAND_SPECS[0].name, "/help");
     }
@@ -439,6 +459,7 @@ mod tests {
         let rendered = render_help_overview();
         assert!(rendered.contains("/help"));
         assert!(rendered.contains("/session"));
+        assert!(rendered.contains("/undo"));
         assert!(rendered.contains("/qa-loop"));
     }
 


### PR DESCRIPTION
## Summary
- add persistent session navigation state (`*.navigation.json`) with undo/redo stacks shared across runtime commands and tools
- add `/undo` and `/redo` runtime commands, wired into command dispatch + lineage reload behavior
- add `undo` and `redo` built-in agent tools with structured reason codes (`session_undo_*`, `session_redo_*`) and navigation diagnostics
- wire existing head-switching session flows (`/branch`, `/resume`, merge/import/compact/repair, alias/bookmark use) through the same navigation transition primitive
- update command catalog/help entries and README session capability scope
- add unit/functional/integration/regression coverage across `tau-session`, `tau-tools`, `tau-ops`, and `tau-coding-agent`

## Risks and Compatibility
- `/resume` output now includes navigation diagnostics fields (`reason_code`, undo/redo depth)
- a new sidecar file (`*.navigation.json`) is written next to session files to persist navigation history
- undo/redo history is pruned when stale heads are removed by compact/repair/import flows

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-session -p tau-tools -p tau-ops -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-session session_runtime_commands`
- `cargo test -p tau-tools undo_tool`
- `cargo test -p tau-tools redo_tool`
- `cargo test -p tau-tools unit_builtin_agent_tool_name_registry_includes_session_tools`
- `cargo test -p tau-ops command_catalog`
- `cargo test -p tau-coding-agent branch_undo_redo_and_resume_commands_reload_agent_messages`
- `cargo test -p tau-coding-agent functional_render_command_help_supports_undo_topic_without_slash`
- `cargo test -p tau-coding-agent functional_render_help_overview_lists_known_commands`

Closes #1456
Refs #1457
