### PR TITLE
ci: enforce roadmap status sync check in main quality lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
 
 env:
@@ -196,6 +197,11 @@ jobs:
       - name: Validate CI helper scripts
         if: steps.helper_scope.outputs.helper_tests_needed == 'true'
         run: python3 -m unittest discover -s .github/scripts -p "test_*.py"
+
+      - name: Check roadmap status sync blocks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/dev/roadmap-status-sync.sh --check
 
       - name: Check rust doc density thresholds
         if: steps.rust_scope.outputs.rust_changed == 'true'


### PR DESCRIPTION
Closes #1579

## Summary of behavior changes
- Added main CI permission `issues: read` to allow issue-state lookup for roadmap checks.
- Added a new `Quality (fmt + clippy + tests)` step:
  - `scripts/dev/roadmap-status-sync.sh --check`
- Step runs with `GH_TOKEN: ${{ github.token }}` so non-interactive CI can query issue state.

## Risks and compatibility notes
- Main CI now depends on roadmap status sync freshness and can fail unrelated PRs if roadmap blocks drift.
- `gh` issue read access is required in CI; permission was explicitly added.
- No runtime/crate behavior changes.

## Validation evidence
- `cargo fmt --all`
- `scripts/dev/roadmap-status-sync.sh --check`
- `scripts/dev/test-roadmap-status-sync.sh`
- `python3 -m unittest discover -s .github/scripts -p "test_*docs*_check.py"`
