### PR TITLE
chore(roadmap): add quiet mode to status sync checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Check roadmap status sync blocks
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/dev/roadmap-status-sync.sh --check
+        run: scripts/dev/roadmap-status-sync.sh --check --quiet
 
       - name: Check rust doc density thresholds
         if: steps.rust_scope.outputs.rust_changed == 'true'

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Check roadmap status sync blocks
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/dev/roadmap-status-sync.sh --check
+        run: scripts/dev/roadmap-status-sync.sh --check --quiet

--- a/docs/guides/roadmap-status-sync.md
+++ b/docs/guides/roadmap-status-sync.md
@@ -33,6 +33,12 @@ scripts/dev/roadmap-status-sync.sh --check
 
 `--check` exits non-zero when either generated block is stale and prints a diff.
 
+Use `--quiet` to suppress informational success output in CI:
+
+```bash
+scripts/dev/roadmap-status-sync.sh --check --quiet
+```
+
 ## Fixture Mode (Deterministic Tests)
 
 ```bash

--- a/scripts/dev/roadmap-status-sync.sh
+++ b/scripts/dev/roadmap-status-sync.sh
@@ -10,6 +10,7 @@ CONFIG_PATH="${REPO_ROOT}/tasks/roadmap-status-config.json"
 FIXTURE_JSON=""
 REPO_SLUG=""
 CHECK_MODE="false"
+QUIET_MODE="false"
 
 TODO_BEGIN="<!-- ROADMAP_STATUS:BEGIN -->"
 TODO_END="<!-- ROADMAP_STATUS:END -->"
@@ -40,6 +41,7 @@ Options:
   --config-path <path>    Override roadmap config path.
   --repo <owner/name>     Override repository for gh queries.
   --fixture-json <path>   Read issue states from fixture JSON instead of GitHub.
+  --quiet                 Suppress informational output.
   --check                 Verify docs are up to date (no writes).
   --help                  Show this message.
 
@@ -58,6 +60,12 @@ require_cmd() {
   if ! command -v "${name}" >/dev/null 2>&1; then
     echo "error: required command '${name}' not found" >&2
     exit 1
+  fi
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
   fi
 }
 
@@ -362,6 +370,9 @@ while [[ $# -gt 0 ]]; do
       shift
       FIXTURE_JSON="$1"
       ;;
+    --quiet)
+      QUIET_MODE="true"
+      ;;
     --check)
       CHECK_MODE="true"
       ;;
@@ -410,12 +421,12 @@ if [[ "${CHECK_MODE}" == "true" ]]; then
     exit 1
   fi
 
-  echo "roadmap status docs are up to date"
+  log_info "roadmap status docs are up to date"
   exit 0
 fi
 
 mv "${tmp_todo}" "${TODO_PATH}"
 mv "${tmp_gap}" "${GAP_PATH}"
-echo "updated roadmap status blocks:"
-echo "  - ${TODO_PATH}"
-echo "  - ${GAP_PATH}"
+log_info "updated roadmap status blocks:"
+log_info "  - ${TODO_PATH}"
+log_info "  - ${GAP_PATH}"

--- a/scripts/dev/test-roadmap-status-sync.sh
+++ b/scripts/dev/test-roadmap-status-sync.sh
@@ -94,7 +94,7 @@ cat >"${malformed_config_path}" <<'EOF'
 EOF
 
 # Unit: all closed fixture should mark epics and summary as complete.
-"${SYNC_SCRIPT}" --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
+"${SYNC_SCRIPT}" --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
 todo_content="$(cat "${todo_path}")"
 gap_content="$(cat "${gap_path}")"
 assert_contains "${todo_content}" "- [x] Closing epics complete" "unit all-closed epic mark"
@@ -104,7 +104,7 @@ assert_contains "${gap_content}" "#1 through #2" "unit gap core-delivery range"
 
 # Functional: second run with same fixture is idempotent.
 first_hash="$(shasum "${todo_path}" "${gap_path}")"
-"${SYNC_SCRIPT}" --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
+"${SYNC_SCRIPT}" --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
 second_hash="$(shasum "${todo_path}" "${gap_path}")"
 if [[ "${first_hash}" != "${second_hash}" ]]; then
   echo "assertion failed (functional idempotent): hashes changed on second run" >&2
@@ -112,10 +112,10 @@ if [[ "${first_hash}" != "${second_hash}" ]]; then
 fi
 
 # Integration: check mode passes when files are up to date.
-"${SYNC_SCRIPT}" --check --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
+"${SYNC_SCRIPT}" --check --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}"
 
 # Regression: open epic should show unchecked epic completion line.
-"${SYNC_SCRIPT}" --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_epic_open}"
+"${SYNC_SCRIPT}" --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_epic_open}"
 todo_content="$(cat "${todo_path}")"
 assert_contains "${todo_content}" "- [ ] Closing epics complete" "regression open-epic mark"
 assert_not_contains "${todo_content}" "- [x] Closing epics complete" "regression should not mark closed"
@@ -125,19 +125,19 @@ cat >"${todo_missing_marker}" <<'EOF'
 # Missing marker file
 no generated block markers in this file
 EOF
-if "${SYNC_SCRIPT}" --todo-path "${todo_missing_marker}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
+if "${SYNC_SCRIPT}" --quiet --todo-path "${todo_missing_marker}" --gap-path "${gap_path}" --config-path "${config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
   echo "assertion failed (regression missing markers): expected sync to fail" >&2
   exit 1
 fi
 
 # Regression: missing config fails closed.
-if "${SYNC_SCRIPT}" --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${missing_config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
+if "${SYNC_SCRIPT}" --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${missing_config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
   echo "assertion failed (regression missing config): expected sync to fail" >&2
   exit 1
 fi
 
 # Regression: malformed config fails closed.
-if "${SYNC_SCRIPT}" --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${malformed_config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
+if "${SYNC_SCRIPT}" --quiet --todo-path "${todo_path}" --gap-path "${gap_path}" --config-path "${malformed_config_path}" --fixture-json "${fixture_all_closed}" >/dev/null 2>&1; then
   echo "assertion failed (regression malformed config): expected sync to fail" >&2
   exit 1
 fi


### PR DESCRIPTION
Closes #1585

## Summary of behavior changes
- Added `--quiet` option to `scripts/dev/roadmap-status-sync.sh`.
- Quiet mode suppresses informational success output while preserving fail-closed errors.
- Updated CI and docs-quality workflow check steps to use `--check --quiet`.
- Updated roadmap sync test harness to use quiet mode in scripted calls.
- Updated roadmap sync guide with quiet mode usage.

## Risks and compatibility notes
- Informational script output is reduced in CI; failures still emit error output and non-zero exit.
- Workflow contract checks continue to validate presence of roadmap check step (substring match remains valid).
- No runtime crate behavior changes.

## Validation evidence
- `bash -n scripts/dev/roadmap-status-sync.sh scripts/dev/test-roadmap-status-sync.sh`
- `scripts/dev/test-roadmap-status-sync.sh`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `cargo fmt --all`
