### PR TITLE
feat(memory): real embedding integration and migration telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,8 @@ name = "tau-memory"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "httpmock",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tau-contract",

--- a/crates/tau-memory/Cargo.toml
+++ b/crates/tau-memory/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
@@ -13,4 +14,5 @@ serde_json = { workspace = true }
 tau-contract = { path = "../tau-contract" }
 
 [dev-dependencies]
+httpmock = "0.8"
 tempfile = "3.25"

--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -17,6 +17,25 @@ User-facing memory tools are available in runtime:
 
 These tools persist under `--memory-state-dir` (default `.tau/memory`).
 
+Optional real-embedding configuration (runtime env):
+
+- `TAU_MEMORY_EMBEDDING_PROVIDER` (`openai` or `openai-compatible`)
+- `TAU_MEMORY_EMBEDDING_MODEL` (for example `text-embedding-3-small`)
+- `TAU_MEMORY_EMBEDDING_API_BASE` (defaults to `--api-base` when provider is set)
+- `TAU_MEMORY_EMBEDDING_API_KEY` (falls back to `OPENAI_API_KEY`/`TAU_API_KEY`)
+- `TAU_MEMORY_EMBEDDING_TIMEOUT_MS` (default `10000`)
+- `TAU_MEMORY_ENABLE_EMBEDDING_MIGRATION` (default `true`)
+- `TAU_MEMORY_BENCHMARK_AGAINST_HASH` (default `false`)
+
+`memory_search` now reports embedding diagnostics:
+
+- `embedding_backend`
+- `embedding_reason_code`
+- `migrated_entries`
+- `query_embedding_latency_ms`
+- `ranking_latency_ms`
+- `baseline_hash_overlap` (when hash benchmark is enabled)
+
 ## Health and observability signals
 
 Primary status signal:
@@ -69,6 +88,8 @@ Primary state files:
   Action: verify `.tau/memory/state.json` exists and contains a `health` object.
 - Symptom: runtime recall quality regresses.
   Action: run `cargo test -p tau-agent-core memory -- --test-threads=1` and inspect embedding/retrieval test failures.
+- Symptom: `memory_search` reports `embedding_reason_code=memory_embedding_provider_failed`.
+  Action: verify provider API base/key/model, then disable migration (`TAU_MEMORY_ENABLE_EMBEDDING_MIGRATION=false`) during incident mitigation.
 - Symptom: health state `failing` (`failure_streak >= 3`).
   Action: treat as rollout gate failure; pause promotion and investigate repeated runtime failures in active memory producers.
 - Symptom: non-zero `queue_depth`.


### PR DESCRIPTION
Closes #1458
Refs #1459

## Summary of behavior changes
- Added real embedding provider integration to `tau-memory` (OpenAI-compatible `/embeddings`).
- Persisted embedding metadata/vector in runtime memory records:
  - `embedding_source`, `embedding_model`, `embedding_vector`, `embedding_reason_code`.
- Added search-time migration from hash vectors to provider vectors (toggleable).
- Added benchmark mode to compare current ranking against hash-baseline overlap.
- Added structured search diagnostics:
  - `embedding_backend`, `embedding_reason_code`, `migrated_entries`,
  - `query_embedding_latency_ms`, `ranking_latency_ms`, `baseline_hash_overlap`.
- Wired embedding config/toggles through tool policy/runtime (`tau-tools`) via env:
  - `TAU_MEMORY_EMBEDDING_PROVIDER`
  - `TAU_MEMORY_EMBEDDING_MODEL`
  - `TAU_MEMORY_EMBEDDING_API_BASE`
  - `TAU_MEMORY_EMBEDDING_API_KEY`
  - `TAU_MEMORY_EMBEDDING_TIMEOUT_MS`
  - `TAU_MEMORY_ENABLE_EMBEDDING_MIGRATION`
  - `TAU_MEMORY_BENCHMARK_AGAINST_HASH`
- Updated memory tool outputs (`memory_write`, `memory_read`, `memory_search`) to include embedding diagnostics.
- Updated runbook docs: `docs/guides/memory-ops.md`.

## Risks and compatibility notes
- Backward compatibility preserved for existing `entries.jsonl`: newly added record fields use serde defaults.
- Provider misconfiguration/outage falls back to deterministic hash embeddings, but `embedding_reason_code` reports fallback reason.
- Search responses now include additional diagnostics fields; existing consumers should continue to work because prior keys are unchanged.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-memory -p tau-tools --all-targets -- -D warnings`
- `cargo test -p tau-memory`
- `cargo test -p tau-tools memory`
- `cargo test -p tau-tools tool_policy_config::tests`
