### PR TITLE
ci: add allow-pragma guard for crates policy

### DIFF
--- a/.github/scripts/test_ci_allow_pragma_guard_contract.py
+++ b/.github/scripts/test_ci_allow_pragma_guard_contract.py
@@ -1,0 +1,30 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class CiAllowPragmaGuardContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_integration_guard_step_exists(self):
+        self.assertIn("name: Verify allow-pragma-free policy", self.workflow)
+        self.assertIn(
+            "if: steps.rust_scope.outputs.rust_changed == 'true'",
+            self.workflow,
+        )
+
+    def test_regression_guard_uses_rg_on_crates_for_allow_pragmas(self):
+        self.assertIn("rg -n --glob '!**/target/**' '^\\s*#\\[\\s*allow\\(' crates", self.workflow)
+        self.assertIn(
+            "::error::#[allow(...)] pragmas are prohibited by repository policy",
+            self.workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,16 @@ jobs:
             exit 1
           fi
 
+      - name: Verify allow-pragma-free policy
+        if: steps.rust_scope.outputs.rust_changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if rg -n --glob '!**/target/**' '^\s*#\[\s*allow\(' crates; then
+            echo "::error::#[allow(...)] pragmas are prohibited by repository policy"
+            exit 1
+          fi
+
       - name: Validate Rust scope (full lane)
         if: steps.rust_scope.outputs.rust_changed == 'true' && steps.quality_mode.outputs.mode != 'codex-light'
         env:


### PR DESCRIPTION
Closes #1601

## Summary
- Added `Verify allow-pragma-free policy` step to `.github/workflows/ci.yml`.
- The step fails CI when any `#[allow(...)]` pragma appears under `crates/`.
- Added workflow contract test `.github/scripts/test_ci_allow_pragma_guard_contract.py`.

## Behavior Changes
- Rust-changing PRs now fail early if `#[allow(` pragmas are introduced in crate sources.

## Risks and Compatibility
- Low risk; policy check only.
- Existing repository state remains compliant (no allow pragmas in `crates/`).

## Validation Evidence
- `rg -n --glob '!**/target/**' '^\s*#\[\s*allow\(' crates || true`
- `python3 -m unittest discover -s .github/scripts -p "test_ci_*.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `cargo fmt --all --check`
