### PR TITLE
ci(docs): enforce roadmap status sync check in docs quality

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**/*.md"
       - "docs/**"
+      - "tasks/**"
+      - "scripts/dev/roadmap-status-sync.sh"
+      - "scripts/dev/test-roadmap-status-sync.sh"
       - ".github/scripts/docs_link_check.py"
       - ".github/scripts/test_docs_link_check.py"
       - ".github/scripts/architecture_docs_check.py"
@@ -18,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   docs-quality:
@@ -37,3 +41,11 @@ jobs:
 
       - name: Check architecture docs freshness
         run: python3 .github/scripts/architecture_docs_check.py --repo-root .
+
+      - name: Validate roadmap status sync script
+        run: scripts/dev/test-roadmap-status-sync.sh
+
+      - name: Check roadmap status sync blocks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/dev/roadmap-status-sync.sh --check


### PR DESCRIPTION
Closes #1577

## Summary of behavior changes
- Extended `docs-quality.yml` pull-request path filters to include:
  - `tasks/**`
  - `scripts/dev/roadmap-status-sync.sh`
  - `scripts/dev/test-roadmap-status-sync.sh`
- Added `issues: read` permission so workflow can query issue state through `gh`.
- Added workflow steps to:
  - run `scripts/dev/test-roadmap-status-sync.sh`
  - enforce generated status freshness with `scripts/dev/roadmap-status-sync.sh --check`

## Risks and compatibility notes
- Docs-quality workflow now depends on `GH_TOKEN` issue-read scope for roadmap check.
- Drift checks may fail legacy PR branches until they re-sync generated roadmap blocks.
- No runtime crate behavior changes.

## Validation evidence
- `cargo fmt --all`
- `python3 -m unittest discover -s .github/scripts -p "test_*docs*_check.py"`
- `scripts/dev/test-roadmap-status-sync.sh`
- `scripts/dev/roadmap-status-sync.sh --check`
