### PR TITLE
ci: skip duplicate fmt in codex-light fast-validate lint

### DIFF
--- a/.github/scripts/test_ci_codex_light_lint_contract.py
+++ b/.github/scripts/test_ci_codex_light_lint_contract.py
@@ -14,11 +14,11 @@ class CiCodexLightLintContractTests(unittest.TestCase):
     def test_integration_codex_light_lint_uses_fast_validate_check_only(self):
         self.assertIn("name: Lint (codex-light lane)", self.workflow)
         self.assertIn(
-            "./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base",
+            "./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --base",
             self.workflow,
         )
         self.assertIn(
-            "./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full",
+            "./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --full",
             self.workflow,
         )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,9 +368,9 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}" || true
-            ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base "${{ github.event.pull_request.base.sha }}"
+            ./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --base "${{ github.event.pull_request.base.sha }}"
           else
-            ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full
+            ./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --full
           fi
 
       - name: Report lint strategy
@@ -383,10 +383,10 @@ jobs:
           elif [[ "${{ steps.quality_mode.outputs.mode }}" == "codex-light" ]]; then
             echo "- Mode: codex-light" >> "$GITHUB_STEP_SUMMARY"
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "- Command: ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --base <pull_request.base.sha>" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Command: ./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --base <pull_request.base.sha>" >> "$GITHUB_STEP_SUMMARY"
               echo "- Scope: directly changed crates only (no reverse-dependency expansion)" >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "- Command: ./scripts/dev/fast-validate.sh --check-only --direct-packages-only --full" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Command: ./scripts/dev/fast-validate.sh --skip-fmt --check-only --direct-packages-only --full" >> "$GITHUB_STEP_SUMMARY"
               echo "- Scope: full workspace check-only" >> "$GITHUB_STEP_SUMMARY"
             fi
           else

--- a/scripts/dev/test-fast-validate.sh
+++ b/scripts/dev/test-fast-validate.sh
@@ -48,9 +48,15 @@ output="$(printf 'docs/README.md\n' | "${FAST_VALIDATE}" --print-packages-from-s
 assert_contains "${output}" "full_workspace=0" "docs-only change should stay package-scoped"
 assert_not_contains "${output}" "package=" "docs-only change should not emit package scope"
 
+output="$(printf 'docs/README.md\n' | "${FAST_VALIDATE}" --print-packages-from-stdin --skip-fmt)"
+assert_contains "${output}" "full_workspace=0" "skip-fmt should not affect package scope derivation"
+
 output="$(printf 'crates/tau-cli/src/lib.rs\ncrates/tau-tools/src/lib.rs\n' | "${FAST_VALIDATE}" --print-packages-from-stdin)"
 assert_contains "${output}" "package=tau-cli" "multi-crate input should include tau-cli"
 assert_contains "${output}" "package=tau-tools" "multi-crate input should include tau-tools"
 assert_contains "${output}" "package=tau-coding-agent" "tau-tools impact scope should include coding-agent"
+
+help_output="$("${FAST_VALIDATE}" --help)"
+assert_contains "${help_output}" "--skip-fmt" "help output should document skip-fmt option"
 
 echo "fast-validate scope tests passed"


### PR DESCRIPTION
Closes #1597

## Summary
- Added `--skip-fmt` option to `scripts/dev/fast-validate.sh`.
- Updated codex-light lint commands in `.github/workflows/ci.yml` to use `--skip-fmt` with check-only direct-scope mode.
- Extended `scripts/dev/test-fast-validate.sh` for `--skip-fmt` parsing/help coverage.
- Updated codex-light lint workflow contract assertions in `.github/scripts/test_ci_codex_light_lint_contract.py`.

## Behavior Changes
- Codex-light lint no longer runs a duplicate formatting pass inside `fast-validate` because formatting is already checked earlier in the job.
- Default `fast-validate` behavior is unchanged; formatting still runs unless `--skip-fmt` is explicitly set.

## Risks and Compatibility
- Low risk; changes are scoped to CI helper script and workflow flags.
- Full validation path remains unchanged.

## Validation Evidence
- `bash -n scripts/dev/fast-validate.sh scripts/dev/test-fast-validate.sh`
- `./scripts/dev/test-fast-validate.sh`
- `python3 -m unittest discover -s .github/scripts -p "test_ci_*.py"`
- `cargo fmt --all --check`
