### PR TITLE
ci: speed up codex-light lint with fast-validate check-only

### DIFF
--- a/.github/scripts/test_ci_codex_light_lint_contract.py
+++ b/.github/scripts/test_ci_codex_light_lint_contract.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class CiCodexLightLintContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_integration_codex_light_lint_uses_fast_validate_check_only(self):
+        self.assertIn("name: Lint (codex-light lane)", self.workflow)
+        self.assertIn(
+            "./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base",
+            self.workflow,
+        )
+        self.assertIn(
+            "./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full",
+            self.workflow,
+        )
+
+    def test_regression_codex_light_lint_no_longer_uses_direct_tau_coding_agent_check(self):
+        self.assertNotIn(
+            "cargo check -p tau-coding-agent --all-targets",
+            self.workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,15 @@ jobs:
 
       - name: Lint (codex-light lane)
         if: steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode == 'codex-light'
-        run: cargo check -p tau-coding-agent --all-targets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}" || true
+            ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base "${{ github.event.pull_request.base.sha }}"
+          else
+            ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full
+          fi
 
       - name: Report lint strategy
         shell: bash
@@ -374,7 +382,13 @@ jobs:
             echo "- Reason: no Rust/Cargo changes in pull_request scope" >> "$GITHUB_STEP_SUMMARY"
           elif [[ "${{ steps.quality_mode.outputs.mode }}" == "codex-light" ]]; then
             echo "- Mode: codex-light" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Command: cargo check -p tau-coding-agent --all-targets" >> "$GITHUB_STEP_SUMMARY"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "- Command: ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base <pull_request.base.sha>" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Scope: directly changed crates only (no reverse-dependency expansion)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- Command: ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Scope: full workspace check-only" >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
             echo "- Mode: full" >> "$GITHUB_STEP_SUMMARY"
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then

--- a/scripts/dev/test-fast-validate.sh
+++ b/scripts/dev/test-fast-validate.sh
@@ -36,6 +36,11 @@ assert_contains "${output}" "full_workspace=0" "crate file should not force work
 assert_contains "${output}" "package=tau-cli" "crate file should map to tau-cli package"
 assert_contains "${output}" "package=tau-coding-agent" "tau-cli impact scope should include reverse dependents"
 
+output="$(printf 'crates/tau-cli/src/cli_args.rs\n' | "${FAST_VALIDATE}" --print-packages-from-stdin --direct-packages-only)"
+assert_contains "${output}" "full_workspace=0" "direct-only mode should not force workspace"
+assert_contains "${output}" "package=tau-cli" "direct-only mode should include directly changed crate"
+assert_not_contains "${output}" "package=tau-coding-agent" "direct-only mode should skip reverse dependents"
+
 output="$(printf 'Cargo.toml\n' | "${FAST_VALIDATE}" --print-packages-from-stdin)"
 assert_contains "${output}" "full_workspace=1" "workspace manifest should force full scope"
 


### PR DESCRIPTION
Closes #1595

## Summary
- Added `--check-only` mode to `scripts/dev/fast-validate.sh` to run `cargo check` (after fmt check) instead of clippy/tests.
- Added `--direct-packages-only` mode to skip reverse-dependency expansion for faster scoped checks.
- Updated codex-light lint in `.github/workflows/ci.yml` to run:
  - PR: `./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base <pull_request.base.sha>`
  - Non-PR fallback: `./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full`
- Extended `scripts/dev/test-fast-validate.sh` with direct-only scope regression coverage.
- Added CI workflow contract test: `.github/scripts/test_ci_codex_light_lint_contract.py`.

## Behavior Changes
- Codex-light lane now validates directly changed crates via `fast-validate` check-only mode, instead of always checking `tau-coding-agent`.
- Full lane behavior remains unchanged (`clippy + tests`).

## Risks and Compatibility
- Low risk: scoped to CI/lint orchestration and helper scripts.
- Compatibility preserved for existing full validation path.

## Validation Evidence
- `bash -n scripts/dev/fast-validate.sh scripts/dev/test-fast-validate.sh`
- `./scripts/dev/test-fast-validate.sh`
- `python3 -m unittest discover -s .github/scripts -p "test_ci_*.py"`
- `cargo fmt --all --check`
