### PR TITLE
docs: define oversized-file policy and auditable exemption validator

### DIFF
--- a/docs/guides/oversized-file-policy.md
+++ b/docs/guides/oversized-file-policy.md
@@ -1,0 +1,61 @@
+# Oversized File Policy
+
+This policy defines line-count thresholds for production source files and the
+temporary exemption process used when staged refactors are in flight.
+
+## Default Thresholds
+
+- Production Rust source files (`crates/*/src/**/*.rs`): `4000` lines
+- Absolute temporary exemption cap: `8000` lines
+- Exemption lifespan: time-bounded and explicitly reviewed before expiry
+
+Guidance:
+
+- Keep modules below the default threshold by splitting into focused domain
+  modules before feature growth continues.
+- Use temporary exemptions only when an active split plan is already scheduled.
+
+## Exemption Metadata Contract
+
+Exemptions are tracked in `tasks/policies/oversized-file-exemptions.json`.
+
+Each exemption entry must include:
+
+- `path`: file path under version control
+- `threshold_lines`: temporary line budget for that file
+- `owner_issue`: active GitHub issue id tracking the split/remediation
+- `rationale`: explicit reason the exemption is needed now
+- `approved_by`: reviewer/maintainer that approved the exemption
+- `approved_at`: approval date (`YYYY-MM-DD`)
+- `expires_on`: expiry date (`YYYY-MM-DD`)
+
+The validator script enforces:
+
+- schema version
+- required fields
+- threshold bounds (`> default`, `<= max`)
+- non-expired exemptions
+- no duplicate file-path exemptions
+
+## Review and Expiry Process
+
+1. Open or link a remediation issue before adding an exemption.
+2. Add exemption metadata with a bounded expiry window.
+3. Run policy validation:
+
+```bash
+scripts/dev/oversized-file-policy.sh
+```
+
+4. Before `expires_on`, either:
+   - remove exemption because file is now under threshold, or
+   - renew with updated rationale, approval, and a new bounded expiry date.
+5. Expired exemptions fail validation and must be resolved immediately.
+
+## CI Output Linkage
+
+Policy-validation output must include this guide path:
+
+- `docs/guides/oversized-file-policy.md`
+
+This keeps failure messages actionable and makes exemption decisions auditable.

