### PR TITLE
feat(gateway): add OpenAI-compatible REST adapters

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses/openai_compat.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/openai_compat.rs
@@ -1,0 +1,323 @@
+//! OpenAI-compatible request/response adapters layered onto the OpenResponses runtime.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::types::{OpenResponsesApiError, OpenResponsesRequest, OpenResponsesResponse};
+
+const OPENAI_OWNER: &str = "tau-gateway";
+const OPENAI_CHAT_COMPLETION_OBJECT: &str = "chat.completion";
+const OPENAI_CHAT_COMPLETION_CHUNK_OBJECT: &str = "chat.completion.chunk";
+const OPENAI_COMPLETION_OBJECT: &str = "text_completion";
+
+#[derive(Debug, Deserialize)]
+pub(super) struct OpenAiChatCompletionsRequest {
+    pub(super) model: Option<String>,
+    #[serde(default)]
+    pub(super) messages: Value,
+    #[serde(default)]
+    pub(super) stream: bool,
+    #[serde(default)]
+    pub(super) user: Option<String>,
+    #[serde(flatten)]
+    pub(super) extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct OpenAiCompletionsRequest {
+    pub(super) model: Option<String>,
+    #[serde(default)]
+    pub(super) prompt: Value,
+    #[serde(default)]
+    pub(super) stream: bool,
+    #[serde(default)]
+    pub(super) user: Option<String>,
+    #[serde(flatten)]
+    pub(super) extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug)]
+pub(super) struct OpenAiCompatRequestTranslation {
+    pub(super) request: OpenResponsesRequest,
+    pub(super) ignored_fields: Vec<String>,
+    pub(super) requested_model: Option<String>,
+    pub(super) stream: bool,
+}
+
+pub(super) fn translate_chat_completions_request(
+    request: OpenAiChatCompletionsRequest,
+) -> Result<OpenAiCompatRequestTranslation, OpenResponsesApiError> {
+    let mut ignored_fields = Vec::new();
+    let messages = match request.messages {
+        Value::Array(messages) => messages,
+        _ => {
+            return Err(OpenResponsesApiError::bad_request(
+                "invalid_messages",
+                "messages must be an array",
+            ));
+        }
+    };
+    if messages.is_empty() {
+        return Err(OpenResponsesApiError::bad_request(
+            "missing_messages",
+            "messages must include at least one item",
+        ));
+    }
+
+    let mut translated_messages = Vec::new();
+    for (index, message) in messages.into_iter().enumerate() {
+        match message {
+            Value::String(text) => {
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    ignored_fields.push(format!("messages[{index}]"));
+                    continue;
+                }
+                translated_messages.push(json!({
+                    "type": "message",
+                    "role": "user",
+                    "content": trimmed,
+                }));
+            }
+            Value::Object(map) => {
+                let role = map
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("user")
+                    .to_string();
+                let content = map.get("content").cloned().unwrap_or(Value::Null);
+                if is_effectively_empty_text(&content) {
+                    ignored_fields.push(format!("messages[{index}].content"));
+                    continue;
+                }
+                translated_messages.push(json!({
+                    "type": "message",
+                    "role": role,
+                    "content": content,
+                }));
+
+                for unsupported in ["tool_calls", "function_call", "audio", "refusal", "name"] {
+                    if map.contains_key(unsupported) {
+                        ignored_fields.push(format!("messages[{index}].{unsupported}"));
+                    }
+                }
+            }
+            _ => ignored_fields.push(format!("messages[{index}]")),
+        }
+    }
+
+    if translated_messages.is_empty() {
+        return Err(OpenResponsesApiError::bad_request(
+            "missing_messages",
+            "messages did not include any textual content",
+        ));
+    }
+
+    let session_user = non_empty_trimmed(request.user.as_deref()).map(str::to_string);
+    let metadata = session_user
+        .as_ref()
+        .map(|user| json!({ "session_id": user }))
+        .unwrap_or_else(|| json!({}));
+    let requested_model = request.model.clone();
+
+    Ok(OpenAiCompatRequestTranslation {
+        stream: request.stream,
+        requested_model,
+        ignored_fields,
+        request: OpenResponsesRequest {
+            model: request.model,
+            input: Value::Array(translated_messages),
+            stream: request.stream,
+            instructions: None,
+            metadata,
+            conversation: session_user,
+            previous_response_id: None,
+            extra: request.extra,
+        },
+    })
+}
+
+pub(super) fn translate_completions_request(
+    request: OpenAiCompletionsRequest,
+) -> Result<OpenAiCompatRequestTranslation, OpenResponsesApiError> {
+    if is_effectively_empty_text(&request.prompt) {
+        return Err(OpenResponsesApiError::bad_request(
+            "missing_prompt",
+            "prompt must include textual content",
+        ));
+    }
+
+    let session_user = non_empty_trimmed(request.user.as_deref()).map(str::to_string);
+    let metadata = session_user
+        .as_ref()
+        .map(|user| json!({ "session_id": user }))
+        .unwrap_or_else(|| json!({}));
+    let requested_model = request.model.clone();
+
+    Ok(OpenAiCompatRequestTranslation {
+        stream: request.stream,
+        requested_model,
+        ignored_fields: Vec::new(),
+        request: OpenResponsesRequest {
+            model: request.model,
+            input: request.prompt,
+            stream: request.stream,
+            instructions: None,
+            metadata,
+            conversation: session_user,
+            previous_response_id: None,
+            extra: request.extra,
+        },
+    })
+}
+
+pub(super) fn build_chat_completions_payload(response: &OpenResponsesResponse) -> Value {
+    json!({
+        "id": chat_completion_id(response.id.as_str()),
+        "object": OPENAI_CHAT_COMPLETION_OBJECT,
+        "created": response.created,
+        "model": response.model,
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": response.output_text,
+            },
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": response.usage.input_tokens,
+            "completion_tokens": response.usage.output_tokens,
+            "total_tokens": response.usage.total_tokens,
+        }
+    })
+}
+
+pub(super) fn build_completions_payload(response: &OpenResponsesResponse) -> Value {
+    json!({
+        "id": completion_id(response.id.as_str()),
+        "object": OPENAI_COMPLETION_OBJECT,
+        "created": response.created,
+        "model": response.model,
+        "choices": [{
+            "index": 0,
+            "text": response.output_text,
+            "logprobs": Value::Null,
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": response.usage.input_tokens,
+            "completion_tokens": response.usage.output_tokens,
+            "total_tokens": response.usage.total_tokens,
+        }
+    })
+}
+
+pub(super) fn build_chat_completions_stream_chunks(response: &OpenResponsesResponse) -> Vec<Value> {
+    vec![
+        json!({
+            "id": chat_completion_id(response.id.as_str()),
+            "object": OPENAI_CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": response.created,
+            "model": response.model,
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": response.output_text,
+                },
+                "finish_reason": Value::Null,
+            }],
+        }),
+        json!({
+            "id": chat_completion_id(response.id.as_str()),
+            "object": OPENAI_CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": response.created,
+            "model": response.model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+        }),
+    ]
+}
+
+pub(super) fn build_completions_stream_chunks(response: &OpenResponsesResponse) -> Vec<Value> {
+    vec![
+        json!({
+            "id": completion_id(response.id.as_str()),
+            "object": OPENAI_COMPLETION_OBJECT,
+            "created": response.created,
+            "model": response.model,
+            "choices": [{
+                "index": 0,
+                "text": response.output_text,
+                "logprobs": Value::Null,
+                "finish_reason": Value::Null,
+            }],
+        }),
+        json!({
+            "id": completion_id(response.id.as_str()),
+            "object": OPENAI_COMPLETION_OBJECT,
+            "created": response.created,
+            "model": response.model,
+            "choices": [{
+                "index": 0,
+                "text": "",
+                "logprobs": Value::Null,
+                "finish_reason": "stop",
+            }],
+        }),
+    ]
+}
+
+pub(super) fn build_models_payload(configured_model: &str, created: u64) -> Value {
+    json!({
+        "object": "list",
+        "data": [{
+            "id": configured_model,
+            "object": "model",
+            "created": created,
+            "owned_by": OPENAI_OWNER,
+        }],
+    })
+}
+
+fn chat_completion_id(response_id: &str) -> String {
+    let suffix = response_id.strip_prefix("resp_").unwrap_or(response_id);
+    format!("chatcmpl_{suffix}")
+}
+
+fn completion_id(response_id: &str) -> String {
+    let suffix = response_id.strip_prefix("resp_").unwrap_or(response_id);
+    format!("cmpl_{suffix}")
+}
+
+fn non_empty_trimmed(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn is_effectively_empty_text(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(text) => text.trim().is_empty(),
+        Value::Array(values) => {
+            if values.is_empty() {
+                return true;
+            }
+            values.iter().all(is_effectively_empty_text)
+        }
+        Value::Object(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                return text.trim().is_empty();
+            }
+            false
+        }
+        _ => false,
+    }
+}

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -412,6 +412,9 @@ cargo run -p tau-coding-agent -- \
 Server endpoints:
 
 - `POST /v1/responses` (OpenResponses subset)
