### PR TITLE
ops: add periodic throughput delta reporting

### DIFF
--- a/scripts/dev/pr-throughput-delta-report.sh
+++ b/scripts/dev/pr-throughput-delta-report.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BASELINE_SCRIPT="${SCRIPT_DIR}/pr-throughput-baseline.sh"
+
+BASELINE_JSON="${REPO_ROOT}/tasks/reports/pr-throughput-baseline.json"
+CURRENT_JSON=""
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/pr-throughput-delta.md"
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/pr-throughput-delta.json"
+REPORTING_INTERVAL="daily"
+REPO_SLUG=""
+LIMIT=60
+SINCE_DAYS=30
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: pr-throughput-delta-report.sh [options]
+
+Generate a current-vs-baseline throughput delta report.
+
+Options:
+  --baseline-json <path>       Baseline report JSON path.
+  --current-json <path>        Current report JSON path (skip live generation when provided).
+  --repo <owner/name>          Repository slug for live current metrics generation.
+  --limit <n>                  Max merged PRs for live current metrics generation.
+  --since-days <n>             Merge window in days for live current metrics generation.
+  --reporting-interval <name>  Reporting interval label (default: daily).
+  --output-md <path>           Markdown report output path.
+  --output-json <path>         JSON report output path.
+  --generated-at <iso>         Override generated timestamp.
+  --quiet                      Suppress informational output.
+  --help                       Show this help text.
+EOF
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+format_duration() {
+  local value="${1:-null}"
+  if [[ -z "${value}" || "${value}" == "null" ]]; then
+    printf 'n/a'
+    return 0
+  fi
+  awk -v seconds="${value}" '
+    BEGIN {
+      if (seconds >= 3600 || seconds <= -3600) {
+        printf "%.2fh", seconds / 3600.0;
+      } else if (seconds >= 60 || seconds <= -60) {
+        printf "%.2fm", seconds / 60.0;
+      } else {
+        printf "%.0fs", seconds;
+      }
+    }
+  '
+}
+
+format_percent() {
+  local value="${1:-null}"
+  if [[ -z "${value}" || "${value}" == "null" ]]; then
+    printf 'n/a'
+    return 0
+  fi
+  awk -v pct="${value}" 'BEGIN { printf "%+.2f%%", pct }'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline-json)
+      BASELINE_JSON="$2"
+      shift 2
+      ;;
+    --current-json)
+      CURRENT_JSON="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO_SLUG="$2"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="$2"
+      shift 2
+      ;;
+    --since-days)
+      SINCE_DAYS="$2"
+      shift 2
+      ;;
+    --reporting-interval)
+      REPORTING_INTERVAL="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd jq
+
+if ! [[ "${LIMIT}" =~ ^[0-9]+$ ]]; then
+  echo "error: --limit must be a non-negative integer" >&2
+  exit 1
+fi
+if ! [[ "${SINCE_DAYS}" =~ ^[0-9]+$ ]]; then
+  echo "error: --since-days must be a non-negative integer" >&2
+  exit 1
+fi
+
+if [[ ! -f "${BASELINE_JSON}" ]]; then
+  echo "error: baseline JSON not found: ${BASELINE_JSON}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+current_json_path="${tmp_dir}/current.json"
+current_source="live"
+
+if [[ -n "${CURRENT_JSON}" ]]; then
+  if [[ ! -f "${CURRENT_JSON}" ]]; then
+    echo "error: current JSON not found: ${CURRENT_JSON}" >&2
+    exit 1
+  fi
+  cp "${CURRENT_JSON}" "${current_json_path}"
+  current_source="file"
+else
+  current_source="live"
+  "${BASELINE_SCRIPT}" \
+    --quiet \
+    ${REPO_SLUG:+--repo "${REPO_SLUG}"} \
+    --since-days "${SINCE_DAYS}" \
+    --limit "${LIMIT}" \
+    --generated-at "${GENERATED_AT}" \
+    --output-md "${tmp_dir}/current.md" \
+    --output-json "${current_json_path}"
+fi
+
+delta_json="$(
+  jq -n \
+    --arg generated_at "${GENERATED_AT}" \
+    --arg interval "${REPORTING_INTERVAL}" \
+    --arg baseline_path "${BASELINE_JSON}" \
+    --arg current_path "${CURRENT_JSON:-live-generated}" \
+    --arg current_source "${current_source}" \
+    --slurpfile baseline "${BASELINE_JSON}" \
+    --slurpfile current "${current_json_path}" '
+      def avg_delta($baseline_avg; $current_avg):
+        if ($baseline_avg == null or $current_avg == null) then
+          {
+            baseline_avg_seconds: $baseline_avg,
+            current_avg_seconds: $current_avg,
+            delta_seconds: null,
+            delta_percent: null,
+            status: "unknown"
+          }
+        else
+          ($current_avg - $baseline_avg) as $delta |
+          {
+            baseline_avg_seconds: $baseline_avg,
+            current_avg_seconds: $current_avg,
+            delta_seconds: $delta,
+            delta_percent: (if $baseline_avg == 0 then null else (($delta / $baseline_avg) * 100) end),
+            status: (if $delta < 0 then "improved" elif $delta > 0 then "regressed" else "flat" end)
+          }
+        end;
+
+      ($baseline[0]) as $b |
+      ($current[0]) as $c |
+      {
+        schema_version: 1,
+        generated_at: $generated_at,
+        reporting_interval: $interval,
+        baseline: {
+          path: $baseline_path,
+          generated_at: $b.generated_at,
+          window: $b.window,
+          metrics: $b.metrics
+        },
+        current: {
+          source: $current_source,
+          path: $current_path,
+          generated_at: $c.generated_at,
+          window: $c.window,
+          metrics: $c.metrics
+        },
+        delta: {
+          pr_age: avg_delta($b.metrics.pr_age.avg_seconds; $c.metrics.pr_age.avg_seconds),
+          review_latency: avg_delta($b.metrics.review_latency.avg_seconds; $c.metrics.review_latency.avg_seconds),
+          merge_interval: avg_delta($b.metrics.merge_interval.avg_seconds; $c.metrics.merge_interval.avg_seconds)
+        }
+      } |
+      .summary = (
+        (.delta | [.pr_age.status, .review_latency.status, .merge_interval.status]) as $statuses |
+        {
+          improved_metrics: ($statuses | map(select(. == "improved")) | length),
+          regressed_metrics: ($statuses | map(select(. == "regressed")) | length),
+          flat_metrics: ($statuses | map(select(. == "flat")) | length),
+          unknown_metrics: ($statuses | map(select(. == "unknown")) | length)
+        }
+      )
+    '
+)"
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+printf '%s\n' "${delta_json}" | jq '.' >"${OUTPUT_JSON}"
+
+baseline_generated_at="$(jq -r '.baseline.generated_at // "unknown"' <<<"${delta_json}")"
+baseline_count="$(jq -r '.baseline.window.merged_pr_count // 0' <<<"${delta_json}")"
+current_generated_at="$(jq -r '.current.generated_at // "unknown"' <<<"${delta_json}")"
+current_count="$(jq -r '.current.window.merged_pr_count // 0' <<<"${delta_json}")"
+
+improved_count="$(jq -r '.summary.improved_metrics' <<<"${delta_json}")"
+regressed_count="$(jq -r '.summary.regressed_metrics' <<<"${delta_json}")"
+flat_count="$(jq -r '.summary.flat_metrics' <<<"${delta_json}")"
+unknown_count="$(jq -r '.summary.unknown_metrics' <<<"${delta_json}")"
+
+render_delta_row() {
+  local metric_key="$1"
+  local label="$2"
+  local baseline_avg
+  local current_avg
+  local delta_seconds
+  local delta_percent
+  local status
+  baseline_avg="$(jq -r ".delta.${metric_key}.baseline_avg_seconds" <<<"${delta_json}")"
+  current_avg="$(jq -r ".delta.${metric_key}.current_avg_seconds" <<<"${delta_json}")"
+  delta_seconds="$(jq -r ".delta.${metric_key}.delta_seconds" <<<"${delta_json}")"
+  delta_percent="$(jq -r ".delta.${metric_key}.delta_percent" <<<"${delta_json}")"
+  status="$(jq -r ".delta.${metric_key}.status" <<<"${delta_json}")"
+
+  printf '| %s | %s | %s | %s | %s | %s |\n' \
+    "${label}" \
+    "$(format_duration "${baseline_avg}")" \
+    "$(format_duration "${current_avg}")" \
+    "$(format_duration "${delta_seconds}")" \
+    "$(format_percent "${delta_percent}")" \
+    "${status}"
+}
+
+{
+  cat <<EOF
+# PR Throughput Delta Report
+
+- Generated at: ${GENERATED_AT}
+- Reporting interval: ${REPORTING_INTERVAL}
+- Baseline generated at: ${baseline_generated_at}
+- Current generated at: ${current_generated_at}
+- Baseline sample count: ${baseline_count}
+- Current sample count: ${current_count}
+- Reproduce:
+  - \`scripts/dev/pr-throughput-delta-report.sh --baseline-json ${BASELINE_JSON} --reporting-interval ${REPORTING_INTERVAL} --repo ${REPO_SLUG:-<repo>} --since-days ${SINCE_DAYS} --limit ${LIMIT} --output-md ${OUTPUT_MD} --output-json ${OUTPUT_JSON}\`
+
+## Delta Summary
+
+- Improved metrics: ${improved_count}
+- Regressed metrics: ${regressed_count}
+- Flat metrics: ${flat_count}
+- Unknown metrics: ${unknown_count}
+
+## Average Delta (lower is better)
+
+| Metric | Baseline Avg | Current Avg | Delta | Delta % | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+EOF
+  render_delta_row "pr_age" "PR age (created -> merged)"
+  render_delta_row "review_latency" "Review latency (created -> first review)"
+  render_delta_row "merge_interval" "Merge interval (between merged PRs)"
+  cat <<'EOF'
+
+## Notes Template
+
+- Wins observed:
+  - <capture the highest-confidence contributors to improvements>
+- Regressions observed:
+  - <capture the highest-impact regressions and likely causes>
+- Next actions:
+  1. <action 1>
+  2. <action 2>
+  3. <action 3>
+EOF
+} >"${OUTPUT_MD}"
+
+log_info "wrote throughput delta report:"
+log_info "  - ${OUTPUT_MD}"
+log_info "  - ${OUTPUT_JSON}"

--- a/scripts/dev/test-pr-throughput-delta-report.sh
+++ b/scripts/dev/test-pr-throughput-delta-report.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DELTA_SCRIPT="${SCRIPT_DIR}/pr-throughput-delta-report.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+baseline_json="${tmp_dir}/baseline.json"
+current_json="${tmp_dir}/current.json"
+output_md="${tmp_dir}/delta.md"
+output_json="${tmp_dir}/delta.json"
+unknown_current_json="${tmp_dir}/unknown-current.json"
+unknown_md="${tmp_dir}/delta-unknown.md"
+unknown_out="${tmp_dir}/delta-unknown.json"
+
+cat >"${baseline_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "generated_at": "2026-02-15T00:00:00Z",
+  "window": {
+    "merged_pr_count": 30
+  },
+  "metrics": {
+    "pr_age": { "avg_seconds": 300.0 },
+    "review_latency": { "avg_seconds": 120.0 },
+    "merge_interval": { "avg_seconds": 600.0 }
+  }
+}
+EOF
+
+cat >"${current_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "generated_at": "2026-02-16T00:00:00Z",
+  "window": {
+    "merged_pr_count": 28
+  },
+  "metrics": {
+    "pr_age": { "avg_seconds": 240.0 },
+    "review_latency": { "avg_seconds": 150.0 },
+    "merge_interval": { "avg_seconds": 600.0 }
+  }
+}
+EOF
+
+cat >"${unknown_current_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "generated_at": "2026-02-16T00:00:00Z",
+  "window": {
+    "merged_pr_count": 0
+  },
+  "metrics": {
+    "pr_age": { "avg_seconds": null },
+    "review_latency": { "avg_seconds": null },
+    "merge_interval": { "avg_seconds": null }
+  }
+}
+EOF
+
+# Functional: computes improved/regressed/flat deltas from fixture JSON.
+"${DELTA_SCRIPT}" \
+  --quiet \
+  --baseline-json "${baseline_json}" \
+  --current-json "${current_json}" \
+  --reporting-interval weekly \
+  --generated-at "2026-02-16T12:00:00Z" \
+  --output-md "${output_md}" \
+  --output-json "${output_json}"
+
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional markdown output): missing ${output_md}" >&2
+  exit 1
+fi
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional json output): missing ${output_json}" >&2
+  exit 1
+fi
+
+json_content="$(cat "${output_json}")"
+md_content="$(cat "${output_md}")"
+
+assert_equals "1" "$(jq -r '.schema_version' <<<"${json_content}")" "functional schema version"
+assert_equals "weekly" "$(jq -r '.reporting_interval' <<<"${json_content}")" "functional interval"
+assert_equals "improved" "$(jq -r '.delta.pr_age.status' <<<"${json_content}")" "functional pr-age status"
+assert_equals "regressed" "$(jq -r '.delta.review_latency.status' <<<"${json_content}")" "functional review-latency status"
+assert_equals "flat" "$(jq -r '.delta.merge_interval.status' <<<"${json_content}")" "functional merge-interval status"
+assert_equals "1" "$(jq -r '.summary.improved_metrics' <<<"${json_content}")" "functional improved count"
+assert_equals "1" "$(jq -r '.summary.regressed_metrics' <<<"${json_content}")" "functional regressed count"
+assert_equals "1" "$(jq -r '.summary.flat_metrics' <<<"${json_content}")" "functional flat count"
+assert_contains "${md_content}" "| PR age (created -> merged) | 5.00m | 4.00m | -1.00m | -20.00% | improved |" "functional markdown improved row"
+assert_contains "${md_content}" "| Review latency (created -> first review) | 2.00m | 2.50m | 30s | +25.00% | regressed |" "functional markdown regressed row"
+
+# Regression: handles unknown deltas when current averages are null.
+"${DELTA_SCRIPT}" \
+  --quiet \
+  --baseline-json "${baseline_json}" \
+  --current-json "${unknown_current_json}" \
+  --reporting-interval weekly \
+  --generated-at "2026-02-16T12:00:00Z" \
+  --output-md "${unknown_md}" \
+  --output-json "${unknown_out}"
+
+assert_equals "3" "$(jq -r '.summary.unknown_metrics' <"${unknown_out}")" "regression unknown count"
+assert_contains "$(cat "${unknown_md}")" "| PR age (created -> merged) | 5.00m | n/a | n/a | n/a | unknown |" "regression unknown markdown row"
+
+echo "pr-throughput-delta-report tests passed"

--- a/tasks/reports/pr-throughput-delta.json
+++ b/tasks/reports/pr-throughput-delta.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-02-15T09:54:15Z",
+  "reporting_interval": "daily",
+  "baseline": {
+    "path": "tasks/reports/pr-throughput-baseline.json",
+    "generated_at": "2026-02-15T09:50:16Z",
+    "window": {
+      "limit": 60,
+      "since_days": 30,
+      "source_pr_count": 200,
+      "merged_pr_count": 60
+    },
+    "metrics": {
+      "pr_age": {
+        "count": 60,
+        "avg_seconds": 2793.733333333333,
+        "p50_seconds": 110,
+        "min_seconds": 14,
+        "max_seconds": 20295
+      },
+      "review_latency": {
+        "count": 60,
+        "avg_seconds": 309.06666666666666,
+        "p50_seconds": 276,
+        "min_seconds": 95,
+        "max_seconds": 756
+      },
+      "merge_interval": {
+        "count": 59,
+        "avg_seconds": 685.2203389830509,
+        "p50_seconds": 494,
+        "min_seconds": 2,
+        "max_seconds": 2910
+      }
+    }
+  },
+  "current": {
+    "source": "live",
+    "path": "live-generated",
+    "generated_at": "2026-02-15T09:54:15Z",
+    "window": {
+      "limit": 60,
+      "since_days": 30,
+      "source_pr_count": 200,
+      "merged_pr_count": 60
+    },
+    "metrics": {
+      "pr_age": {
+        "count": 60,
+        "avg_seconds": 2557.7,
+        "p50_seconds": 103,
+        "min_seconds": 14,
+        "max_seconds": 20295
+      },
+      "review_latency": {
+        "count": 59,
+        "avg_seconds": 311.271186440678,
+        "p50_seconds": 279,
+        "min_seconds": 95,
+        "max_seconds": 756
+      },
+      "merge_interval": {
+        "count": 59,
+        "avg_seconds": 693.6101694915254,
+        "p50_seconds": 494,
+        "min_seconds": 2,
+        "max_seconds": 2910
+      }
+    }
+  },
+  "delta": {
+    "pr_age": {
+      "baseline_avg_seconds": 2793.733333333333,
+      "current_avg_seconds": 2557.7,
+      "delta_seconds": -236.0333333333333,
+      "delta_percent": -8.448670834725338,
+      "status": "improved"
+    },
+    "review_latency": {
+      "baseline_avg_seconds": 309.06666666666666,
+      "current_avg_seconds": 311.271186440678,
+      "delta_seconds": 2.2045197740113167,
+      "delta_percent": 0.7132829294687176,
+      "status": "regressed"
+    },
+    "merge_interval": {
+      "baseline_avg_seconds": 685.2203389830509,
+      "current_avg_seconds": 693.6101694915254,
+      "delta_seconds": 8.389830508474574,
+      "delta_percent": 1.2243989314336594,
+      "status": "regressed"
+    }
+  },
+  "summary": {
+    "improved_metrics": 1,
+    "regressed_metrics": 2,
+    "flat_metrics": 0,
+    "unknown_metrics": 0
+  }
+}

--- a/tasks/reports/pr-throughput-delta.md
+++ b/tasks/reports/pr-throughput-delta.md
@@ -1,0 +1,36 @@
+# PR Throughput Delta Report
+
+- Generated at: 2026-02-15T09:54:15Z
+- Reporting interval: daily
+- Baseline generated at: 2026-02-15T09:50:16Z
+- Current generated at: 2026-02-15T09:54:15Z
+- Baseline sample count: 60
+- Current sample count: 60
+- Reproduce:
+  - `scripts/dev/pr-throughput-delta-report.sh --baseline-json tasks/reports/pr-throughput-baseline.json --reporting-interval daily --repo njfio/Tau --since-days 30 --limit 60 --output-md tasks/reports/pr-throughput-delta.md --output-json tasks/reports/pr-throughput-delta.json`
+
+## Delta Summary
+
+- Improved metrics: 1
+- Regressed metrics: 2
+- Flat metrics: 0
+- Unknown metrics: 0
+
+## Average Delta (lower is better)
+
+| Metric | Baseline Avg | Current Avg | Delta | Delta % | Status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| PR age (created -> merged) | 46.56m | 42.63m | -3.93m | -8.45% | improved |
+| Review latency (created -> first review) | 5.15m | 5.19m | 2s | +0.71% | regressed |
+| Merge interval (between merged PRs) | 11.42m | 11.56m | 8s | +1.22% | regressed |
+
+## Notes Template
+
+- Wins observed:
+  - <capture the highest-confidence contributors to improvements>
+- Regressions observed:
+  - <capture the highest-impact regressions and likely causes>
+- Next actions:
+  1. <action 1>
+  2. <action 2>
+  3. <action 3>


### PR DESCRIPTION
Closes #1776

## Summary
- added `scripts/dev/pr-throughput-delta-report.sh` to compute periodic current-vs-baseline throughput deltas
- report includes interval labeling, baseline/current context, delta classification (`improved`/`regressed`/`flat`/`unknown`), and a reusable notes template
- added fixture-based regression harness `scripts/dev/test-pr-throughput-delta-report.sh`
- published periodic report artifacts:
  - `tasks/reports/pr-throughput-delta.md`
  - `tasks/reports/pr-throughput-delta.json`

## Risks and compatibility
- additive only; no runtime behavior changes
- live mode depends on baseline script + `gh` + `jq`
- delta snapshots are point-in-time and expected to be regenerated per interval

## Validation evidence
- `./scripts/dev/test-pr-throughput-delta-report.sh`
- `./scripts/dev/pr-throughput-delta-report.sh --baseline-json tasks/reports/pr-throughput-baseline.json --repo njfio/Tau --since-days 30 --limit 60 --reporting-interval daily --output-md tasks/reports/pr-throughput-delta.md --output-json tasks/reports/pr-throughput-delta.json`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
