### PR TITLE
feat(ci): complete 5.3 release automation pipeline and installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
             fast_validate:
               - "scripts/dev/fast-validate.sh"
               - "scripts/dev/test-fast-validate.sh"
+            release_helpers:
+              - "scripts/release/**"
+              - ".github/workflows/release.yml"
             wasm_smoke:
               - "crates/kamn-core/**"
               - "crates/kamn-sdk/**"
@@ -219,6 +222,25 @@ jobs:
       - name: Validate fast-validate script
         if: steps.fast_validate_scope.outputs.fast_validate_tests_needed == 'true'
         run: ./scripts/dev/test-fast-validate.sh
+
+      - name: Determine release-helper scope
+        id: release_helper_scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_helper_tests_needed="${{ steps.change_scope.outputs.release_helpers }}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            release_helper_tests_needed="true"
+          elif [[ -z "${release_helper_tests_needed}" ]]; then
+            release_helper_tests_needed="false"
+          fi
+          echo "release_helper_tests_needed=${release_helper_tests_needed}" >> "$GITHUB_OUTPUT"
+          echo "### Release Helper Scope" >> "$GITHUB_STEP_SUMMARY"
+          echo "- release helper tests needed: ${release_helper_tests_needed}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate release install/update helper scripts
+        if: steps.release_helper_scope.outputs.release_helper_tests_needed == 'true'
+        run: ./scripts/release/test-install-helpers.sh
 
       - name: Determine wasm smoke scope
         id: wasm_scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
         description: "Tag to release (for example: v1.2.3)"
         required: true
         type: string
+      enable_signing_hooks:
+        description: "Run optional signing hooks when hook scripts are present"
+        required: false
+        default: false
+        type: boolean
+      enable_notarization_hooks:
+        description: "Run optional macOS notarization hook when hook script is present"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -20,6 +30,8 @@ env:
   CARGO_TERM_COLOR: always
   APP_NAME: tau-coding-agent
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+  ENABLE_SIGNING_HOOKS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_signing_hooks || vars.RELEASE_ENABLE_SIGNING_HOOKS || 'false' }}
+  ENABLE_NOTARIZATION_HOOKS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_notarization_hooks || vars.RELEASE_ENABLE_NOTARIZATION_HOOKS || 'false' }}
 
 jobs:
   build:
@@ -33,9 +45,17 @@ jobs:
             target: x86_64-unknown-linux-gnu
             platform: linux-amd64
             archive_ext: tar.gz
-          - os: macos-latest
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            platform: linux-arm64
+            archive_ext: tar.gz
+          - os: macos-14
             target: x86_64-apple-darwin
             platform: macos-amd64
+            archive_ext: tar.gz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            platform: macos-arm64
             archive_ext: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -53,12 +73,22 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Linux ARM64 linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes gcc-aarch64-linux-gnu
+
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
 
       - name: Build/package/smoke (Unix)
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
         run: |
           set -euo pipefail
           cargo build --release -p "${APP_NAME}" --target "${{ matrix.target }}"
@@ -70,10 +100,38 @@ jobs:
           cp "${binary_path}" "${packaged_binary}"
           chmod +x "${packaged_binary}"
 
+          if [[ "${ENABLE_SIGNING_HOOKS}" == "true" ]]; then
+            if [[ "${RUNNER_OS}" == "Linux" ]]; then
+              hook_path="scripts/release/hooks/sign-linux.sh"
+            else
+              hook_path="scripts/release/hooks/sign-macos.sh"
+            fi
+
+            if [[ -x "${hook_path}" ]]; then
+              "${hook_path}" "${packaged_binary}" "${{ matrix.target }}" "${RELEASE_TAG}"
+            else
+              echo "release_hook_reason=sign_hook_missing hook=${hook_path}"
+            fi
+          else
+            echo "release_hook_reason=sign_hooks_disabled"
+          fi
+
           # Smoke test gate: artifact must execute and print help before publish.
           "${packaged_binary}" --help > /dev/null
 
-          tar -czf "dist/${APP_NAME}-${{ matrix.platform }}.tar.gz" -C dist "${APP_NAME}-${{ matrix.platform }}"
+          archive_path="dist/${APP_NAME}-${{ matrix.platform }}.tar.gz"
+          tar -czf "${archive_path}" -C dist "${APP_NAME}-${{ matrix.platform }}"
+
+          if [[ "${RUNNER_OS}" == "macOS" && "${ENABLE_NOTARIZATION_HOOKS}" == "true" ]]; then
+            hook_path="scripts/release/hooks/notarize-macos.sh"
+            if [[ -x "${hook_path}" ]]; then
+              "${hook_path}" "${archive_path}" "${{ matrix.target }}" "${RELEASE_TAG}"
+            else
+              echo "release_hook_reason=notarize_hook_missing hook=${hook_path}"
+            fi
+          elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+            echo "release_hook_reason=notarization_hooks_disabled"
+          fi
 
       - name: Build/package/smoke (Windows)
         if: runner.os == 'Windows'
@@ -87,6 +145,17 @@ jobs:
           $packagedBinary = "dist\\$env:APP_NAME-${{ matrix.platform }}.exe"
 
           Copy-Item "$binaryPath" "$packagedBinary"