+- `POST /v1/chat/completions` (OpenAI-compatible chat surface)
+- `POST /v1/completions` (OpenAI-compatible completions surface)
+- `GET /v1/models` (OpenAI-compatible model listing)
 - `POST /gateway/auth/session` (only when `--gateway-openresponses-auth-mode=password-session`)
 - `GET /gateway/status`
 - `GET /gateway/ws` (websocket control protocol)

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -93,7 +93,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `daemon_runtime.rs`: Tau daemon lifecycle install/start/stop/status helpers, profile rendering (launchd/systemd-user), and lifecycle diagnostics.
-- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus gateway auth/session (`/gateway/auth/session`), gateway status (`/gateway/status`), websocket control (`/gateway/ws`), and webchat endpoint.
+- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus OpenAI-compatible adapters (`/v1/chat/completions`, `/v1/completions`, `/v1/models`), gateway auth/session (`/gateway/auth/session`), gateway status (`/gateway/status`), websocket control (`/gateway/ws`), and webchat endpoint.
 - `crates/tau-gateway/src/gateway_ws_protocol.rs`: websocket control-plane frame schema, version compatibility, parse/error contracts, and fixture replay compatibility tests.
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
 - `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).


### PR DESCRIPTION
## Summary
- add OpenAI-compatible REST surfaces on the gateway server: `POST /v1/chat/completions`, `POST /v1/completions`, and `GET /v1/models`
- add compatibility request/response translation module at `crates/tau-gateway/src/gateway_openresponses/openai_compat.rs`
- preserve existing auth, rate-limit, and session behavior by routing compatibility handlers through the same gateway runtime execution path
- add structured operator diagnostics for compatibility traffic in `/gateway/status` under `gateway.openai_compat.runtime` (request counters, stream counters, translation/execution failures, reason-code and ignored-field counters)
- add unit/functional/integration/regression coverage for compatibility adapters and status diagnostics
- update operator docs/runbooks and transport/code-map references for the new endpoints

## Risks and Compatibility Notes
- streaming compatibility responses currently stream gateway output as OpenAI SSE frames and terminate with `[DONE]`; chunk emission is gateway-runtime driven and designed for interoperability, not byte-for-byte parity with every upstream provider quirk
- request fields unsupported by Tau gateway are intentionally ignored and tracked in compatibility diagnostics
- compatibility `model` in payload is accepted for client compatibility and ignored in execution (runtime model remains CLI-configured)

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-gateway --all-targets -- -D warnings`
- `cargo test -p tau-gateway unit_ -- --test-threads=1`
- `cargo test -p tau-gateway functional_ -- --test-threads=1`
- `cargo test -p tau-gateway integration_ -- --test-threads=1`
- `cargo test -p tau-gateway regression_ -- --test-threads=1`

### Test Matrix
- Unit: `15 passed; 0 failed`
- Functional: `17 passed; 0 failed`
- Integration: `16 passed; 0 failed`
- Regression: `24 passed; 0 failed`

### Live run / real execution proof
- real HTTP runtime executions are covered by new gateway functional/integration tests that boot an Axum server and exercise `/v1/chat/completions`, `/v1/completions`, `/v1/models`, and `/gateway/status` over network calls:
  - `functional_openai_chat_completions_endpoint_returns_non_stream_response`
  - `functional_openai_chat_completions_endpoint_streams_sse_for_stream_true`
  - `functional_openai_completions_endpoint_returns_non_stream_response`
  - `functional_openai_completions_endpoint_streams_sse_for_stream_true`
  - `integration_openai_chat_completions_http_roundtrip_persists_session_state`
  - `integration_gateway_status_endpoint_reports_openai_compat_runtime_counters`

Closes #1478
