### PR TITLE
feat(gateway): deliver multi-view runtime web UI operations

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses/types.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/types.rs
@@ -36,6 +36,14 @@ impl OpenResponsesApiError {
         )
     }
 
+    pub(super) fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::FORBIDDEN, code, message)
+    }
+
+    pub(super) fn not_found(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, code, message)
+    }
+
     pub(super) fn payload_too_large(message: impl Into<String>) -> Self {
         Self::new(StatusCode::PAYLOAD_TOO_LARGE, "input_too_large", message)
     }
@@ -95,6 +103,39 @@ pub(super) struct OpenResponsesRequest {
 #[derive(Debug, Deserialize)]
 pub(super) struct GatewayAuthSessionRequest {
     pub(super) password: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GatewaySessionAppendRequest {
+    pub(super) role: String,
+    pub(super) content: String,
+    #[serde(default)]
+    pub(super) policy_gate: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GatewaySessionResetRequest {
+    #[serde(default)]
+    pub(super) policy_gate: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GatewayMemoryUpdateRequest {
+    pub(super) content: String,
+    #[serde(default)]
+    pub(super) policy_gate: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GatewayUiTelemetryRequest {
+    pub(super) view: String,
+    pub(super) action: String,
+    #[serde(default)]
+    pub(super) session_key: Option<String>,
+    #[serde(default)]
+    pub(super) reason_code: Option<String>,
+    #[serde(default)]
+    pub(super) metadata: Value,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/tau-gateway/src/gateway_openresponses/webchat_page.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/webchat_page.rs
@@ -13,104 +13,159 @@ pub(super) fn render_gateway_webchat_page() -> String {
     :root {{
       color-scheme: light;
       font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      --bg: #f4f6f8;
+      --panel: #ffffff;
+      --ink: #102736;
+      --ink-muted: #415d70;
+      --line: #d4dee6;
+      --ok: #0f7d5f;
+      --warn: #a55e00;
+      --bad: #b42318;
+      --primary: #0b6f56;
+      --secondary: #36566b;
     }}
     body {{
       margin: 0;
-      background: linear-gradient(160deg, #f4f6f8 0%, #eef2f7 100%);
-      color: #13232f;
+      background: radial-gradient(circle at top right, #eaf1f8 0%, var(--bg) 45%, #eef3f7 100%);
+      color: var(--ink);
     }}
     .container {{
-      max-width: 980px;
+      max-width: 1200px;
       margin: 0 auto;
-      padding: 1.5rem;
+      padding: 1.25rem;
+    }}
+    .header {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-end;
+      justify-content: space-between;
+      margin-bottom: 0.9rem;
     }}
     h1 {{
-      margin: 0 0 0.5rem 0;
-      font-size: 1.5rem;
+      margin: 0;
+      font-size: 1.55rem;
+      letter-spacing: 0.01em;
     }}
-    p {{
-      margin: 0.25rem 0 1rem 0;
-      color: #3a4f5f;
+    .subtitle {{
+      margin: 0.15rem 0 0 0;
+      color: var(--ink-muted);
+      font-size: 0.95rem;
     }}
-    .grid {{
+    .shell {{
       display: grid;
-      gap: 1rem;
-      grid-template-columns: 1fr;
+      gap: 0.9rem;
     }}
     .panel {{
-      background: #ffffff;
-      border: 1px solid #d2dde6;
+      background: var(--panel);
+      border: 1px solid var(--line);
       border-radius: 12px;
-      padding: 1rem;
-      box-shadow: 0 8px 20px rgba(12, 25, 38, 0.06);
-    }}
-    label {{
-      display: block;
-      font-size: 0.85rem;
-      margin-bottom: 0.25rem;
-      color: #375062;
-    }}
-    input[type="text"], textarea {{
-      width: 100%;
-      box-sizing: border-box;
-      border: 1px solid #b8c9d6;
-      border-radius: 8px;
-      padding: 0.55rem 0.7rem;
-      font-size: 0.95rem;
-      background: #fbfdff;
-      color: #13232f;
-    }}
-    textarea {{
-      min-height: 150px;
-      resize: vertical;
+      box-shadow: 0 8px 24px rgba(17, 31, 44, 0.08);
+      padding: 0.9rem;
     }}
     .row {{
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 0.8rem;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 0.7rem;
       margin-bottom: 0.8rem;
+    }}
+    label {{
+      display: block;
+      margin-bottom: 0.2rem;
+      font-size: 0.8rem;
+      color: var(--ink-muted);
+      letter-spacing: 0.02em;
+    }}
+    input[type="text"],
+    input[type="password"],
+    select,
+    textarea {{
+      width: 100%;
+      box-sizing: border-box;
+      border: 1px solid #becdd9;
+      border-radius: 8px;
+      padding: 0.5rem 0.65rem;
+      font-size: 0.93rem;
+      color: var(--ink);
+      background: #fcfeff;
+    }}
+    textarea {{
+      min-height: 130px;
+      resize: vertical;
+    }}
+    .tabs {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+      margin-bottom: 0.8rem;
+    }}
+    .tab {{
+      border: 1px solid #c2d2de;
+      background: #eaf2f8;
+      color: #173548;
+      border-radius: 999px;
+      padding: 0.4rem 0.75rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+    }}
+    .tab.active {{
+      background: #11405a;
+      border-color: #11405a;
+      color: #ffffff;
+    }}
+    .view {{
+      display: none;
+    }}
+    .view.active {{
+      display: block;
     }}
     .actions {{
       display: flex;
-      gap: 0.5rem;
       flex-wrap: wrap;
-      margin-top: 0.8rem;
+      gap: 0.5rem;
+      margin-top: 0.65rem;
     }}
     button {{
       border: 0;
       border-radius: 8px;
-      background: #0f7d5f;
+      background: var(--primary);
       color: #ffffff;
-      padding: 0.55rem 0.9rem;
+      padding: 0.52rem 0.86rem;
+      font-size: 0.9rem;
       font-weight: 600;
       cursor: pointer;
     }}
     button.secondary {{
-      background: #3f5f74;
+      background: var(--secondary);
+    }}
+    button.warn {{
+      background: #9b2c21;
     }}
     button:disabled {{
       cursor: wait;
-      opacity: 0.6;
+      opacity: 0.65;
     }}
     .checkbox {{
       display: inline-flex;
       align-items: center;
-      gap: 0.4rem;
-      margin-top: 0.2rem;
-      color: #274355;
+      gap: 0.38rem;
+      margin-top: 0.1rem;
       font-size: 0.9rem;
+      color: #203f52;
     }}
     pre {{
       margin: 0;
       background: #0f1f2b;
       color: #d9ecf7;
       border-radius: 10px;
-      padding: 0.8rem;
+      padding: 0.75rem;
       overflow: auto;
-      max-height: 300px;
+      max-height: 340px;
       white-space: pre-wrap;
       word-break: break-word;
-      font-size: 0.85rem;
+      font-size: 0.82rem;
+      line-height: 1.4;
     }}
     .status-dashboard {{
       display: grid;
@@ -141,15 +196,9 @@ pub(super) fn render_gateway_webchat_page() -> String {
       font-weight: 700;
       color: #173142;
     }}
-    .metric-value.ok {{
-      color: #0f7d5f;
-    }}
-    .metric-value.warn {{
-      color: #ad6700;
-    }}
-    .metric-value.bad {{
-      color: #b42318;
-    }}
+    .metric-value.ok {{ color: var(--ok); }}
+    .metric-value.warn {{ color: var(--warn); }}
+    .metric-value.bad {{ color: var(--bad); }}
     .table-scroll {{
       overflow: auto;
       border: 1px solid #d2dde6;
@@ -159,7 +208,7 @@ pub(super) fn render_gateway_webchat_page() -> String {
     table.status-table {{
       width: 100%;
       border-collapse: collapse;
-      min-width: 420px;
+      min-width: 460px;
     }}
     table.status-table th {{
       text-align: left;
@@ -182,45 +231,103 @@ pub(super) fn render_gateway_webchat_page() -> String {
     table.status-table tbody tr:last-child td {{
       border-bottom: none;
     }}
-    @media (min-width: 900px) {{
-      .grid {{
-        grid-template-columns: 1.4fr 1fr;
+    .split {{
+      display: grid;
+      gap: 0.8rem;
+      grid-template-columns: 1fr;
+    }}
+    .list {{
+      max-height: 240px;
+      overflow: auto;
+      border: 1px solid #d0dae2;
+      border-radius: 10px;
+      background: #f9fcff;
+      padding: 0.45rem;
+    }}
+    .list button {{
+      display: block;
+      width: 100%;
+      text-align: left;
+      margin-bottom: 0.35rem;
+      background: #1f5574;
+      font-size: 0.82rem;
+    }}
+    .mono {{
+      font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
+      font-size: 0.8rem;
+      color: #213f52;
+      background: #edf3f8;
+      padding: 0.35rem 0.45rem;
+      border-radius: 6px;
+      border: 1px solid #d1dce5;
+      display: inline-block;
+    }}
+    @media (min-width: 960px) {{
+      .split {{
+        grid-template-columns: 1fr 1.3fr;
       }}
     }}
   </style>
 </head>
 <body>
   <main class="container">
-    <h1>Tau Gateway Webchat</h1>
-    <p>Operator webchat for the OpenResponses gateway runtime.</p>
-    <div class="grid">
-      <section class="panel">
-        <div class="row">
-          <div>
-            <label for="authToken">Bearer token</label>
-            <input id="authToken" type="text" autocomplete="off" placeholder="gateway auth token" />
-          </div>
-          <div>
-            <label for="sessionKey">Session key</label>
-            <input id="sessionKey" type="text" autocomplete="off" value="{default_session_key}" />
-          </div>
+    <header class="header">
+      <div>
+        <h1>Tau Gateway Webchat</h1>
+        <p class="subtitle">Multi-view runtime operator shell for conversation, tools, sessions, memory, and configuration.</p>
+      </div>
+      <div class="mono">WebSocket: {websocket_endpoint}</div>
+    </header>
+
+    <section class="panel" aria-label="Gateway controls">
+      <div class="row">
+        <div>
+          <label for="authToken">Bearer token</label>
+          <input id="authToken" type="password" autocomplete="off" placeholder="gateway auth token" />
         </div>
-        <label class="checkbox">
-          <input id="stream" type="checkbox" checked />
-          Stream response (SSE)
-        </label>
-        <div style="margin-top: 0.8rem;">
-          <label for="prompt">Prompt</label>
-          <textarea id="prompt" placeholder="Ask Tau through the gateway..."></textarea>
+        <div>
+          <label for="sessionKey">Session key</label>
+          <input id="sessionKey" type="text" autocomplete="off" value="{default_session_key}" />
         </div>
+        <div>
+          <label for="apiMode">API mode</label>
+          <select id="apiMode">
+            <option value="responses">/v1/responses</option>
+            <option value="chat_completions">/v1/chat/completions</option>
+            <option value="completions">/v1/completions</option>
+          </select>
+        </div>
+      </div>
+      <label class="checkbox">
+        <input id="stream" type="checkbox" checked />
+        Stream response (SSE)
+      </label>
+    </section>
+
+    <section class="panel">
+      <nav class="tabs" role="tablist" aria-label="Gateway web UI views">
+        <button class="tab active" data-view="conversation" role="tab" aria-selected="true">Conversation</button>
+        <button class="tab" data-view="tools" role="tab" aria-selected="false">Tools</button>
+        <button class="tab" data-view="sessions" role="tab" aria-selected="false">Sessions</button>
+        <button class="tab" data-view="memory" role="tab" aria-selected="false">Memory</button>
+        <button class="tab" data-view="configuration" role="tab" aria-selected="false">Configuration</button>
+      </nav>
+
+      <section id="view-conversation" class="view active" role="tabpanel">
+        <label for="prompt">Prompt</label>
+        <textarea id="prompt" placeholder="Ask Tau through the gateway..."></textarea>
         <div class="actions">
           <button id="send">Send</button>
-          <button id="refreshStatus" class="secondary">Refresh status</button>
           <button id="clearOutput" class="secondary">Clear output</button>
         </div>
+        <h2 style="margin: 0.8rem 0 0.4rem 0; font-size: 1rem;">Response output</h2>
+        <pre id="output">No response yet.</pre>
       </section>
-      <section class="panel">
-        <h2 style="margin: 0 0 0.5rem 0; font-size: 1rem;">Gateway status</h2>
+
+      <section id="view-tools" class="view" role="tabpanel" aria-hidden="true">
+        <div class="actions" style="margin-top: 0;">
+          <button id="refreshStatus" class="secondary">Refresh status</button>
+        </div>
         <div class="status-dashboard">
           <div class="status-cards">
             <article class="metric-card">
@@ -282,20 +389,89 @@ pub(super) fn render_gateway_webchat_page() -> String {
         </div>
         <pre id="status">Press "Refresh status" to inspect gateway service state, multi-channel lifecycle summary, connector counters, and recent reason codes.</pre>
       </section>
-    </div>
-    <section class="panel" style="margin-top: 1rem;">
-      <h2 style="margin: 0 0 0.5rem 0; font-size: 1rem;">Response output</h2>
-      <pre id="output">No response yet.</pre>
+
+      <section id="view-sessions" class="view" role="tabpanel" aria-hidden="true">
+        <div class="split">
+          <div>
+            <div class="actions" style="margin-top: 0;">
+              <button id="loadSessions" class="secondary">Load sessions</button>
+              <button id="loadSessionDetail" class="secondary">Open current session</button>
+            </div>
+            <div id="sessionsList" class="list" aria-label="Session list">
+              <div>No sessions loaded.</div>
+            </div>
+          </div>
+          <div>
+            <div class="row">
+              <div>
+                <label for="appendRole">Append role</label>
+                <select id="appendRole">
+                  <option value="user">user</option>
+                  <option value="assistant">assistant</option>
+                  <option value="system">system</option>
+                </select>
+              </div>
+              <div>
+                <label for="sessionPolicyGate">Session policy gate</label>
+                <input id="sessionPolicyGate" type="text" value="{session_policy_gate}" />
+              </div>
+            </div>
+            <label for="appendContent">Append content</label>
+            <textarea id="appendContent" placeholder="Message text to append to the current session"></textarea>
+            <div class="actions">
+              <button id="appendSession">Append message</button>
+              <button id="resetSession" class="warn">Reset session</button>
+            </div>
+            <pre id="sessionDetail">Session details will appear here.</pre>
+          </div>
+        </div>
+      </section>
+
+      <section id="view-memory" class="view" role="tabpanel" aria-hidden="true">
+        <div class="row">
+          <div>
+            <label for="memoryPolicyGate">Memory policy gate</label>
+            <input id="memoryPolicyGate" type="text" value="{memory_policy_gate}" />
+          </div>
+        </div>
+        <div class="actions" style="margin-top: 0;">
+          <button id="loadMemory" class="secondary">Load memory</button>
+          <button id="saveMemory">Save memory</button>
+        </div>
+        <label for="memoryContent" style="margin-top: 0.6rem;">Memory content</label>
+        <textarea id="memoryContent" placeholder="Editable memory note for the active session"></textarea>
+        <pre id="memoryStatus">Memory status will appear here.</pre>
+      </section>
+
+      <section id="view-configuration" class="view" role="tabpanel" aria-hidden="true">
+        <p style="margin: 0 0 0.5rem 0; color: var(--ink-muted);">Runtime endpoints and policy gates discovered from gateway configuration.</p>
+        <pre id="configView"></pre>
+      </section>
     </section>
   </main>
+
   <script>
     const RESPONSES_ENDPOINT = "{responses_endpoint}";
+    const CHAT_COMPLETIONS_ENDPOINT = "{chat_completions_endpoint}";
+    const COMPLETIONS_ENDPOINT = "{completions_endpoint}";
+    const MODELS_ENDPOINT = "{models_endpoint}";
     const STATUS_ENDPOINT = "{status_endpoint}";
     const WEBSOCKET_ENDPOINT = "{websocket_endpoint}";
+    const SESSIONS_ENDPOINT = "{sessions_endpoint}";
+    const MEMORY_ENDPOINT_TEMPLATE = "{memory_endpoint_template}";
+    const SESSION_DETAIL_ENDPOINT_TEMPLATE = "{session_detail_endpoint_template}";
+    const SESSION_APPEND_ENDPOINT_TEMPLATE = "{session_append_endpoint_template}";
+    const SESSION_RESET_ENDPOINT_TEMPLATE = "{session_reset_endpoint_template}";
+    const UI_TELEMETRY_ENDPOINT = "{ui_telemetry_endpoint}";
+    const SESSION_WRITE_POLICY_GATE = "{session_policy_gate}";
+    const MEMORY_WRITE_POLICY_GATE = "{memory_policy_gate}";
+
     const STORAGE_TOKEN = "tau.gateway.webchat.token";
     const STORAGE_SESSION = "tau.gateway.webchat.session";
+
     const tokenInput = document.getElementById("authToken");
     const sessionInput = document.getElementById("sessionKey");
+    const apiModeInput = document.getElementById("apiMode");
     const streamInput = document.getElementById("stream");
     const promptInput = document.getElementById("prompt");
     const outputPre = document.getElementById("output");
@@ -306,18 +482,34 @@ pub(super) fn render_gateway_webchat_page() -> String {
     const failureStreakValue = document.getElementById("failureStreakValue");
     const connectorTableBody = document.getElementById("connectorTableBody");
     const reasonCodeTableBody = document.getElementById("reasonCodeTableBody");
+    const sessionsList = document.getElementById("sessionsList");
+    const sessionDetailPre = document.getElementById("sessionDetail");
+    const appendRoleInput = document.getElementById("appendRole");
+    const appendContentInput = document.getElementById("appendContent");
+    const sessionPolicyGateInput = document.getElementById("sessionPolicyGate");
+    const memoryPolicyGateInput = document.getElementById("memoryPolicyGate");
+    const memoryContentInput = document.getElementById("memoryContent");
+    const memoryStatusPre = document.getElementById("memoryStatus");
+    const configViewPre = document.getElementById("configView");
+
     const sendButton = document.getElementById("send");
-    const refreshButton = document.getElementById("refreshStatus");
     const clearButton = document.getElementById("clearOutput");
+    const refreshButton = document.getElementById("refreshStatus");
+    const loadSessionsButton = document.getElementById("loadSessions");
+    const loadSessionDetailButton = document.getElementById("loadSessionDetail");
+    const appendSessionButton = document.getElementById("appendSession");
+    const resetSessionButton = document.getElementById("resetSession");
+    const loadMemoryButton = document.getElementById("loadMemory");
+    const saveMemoryButton = document.getElementById("saveMemory");
 
     function loadLocalValues() {{
-      const storedToken = window.localStorage.getItem(STORAGE_TOKEN);
-      const storedSession = window.localStorage.getItem(STORAGE_SESSION);
-      if (storedToken) {{
-        tokenInput.value = storedToken;
+      const token = window.localStorage.getItem(STORAGE_TOKEN);
+      const sessionKey = window.localStorage.getItem(STORAGE_SESSION);
+      if (token) {{
+        tokenInput.value = token;
       }}
-      if (storedSession) {{
-        sessionInput.value = storedSession;
+      if (sessionKey) {{
+        sessionInput.value = sessionKey;
       }}
     }}
 
@@ -331,9 +523,7 @@ pub(super) fn render_gateway_webchat_page() -> String {
       if (token.length === 0) {{
         return {{}};
       }}
-      return {{
-        "Authorization": "Bearer " + token
-      }};
+      return {{ "Authorization": "Bearer " + token }};
     }}
 
     function setOutput(text) {{
@@ -347,66 +537,51 @@ pub(super) fn render_gateway_webchat_page() -> String {
       outputPre.textContent += text;
     }}
 
-    function processSseFrame(frame) {{
-      if (!frame || frame.trim().length === 0) {{
-        return;
+    function currentSessionKey() {{
+      return (sessionInput.value.trim() || "{default_session_key}");
+    }}
+
+    function endpointForMode(mode) {{
+      if (mode === "chat_completions") {{
+        return CHAT_COMPLETIONS_ENDPOINT;
       }}
-      let eventName = "";
-      let data = "";
-      const lines = frame.split(/\r?\n/);
-      for (const line of lines) {{
-        if (line.startsWith("event:")) {{
-          eventName = line.slice("event:".length).trim();
-        }} else if (line.startsWith("data:")) {{
-          data += line.slice("data:".length).trim();
-        }}
+      if (mode === "completions") {{
+        return COMPLETIONS_ENDPOINT;
       }}
-      if (data.length === 0 || data === "[DONE]") {{
-        return;
-      }}
-      let payload = null;
+      return RESPONSES_ENDPOINT;
+    }}
+
+    function telemetryPayload(view, action, reasonCode, metadata) {{
+      return {{
+        view: view,
+        action: action,
+        reason_code: reasonCode,
+        session_key: currentSessionKey(),
+        metadata: metadata || {{}}
+      }};
+    }}
+
+    async function emitUiTelemetry(view, action, reasonCode, metadata) {{
       try {{
-        payload = JSON.parse(data);
-      }} catch (error) {{
-        appendOutput("\n[invalid sse payload] " + data + "\n");
-        return;
-      }}
-      if (eventName === "response.output_text.delta") {{
-        appendOutput(payload.delta || "");
-        return;
-      }}
-      if (eventName === "response.output_text.done") {{
-        appendOutput("\n");
-        return;
-      }}
-      if (eventName === "response.failed") {{
-        const message = payload && payload.error ? payload.error.message : "unknown";
-        appendOutput("\n[gateway error] " + message + "\n");
+        await fetch(UI_TELEMETRY_ENDPOINT, {{
+          method: "POST",
+          headers: Object.assign({{ "Content-Type": "application/json" }}, authHeaders()),
+          body: JSON.stringify(telemetryPayload(view, action, reasonCode, metadata))
+        }});
+      }} catch (_error) {{
+        // best-effort telemetry path
       }}
     }}
 
-    async function readSseBody(response) {{
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      while (true) {{
-        const result = await reader.read();
-        if (result.done) {{
-          break;
-        }}
-        buffer += decoder.decode(result.value, {{ stream: true }});
-        while (true) {{
-          const splitIndex = buffer.indexOf("\n\n");
-          if (splitIndex < 0) {{
-            break;
-          }}
-          const frame = buffer.slice(0, splitIndex);
-          buffer = buffer.slice(splitIndex + 2);
-          processSseFrame(frame);
-        }}
-      }}
-      if (buffer.trim().length > 0) {{
-        processSseFrame(buffer);
+    function encodeSessionPath(template) {{
+      return template.replace("{{session_key}}", encodeURIComponent(currentSessionKey()));
+    }}
+
+    function applyMetricValue(node, value, tone) {{
+      node.textContent = String(value);
+      node.classList.remove("ok", "warn", "bad");
+      if (tone) {{
+        node.classList.add(tone);
       }}
     }}
 
@@ -421,14 +596,6 @@ pub(super) fn render_gateway_webchat_page() -> String {
         }}
       }}
       return 0;
-    }}
-
-    function applyMetricValue(node, value, tone) {{
-      node.textContent = String(value);
-      node.classList.remove("ok", "warn", "bad");
-      if (tone) {{
-        node.classList.add(tone);
-      }}
     }}
 
     function escapeHtml(value) {{
@@ -482,7 +649,7 @@ pub(super) fn render_gateway_webchat_page() -> String {
           "<td>" + String(toSafeInteger(row.auth_failures)) + "</td>",
           "<td>" + String(toSafeInteger(row.parse_failures)) + "</td>",
           "<td>" + String(toSafeInteger(row.provider_failures)) + "</td>",
-          "</tr>",
+          "</tr>"
         ].join("");
       }}).join("");
     }}
@@ -570,16 +737,207 @@ pub(super) fn render_gateway_webchat_page() -> String {
         "connectors: state_present=" + String(Boolean(connectors.state_present)) +
           " processed=" + String(connectors.processed_event_count || 0),
         "connector_channels:\n" + renderMultiChannelChannelRows(connectors),
-        "multi_channel_diagnostics: " + diagnostics,
+        "multi_channel_diagnostics: " + diagnostics
       ].join("\n");
+    }}
+
+    function formatConfigView(payload) {{
+      const gateway = payload && payload.gateway ? payload.gateway : {{}};
+      return JSON.stringify({{
+        endpoints: {{
+          responses: RESPONSES_ENDPOINT,
+          chat_completions: CHAT_COMPLETIONS_ENDPOINT,
+          completions: COMPLETIONS_ENDPOINT,
+          models: MODELS_ENDPOINT,
+          status: STATUS_ENDPOINT,
+          sessions: SESSIONS_ENDPOINT,
+          session_detail: SESSION_DETAIL_ENDPOINT_TEMPLATE,
+          session_append: SESSION_APPEND_ENDPOINT_TEMPLATE,
+          session_reset: SESSION_RESET_ENDPOINT_TEMPLATE,
+          memory: MEMORY_ENDPOINT_TEMPLATE,
+          ui_telemetry: UI_TELEMETRY_ENDPOINT,
+          websocket: WEBSOCKET_ENDPOINT
+        }},
+        policy_gates: {{
+          session_write: SESSION_WRITE_POLICY_GATE,
+          memory_write: MEMORY_WRITE_POLICY_GATE
+        }},
+        gateway_status_summary: gateway
+      }}, null, 2);
+    }}
+
+    function parseSseFrame(rawFrame) {{
+      const lines = rawFrame.split(/\r?\n/);
+      let eventName = "";
+      let data = "";
+      for (const line of lines) {{
+        if (line.startsWith("event:")) {{
+          eventName = line.slice("event:".length).trim();
+        }} else if (line.startsWith("data:")) {{
+          data += line.slice("data:".length).trim();
+        }}
+      }}
+      if (eventName.length === 0 && data.length === 0) {{
+        return null;
+      }}
+      return {{ eventName, data }};
+    }}
+
+    function processSseFrame(frame, mode) {{
+      if (!frame) {{
+        return;
+      }}
+      if (frame.data === "[DONE]") {{
+        appendOutput("\n");
+        return;
+      }}
+      if (!frame.data) {{
+        return;
+      }}
+
+      let payload = null;
+      try {{
+        payload = JSON.parse(frame.data);
+      }} catch (_error) {{
+        appendOutput("\n[invalid sse payload] " + frame.data + "\n");
+        return;
+      }}
+
+      if (mode === "responses") {{
+        if (frame.eventName === "response.output_text.delta") {{
+          appendOutput(payload.delta || "");
+          return;
+        }}
+        if (frame.eventName === "response.failed") {{
+          const message = payload && payload.error ? payload.error.message : "unknown";
+          appendOutput("\n[gateway error] " + message + "\n");
+        }}
+        return;
+      }}
+
+      if (mode === "chat_completions") {{
+        const choice = payload && Array.isArray(payload.choices) ? payload.choices[0] : null;
+        const delta = choice && choice.delta ? choice.delta : null;
+        if (delta && typeof delta.content === "string") {{
+          appendOutput(delta.content);
+        }}
+        return;
+      }}
+
+      if (mode === "completions") {{
+        const choice = payload && Array.isArray(payload.choices) ? payload.choices[0] : null;
+        if (choice && typeof choice.text === "string") {{
+          appendOutput(choice.text);
+        }}
+      }}
+    }}
+
+    async function readSseBody(response, mode) {{
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {{
+        const result = await reader.read();
+        if (result.done) {{
+          break;
+        }}
+        buffer += decoder.decode(result.value, {{ stream: true }});
+        while (true) {{
+          const splitIndex = buffer.indexOf("\n\n");
+          if (splitIndex < 0) {{
+            break;
+          }}
+          const rawFrame = buffer.slice(0, splitIndex);
+          buffer = buffer.slice(splitIndex + 2);
+          processSseFrame(parseSseFrame(rawFrame), mode);
+        }}
+      }}
+      if (buffer.trim().length > 0) {{
+        processSseFrame(parseSseFrame(buffer), mode);
+      }}
+    }}
+
+    function buildRequestPayload(mode, prompt, stream) {{
+      if (mode === "chat_completions") {{
+        return {{
+          messages: [{{ role: "user", content: prompt }}],
+          user: currentSessionKey(),
+          stream: stream
+        }};
+      }}
+      if (mode === "completions") {{
+        return {{
+          prompt: prompt,
+          user: currentSessionKey(),
+          stream: stream
+        }};
+      }}
+      return {{
+        input: prompt,
+        stream: stream,
+        metadata: {{ session_id: currentSessionKey() }}
+      }};
+    }}
+
+    function extractNonStreamOutput(mode, payload) {{
+      if (mode === "chat_completions") {{
+        return payload && payload.choices && payload.choices[0] && payload.choices[0].message
+          ? (payload.choices[0].message.content || "")
+          : JSON.stringify(payload, null, 2);
+      }}
+      if (mode === "completions") {{
+        return payload && payload.choices && payload.choices[0]
+          ? (payload.choices[0].text || "")
+          : JSON.stringify(payload, null, 2);
+      }}
+      return typeof payload.output_text === "string" ? payload.output_text : JSON.stringify(payload, null, 2);
+    }}
+
+    async function sendPrompt() {{
+      const prompt = promptInput.value.trim();
+      if (prompt.length === 0) {{
+        setOutput("Prompt is required.");
+        return;
+      }}
+
+      saveLocalValues();
+      sendButton.disabled = true;
+      const mode = apiModeInput.value;
+      try {{
+        setOutput("");
+        const payload = buildRequestPayload(mode, prompt, streamInput.checked);
+        const response = await fetch(endpointForMode(mode), {{
+          method: "POST",
+          headers: Object.assign({{ "Content-Type": "application/json" }}, authHeaders()),
+          body: JSON.stringify(payload)
+        }});
+        if (!response.ok) {{
+          setOutput("request failed: status=" + response.status + "\n" + await response.text());
+          await emitUiTelemetry("conversation", "send", "prompt_failed", {{ mode: mode, status: response.status }});
+          return;
+        }}
+
+        if (streamInput.checked) {{
+          await readSseBody(response, mode);
+        }} else {{
+          const body = await response.json();
+          setOutput(extractNonStreamOutput(mode, body));
+        }}
+
+        await emitUiTelemetry("conversation", "send", "prompt_completed", {{ mode: mode, stream: streamInput.checked }});
+        await refreshStatus();
+      }} catch (error) {{
+        setOutput("request failed: " + String(error));
+        await emitUiTelemetry("conversation", "send", "prompt_exception", {{ mode: mode }});
+      }} finally {{
+        sendButton.disabled = false;
+      }}
     }}
 
     async function refreshStatus() {{
       statusPre.textContent = "Loading gateway status...";
       try {{
-        const response = await fetch(STATUS_ENDPOINT, {{
-          headers: authHeaders()
-        }});
+        const response = await fetch(STATUS_ENDPOINT, {{ headers: authHeaders() }});
         const raw = await response.text();
         if (!response.ok) {{
           renderStatusDashboard(null);
@@ -588,75 +946,222 @@ pub(super) fn render_gateway_webchat_page() -> String {
         }}
         const payload = JSON.parse(raw);
         renderStatusDashboard(payload);
-        const summary = formatGatewayStatusSummary(payload);
-        statusPre.textContent = summary + "\n\nraw_payload:\n" + JSON.stringify(payload, null, 2);
+        statusPre.textContent = formatGatewayStatusSummary(payload) + "\n\nraw_payload:\n" + JSON.stringify(payload, null, 2);
+        configViewPre.textContent = formatConfigView(payload);
+        await emitUiTelemetry("tools", "refresh_status", "status_refreshed", {{ health_state: payload.multi_channel ? payload.multi_channel.health_state : "unknown" }});
       }} catch (error) {{
         renderStatusDashboard(null);
         statusPre.textContent = "status request failed: " + String(error);
       }}
     }}
 
-    async function sendPrompt() {{
-      const prompt = promptInput.value.trim();
-      const sessionKey = sessionInput.value.trim() || "{default_session_key}";
-      if (prompt.length === 0) {{
-        setOutput("Prompt is required.");
-        return;
-      }}
-      saveLocalValues();
-      sendButton.disabled = true;
+    async function loadSessions() {{
+      sessionsList.innerHTML = "<div>Loading sessions...</div>";
       try {{
-        setOutput("");
-        const payload = {{
-          input: prompt,
-          stream: streamInput.checked,
-          metadata: {{
-            session_id: sessionKey
-          }}
-        }};
-        const response = await fetch(RESPONSES_ENDPOINT, {{
-          method: "POST",
-          headers: Object.assign({{
-            "Content-Type": "application/json"
-          }}, authHeaders()),
-          body: JSON.stringify(payload)
-        }});
+        const response = await fetch(SESSIONS_ENDPOINT, {{ headers: authHeaders() }});
+        const payload = await response.json();
         if (!response.ok) {{
-          setOutput("request failed: status=" + response.status + "\n" + await response.text());
+          sessionsList.textContent = JSON.stringify(payload, null, 2);
           return;
         }}
-        if (streamInput.checked) {{
-          await readSseBody(response);
-        }} else {{
-          const body = await response.json();
-          const outputText = typeof body.output_text === "string"
-            ? body.output_text
-            : JSON.stringify(body, null, 2);
-          setOutput(outputText);
+        const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+        if (sessions.length === 0) {{
+          sessionsList.innerHTML = "<div>No session files found.</div>";
+          return;
         }}
-        await refreshStatus();
+        sessionsList.innerHTML = "";
+        for (const session of sessions) {{
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "secondary";
+          button.textContent = session.session_key + " (" + String(session.message_count || 0) + " entries)";
+          button.addEventListener("click", () => {{
+            sessionInput.value = session.session_key;
+            loadSessionDetail();
+          }});
+          sessionsList.appendChild(button);
+        }}
+        await emitUiTelemetry("sessions", "list", "session_list_loaded", {{ count: sessions.length }});
       }} catch (error) {{
-        setOutput("request failed: " + String(error));
-      }} finally {{
-        sendButton.disabled = false;
+        sessionsList.textContent = "Failed to load sessions: " + String(error);
       }}
     }}
 
+    async function loadSessionDetail() {{
+      const endpoint = encodeSessionPath(SESSION_DETAIL_ENDPOINT_TEMPLATE);
+      sessionDetailPre.textContent = "Loading session detail...";
+      try {{
+        const response = await fetch(endpoint, {{ headers: authHeaders() }});
+        const payload = await response.json();
+        sessionDetailPre.textContent = JSON.stringify(payload, null, 2);
+        if (response.ok) {{
+          await emitUiTelemetry("sessions", "detail", "session_detail_loaded", {{ entry_count: payload.entry_count || 0 }});
+        }}
+      }} catch (error) {{
+        sessionDetailPre.textContent = "Failed to load session detail: " + String(error);
+      }}
+    }}
+
+    async function appendSessionMessage() {{
+      const endpoint = encodeSessionPath(SESSION_APPEND_ENDPOINT_TEMPLATE);
+      const content = appendContentInput.value.trim();
+      if (content.length === 0) {{
+        sessionDetailPre.textContent = "Append content is required.";
+        return;
+      }}
+      const body = {{
+        role: appendRoleInput.value,
+        content: content,
+        policy_gate: sessionPolicyGateInput.value.trim()
+      }};
+      try {{
+        const response = await fetch(endpoint, {{
+          method: "POST",
+          headers: Object.assign({{ "Content-Type": "application/json" }}, authHeaders()),
+          body: JSON.stringify(body)
+        }});
+        const payload = await response.json();
+        sessionDetailPre.textContent = JSON.stringify(payload, null, 2);
+        if (response.ok) {{
+          appendContentInput.value = "";
+          await emitUiTelemetry("sessions", "append", "session_append_applied", {{ role: body.role }});
+          await loadSessionDetail();
+          await loadSessions();
+        }} else {{
+          await emitUiTelemetry("sessions", "append", "session_append_failed", {{ status: response.status }});
+        }}
+      }} catch (error) {{
+        sessionDetailPre.textContent = "Failed to append session message: " + String(error);
+      }}
+    }}
+
+    async function resetSession() {{
+      const endpoint = encodeSessionPath(SESSION_RESET_ENDPOINT_TEMPLATE);
+      const body = {{ policy_gate: sessionPolicyGateInput.value.trim() }};
+      try {{
+        const response = await fetch(endpoint, {{
+          method: "POST",
+          headers: Object.assign({{ "Content-Type": "application/json" }}, authHeaders()),
+          body: JSON.stringify(body)
+        }});
+        const payload = await response.json();
+        sessionDetailPre.textContent = JSON.stringify(payload, null, 2);
+        if (response.ok) {{
+          await emitUiTelemetry("sessions", "reset", "session_reset_applied", {{}});
+          await loadSessions();
+        }} else {{
+          await emitUiTelemetry("sessions", "reset", "session_reset_failed", {{ status: response.status }});
+        }}
+      }} catch (error) {{
+        sessionDetailPre.textContent = "Failed to reset session: " + String(error);
+      }}
+    }}
+
+    async function loadMemory() {{
+      const endpoint = encodeSessionPath(MEMORY_ENDPOINT_TEMPLATE);
+      memoryStatusPre.textContent = "Loading memory...";
+      try {{
+        const response = await fetch(endpoint, {{ headers: authHeaders() }});
+        const payload = await response.json();
+        memoryStatusPre.textContent = JSON.stringify(payload, null, 2);
+        if (response.ok) {{
+          memoryContentInput.value = payload.content || "";
+          await emitUiTelemetry("memory", "read", "memory_read_loaded", {{ exists: Boolean(payload.exists) }});
+        }}
+      }} catch (error) {{
+        memoryStatusPre.textContent = "Failed to load memory: " + String(error);
+      }}
+    }}
+
+    async function saveMemory() {{
+      const endpoint = encodeSessionPath(MEMORY_ENDPOINT_TEMPLATE);
+      const body = {{
+        content: memoryContentInput.value,
+        policy_gate: memoryPolicyGateInput.value.trim()
+      }};
+      try {{
+        const response = await fetch(endpoint, {{
+          method: "PUT",
+          headers: Object.assign({{ "Content-Type": "application/json" }}, authHeaders()),
+          body: JSON.stringify(body)
+        }});
+        const payload = await response.json();
+        memoryStatusPre.textContent = JSON.stringify(payload, null, 2);
+        if (response.ok) {{
+          await emitUiTelemetry("memory", "write", "memory_write_applied", {{ bytes: payload.bytes || 0 }});
+        }} else {{
+          await emitUiTelemetry("memory", "write", "memory_write_failed", {{ status: response.status }});
+        }}
+      }} catch (error) {{
+        memoryStatusPre.textContent = "Failed to write memory: " + String(error);
+      }}
+    }}
+
+    function activateView(viewKey) {{
+      const tabs = Array.from(document.querySelectorAll(".tab"));
+      const views = Array.from(document.querySelectorAll(".view"));
+      tabs.forEach((tab) => {{
+        const selected = tab.getAttribute("data-view") === viewKey;
+        tab.classList.toggle("active", selected);
+        tab.setAttribute("aria-selected", selected ? "true" : "false");
+      }});
+      views.forEach((view) => {{
+        const selected = view.id === "view-" + viewKey;
+        view.classList.toggle("active", selected);
+        view.setAttribute("aria-hidden", selected ? "false" : "true");
+      }});
+      emitUiTelemetry("navigation", "switch_view", "view_activated", {{ view: viewKey }});
+    }}
+
+    document.querySelectorAll(".tab").forEach((tab) => {{
+      tab.addEventListener("click", () => activateView(tab.getAttribute("data-view")));
+    }});
+
     sendButton.addEventListener("click", sendPrompt);
-    refreshButton.addEventListener("click", refreshStatus);
     clearButton.addEventListener("click", () => setOutput("No response yet."));
+    refreshButton.addEventListener("click", refreshStatus);
+    loadSessionsButton.addEventListener("click", loadSessions);
+    loadSessionDetailButton.addEventListener("click", loadSessionDetail);
+    appendSessionButton.addEventListener("click", appendSessionMessage);
+    resetSessionButton.addEventListener("click", resetSession);
+    loadMemoryButton.addEventListener("click", loadMemory);
+    saveMemoryButton.addEventListener("click", saveMemory);
+
     tokenInput.addEventListener("change", saveLocalValues);
-    sessionInput.addEventListener("change", saveLocalValues);
+    sessionInput.addEventListener("change", () => {{
+      saveLocalValues();
+      loadSessionDetail();
+      loadMemory();
+    }});
 
     loadLocalValues();
+    sessionPolicyGateInput.value = SESSION_WRITE_POLICY_GATE;
+    memoryPolicyGateInput.value = MEMORY_WRITE_POLICY_GATE;
+    configViewPre.textContent = formatConfigView({{ gateway: {{}} }});
+
+    // renderStatusDashboard(payload) is intentionally invoked after status fetch.
     refreshStatus();
+    loadSessions();
+    loadSessionDetail();
+    loadMemory();
   </script>
 </body>
 </html>
 "#,
         responses_endpoint = OPENRESPONSES_ENDPOINT,
+        chat_completions_endpoint = OPENAI_CHAT_COMPLETIONS_ENDPOINT,
+        completions_endpoint = OPENAI_COMPLETIONS_ENDPOINT,
+        models_endpoint = OPENAI_MODELS_ENDPOINT,
         status_endpoint = GATEWAY_STATUS_ENDPOINT,
         websocket_endpoint = GATEWAY_WS_ENDPOINT,
+        sessions_endpoint = GATEWAY_SESSIONS_ENDPOINT,
+        memory_endpoint_template = GATEWAY_MEMORY_ENDPOINT,
+        session_detail_endpoint_template = GATEWAY_SESSION_DETAIL_ENDPOINT,
+        session_append_endpoint_template = GATEWAY_SESSION_APPEND_ENDPOINT,
+        session_reset_endpoint_template = GATEWAY_SESSION_RESET_ENDPOINT,
+        ui_telemetry_endpoint = GATEWAY_UI_TELEMETRY_ENDPOINT,
+        session_policy_gate = SESSION_WRITE_POLICY_GATE,
+        memory_policy_gate = MEMORY_WRITE_POLICY_GATE,
         default_session_key = DEFAULT_SESSION_KEY,
     )
 }

--- a/docs/guides/gateway-ops.md
+++ b/docs/guides/gateway-ops.md
@@ -192,7 +192,12 @@ Webchat/control surface:
 - Token mode: paste the configured bearer token (`local-dev-token` in this example).
 - Password-session mode: first issue a session token from `/gateway/auth/session`, then paste that token.
 - Localhost-dev mode: token can be left empty.
-- Use the status refresh control to inspect `/gateway/status` from the same page.
+- Use the multi-view tabs for:
+  - `Conversation` (OpenResponses + OpenAI-compatible send/stream)
+  - `Tools` (status/connector/reason-code diagnostics)
+  - `Sessions` (browse/detail/append/reset with policy gate)
+  - `Memory` (session-scoped memory note read/write with policy gate)
+  - `Configuration` (runtime endpoint/gate summary)
 
 Direct status endpoint check:
 
@@ -217,6 +222,41 @@ curl -sS http://127.0.0.1:8787/gateway/status \
 - endpoint paths (`chat_completions_endpoint`, `completions_endpoint`, `models_endpoint`)
 - runtime counters (`total_requests`, `chat_completions_requests`, `completions_requests`, `models_requests`, `stream_requests`)
 - diagnostics (`translation_failures`, `execution_failures`, `reason_code_counts`, `ignored_field_counts`, `last_reason_codes`)
+
+`/gateway/status` includes `gateway.web_ui` with:
+
+- endpoint paths (`sessions_endpoint`, `session_detail_endpoint`, `session_append_endpoint`, `session_reset_endpoint`, `memory_endpoint`, `ui_telemetry_endpoint`)
+- policy gates (`policy_gates.session_write`, `policy_gates.memory_write`)
+- UI telemetry runtime counters (`telemetry_runtime.total_events`, `last_event_unix_ms`, `view_counts`, `action_counts`, `reason_code_counts`)
+
+Session admin API examples:
+
+```bash
+curl -sS http://127.0.0.1:8787/gateway/sessions \
+  -H "Authorization: Bearer local-dev-token"
+
+curl -sS http://127.0.0.1:8787/gateway/sessions/default/append \
+  -H "Authorization: Bearer local-dev-token" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"user","content":"manual session note","policy_gate":"allow_session_write"}'
+
+curl -sS http://127.0.0.1:8787/gateway/sessions/default/reset \
+  -H "Authorization: Bearer local-dev-token" \
+  -H "Content-Type: application/json" \
+  -d '{"policy_gate":"allow_session_write"}'
+```
+
+Memory admin API examples:
+
+```bash
+curl -sS http://127.0.0.1:8787/gateway/memory/default \
+  -H "Authorization: Bearer local-dev-token"
+
+curl -sS -X PUT http://127.0.0.1:8787/gateway/memory/default \
+  -H "Authorization: Bearer local-dev-token" \
+  -H "Content-Type: application/json" \
+  -d '{"content":"operator memory note","policy_gate":"allow_memory_write"}'
+```
 
 `/gateway/status` also includes a `runtime_heartbeat` block with:
 

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -415,6 +415,13 @@ Server endpoints:
 - `POST /v1/chat/completions` (OpenAI-compatible chat surface)
 - `POST /v1/completions` (OpenAI-compatible completions surface)
 - `GET /v1/models` (OpenAI-compatible model listing)
+- `GET /gateway/sessions`
+- `GET /gateway/sessions/{session_key}`
+- `POST /gateway/sessions/{session_key}/append` (requires `policy_gate=allow_session_write`)
+- `POST /gateway/sessions/{session_key}/reset` (requires `policy_gate=allow_session_write`)
+- `GET /gateway/memory/{session_key}`
+- `PUT /gateway/memory/{session_key}` (requires `policy_gate=allow_memory_write`)
+- `POST /gateway/ui/telemetry`
 - `POST /gateway/auth/session` (only when `--gateway-openresponses-auth-mode=password-session`)
 - `GET /gateway/status`
 - `GET /gateway/ws` (websocket control protocol)

--- a/docs/tau-coding-agent/code-map.md
+++ b/docs/tau-coding-agent/code-map.md
@@ -93,7 +93,7 @@ Use this area for skill packaging, verification, registry support, and lock work
 - `dashboard_contract.rs`: web dashboard/operator control-plane fixture/schema contract definitions and validators.
 - `dashboard_runtime.rs`: dashboard runtime loop (state transitions, retries, dedupe, channel-store writes).
 - `daemon_runtime.rs`: Tau daemon lifecycle install/start/stop/status helpers, profile rendering (launchd/systemd-user), and lifecycle diagnostics.
-- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`) plus OpenAI-compatible adapters (`/v1/chat/completions`, `/v1/completions`, `/v1/models`), gateway auth/session (`/gateway/auth/session`), gateway status (`/gateway/status`), websocket control (`/gateway/ws`), and webchat endpoint.
+- `gateway_openresponses.rs`: OpenResponses HTTP server (`/v1/responses`), OpenAI-compatible adapters (`/v1/chat/completions`, `/v1/completions`, `/v1/models`), session/memory admin endpoints (`/gateway/sessions/*`, `/gateway/memory/*`), UI telemetry ingestion (`/gateway/ui/telemetry`), gateway auth/session (`/gateway/auth/session`), gateway status (`/gateway/status`), websocket control (`/gateway/ws`), and multi-view webchat endpoint.
 - `crates/tau-gateway/src/gateway_ws_protocol.rs`: websocket control-plane frame schema, version compatibility, parse/error contracts, and fixture replay compatibility tests.
 - `deployment_contract.rs`: cloud deployment + WASM deliverable fixture/schema contract definitions and validators.
 - `deployment_runtime.rs`: deployment/WASM runtime loop (queueing, retries, dedupe, channel-store writes).


### PR DESCRIPTION
## Summary
- replace the basic webchat shell with a multi-view runtime operator UI in `gateway_openresponses/webchat_page.rs`:
  - `Conversation`
  - `Tools`
  - `Sessions`
  - `Memory`
  - `Configuration`
- add gateway session admin HTTP surfaces with explicit policy gates:
  - `GET /gateway/sessions`
  - `GET /gateway/sessions/{session_key}`
  - `POST /gateway/sessions/{session_key}/append` (`policy_gate=allow_session_write`)
  - `POST /gateway/sessions/{session_key}/reset` (`policy_gate=allow_session_write`)
- add gateway memory admin HTTP surfaces with explicit policy gate:
  - `GET /gateway/memory/{session_key}`
  - `PUT /gateway/memory/{session_key}` (`policy_gate=allow_memory_write`)
- add UI interaction telemetry ingestion:
  - `POST /gateway/ui/telemetry` writes JSONL events under gateway state and increments runtime counters
- extend `/gateway/status` gateway metadata with:
  - `gateway.web_ui` endpoint map
  - policy gate descriptors
  - `telemetry_runtime` counters and reason-code maps
- update gateway docs/runbook and transport/code-map references for new UI/admin surfaces

## Risks and Compatibility Notes
- session/memory write operations are intentionally policy-gated and return `403` unless the expected `policy_gate` value is present
- memory API is session-scoped operator memory notes under gateway state; it does not replace upstream model-context memory primitives
- web UI telemetry endpoint is best-effort and append-only JSONL; UI interaction should continue even if telemetry write fails

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-gateway --all-targets -- -D warnings`
- `cargo test -p tau-gateway unit_ -- --test-threads=1`
- `cargo test -p tau-gateway functional_ -- --test-threads=1`
- `cargo test -p tau-gateway integration_ -- --test-threads=1`
- `cargo test -p tau-gateway regression_ -- --test-threads=1`

### Test Matrix
- Unit: `15 passed; 0 failed`
- Functional: `19 passed; 0 failed`
- Integration: `17 passed; 0 failed`
- Regression: `26 passed; 0 failed`

### Live run / real execution proof
- HTTP live-server tests now exercise the new runtime surfaces and policy gates end-to-end:
  - `functional_gateway_sessions_endpoints_support_list_detail_append_and_reset`
  - `functional_gateway_memory_endpoint_supports_read_and_policy_gated_write`
  - `integration_gateway_ui_telemetry_endpoint_persists_events_and_status_counters`

Closes #1479
