### PR TITLE
Routine scheduling: persist execution history and expose diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,6 +3165,7 @@ dependencies = [
  "tau-ai",
  "tau-cli",
  "tau-core",
+ "tau-events",
  "tau-multi-channel",
  "tau-release-channel",
  "tau-runtime",

--- a/crates/tau-cli/src/cli_args.rs
+++ b/crates/tau-cli/src/cli_args.rs
@@ -2276,7 +2276,7 @@ pub struct Cli {
         long = "events-state-path",
         env = "TAU_EVENTS_STATE_PATH",
         default_value = ".tau/events/state.json",
-        help = "Persistent scheduler state path for periodic/debounce tracking"
+        help = "Persistent scheduler state path for periodic/debounce tracking and execution history"
     )]
     pub events_state_path: PathBuf,
 

--- a/crates/tau-events/src/events_cli_commands.rs
+++ b/crates/tau-events/src/events_cli_commands.rs
@@ -188,7 +188,7 @@ pub fn execute_events_dry_run_command(cli: &Cli) -> Result<()> {
 
 fn render_events_inspect_report(report: &EventsInspectReport) -> String {
     format!(
-        "events inspect: events_dir={} state_path={} now_unix_ms={} discovered_events={} malformed_events={} enabled_events={} disabled_events={} due_now_events={} queued_now_events={} not_due_events={} stale_immediate_events={} due_eval_failed_events={} schedule_immediate_events={} schedule_at_events={} schedule_periodic_events={} periodic_with_last_run_state={} periodic_missing_last_run_state={} queue_limit={} stale_immediate_max_age_seconds={}",
+        "events inspect: events_dir={} state_path={} now_unix_ms={} discovered_events={} malformed_events={} enabled_events={} disabled_events={} due_now_events={} queued_now_events={} not_due_events={} stale_immediate_events={} due_eval_failed_events={} schedule_immediate_events={} schedule_at_events={} schedule_periodic_events={} periodic_with_last_run_state={} periodic_missing_last_run_state={} execution_history_entries={} execution_history_limit={} executed_history_entries={} failed_history_entries={} skipped_history_entries={} last_execution_unix_ms={} last_execution_reason_code={} queue_limit={} stale_immediate_max_age_seconds={}",
         report.events_dir,
         report.state_path,
         report.now_unix_ms,
@@ -206,6 +206,20 @@ fn render_events_inspect_report(report: &EventsInspectReport) -> String {
         report.schedule_periodic_events,
         report.periodic_with_last_run_state,
         report.periodic_missing_last_run_state,
+        report.execution_history_entries,
+        report.execution_history_limit,
+        report.executed_history_entries,
+        report.failed_history_entries,
+        report.skipped_history_entries,
+        report
+            .last_execution_unix_ms
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        report
+            .last_execution_reason_code
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("none"),
         report.queue_limit,
         report.stale_immediate_max_age_seconds,
     )

--- a/crates/tau-gateway/src/gateway_openresponses.rs
+++ b/crates/tau-gateway/src/gateway_openresponses.rs
@@ -76,6 +76,8 @@ const DASHBOARD_QUEUE_TIMELINE_ENDPOINT: &str = "/dashboard/queue-timeline";
 const DASHBOARD_ALERTS_ENDPOINT: &str = "/dashboard/alerts";
 const DASHBOARD_ACTIONS_ENDPOINT: &str = "/dashboard/actions";
 const DASHBOARD_STREAM_ENDPOINT: &str = "/dashboard/stream";
+const GATEWAY_EVENTS_INSPECT_QUEUE_LIMIT: usize = 64;
+const GATEWAY_EVENTS_STALE_IMMEDIATE_MAX_AGE_SECONDS: u64 = 86_400;
 const DEFAULT_SESSION_KEY: &str = "default";
 const INPUT_BODY_SIZE_MULTIPLIER: usize = 8;
 const GATEWAY_WS_HEARTBEAT_REQUEST_ID: &str = "gateway-heartbeat";
@@ -299,6 +301,97 @@ struct GatewayMultiChannelConnectorsStateFile {
     >,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct GatewayEventsStatusReport {
+    state_present: bool,
+    events_dir: String,
+    state_path: String,
+    health_state: String,
+    rollout_gate: String,
+    reason_code: String,
+    health_reason: String,
+    discovered_events: usize,
+    enabled_events: usize,
+    due_now_events: usize,
+    queued_now_events: usize,
+    not_due_events: usize,
+    stale_immediate_events: usize,
+    malformed_events: usize,
+    due_eval_failed_events: usize,
+    execution_history_entries: usize,
+    executed_history_entries: usize,
+    failed_history_entries: usize,
+    skipped_history_entries: usize,
+    last_execution_unix_ms: Option<u64>,
+    last_execution_reason_code: Option<String>,
+    diagnostics: Vec<String>,
+}
+
+impl Default for GatewayEventsStatusReport {
+    fn default() -> Self {
+        Self {
+            state_present: false,
+            events_dir: String::new(),
+            state_path: String::new(),
+            health_state: "unknown".to_string(),
+            rollout_gate: "hold".to_string(),
+            reason_code: "events_status_unavailable".to_string(),
+            health_reason: "events scheduler status is unavailable".to_string(),
+            discovered_events: 0,
+            enabled_events: 0,
+            due_now_events: 0,
+            queued_now_events: 0,
+            not_due_events: 0,
+            stale_immediate_events: 0,
+            malformed_events: 0,
+            due_eval_failed_events: 0,
+            execution_history_entries: 0,
+            executed_history_entries: 0,
+            failed_history_entries: 0,
+            skipped_history_entries: 0,
+            last_execution_unix_ms: None,
+            last_execution_reason_code: None,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GatewayEventDefinition {
+    id: String,
+    channel: String,
+    schedule: GatewayEventSchedule,
+    #[serde(default = "default_gateway_event_enabled")]
+    enabled: bool,
+    #[serde(default)]
+    created_unix_ms: Option<u64>,
+}
+
+fn default_gateway_event_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum GatewayEventSchedule {
+    Immediate,
+    At { at_unix_ms: u64 },
+    Periodic { cron: String, timezone: String },
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct GatewayEventsStateFile {
+    #[serde(default)]
+    recent_executions: Vec<GatewayEventExecutionRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GatewayEventExecutionRecord {
+    timestamp_unix_ms: u64,
+    outcome: String,
+    reason_code: String,
+}
+
 pub async fn run_gateway_openresponses_server(
     config: GatewayOpenResponsesServerConfig,
 ) -> Result<()> {
@@ -406,6 +499,7 @@ async fn handle_gateway_status(
             }
         };
     let multi_channel_report = collect_gateway_multi_channel_status_report(&state.config.state_dir);
+    let events_report = collect_gateway_events_status_report(&state.config.state_dir);
     let dashboard_snapshot = collect_gateway_dashboard_snapshot(&state.config.state_dir);
     let runtime_heartbeat = inspect_runtime_heartbeat(&state.config.runtime_heartbeat.state_path);
 
@@ -415,6 +509,7 @@ async fn handle_gateway_status(
             "service": service_report,
             "auth": collect_gateway_auth_status_report(&state),
             "multi_channel": multi_channel_report,
+            "events": events_report,
             "training": dashboard_snapshot.training,
             "runtime_heartbeat": runtime_heartbeat,
             "gateway": {
@@ -437,6 +532,242 @@ async fn handle_gateway_status(
         })),
     )
         .into_response()
+}
+
+fn collect_gateway_events_status_report(gateway_state_dir: &Path) -> GatewayEventsStatusReport {
+    let tau_root = gateway_state_dir.parent().unwrap_or(gateway_state_dir);
+    let events_dir = tau_root.join("events");
+    let state_path = events_dir.join("state.json");
+    let events_dir_exists = events_dir.is_dir();
+    let state_present = state_path.is_file();
+
+    if !events_dir_exists && !state_present {
+        return GatewayEventsStatusReport {
+            state_present: false,
+            events_dir: events_dir.display().to_string(),
+            state_path: state_path.display().to_string(),
+            health_state: "healthy".to_string(),
+            rollout_gate: "pass".to_string(),
+            reason_code: "events_not_configured".to_string(),
+            health_reason: "events scheduler is not configured".to_string(),
+            diagnostics: vec![
+                "create event definitions under events_dir to enable routine scheduling"
+                    .to_string(),
+            ],
+            ..GatewayEventsStatusReport::default()
+        };
+    }
+
+    let state = if state_present {
+        match std::fs::read_to_string(&state_path) {
+            Ok(payload) => match serde_json::from_str::<GatewayEventsStateFile>(&payload) {
+                Ok(parsed) => Some(parsed),
+                Err(error) => {
+                    return GatewayEventsStatusReport {
+                        state_present,
+                        events_dir: events_dir.display().to_string(),
+                        state_path: state_path.display().to_string(),
+                        health_state: "failing".to_string(),
+                        rollout_gate: "hold".to_string(),
+                        reason_code: "events_state_parse_failed".to_string(),
+                        health_reason: "failed to parse events state payload".to_string(),
+                        diagnostics: vec![error.to_string()],
+                        ..GatewayEventsStatusReport::default()
+                    };
+                }
+            },
+            Err(error) => {
+                return GatewayEventsStatusReport {
+                    state_present,
+                    events_dir: events_dir.display().to_string(),
+                    state_path: state_path.display().to_string(),
+                    health_state: "failing".to_string(),
+                    rollout_gate: "hold".to_string(),
+                    reason_code: "events_state_read_failed".to_string(),
+                    health_reason: "failed to read events state payload".to_string(),
+                    diagnostics: vec![error.to_string()],
+                    ..GatewayEventsStatusReport::default()
+                };
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut discovered_events = 0usize;
+    let mut enabled_events = 0usize;
+    let mut due_now_events = 0usize;
+    let mut not_due_events = 0usize;
+    let mut stale_immediate_events = 0usize;
+    let mut malformed_events = 0usize;
+    let due_eval_failed_events = 0usize;
+    let now_unix_ms = current_unix_timestamp_ms();
+
+    if events_dir_exists {
+        let entries = match std::fs::read_dir(&events_dir) {
+            Ok(entries) => entries,
+            Err(error) => {
+                return GatewayEventsStatusReport {
+                    state_present,
+                    events_dir: events_dir.display().to_string(),
+                    state_path: state_path.display().to_string(),
+                    health_state: "failing".to_string(),
+                    rollout_gate: "hold".to_string(),
+                    reason_code: "events_dir_read_failed".to_string(),
+                    health_reason: "failed to read events definitions directory".to_string(),
+                    diagnostics: vec![error.to_string()],
+                    ..GatewayEventsStatusReport::default()
+                };
+            }
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(value) => value,
+                Err(_) => {
+                    malformed_events = malformed_events.saturating_add(1);
+                    continue;
+                }
+            };
+            let path = entry.path();
+            if path == state_path {
+                continue;
+            }
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let payload = match std::fs::read_to_string(&path) {
+                Ok(payload) => payload,
+                Err(_) => {
+                    malformed_events = malformed_events.saturating_add(1);
+                    continue;
+                }
+            };
+            let definition = match serde_json::from_str::<GatewayEventDefinition>(&payload) {
+                Ok(definition) => definition,
+                Err(_) => {
+                    malformed_events = malformed_events.saturating_add(1);
+                    continue;
+                }
+            };
+            let _ = (&definition.id, &definition.channel);
+            discovered_events = discovered_events.saturating_add(1);
+            if definition.enabled {
+                enabled_events = enabled_events.saturating_add(1);
+            } else {
+                not_due_events = not_due_events.saturating_add(1);
+                continue;
+            }
+
+            match definition.schedule {
+                GatewayEventSchedule::Immediate => {
+                    let created = definition.created_unix_ms.unwrap_or(now_unix_ms);
+                    let max_age_ms =
+                        GATEWAY_EVENTS_STALE_IMMEDIATE_MAX_AGE_SECONDS.saturating_mul(1_000);
+                    if GATEWAY_EVENTS_STALE_IMMEDIATE_MAX_AGE_SECONDS > 0
+                        && now_unix_ms.saturating_sub(created) > max_age_ms
+                    {
+                        stale_immediate_events = stale_immediate_events.saturating_add(1);
+                    } else {
+                        due_now_events = due_now_events.saturating_add(1);
+                    }
+                }
+                GatewayEventSchedule::At { at_unix_ms } => {
+                    if now_unix_ms >= at_unix_ms {
+                        due_now_events = due_now_events.saturating_add(1);
+                    } else {
+                        not_due_events = not_due_events.saturating_add(1);
+                    }
+                }
+                GatewayEventSchedule::Periodic { cron, timezone } => {
+                    let _ = (cron, timezone);
+                    not_due_events = not_due_events.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    let queued_now_events = due_now_events.min(GATEWAY_EVENTS_INSPECT_QUEUE_LIMIT.max(1));
+    let executions = state
+        .as_ref()
+        .map(|value| value.recent_executions.clone())
+        .unwrap_or_default();
+    let execution_history_entries = executions.len();
+    let executed_history_entries = executions
+        .iter()
+        .filter(|entry| entry.outcome == "executed")
+        .count();
+    let failed_history_entries = executions
+        .iter()
+        .filter(|entry| entry.outcome == "failed")
+        .count();
+    let skipped_history_entries = executions
+        .iter()
+        .filter(|entry| entry.outcome == "skipped")
+        .count();
+    let last_execution_unix_ms = executions.last().map(|entry| entry.timestamp_unix_ms);
+    let last_execution_reason_code = executions.last().map(|entry| entry.reason_code.clone());
+
+    let mut health_state = "healthy".to_string();
+    let mut rollout_gate = "pass".to_string();
+    let mut reason_code = "events_ready".to_string();
+    let mut health_reason = "events scheduler diagnostics are healthy".to_string();
+    let mut diagnostics = Vec::new();
+
+    if discovered_events == 0 {
+        reason_code = "events_none_discovered".to_string();
+        health_reason = "events directory is configured but contains no definitions".to_string();
+        diagnostics.push("add event definition files to enable scheduled routines".to_string());
+    }
+    if malformed_events > 0 {
+        health_state = "degraded".to_string();
+        rollout_gate = "hold".to_string();
+        reason_code = "events_malformed_definitions".to_string();
+        health_reason = format!(
+            "events inspect found {} malformed definition files",
+            malformed_events
+        );
+        diagnostics
+            .push("run --events-validate to repair malformed event definition files".to_string());
+    }
+    if failed_history_entries > 0 {
+        health_state = "degraded".to_string();
+        rollout_gate = "hold".to_string();
+        reason_code = "events_recent_failures".to_string();
+        health_reason = format!(
+            "events execution history includes {} failed runs",
+            failed_history_entries
+        );
+        diagnostics.push(
+            "inspect channel-store logs and recent execution history for failing routines"
+                .to_string(),
+        );
+    }
+
+    GatewayEventsStatusReport {
+        state_present,
+        events_dir: events_dir.display().to_string(),
+        state_path: state_path.display().to_string(),
+        health_state,
+        rollout_gate,
+        reason_code,
+        health_reason,
+        discovered_events,
+        enabled_events,
+        due_now_events,
+        queued_now_events,
+        not_due_events,
+        stale_immediate_events,
+        malformed_events,
+        due_eval_failed_events,
+        execution_history_entries,
+        executed_history_entries,
+        failed_history_entries,
+        skipped_history_entries,
+        last_execution_unix_ms,
+        last_execution_reason_code,
+        diagnostics,
+    }
 }
 
 fn authorize_dashboard_request(

--- a/crates/tau-ops/Cargo.toml
+++ b/crates/tau-ops/Cargo.toml
@@ -16,6 +16,7 @@ tau-access = { path = "../tau-access" }
 tau-ai = { path = "../tau-ai" }
 tau-cli = { path = "../tau-cli" }
 tau-core = { path = "../tau-core" }
+tau-events = { path = "../tau-events" }
 tau-runtime = { path = "../tau-runtime" }
 tau-session = { path = "../tau-session" }
 tau-multi-channel = { path = "../tau-multi-channel" }

--- a/crates/tau-ops/src/channel_store_admin/tests.rs
+++ b/crates/tau-ops/src/channel_store_admin/tests.rs
@@ -2246,6 +2246,7 @@ fn functional_operator_control_summary_render_includes_expected_sections() {
     assert!(rendered.contains("operator control policy posture:"));
     assert!(rendered.contains("operator control daemon:"));
     assert!(rendered.contains("operator control release channel:"));
+    assert!(rendered.contains("operator control component: component=events"));
     assert!(rendered.contains("operator control component: component=gateway"));
 }
 
@@ -2510,9 +2511,17 @@ fn regression_operator_control_summary_handles_missing_state_files_with_explicit
 
     let report = collect_operator_control_summary_report(&cli).expect("collect summary");
     assert_eq!(report.rollout_gate, "hold");
+    let events_row = report
+        .components
+        .iter()
+        .find(|row| row.component == "events")
+        .expect("events row");
+    assert_eq!(events_row.reason_code, "events_not_configured");
+    assert_eq!(events_row.rollout_gate, "pass");
     assert!(report
         .components
         .iter()
+        .filter(|row| row.component != "events")
         .all(|row| row.reason_code == "state_unavailable"));
     assert_eq!(report.health_state, "failing");
 

--- a/docs/guides/events.md
+++ b/docs/guides/events.md
@@ -46,6 +46,10 @@ cargo run -p tau-coding-agent -- \
   --events-dry-run-json
 ```
 
+Inspect output now includes persisted execution-history counters (`execution_history_entries`,
+`executed_history_entries`, `failed_history_entries`, `skipped_history_entries`) sourced from
+`--events-state-path`.
+
 Strict dry-run gating for CI:
 
 ```bash
@@ -115,3 +119,8 @@ cargo run -p tau-coding-agent -- \
 ./scripts/demo/events.sh
 ./scripts/demo-smoke.sh
 ```
+
+## Gateway API visibility
+
+When `--gateway-openresponses-server` is running, `/gateway/status` includes an `events` block with
+routine scheduler diagnostics (definition counts, queue posture, and execution-history summaries).

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -199,6 +199,14 @@ curl -sS http://127.0.0.1:8787/gateway/status \
 - `reason_codes[]`
 - `diagnostics[]`
 
+`/gateway/status` includes an `events` block for routine scheduler posture:
+
+- `health_state`, `rollout_gate`, `reason_code`, `health_reason`
+- definition counters (`discovered_events`, `enabled_events`, `malformed_events`)
+- queue posture (`due_now_events`, `queued_now_events`, `not_due_events`)
+- execution history (`execution_history_entries`, `executed_history_entries`, `failed_history_entries`, `skipped_history_entries`, `last_execution_unix_ms`, `last_execution_reason_code`)
+- `diagnostics[]`
+
 ## Runtime heartbeat scheduler
 
 Enable/disable and tune scheduler cadence:

--- a/docs/guides/operator-control-summary.md
+++ b/docs/guides/operator-control-summary.md
@@ -5,6 +5,7 @@ Run from repository root.
 ## Purpose
 
 `--operator-control-summary` gives one day-2 control-plane view that combines:
+- events scheduler (routine) queue/execution-history diagnostics
 - transport and runtime health for dashboard, multi-channel, multi-agent, gateway, deployment, custom-command, and voice
 - gateway remote-access policy posture
 - daemon lifecycle state
@@ -79,6 +80,10 @@ Common hold reason codes and actions:
   - action: initialize or repair component state (`state.json`) and rerun summary
 - `gateway:service_stopped`
   - action: start gateway service mode (`--gateway-service-start`) before resuming traffic
+- `events:events_definition_invalid`
+  - action: run `--events-validate --events-validate-json`, fix malformed/invalid schedules, then rerun summary
+- `events:events_recent_failures`
+  - action: inspect channel-store logs and `.tau/events/state.json` execution history for failing routines
 - `daemon:daemon_not_installed`
   - action: install daemon (`--daemon-install`) if background lifecycle management is required
 - `daemon:daemon_not_running`

--- a/examples/events-state.json
+++ b/examples/events-state.json
@@ -2,5 +2,6 @@
   "schema_version": 1,
   "periodic_last_run_unix_ms": {},
   "debounce_last_seen_unix_ms": {},
-  "signature_replay_last_seen_unix_ms": {}
+  "signature_replay_last_seen_unix_ms": {},
+  "recent_executions": []
 }


### PR DESCRIPTION
## Summary
- persist bounded routine execution history in events runner state (`recent_executions`) and surface history counters in `events inspect`
- expose routine scheduler status in gateway API (`/gateway/status` -> `events` block) including queue posture, reason-codes, and execution-history summaries
- include routine scheduler posture in operator control summary as an `events` component with rollout gate/recommendation wiring
- update operator/docs/runbooks and example scheduler state fixture for the new history fields

## Risks / Compatibility
- events state schema version is unchanged (`schema_version: 1`); new `recent_executions` field is additive and defaults cleanly when absent
- gateway `events` status uses lightweight local inspection for API diagnostics and does not alter runtime execution behavior
- operator summary now includes one additional component row (`events`), which can affect snapshot diffs as expected

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-events -p tau-gateway -p tau-ops --all-targets -- -D warnings`
- `cargo test -p tau-events`
- `cargo test -p tau-gateway gateway_openresponses::tests::integration_gateway_status_endpoint_returns`
- `cargo test -p tau-ops operator_control_summary`
- `./scripts/demo/events.sh`

Closes #1473
Closes #1472