--- a/scripts/dev/oversized-file-policy.sh
+++ b/scripts/dev/oversized-file-policy.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+EXEMPTIONS_JSON="${REPO_ROOT}/tasks/policies/oversized-file-exemptions.json"
+DOC_PATH="docs/guides/oversized-file-policy.md"
+DEFAULT_THRESHOLD_LINES=4000
+MAX_THRESHOLD_LINES=8000
+TODAY_UTC="$(date -u +%Y-%m-%d)"
+QUIET_MODE="false"
+OUTPUT_MD=""
+
+usage() {
+  cat <<'EOF'
+Usage: oversized-file-policy.sh [options]
+
+Validate oversized-file exemption metadata against policy requirements.
+
+Options:
+  --exemptions-json <path>       Exemption metadata JSON path.
+  --default-threshold-lines <n>  Default production-file line threshold (default: 4000).
+  --max-threshold-lines <n>      Absolute max exemption threshold (default: 8000).
+  --today <YYYY-MM-DD>           Override current UTC date (for deterministic tests).
+  --output-md <path>             Write markdown policy summary report.
+  --quiet                        Suppress informational output.
+  --help                         Show this help text.
+
+Expected JSON shape:
+{
+  "schema_version": 1,
+  "exemptions": [
+    {
+      "path": "crates/example/src/large_file.rs",
+      "threshold_lines": 5200,
+      "owner_issue": 1234,
+      "rationale": "why this temporary exemption exists",
+      "approved_by": "reviewer-handle",
+      "approved_at": "2026-02-15",
+      "expires_on": "2026-03-15"
+    }
+  ]
+}
+EOF
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+is_iso_date() {
+  local value="$1"
+  [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --exemptions-json)
+      EXEMPTIONS_JSON="$2"
+      shift 2
+      ;;
+    --default-threshold-lines)
+      DEFAULT_THRESHOLD_LINES="$2"
+      shift 2
+      ;;
+    --max-threshold-lines)
+      MAX_THRESHOLD_LINES="$2"
+      shift 2
+      ;;
+    --today)
+      TODAY_UTC="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd jq
+
+if ! [[ "${DEFAULT_THRESHOLD_LINES}" =~ ^[0-9]+$ ]] || (( DEFAULT_THRESHOLD_LINES < 1 )); then
+  echo "error: --default-threshold-lines must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "${MAX_THRESHOLD_LINES}" =~ ^[0-9]+$ ]] || (( MAX_THRESHOLD_LINES < DEFAULT_THRESHOLD_LINES )); then
+  echo "error: --max-threshold-lines must be an integer >= default threshold" >&2
+  exit 1
+fi
+if ! is_iso_date "${TODAY_UTC}"; then
+  echo "error: --today must be in YYYY-MM-DD format" >&2
+  exit 1
+fi
+if [[ ! -f "${EXEMPTIONS_JSON}" ]]; then
+  echo "error: exemptions JSON not found: ${EXEMPTIONS_JSON}" >&2
+  exit 1
+fi
+
+errors=()
+warns=()
+
+schema_version="$(jq -r '.schema_version // "null"' "${EXEMPTIONS_JSON}")"
+if [[ "${schema_version}" != "1" ]]; then
+  errors+=("schema_version must be 1")
+fi
+
+if ! jq -e '.exemptions | type == "array"' "${EXEMPTIONS_JSON}" >/dev/null 2>&1; then
+  errors+=("exemptions must be an array")
+fi
+
+exemption_count="$(jq -r '.exemptions | length' "${EXEMPTIONS_JSON}" 2>/dev/null || printf '0')"
+if ! [[ "${exemption_count}" =~ ^[0-9]+$ ]]; then
+  errors+=("unable to determine exemptions count")
+  exemption_count=0
+fi
+
+for ((i = 0; i < exemption_count; i++)); do
+  base=".exemptions[${i}]"
+  path_value="$(jq -r "${base}.path // \"\"" "${EXEMPTIONS_JSON}")"
+  threshold_value="$(jq -r "${base}.threshold_lines // \"\"" "${EXEMPTIONS_JSON}")"
+  owner_issue_value="$(jq -r "${base}.owner_issue // \"\"" "${EXEMPTIONS_JSON}")"
+  rationale_value="$(jq -r "${base}.rationale // \"\"" "${EXEMPTIONS_JSON}")"
+  approved_by_value="$(jq -r "${base}.approved_by // \"\"" "${EXEMPTIONS_JSON}")"
+  approved_at_value="$(jq -r "${base}.approved_at // \"\"" "${EXEMPTIONS_JSON}")"
+  expires_on_value="$(jq -r "${base}.expires_on // \"\"" "${EXEMPTIONS_JSON}")"
+
+  if [[ -z "${path_value}" ]]; then
+    errors+=("exemptions[${i}].path is required")
+  fi
+
+  if ! [[ "${threshold_value}" =~ ^[0-9]+$ ]]; then
+    errors+=("exemptions[${i}].threshold_lines must be a positive integer")
+  else
+    if (( threshold_value <= DEFAULT_THRESHOLD_LINES )); then
+      errors+=("exemptions[${i}].threshold_lines must be greater than default threshold (${DEFAULT_THRESHOLD_LINES})")
+    fi
+    if (( threshold_value > MAX_THRESHOLD_LINES )); then
+      errors+=("exemptions[${i}].threshold_lines exceeds max threshold (${MAX_THRESHOLD_LINES})")
+    fi
+  fi
+
+  if ! [[ "${owner_issue_value}" =~ ^[0-9]+$ ]] || (( owner_issue_value < 1 )); then
+    errors+=("exemptions[${i}].owner_issue must be a positive integer issue id")
+  fi
+
+  if [[ -z "${rationale_value}" ]]; then
+    errors+=("exemptions[${i}].rationale is required")
+  fi
+
+  if [[ -z "${approved_by_value}" ]]; then
+    errors+=("exemptions[${i}].approved_by is required")
+  fi
+
+  if ! is_iso_date "${approved_at_value}"; then
+    errors+=("exemptions[${i}].approved_at must be YYYY-MM-DD")
+  fi
+
+  if ! is_iso_date "${expires_on_value}"; then
+    errors+=("exemptions[${i}].expires_on must be YYYY-MM-DD")
+  fi
+
+  if is_iso_date "${approved_at_value}" && is_iso_date "${expires_on_value}"; then
+    if [[ "${expires_on_value}" < "${approved_at_value}" ]]; then
+      errors+=("exemptions[${i}] expires_on must be on/after approved_at")
+    fi
+    if [[ "${expires_on_value}" < "${TODAY_UTC}" ]]; then
+      errors+=("exemptions[${i}] (${path_value}) is expired as of ${TODAY_UTC}")
+    fi
+  fi
+done
+
+duplicate_paths="$(
+  jq -r '.exemptions[]?.path // empty' "${EXEMPTIONS_JSON}" \
+    | sort \
+    | uniq -d \
+    | sed '/^$/d' || true
+)"
+if [[ -n "${duplicate_paths}" ]]; then
+  while IFS= read -r duplicate_path; do
+    errors+=("duplicate exemption path: ${duplicate_path}")
+  done <<<"${duplicate_paths}"
+fi
+
+if (( ${#errors[@]} > 0 )); then
+  echo "oversized-file policy validation failed:" >&2
+  for error in "${errors[@]}"; do
+    echo "  - ${error}" >&2
+  done
+  echo "policy guide: ${DOC_PATH}" >&2
+  exit 1
+fi
+
+if [[ -n "${OUTPUT_MD}" ]]; then
+  mkdir -p "$(dirname "${OUTPUT_MD}")"
+  {
+    cat <<EOF
+# Oversized File Policy Check
+
+- Generated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+- Policy guide: \`${DOC_PATH}\`
+- Default threshold: ${DEFAULT_THRESHOLD_LINES}
+- Max exemption threshold: ${MAX_THRESHOLD_LINES}
+- Validation date: ${TODAY_UTC}
+- Active exemptions: ${exemption_count}
+
+## Exemptions
+
+| Path | Threshold | Owner Issue | Expires On | Approved By |
+| --- | ---: | ---: | --- | --- |
+EOF
+    if (( exemption_count == 0 )); then
+      echo "| _none_ | - | - | - | - |"
+    else
+      jq -r '.exemptions[] | [.path, (.threshold_lines|tostring), (.owner_issue|tostring), .expires_on, .approved_by] | @tsv' "${EXEMPTIONS_JSON}" \
+        | while IFS=$'\t' read -r path threshold owner_issue expires_on approved_by; do
+            printf '| %s | %s | %s | %s | %s |\n' \
+              "${path}" "${threshold}" "${owner_issue}" "${expires_on}" "${approved_by}"
+          done
+    fi
+  } >"${OUTPUT_MD}"
+fi
+
+log_info "oversized-file policy validation passed"
+log_info "policy guide: ${DOC_PATH}"
+log_info "active exemptions: ${exemption_count}"
+if [[ -n "${OUTPUT_MD}" ]]; then
+  log_info "report: ${OUTPUT_MD}"
+fi

--- a/scripts/dev/test-oversized-file-policy.sh
+++ b/scripts/dev/test-oversized-file-policy.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLICY_SCRIPT="${SCRIPT_DIR}/oversized-file-policy.sh"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+valid_json="${tmp_dir}/valid.json"
+expired_json="${tmp_dir}/expired.json"
+duplicate_json="${tmp_dir}/duplicate.json"
+output_md="${tmp_dir}/policy.md"
+
+cat >"${valid_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "exemptions": [
+    {
+      "path": "crates/tau-tools/src/tools.rs",
+      "threshold_lines": 5600,
+      "owner_issue": 1749,
+      "rationale": "first-pass split landed; second pass in progress",
+      "approved_by": "runtime-maintainer",
+      "approved_at": "2026-02-10",
+      "expires_on": "2026-03-10"
+    }
+  ]
+}
+EOF
+
+cat >"${expired_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "exemptions": [
+    {
+      "path": "crates/tau-tools/src/tools.rs",
+      "threshold_lines": 5600,
+      "owner_issue": 1750,
+      "rationale": "expired exemption fixture",
+      "approved_by": "runtime-maintainer",
+      "approved_at": "2026-01-01",
+      "expires_on": "2026-01-15"
+    }
+  ]
+}
+EOF
+
+cat >"${duplicate_json}" <<'EOF'
+{
+  "schema_version": 1,
+  "exemptions": [
+    {
+      "path": "crates/tau-tools/src/tools.rs",
+      "threshold_lines": 5600,
+      "owner_issue": 1750,
+      "rationale": "duplicate path A",
+      "approved_by": "runtime-maintainer",
+      "approved_at": "2026-02-10",
+      "expires_on": "2026-03-10"
+    },
+    {
+      "path": "crates/tau-tools/src/tools.rs",
+      "threshold_lines": 5800,
+      "owner_issue": 1751,
+      "rationale": "duplicate path B",
+      "approved_by": "runtime-maintainer",
+      "approved_at": "2026-02-11",
+      "expires_on": "2026-03-11"
+    }
+  ]
+}
+EOF
+
+# Functional: valid metadata passes and emits markdown summary.
+valid_output="$(
+  "${POLICY_SCRIPT}" \
+    --exemptions-json "${valid_json}" \
+    --today 2026-02-15 \
+    --output-md "${output_md}" \
+    --quiet
+)"
+assert_equals "" "${valid_output}" "functional quiet mode output"
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional markdown output): missing ${output_md}" >&2
+  exit 1
+fi
+assert_contains "$(cat "${output_md}")" "docs/guides/oversized-file-policy.md" "functional markdown policy link"
+assert_contains "$(cat "${output_md}")" "| crates/tau-tools/src/tools.rs | 5600 | 1749 | 2026-03-10 | runtime-maintainer |" "functional markdown row"
+
+# Regression: expired exemptions fail validation with explicit reason.
+set +e
+expired_output="$(
+  "${POLICY_SCRIPT}" \
+    --exemptions-json "${expired_json}" \
+    --today 2026-02-15 2>&1
+)"
+expired_exit=$?
+set -e
+if [[ ${expired_exit} -eq 0 ]]; then
+  echo "assertion failed (regression expired exemption): expected non-zero exit" >&2
+  exit 1
+fi
+assert_contains "${expired_output}" "is expired as of 2026-02-15" "regression expired message"
+
+# Regression: duplicate paths are rejected for auditability.
+set +e
+duplicate_output="$(
+  "${POLICY_SCRIPT}" \
+    --exemptions-json "${duplicate_json}" \
+    --today 2026-02-15 2>&1
+)"
+duplicate_exit=$?
+set -e
+if [[ ${duplicate_exit} -eq 0 ]]; then
+  echo "assertion failed (regression duplicate path): expected non-zero exit" >&2
+  exit 1
+fi
+assert_contains "${duplicate_output}" "duplicate exemption path" "regression duplicate message"
+
+echo "oversized-file-policy tests passed"

--- a/tasks/policies/oversized-file-exemptions.json
+++ b/tasks/policies/oversized-file-exemptions.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "exemptions": []
+}


### PR DESCRIPTION
## Summary
- add oversized-file policy guide at `docs/guides/oversized-file-policy.md`
- add policy validator script `scripts/dev/oversized-file-policy.sh` for threshold and exemption metadata enforcement
- add regression/functional test harness `scripts/dev/test-oversized-file-policy.sh`
- add auditable exemption registry file `tasks/policies/oversized-file-exemptions.json`

## Behavior Changes
- policy metadata now has a documented schema and enforcement contract
- validator now fails on:
  - missing required exemption metadata
  - invalid threshold bounds
  - duplicate exemption paths
  - expired exemptions
- validator output links directly to policy guide for remediation context

## Risks and Compatibility
- low risk: additive docs/scripts with no runtime behavior changes to production crates
- validation script requires `jq` (consistent with existing script dependencies)
- empty default exemption registry is intentionally strict and auditable

## Validation Evidence
- `scripts/dev/test-oversized-file-policy.sh`
- `scripts/dev/oversized-file-policy.sh --quiet`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`

Closes #1753