+
+          if ($env:ENABLE_SIGNING_HOOKS -eq "true") {
+            $hookPath = "scripts/release/hooks/sign-windows.ps1"
+            if (Test-Path $hookPath) {
+              & $hookPath -BinaryPath "$packagedBinary" -Target "${{ matrix.target }}" -Tag "$env:RELEASE_TAG"
+            } else {
+              Write-Output "release_hook_reason=sign_hook_missing hook=$hookPath"
+            }
+          } else {
+            Write-Output "release_hook_reason=sign_hooks_disabled"
+          }
 
           # Smoke test gate: artifact must execute and print help before publish.
           & "$packagedBinary" --help | Out-Null

--- a/README.md
+++ b/README.md
@@ -153,5 +153,8 @@ GitHub Actions workflows:
   - optional manual coverage and cross-platform compile smoke
 - Security: [`.github/workflows/security.yml`](.github/workflows/security.yml)
 - Release: [`.github/workflows/release.yml`](.github/workflows/release.yml)
+  - Multi-platform artifacts: linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`), windows (`amd64`)
+  - Optional signing/notarization hook integration (`scripts/release/hooks/*`)
+  - Installer helpers: `scripts/release/install-tau.sh`, `scripts/release/update-tau.sh`, `scripts/release/install-tau.ps1`, `scripts/release/update-tau.ps1`
 
 Dependency automation: [`.github/dependabot.yml`](.github/dependabot.yml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This index maps Tau documentation by audience and task.
 | Prompt optimization integration operator | [Prompt Optimization Proxy Operations Guide](guides/training-proxy-ops.md) | OpenAI-compatible proxy mode with rollout/attempt attribution logs |
 | Workspace operator | [Project Index Guide](guides/project-index.md) | Build/query/inspect deterministic local code index |
 | Runtime operator / SRE | [Operator Control Summary](guides/operator-control-summary.md) | Unified control-plane status, policy posture, daemon/release checks, triage map |
+| Release operator | [Release Automation Operations Guide](guides/release-automation-ops.md) | Multi-platform build/publish flow, hook contracts, installer scripts, reason-code diagnostics |
 | Runtime contributor | [Startup DI Pipeline](guides/startup-di-pipeline.md) | 3-stage startup resolution: preflight gate, dependency/context composition, mode dispatch |
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
 | Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |

--- a/docs/guides/release-automation-ops.md
+++ b/docs/guides/release-automation-ops.md
@@ -1,0 +1,122 @@
+# Release Automation Operations Guide
+
+This guide covers release build/publish automation, optional signing/notarization hooks, and installer helper scripts.
+
+## Release workflow
+
+Workflow file: [`.github/workflows/release.yml`](../../.github/workflows/release.yml)
+
+Trigger modes:
+
+- Tag push: `v*`
+- Manual dispatch: `workflow_dispatch` (required `tag` input)
+
+Default artifact matrix:
+
+- `linux-amd64` (`x86_64-unknown-linux-gnu`)
+- `linux-arm64` (`aarch64-unknown-linux-gnu`, cross-compiled on Ubuntu with `gcc-aarch64-linux-gnu`)
+- `macos-amd64` (`x86_64-apple-darwin`)
+- `macos-arm64` (`aarch64-apple-darwin`)
+- `windows-amd64` (`x86_64-pc-windows-msvc`)
+
+The workflow publishes release archives plus checksum manifests to GitHub Releases:
+
+- `*.tar.gz` / `*.zip`
+- `*.sha256`
+- `SHA256SUMS`
+
+## Optional signing/notarization hooks
+
+Hook execution is controlled by workflow inputs/vars:
+
+- `enable_signing_hooks` (dispatch input) or `RELEASE_ENABLE_SIGNING_HOOKS` (repo variable)
+- `enable_notarization_hooks` (dispatch input) or `RELEASE_ENABLE_NOTARIZATION_HOOKS` (repo variable)
+
+Hook lookup paths:
+
+- Linux signing: `scripts/release/hooks/sign-linux.sh`
+- macOS signing: `scripts/release/hooks/sign-macos.sh`
+- macOS notarization: `scripts/release/hooks/notarize-macos.sh`
+- Windows signing: `scripts/release/hooks/sign-windows.ps1`
+
+If a hook is enabled but missing, release logs include explicit reason codes:
+
+- `release_hook_reason=sign_hook_missing`
+- `release_hook_reason=notarize_hook_missing`
+
+If disabled, release logs include:
+
+- `release_hook_reason=sign_hooks_disabled`
+- `release_hook_reason=notarization_hooks_disabled`
+
+## Installer helper scripts
+
+Scripts:
+
+- Shell installer: [`scripts/release/install-tau.sh`](../../scripts/release/install-tau.sh)
+- Shell updater: [`scripts/release/update-tau.sh`](../../scripts/release/update-tau.sh)
+- PowerShell installer: [`scripts/release/install-tau.ps1`](../../scripts/release/install-tau.ps1)
+- PowerShell updater: [`scripts/release/update-tau.ps1`](../../scripts/release/update-tau.ps1)
+
+Shell examples:
+
+```bash
+# Install latest to ~/.local/bin
+./scripts/release/install-tau.sh
+
+# Install an explicit tag and force overwrite
+./scripts/release/install-tau.sh --version v0.1.0 --force
+
+# Update an existing install in place
+./scripts/release/update-tau.sh --version v0.1.1
+```
+
+PowerShell examples:
+
+```powershell
+# Install latest (Windows default install dir: $env:LOCALAPPDATA\Tau\bin)
+./scripts/release/install-tau.ps1
+
+# Install a specific tag
+./scripts/release/install-tau.ps1 -Version v0.1.0
+
+# Update an existing install
+./scripts/release/update-tau.ps1 -Version v0.1.1
+```
+
+Common behavior:
+
+- Archive + `.sha256` checksum fetch
+- SHA256 verification by default (`--no-verify` / `-NoVerify` to bypass)
+- Post-install `--help` smoke gate
+- Backup/rollback on smoke failure
+- Structured reason-coded logs for diagnostics
+
+## Installer telemetry reason codes
+
+Installer scripts emit JSON log lines with `reason_code` values, including:
+
+- `download_started`
+- `checksum_fetch_started`
+- `checksum_verified`
+- `checksum_verification_skipped`
+- `install_complete`
+- `update_complete`
+- `checksum_mismatch`
+- `update_target_missing`
+- `destination_exists`
+- `smoke_test_failed`
+- `unsupported_os`
+- `unsupported_arch`
+
+## Local validation
+
+Run helper-script tests:
+
+```bash
+./scripts/release/test-install-helpers.sh
+```
+
+Run release workflow lint/validation via PR CI:
+
+- Release helper test scope is automatically triggered when `scripts/release/**` or `.github/workflows/release.yml` changes.

--- a/scripts/release/hooks/README.md
+++ b/scripts/release/hooks/README.md
@@ -1,0 +1,20 @@
+# Release Hook Contracts
+
+Optional signing/notarization hooks are invoked by [`.github/workflows/release.yml`](../../../.github/workflows/release.yml) when enabled.
+
+Supported hook paths:
+
+- `scripts/release/hooks/sign-linux.sh`
+  - args: `<packaged_binary_path> <target_triple> <release_tag>`
+- `scripts/release/hooks/sign-macos.sh`
+  - args: `<packaged_binary_path> <target_triple> <release_tag>`
+- `scripts/release/hooks/notarize-macos.sh`
+  - args: `<archive_path> <target_triple> <release_tag>`
+- `scripts/release/hooks/sign-windows.ps1`
+  - params: `-BinaryPath <path> -Target <triple> -Tag <release_tag>`
+
+Hook requirements:
+
+- Exit code `0` on success.
+- Non-zero exit code fails the release job.
+- Handle secret/material loading internally (for example from GitHub Actions secrets).

--- a/scripts/release/install-tau.ps1
+++ b/scripts/release/install-tau.ps1
@@ -1,0 +1,218 @@
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$InstallDir = "",
+    [string]$BinaryName = "tau-coding-agent",
+    [switch]$Update,
+    [switch]$Force,
+    [switch]$DryRun,
+    [switch]$NoVerify,
+    [switch]$PrintTarget
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$AppName = "tau-coding-agent"
+$RepoSlug = if ($env:TAU_RELEASE_REPO) { $env:TAU_RELEASE_REPO } else { "njfio/Tau" }
+$ReleaseBaseUrl = if ($env:TAU_RELEASE_BASE_URL) { $env:TAU_RELEASE_BASE_URL } else { "https://github.com/$RepoSlug/releases/download" }
+$LatestBaseUrl = if ($env:TAU_RELEASE_LATEST_URL) { $env:TAU_RELEASE_LATEST_URL } else { "https://github.com/$RepoSlug/releases/latest/download" }
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    if ($IsWindows) {
+        $InstallDir = Join-Path $env:LOCALAPPDATA "Tau\bin"
+    }
+    else {
+        $InstallDir = Join-Path $HOME ".local/bin"
+    }
+}
+
+function Write-Reason {
+    param(
+        [string]$Level,
+        [string]$ReasonCode,
+        [string]$Message
+    )
+    $payload = [ordered]@{
+        ts          = (Get-Date).ToUniversalTime().ToString("o")
+        component   = "release-installer"
+        level       = $Level
+        reason_code = $ReasonCode
+        message     = $Message
+    }
+    Write-Output ($payload | ConvertTo-Json -Compress)
+}
+
+function Fail-Reason {
+    param(
+        [string]$ReasonCode,
+        [string]$Message
+    )
+    Write-Reason -Level "error" -ReasonCode $ReasonCode -Message $Message | Write-Error
+    throw $Message
+}
+
+function Resolve-OsSlug {
+    if ($env:TAU_INSTALL_TEST_OS) {
+        $candidate = $env:TAU_INSTALL_TEST_OS.ToLowerInvariant()
+    }
+    elseif ($IsWindows) {
+        $candidate = "windows"
+    }
+    elseif ($IsLinux) {
+        $candidate = "linux"
+    }
+    elseif ($IsMacOS) {
+        $candidate = "macos"
+    }
+    else {
+        Fail-Reason -ReasonCode "unsupported_os" -Message "unsupported operating system"
+    }
+
+    switch ($candidate) {
+        "windows" { return "windows" }
+        "linux" { return "linux" }
+        "macos" { return "macos" }
+        default { Fail-Reason -ReasonCode "unsupported_os" -Message "unsupported operating system: $candidate" }
+    }
+}
+
+function Resolve-ArchSlug {
+    if ($env:TAU_INSTALL_TEST_ARCH) {
+        $candidate = $env:TAU_INSTALL_TEST_ARCH.ToLowerInvariant()
+    }
+    else {
+        $candidate = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+    }
+
+    switch ($candidate) {
+        { $_ -in @("x64", "x86_64", "amd64") } { return "amd64" }
+        { $_ -in @("arm64", "aarch64") } { return "arm64" }
+        default { Fail-Reason -ReasonCode "unsupported_arch" -Message "unsupported architecture: $candidate" }
+    }
+}
+
+function Read-ChecksumHash {
+    param([string]$ChecksumPath)
+    $line = Get-Content -Path $ChecksumPath -TotalCount 1
+    if ([string]::IsNullOrWhiteSpace($line)) {
+        Fail-Reason -ReasonCode "checksum_manifest_invalid" -Message "checksum manifest is empty"
+    }
+    $parts = $line -split "\s+"
+    $hash = $parts[0].ToLowerInvariant()
+    if ($hash -notmatch "^[a-f0-9]{64}$") {
+        Fail-Reason -ReasonCode "checksum_manifest_invalid" -Message "checksum manifest does not contain a valid SHA256"
+    }
+    return $hash
+}
+
+$OsSlug = Resolve-OsSlug
+$ArchSlug = Resolve-ArchSlug
+$Platform = "$OsSlug-$ArchSlug"
+$ArchiveExt = if ($OsSlug -eq "windows") { "zip" } else { "tar.gz" }
+$ArchiveName = "$AppName-$Platform.$ArchiveExt"
+$ArchiveUrl = if ([string]::IsNullOrWhiteSpace($Version)) { "$LatestBaseUrl/$ArchiveName" } else { "$ReleaseBaseUrl/$Version/$ArchiveName" }
+$ChecksumUrl = "$ArchiveUrl.sha256"
+
+if ($PrintTarget) {
+    Write-Output "platform=$Platform"
+    Write-Output "archive=$ArchiveName"
+    Write-Output "archive_url=$ArchiveUrl"
+    Write-Output "checksum_url=$ChecksumUrl"
+    exit 0
+}
+
+if ($DryRun) {
+    Write-Reason -Level "info" -ReasonCode "dry_run" -Message "resolved install metadata only"
+    Write-Output "platform=$Platform"
+    Write-Output "archive_url=$ArchiveUrl"
+    Write-Output "install_dir=$InstallDir"
+    exit 0
+}
+
+$WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) ("tau-install-" + [System.Guid]::NewGuid().ToString("N"))
+$ExtractDir = Join-Path $WorkDir "extract"
+$ArchivePath = Join-Path $WorkDir $ArchiveName
+$ChecksumPath = Join-Path $WorkDir "$ArchiveName.sha256"
+$DestinationName = if ($OsSlug -eq "windows" -and -not $BinaryName.EndsWith(".exe")) { "$BinaryName.exe" } else { $BinaryName }
+$DestinationPath = Join-Path $InstallDir $DestinationName
+$BackupPath = ""
+
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+New-Item -ItemType Directory -Path $ExtractDir -Force | Out-Null
+
+try {
+    if ($Update -and -not (Test-Path -Path $DestinationPath -PathType Leaf)) {
+        Fail-Reason -ReasonCode "update_target_missing" -Message "update requested but destination does not exist: $DestinationPath"
+    }
+    if (-not $Update -and (Test-Path -Path $DestinationPath -PathType Leaf) -and -not $Force) {
+        Fail-Reason -ReasonCode "destination_exists" -Message "destination exists; rerun with -Force or -Update: $DestinationPath"
+    }
+
+    Write-Reason -Level "info" -ReasonCode "download_started" -Message "downloading release archive"
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $ArchivePath
+
+    if (-not $NoVerify) {
+        Write-Reason -Level "info" -ReasonCode "checksum_fetch_started" -Message "downloading checksum manifest"
+        Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumPath
+        $expectedHash = Read-ChecksumHash -ChecksumPath $ChecksumPath
+        $actualHash = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -ne $expectedHash) {
+            Fail-Reason -ReasonCode "checksum_mismatch" -Message "archive checksum mismatch"
+        }
+        Write-Reason -Level "info" -ReasonCode "checksum_verified" -Message "checksum verification succeeded"
+    }
+    else {
+        Write-Reason -Level "warn" -ReasonCode "checksum_verification_skipped" -Message "checksum verification disabled by operator"
+    }
+
+    if ($ArchiveExt -eq "zip") {
+        Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+        $PackagedBinaryName = "$AppName-$Platform.exe"
+    }
+    else {
+        tar -xzf $ArchivePath -C $ExtractDir
+        $PackagedBinaryName = "$AppName-$Platform"
+    }
+
+    $SourceItem = Get-ChildItem -Path $ExtractDir -Recurse -File | Where-Object { $_.Name -eq $PackagedBinaryName } | Select-Object -First 1
+    if ($null -eq $SourceItem) {
+        Fail-Reason -ReasonCode "binary_not_found" -Message "packaged binary not found in archive: $PackagedBinaryName"
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    if (Test-Path -Path $DestinationPath -PathType Leaf) {
+        $BackupPath = "$DestinationPath.bak.$PID"
+        Copy-Item -Path $DestinationPath -Destination $BackupPath -Force
+    }
+
+    try {
+        Copy-Item -Path $SourceItem.FullName -Destination $DestinationPath -Force
+        if ($OsSlug -ne "windows") {
+            chmod +x $DestinationPath
+        }
+        & $DestinationPath --help | Out-Null
+    }
+    catch {
+        if ($BackupPath -and (Test-Path -Path $BackupPath -PathType Leaf)) {
+            Copy-Item -Path $BackupPath -Destination $DestinationPath -Force
+        }
+        Fail-Reason -ReasonCode "smoke_test_failed" -Message "installed binary failed --help smoke test"
+    }
+    finally {
+        if ($BackupPath -and (Test-Path -Path $BackupPath -PathType Leaf)) {
+            Remove-Item -Path $BackupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    if ($Update) {
+        Write-Reason -Level "info" -ReasonCode "update_complete" -Message "update completed successfully"
+    }
+    else {
+        Write-Reason -Level "info" -ReasonCode "install_complete" -Message "install completed successfully"
+    }
+    Write-Output "install_path=$DestinationPath"
+}
+finally {
+    Remove-Item -Path $WorkDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/release/install-tau.sh
+++ b/scripts/release/install-tau.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="tau-coding-agent"
+SCRIPT_NAME="$(basename "$0")"
+
+REPO_SLUG="${TAU_RELEASE_REPO:-njfio/Tau}"
+RELEASE_BASE_URL="${TAU_RELEASE_BASE_URL:-https://github.com/${REPO_SLUG}/releases/download}"
+LATEST_BASE_URL="${TAU_RELEASE_LATEST_URL:-https://github.com/${REPO_SLUG}/releases/latest/download}"
+
+INSTALL_DIR="${TAU_INSTALL_DIR:-${HOME}/.local/bin}"
+BINARY_NAME="${TAU_BINARY_NAME:-${APP_NAME}}"
+
+VERSION=""
+UPDATE_MODE="false"
+DRY_RUN="false"
+FORCE_MODE="false"
+VERIFY_CHECKSUMS="true"
+PRINT_TARGET="false"
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "${value}"
+}
+
+log_event() {
+  local level="$1"
+  local reason_code="$2"
+  local message="$3"
+  printf '{"ts":"%s","component":"release-installer","level":"%s","reason_code":"%s","message":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "${level}" \
+    "${reason_code}" \
+    "$(json_escape "${message}")"
+}
+
+fail_reason() {
+  local reason_code="$1"
+  local message="$2"
+  log_event "error" "${reason_code}" "${message}" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Install or update ${APP_NAME} from GitHub Releases.
+
+Options:
+  --version <tag>      Install a specific release tag (for example: v0.4.2).
+                       Default is latest release.
+  --install-dir <dir>  Destination directory (default: ${INSTALL_DIR}).
+  --binary-name <name> Destination binary filename (default: ${BINARY_NAME}).
+  --update             Update an existing install in place.
+  --force              Overwrite destination for non-update installs.
+  --dry-run            Resolve URLs/targets and exit without downloading.
+  --no-verify          Skip SHA256 checksum verification.
+  --print-target       Print resolved platform/archive metadata and exit.
+  --help, -h           Show this message.
+
+Environment overrides:
+  TAU_RELEASE_REPO, TAU_RELEASE_BASE_URL, TAU_RELEASE_LATEST_URL
+  TAU_INSTALL_DIR, TAU_BINARY_NAME
+  TAU_INSTALL_TEST_OS, TAU_INSTALL_TEST_ARCH (test-only overrides)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      shift
+      [[ $# -gt 0 ]] || fail_reason "argument_missing" "--version requires a value"
+      VERSION="$1"
+      ;;
+    --install-dir)
+      shift
+      [[ $# -gt 0 ]] || fail_reason "argument_missing" "--install-dir requires a value"
+      INSTALL_DIR="$1"
+      ;;
+    --binary-name)
+      shift
+      [[ $# -gt 0 ]] || fail_reason "argument_missing" "--binary-name requires a value"
+      BINARY_NAME="$1"
+      ;;
+    --update)
+      UPDATE_MODE="true"
+      ;;
+    --force)
+      FORCE_MODE="true"
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      ;;
+    --no-verify)
+      VERIFY_CHECKSUMS="false"
+      ;;
+    --print-target)
+      PRINT_TARGET="true"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail_reason "argument_unknown" "unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+resolve_os_slug() {
+  local raw_os
+  raw_os="$(printf '%s' "${TAU_INSTALL_TEST_OS:-$(uname -s)}" | tr '[:upper:]' '[:lower:]')"
+  case "${raw_os}" in
+    linux|linux*)
+      printf '%s\n' "linux"
+      ;;
+    darwin|darwin*|macos|macos*)
+      printf '%s\n' "macos"
+      ;;
+    *)
+      fail_reason "unsupported_os" "unsupported operating system: ${raw_os}"
+      ;;
+  esac
+}
+
+resolve_arch_slug() {
+  local raw_arch
+  raw_arch="$(printf '%s' "${TAU_INSTALL_TEST_ARCH:-$(uname -m)}" | tr '[:upper:]' '[:lower:]')"
+  case "${raw_arch}" in
+    x86_64|amd64)
+      printf '%s\n' "amd64"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "arm64"
+      ;;
+    *)
+      fail_reason "unsupported_arch" "unsupported architecture: ${raw_arch}"
+      ;;
+  esac
+}
+
+download_to() {
+  local source_url="$1"
+  local output_path="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
+      --output "${output_path}" "${source_url}"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget --quiet -O "${output_path}" "${source_url}"
+    return
+  fi
+  fail_reason "download_tool_missing" "missing curl/wget required for download"
+}
+
+sha256_file() {
+  local file_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file_path}" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file_path}" | awk '{print $1}'
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "${file_path}" | awk '{print $2}'
+    return
+  fi
+  fail_reason "checksum_tool_missing" "missing sha256sum/shasum/openssl for checksum verification"
+}
+
+OS_SLUG="$(resolve_os_slug)"
+ARCH_SLUG="$(resolve_arch_slug)"
+PLATFORM="${OS_SLUG}-${ARCH_SLUG}"
+ARCHIVE_NAME="${APP_NAME}-${PLATFORM}.tar.gz"
+
+if [[ -n "${VERSION}" ]]; then
+  ARCHIVE_URL="${RELEASE_BASE_URL}/${VERSION}/${ARCHIVE_NAME}"
+else
+  ARCHIVE_URL="${LATEST_BASE_URL}/${ARCHIVE_NAME}"
+fi
+CHECKSUM_URL="${ARCHIVE_URL}.sha256"
+
+if [[ "${PRINT_TARGET}" == "true" ]]; then
+  printf '%s\n' "platform=${PLATFORM}"
+  printf '%s\n' "archive=${ARCHIVE_NAME}"
+  printf '%s\n' "archive_url=${ARCHIVE_URL}"
+  printf '%s\n' "checksum_url=${CHECKSUM_URL}"
+  exit 0
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  log_event "info" "dry_run" "resolved install metadata only"
+  printf '%s\n' "platform=${PLATFORM}"
+  printf '%s\n' "archive_url=${ARCHIVE_URL}"
+  printf '%s\n' "install_dir=${INSTALL_DIR}"
+  exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+EXTRACT_DIR="${WORK_DIR}/extract"
+ARCHIVE_PATH="${WORK_DIR}/${ARCHIVE_NAME}"
+CHECKSUM_PATH="${WORK_DIR}/${ARCHIVE_NAME}.sha256"
+DESTINATION_PATH="${INSTALL_DIR}/${BINARY_NAME}"
+BACKUP_PATH=""
+
+cleanup() {
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+if [[ "${UPDATE_MODE}" == "true" && ! -f "${DESTINATION_PATH}" ]]; then
+  fail_reason "update_target_missing" "update requested but destination does not exist: ${DESTINATION_PATH}"
+fi
+
+if [[ "${UPDATE_MODE}" != "true" && -f "${DESTINATION_PATH}" && "${FORCE_MODE}" != "true" ]]; then
+  fail_reason "destination_exists" "destination exists; rerun with --force or --update: ${DESTINATION_PATH}"
+fi
+
+log_event "info" "download_started" "downloading release archive"
+download_to "${ARCHIVE_URL}" "${ARCHIVE_PATH}" || fail_reason "download_failed" "failed to download archive: ${ARCHIVE_URL}"
+
+if [[ "${VERIFY_CHECKSUMS}" == "true" ]]; then
+  log_event "info" "checksum_fetch_started" "downloading checksum manifest"
+  download_to "${CHECKSUM_URL}" "${CHECKSUM_PATH}" || fail_reason "checksum_download_failed" "failed to download checksum: ${CHECKSUM_URL}"
+  expected_hash="$(awk '{print $1}' "${CHECKSUM_PATH}" | head -n 1 | tr '[:upper:]' '[:lower:]')"
+  if [[ ! "${expected_hash}" =~ ^[a-f0-9]{64}$ ]]; then
+    fail_reason "checksum_manifest_invalid" "checksum manifest did not contain a valid SHA256"
+  fi
+  actual_hash="$(sha256_file "${ARCHIVE_PATH}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${actual_hash}" != "${expected_hash}" ]]; then
+    fail_reason "checksum_mismatch" "archive checksum mismatch"
+  fi
+  log_event "info" "checksum_verified" "checksum verification succeeded"
+else
+  log_event "warn" "checksum_verification_skipped" "checksum verification disabled by operator"
+fi
+
+mkdir -p "${EXTRACT_DIR}"
+tar -xzf "${ARCHIVE_PATH}" -C "${EXTRACT_DIR}" || fail_reason "archive_extract_failed" "failed to extract archive"
+
+PACKAGED_BINARY="${APP_NAME}-${PLATFORM}"
+SOURCE_PATH="$(find "${EXTRACT_DIR}" -maxdepth 2 -type f -name "${PACKAGED_BINARY}" | head -n 1)"
+if [[ -z "${SOURCE_PATH}" ]]; then
+  fail_reason "binary_not_found" "packaged binary not found in archive: ${PACKAGED_BINARY}"
+fi
+
+mkdir -p "${INSTALL_DIR}"
+if [[ -f "${DESTINATION_PATH}" ]]; then
+  BACKUP_PATH="${DESTINATION_PATH}.bak.$$"
+  cp "${DESTINATION_PATH}" "${BACKUP_PATH}"
+fi
+
+cp "${SOURCE_PATH}" "${DESTINATION_PATH}" || fail_reason "install_copy_failed" "failed to copy binary to destination"
+chmod +x "${DESTINATION_PATH}" || fail_reason "install_chmod_failed" "failed to make destination executable"
+
+if ! "${DESTINATION_PATH}" --help >/dev/null 2>&1; then
+  if [[ -n "${BACKUP_PATH}" && -f "${BACKUP_PATH}" ]]; then
+    cp "${BACKUP_PATH}" "${DESTINATION_PATH}"
+    chmod +x "${DESTINATION_PATH}" || true
+  fi
+  fail_reason "smoke_test_failed" "installed binary failed --help smoke test"
+fi
+
+if [[ -n "${BACKUP_PATH}" && -f "${BACKUP_PATH}" ]]; then
+  rm -f "${BACKUP_PATH}"
+fi
+
+if [[ "${UPDATE_MODE}" == "true" ]]; then
+  log_event "info" "update_complete" "update completed successfully"
+else
+  log_event "info" "install_complete" "install completed successfully"
+fi
+printf '%s\n' "install_path=${DESTINATION_PATH}"

--- a/scripts/release/test-install-helpers.sh
+++ b/scripts/release/test-install-helpers.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+INSTALL_SH="${SCRIPT_DIR}/install-tau.sh"
+UPDATE_SH="${SCRIPT_DIR}/update-tau.sh"
+INSTALL_PS1="${SCRIPT_DIR}/install-tau.ps1"
+UPDATE_PS1="${SCRIPT_DIR}/update-tau.ps1"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local label="$2"
+  if [[ ! -f "${path}" ]]; then
+    echo "assertion failed (${label}): expected file '${path}' to exist" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  local file_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file_path}" | awk '{print $1}'
+    return
+  fi
+  shasum -a 256 "${file_path}" | awk '{print $1}'
+}
+
+create_linux_release_fixture() {
+  local fixture_root="$1"
+  local version="$2"
+  local marker="$3"
+  local platform="linux-amd64"
+  local binary_name="tau-coding-agent-${platform}"
+  local archive_name="${binary_name}.tar.gz"
+  local payload_dir="${fixture_root}/payload/${version}"
+  local release_dir="${fixture_root}/download/${version}"
+
+  mkdir -p "${payload_dir}" "${release_dir}"
+  cat > "${payload_dir}/${binary_name}" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--help" ]]; then
+  echo "${marker}"
+  exit 0
+fi
+echo "${marker} \$*"
+EOF
+  chmod +x "${payload_dir}/${binary_name}"
+  tar -czf "${release_dir}/${archive_name}" -C "${payload_dir}" "${binary_name}"
+  sha256_file "${release_dir}/${archive_name}" > "${release_dir}/${archive_name}.sha256"
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+release_root="${tmp_dir}/releases"
+create_linux_release_fixture "${release_root}" "v9.9.9" "fixture-v9.9.9"
+create_linux_release_fixture "${release_root}" "v9.9.10" "fixture-v9.9.10"
+create_linux_release_fixture "${release_root}" "v9.9.11" "fixture-v9.9.11"
+
+# Unit: resolved target metadata should map canonical os/arch aliases.
+target_output="$(TAU_INSTALL_TEST_OS=linux TAU_INSTALL_TEST_ARCH=amd64 "${INSTALL_SH}" --version v9.9.9 --print-target)"
+assert_contains "${target_output}" "platform=linux-amd64" "print-target platform"
+assert_contains "${target_output}" "archive=tau-coding-agent-linux-amd64.tar.gz" "print-target archive"
+
+# Functional: install should fetch fixture release and place executable in destination.
+install_dir="${tmp_dir}/bin"
+TAU_RELEASE_BASE_URL="file://${release_root}/download" \
+TAU_INSTALL_TEST_OS=linux \
+TAU_INSTALL_TEST_ARCH=amd64 \
+"${INSTALL_SH}" --version v9.9.9 --install-dir "${install_dir}"
+assert_file_exists "${install_dir}/tau-coding-agent" "installed binary"
+help_output="$("${install_dir}/tau-coding-agent" --help)"
+assert_contains "${help_output}" "fixture-v9.9.9" "installed binary payload marker"
+
+# Integration: update wrapper should route through installer update mode and replace binary.
+TAU_RELEASE_BASE_URL="file://${release_root}/download" \
+TAU_INSTALL_TEST_OS=linux \
+TAU_INSTALL_TEST_ARCH=amd64 \
+"${UPDATE_SH}" --version v9.9.10 --install-dir "${install_dir}"
+updated_help_output="$("${install_dir}/tau-coding-agent" --help)"
+assert_contains "${updated_help_output}" "fixture-v9.9.10" "updated binary payload marker"
+
+# Regression: corrupted checksum must fail with checksum_mismatch reason code.
+echo "0000000000000000000000000000000000000000000000000000000000000000  tau-coding-agent-linux-amd64.tar.gz" \
+  > "${release_root}/download/v9.9.11/tau-coding-agent-linux-amd64.tar.gz.sha256"
+set +e
+corrupt_output="$(TAU_RELEASE_BASE_URL="file://${release_root}/download" \
+  TAU_INSTALL_TEST_OS=linux \
+  TAU_INSTALL_TEST_ARCH=amd64 \
+  "${INSTALL_SH}" --version v9.9.11 --install-dir "${tmp_dir}/corrupt-bin" 2>&1)"
+corrupt_exit_code=$?
+set -e
+if [[ ${corrupt_exit_code} -eq 0 ]]; then
+  echo "assertion failed (checksum regression): install unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "${corrupt_output}" "\"reason_code\":\"checksum_mismatch\"" "checksum mismatch reason code"
+
+# Regression: update wrapper should fail when install target is missing.
+set +e
+missing_update_output="$(TAU_RELEASE_BASE_URL="file://${release_root}/download" \
+  TAU_INSTALL_TEST_OS=linux \
+  TAU_INSTALL_TEST_ARCH=amd64 \
+  "${UPDATE_SH}" --version v9.9.10 --install-dir "${tmp_dir}/missing-update" 2>&1)"
+missing_update_exit_code=$?
+set -e
+if [[ ${missing_update_exit_code} -eq 0 ]]; then
+  echo "assertion failed (update missing target): update unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "${missing_update_output}" "\"reason_code\":\"update_target_missing\"" "update missing target reason code"
+
+# PowerShell script smoke tests (executed when pwsh is available on host).
+if command -v pwsh >/dev/null 2>&1; then
+  ps_target_output="$(TAU_INSTALL_TEST_OS=windows TAU_INSTALL_TEST_ARCH=amd64 \
+    pwsh -NoProfile -File "${INSTALL_PS1}" -Version v9.9.9 -PrintTarget)"
+  assert_contains "${ps_target_output}" "platform=windows-amd64" "PowerShell print-target platform"
+
+  ps_dry_run_output="$(TAU_INSTALL_TEST_OS=windows TAU_INSTALL_TEST_ARCH=amd64 \
+    pwsh -NoProfile -File "${UPDATE_PS1}" -Version v9.9.9 -DryRun 2>&1)"
+  assert_contains "${ps_dry_run_output}" "\"reason_code\":\"dry_run\"" "PowerShell dry-run reason code"
+fi
+
+echo "release install/update helper tests passed"

--- a/scripts/release/update-tau.ps1
+++ b/scripts/release/update-tau.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$InstallDir = "",
+    [string]$BinaryName = "tau-coding-agent",
+    [switch]$Force,
+    [switch]$DryRun,
+    [switch]$NoVerify,
+    [switch]$PrintTarget
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptPath = Join-Path $PSScriptRoot "install-tau.ps1"
+$Params = @{
+    Update = $true
+}
+
+if ($PSBoundParameters.ContainsKey("Version")) {
+    $Params["Version"] = $Version
+}
+if ($PSBoundParameters.ContainsKey("InstallDir")) {
+    $Params["InstallDir"] = $InstallDir
+}
+if ($PSBoundParameters.ContainsKey("BinaryName")) {
+    $Params["BinaryName"] = $BinaryName
+}
+if ($Force) {
+    $Params["Force"] = $true
+}
+if ($DryRun) {
+    $Params["DryRun"] = $true
+}
+if ($NoVerify) {
+    $Params["NoVerify"] = $true
+}
+if ($PrintTarget) {
+    $Params["PrintTarget"] = $true
+}
+
+& $ScriptPath @Params

--- a/scripts/release/update-tau.sh
+++ b/scripts/release/update-tau.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/install-tau.sh" --update "$@"


### PR DESCRIPTION
Closes #1480

## Summary
- Expanded release automation matrix in `.github/workflows/release.yml`:
  - linux: `amd64`, `arm64`
  - macOS: `amd64`, `arm64`
  - windows: `amd64`
- Added linux arm64 cross-compile toolchain install (`gcc-aarch64-linux-gnu`) and linker wiring.
- Added optional signing/notarization hook integration points (Linux/macOS/Windows signing + macOS notarization) with explicit reason-code diagnostics when disabled/missing.
- Added release install/update helper scripts with checksum verification + smoke gate:
  - `scripts/release/install-tau.sh`
  - `scripts/release/update-tau.sh`
  - `scripts/release/install-tau.ps1`
  - `scripts/release/update-tau.ps1`
- Added structured installer telemetry (`reason_code`) for operator diagnostics.
- Added deterministic helper tests and CI wiring:
  - `scripts/release/test-install-helpers.sh`
  - CI scope filter + test execution in `.github/workflows/ci.yml`
- Added release runbook docs and index links:
  - `docs/guides/release-automation-ops.md`
  - `scripts/release/hooks/README.md`
  - updates in `docs/README.md` and `README.md`

## Risks and Compatibility
- Release workflow now builds additional arm64 artifacts; build duration for release workflows will increase.
- Signing/notarization hooks are opt-in and non-breaking by default; disabled/missing hooks only emit diagnostic reason-codes.
- Installer scripts are additive and do not change existing CLI/runtime behavior.

## Validation Evidence
- `cargo fmt --all`
- `cargo clippy -p tau-cli --all-targets -- -D warnings`
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`
- `./scripts/release/test-install-helpers.sh`

## Test Matrix Coverage
- Unit: target/platform resolution assertions in `scripts/release/test-install-helpers.sh`.
- Functional: release fixture install path verification + post-install smoke execution.
- Integration: update wrapper path exercises installer update mode and binary replacement.
- Regression: checksum mismatch + missing update-target fail-closed checks with explicit reason codes.
