### PR TITLE
docs: refresh README for current runtime and feature state

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Core guides:
 - Project index workflow: [`docs/guides/project-index.md`](docs/guides/project-index.md)
 - Startup DI pipeline: [`docs/guides/startup-di-pipeline.md`](docs/guides/startup-di-pipeline.md)
 - Contract lifecycle: [`docs/guides/contract-pattern-lifecycle.md`](docs/guides/contract-pattern-lifecycle.md)
+- Multi-channel event pipeline: [`docs/guides/multi-channel-event-pipeline.md`](docs/guides/multi-channel-event-pipeline.md)
 - Prompt optimization ops: [`docs/guides/training-ops.md`](docs/guides/training-ops.md)
 - Prompt optimization proxy ops: [`docs/guides/training-proxy-ops.md`](docs/guides/training-proxy-ops.md)
 - Memory ops: [`docs/guides/memory-ops.md`](docs/guides/memory-ops.md)
@@ -178,6 +179,7 @@ Core guides:
 - Custom command ops: [`docs/guides/custom-command-ops.md`](docs/guides/custom-command-ops.md)
 - Voice ops: [`docs/guides/voice-ops.md`](docs/guides/voice-ops.md)
 - Deployment ops: [`docs/guides/deployment-ops.md`](docs/guides/deployment-ops.md)
+- Doc density scorecard: [`docs/guides/doc-density-scorecard.md`](docs/guides/doc-density-scorecard.md)
 
 Contributor references:
 


### PR DESCRIPTION
## Summary
- rewrite `README.md` to reflect current Tau workspace scope and runtime surfaces
- add an explicit capability-status section that calls out diagnostics-first vs active runner paths
- update quickstart/demo commands to match current scripts (`index.sh`, `all.sh`, browser automation live, voice live, gateway remote access)
- update docs navigation links and contributing workflow notes to align with current issue-first policy

Closes #1603

## Risks and compatibility
- documentation-only change; no runtime behavior changes
- low risk: command/docs drift only if future flags/scripts change without README updates

## Validation evidence
- `python3` local link check for README markdown links: `checked_links=23 missing=0`
- `./scripts/dev/fast-validate.sh --check-only --direct-packages-only --skip-fmt`
  - result: `changed_files=1 impacted_packages=0`
  - result: `no crate changes detected; fmt check completed`
- `cargo fmt`, strict `clippy`, and tests were not run because this PR only modifies markdown and no Rust crates are in scope
