### PR TITLE
ci: decouple wasm smoke trigger from generic workflow edits

### DIFF
--- a/.github/scripts/test_ci_wasm_smoke_contract.py
+++ b/.github/scripts/test_ci_wasm_smoke_contract.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def extract_section(raw: str, start_marker: str, end_marker: str) -> str:
+    start = raw.find(start_marker)
+    if start == -1:
+        return ""
+    end = raw.find(end_marker, start)
+    if end == -1:
+        return raw[start:]
+    return raw[start:end]
+
+
+class CiWasmSmokeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.wasm_scope_section = extract_section(
+            cls.workflow,
+            "wasm_smoke:",
+            "demo_smoke:",
+        )
+
+    def test_integration_wasm_scope_lists_wasm_relevant_paths(self):
+        self.assertIn("wasm_smoke:", self.wasm_scope_section)
+        self.assertIn('- "scripts/dev/wasm-smoke.sh"', self.wasm_scope_section)
+        self.assertIn('- "scripts/dev/test-wasm-smoke.sh"', self.wasm_scope_section)
+        self.assertIn('- "crates/kamn-core/**"', self.wasm_scope_section)
+
+    def test_regression_wasm_scope_not_broadly_triggered_by_ci_workflow_edits(self):
+        self.assertNotIn('.github/workflows/ci.yml', self.wasm_scope_section)
+
+    def test_integration_wasm_job_still_executes_harness(self):
+        self.assertIn("name: WASM compile smoke", self.workflow)
+        self.assertIn("run: ./scripts/dev/wasm-smoke.sh", self.workflow)
+        self.assertIn("name: Determine wasm smoke scope", self.workflow)
+        self.assertIn("id: wasm_scope", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
               - "scripts/dev/wasm-smoke.sh"
               - "scripts/dev/test-wasm-smoke.sh"
               - "scripts/edge/**"
-              - ".github/workflows/ci.yml"
             demo_smoke:
               - "crates/tau-coding-agent/**"
               - ".github/demo-smoke-manifest.json"


### PR DESCRIPTION
Closes #1599

## Summary
- Removed broad `.github/workflows/ci.yml` trigger from the `wasm_smoke` path scope in CI.
- Added workflow contract test `.github/scripts/test_ci_wasm_smoke_contract.py` to ensure wasm smoke wiring remains intact.

## Behavior Changes
- Generic CI workflow edits no longer automatically trigger `WASM compile smoke`.
- WASM smoke still triggers for WASM-relevant crate/script/edge path changes.

## Risks and Compatibility
- Low risk; workflow trigger narrowing only.
- Regression guard added to keep wasm smoke job/steps and scope plumbing in place.

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p "test_ci_*.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `cargo fmt --all --check`
