### PR TITLE
ci: gate codex-light demo smoke to relevant changes

### DIFF
--- a/.github/scripts/test_ci_demo_smoke_scope.py
+++ b/.github/scripts/test_ci_demo_smoke_scope.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class CiDemoSmokeScopeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_integration_paths_filter_defines_demo_smoke_scope(self):
+        self.assertIn("demo_smoke:", self.workflow)
+        self.assertIn('- "crates/tau-coding-agent/**"', self.workflow)
+        self.assertIn('- ".github/demo-smoke-manifest.json"', self.workflow)
+        self.assertIn('- ".github/scripts/demo_smoke_runner.py"', self.workflow)
+
+    def test_integration_demo_smoke_scope_step_is_present(self):
+        self.assertIn("name: Determine codex demo smoke scope", self.workflow)
+        self.assertIn("id: demo_smoke_scope", self.workflow)
+        self.assertIn(
+            'demo_smoke_needed="${{ steps.change_scope.outputs.demo_smoke }}"',
+            self.workflow,
+        )
+
+    def test_regression_codex_demo_smoke_run_is_gated_by_scope_output(self):
+        self.assertIn("name: Run codex light demo smoke", self.workflow)
+        self.assertIn(
+            "steps.demo_smoke_scope.outputs.demo_smoke_needed == 'true'",
+            self.workflow,
+        )
+
+    def test_regression_codex_demo_smoke_upload_is_gated_by_scope_output(self):
+        self.assertIn("name: Upload codex light demo smoke logs", self.workflow)
+        self.assertIn(
+            "steps.demo_smoke_scope.outputs.demo_smoke_needed == 'true'",
+            self.workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,13 @@ jobs:
               - "scripts/dev/test-wasm-smoke.sh"
               - "scripts/edge/**"
               - ".github/workflows/ci.yml"
+            demo_smoke:
+              - "crates/tau-coding-agent/**"
+              - ".github/demo-smoke-manifest.json"
+              - ".github/scripts/demo_smoke_runner.py"
+              - ".github/scripts/test_demo_smoke_runner.py"
+              - "scripts/demo-smoke.sh"
+              - ".github/workflows/ci.yml"
 
       - name: Determine rust scope
         id: rust_scope
@@ -269,6 +276,21 @@ jobs:
         if: steps.wasm_scope.outputs.wasm_smoke_needed == 'true'
         run: ./scripts/dev/test-wasm-smoke.sh
 
+      - name: Determine codex demo smoke scope
+        id: demo_smoke_scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          demo_smoke_needed="${{ steps.change_scope.outputs.demo_smoke }}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            demo_smoke_needed="true"
+          elif [[ -z "${demo_smoke_needed}" ]]; then
+            demo_smoke_needed="false"
+          fi
+          echo "demo_smoke_needed=${demo_smoke_needed}" >> "$GITHUB_OUTPUT"
+          echo "### Codex Demo Smoke Scope" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Demo smoke needed: ${demo_smoke_needed}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Determine quality mode
         id: quality_mode
         shell: bash
@@ -365,7 +387,7 @@ jobs:
           fi
 
       - name: Run codex light demo smoke
-        if: steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode == 'codex-light'
+        if: steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode == 'codex-light' && steps.demo_smoke_scope.outputs.demo_smoke_needed == 'true'
         env:
           RUST_MIN_STACK: "8388608"
         run: |
@@ -378,7 +400,7 @@ jobs:
             --build
 
       - name: Upload codex light demo smoke logs
-        if: always() && steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode == 'codex-light'
+        if: always() && steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode == 'codex-light' && steps.demo_smoke_scope.outputs.demo_smoke_needed == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: demo-smoke-logs


### PR DESCRIPTION
Closes #1593

## Summary
- Added a `demo_smoke` path filter in `.github/workflows/ci.yml` to detect codex/demo-smoke related changes.
- Added `Determine codex demo smoke scope` step that resolves `demo_smoke_needed` for PR and non-PR events.
- Gated `Run codex light demo smoke` and demo-smoke artifact upload on `steps.demo_smoke_scope.outputs.demo_smoke_needed == 'true'`.
- Added workflow contract test: `.github/scripts/test_ci_demo_smoke_scope.py`.

## Behavior Changes
- In `codex-light` mode, demo smoke now runs only when PR changes touch demo-smoke-relevant paths.
- Non-PR events still force demo smoke (`demo_smoke_needed=true`).

## Risks and Compatibility
- Low risk; change is limited to CI step conditionals and guard coverage tests.
- No runtime code changes.

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_ci_*.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `cargo fmt --all --check`
