### PR TITLE
ops: add automated M21 validation matrix generation artifacts

### DIFF
--- a/scripts/dev/m21-validation-matrix.sh
+++ b/scripts/dev/m21-validation-matrix.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+REPO_SLUG=""
+MILESTONE_NUMBER=21
+REPORTS_DIR="${REPO_ROOT}/tasks/reports"
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m21-validation-matrix.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m21-validation-matrix.md"
+SCHEMA_PATH="${REPO_ROOT}/tasks/schemas/m21-validation-matrix.schema.json"
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+FIXTURE_ISSUES_JSON=""
+FIXTURE_MILESTONE_JSON=""
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: m21-validation-matrix.sh [options]
+
+Generate reproducible M21 validation matrix artifacts from milestone issue state
+and local report artifacts.
+
+Options:
+  --repo <owner/name>             Repository slug (defaults to current gh repo).
+  --milestone-number <n>          Milestone number (default: 21).
+  --reports-dir <path>            Directory to scan for local report artifacts.
+  --output-json <path>            JSON matrix output path.
+  --output-md <path>              Markdown matrix output path.
+  --schema-path <path>            Matrix schema file path reference.
+  --generated-at <iso>            Override generated timestamp.
+  --fixture-issues-json <path>    Fixture issues JSON (skips live GitHub API).
+  --fixture-milestone-json <path> Fixture milestone JSON (skips live GitHub API).
+  --quiet                         Suppress informational output.
+  --help                          Show this help text.
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO_SLUG="$2"
+      shift 2
+      ;;
+    --milestone-number)
+      MILESTONE_NUMBER="$2"
+      shift 2
+      ;;
+    --reports-dir)
+      REPORTS_DIR="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --schema-path)
+      SCHEMA_PATH="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --fixture-issues-json)
+      FIXTURE_ISSUES_JSON="$2"
+      shift 2
+      ;;
+    --fixture-milestone-json)
+      FIXTURE_MILESTONE_JSON="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd jq
+require_cmd python3
+
+if ! [[ "${MILESTONE_NUMBER}" =~ ^[0-9]+$ ]]; then
+  echo "error: --milestone-number must be a non-negative integer" >&2
+  exit 1
+fi
+
+using_fixtures="false"
+if [[ -n "${FIXTURE_ISSUES_JSON}" || -n "${FIXTURE_MILESTONE_JSON}" ]]; then
+  using_fixtures="true"
+fi
+
+if [[ "${using_fixtures}" == "true" ]]; then
+  if [[ -z "${FIXTURE_ISSUES_JSON}" || -z "${FIXTURE_MILESTONE_JSON}" ]]; then
+    echo "error: --fixture-issues-json and --fixture-milestone-json must be provided together" >&2
+    exit 1
+  fi
+  if [[ ! -f "${FIXTURE_ISSUES_JSON}" ]]; then
+    echo "error: fixture issues JSON not found: ${FIXTURE_ISSUES_JSON}" >&2
+    exit 1
+  fi
+  if [[ ! -f "${FIXTURE_MILESTONE_JSON}" ]]; then
+    echo "error: fixture milestone JSON not found: ${FIXTURE_MILESTONE_JSON}" >&2
+    exit 1
+  fi
+else
+  require_cmd gh
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+issues_path="${tmp_dir}/issues.json"
+milestone_path="${tmp_dir}/milestone.json"
+
+if [[ "${using_fixtures}" == "true" ]]; then
+  cp "${FIXTURE_ISSUES_JSON}" "${issues_path}"
+  cp "${FIXTURE_MILESTONE_JSON}" "${milestone_path}"
+  if [[ -z "${REPO_SLUG}" ]]; then
+    REPO_SLUG="fixture/repository"
+  fi
+else
+  if [[ -z "${REPO_SLUG}" ]]; then
+    REPO_SLUG="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  fi
+  gh api "repos/${REPO_SLUG}/milestones/${MILESTONE_NUMBER}" >"${milestone_path}"
+  gh api \
+    --paginate \
+    --slurp \
+    "repos/${REPO_SLUG}/issues?state=all&milestone=${MILESTONE_NUMBER}&per_page=100" \
+    | jq '[.[][] | select(.pull_request | not)]' >"${issues_path}"
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${issues_path}" \
+  "${milestone_path}" \
+  "${REPORTS_DIR}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${REPO_SLUG}" \
+  "${MILESTONE_NUMBER}" \
+  "${SCHEMA_PATH}" \
+  "${GENERATED_AT}" <<'PY'
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+(
+    issues_path,
+    milestone_path,
+    reports_dir,
+    output_json,
+    output_md,
+    repo_slug,
+    milestone_number,
+    schema_path,
+    generated_at,
+) = sys.argv[1:]
+
+
+def load_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def issue_type(labels):
+    names = set(labels)
+    if "epic" in names:
+        return "epic"
+    if "story" in names:
+        return "story"
+    if "task" in names:
+        return "task"
+    return "issue"
+
+
+def completion_percent(closed, total):
+    if total == 0:
+        return 0.0
+    return round((closed / total) * 100.0, 2)
+
+
+issues_raw = load_json(issues_path)
+if isinstance(issues_raw, dict):
+    issues_raw = issues_raw.get("issues", [])
+if not isinstance(issues_raw, list):
+    raise SystemExit("issues fixture/source must decode to a JSON array")
+
+milestone_raw = load_json(milestone_path)
+if not isinstance(milestone_raw, dict):
+    raise SystemExit("milestone fixture/source must decode to a JSON object")
+
+issues = []
+for issue in issues_raw:
+    if not isinstance(issue, dict):
+        continue
+    if "pull_request" in issue:
+        continue
+    labels = sorted(
+        [label.get("name", "") for label in issue.get("labels", []) if isinstance(label, dict)]
+    )
+    state = issue.get("state", "unknown")
+    entry = {
+        "number": issue.get("number"),
+        "title": issue.get("title", ""),
+        "state": state,
+        "url": issue.get("html_url", ""),
+        "labels": labels,
+        "type": issue_type(labels),
+        "comments": int(issue.get("comments", 0) or 0),
+        "has_comments": int(issue.get("comments", 0) or 0) > 0,
+        "testing_matrix_required": "testing-matrix" in labels,
+        "parent_issue_url": issue.get("parent_issue_url"),
+    }
+    if entry["number"] is None:
+        continue
+    issues.append(entry)
+
+issues.sort(key=lambda entry: int(entry["number"]))
+
+total = len(issues)
+closed = sum(1 for issue in issues if issue["state"] == "closed")
+open_count = sum(1 for issue in issues if issue["state"] == "open")
+epics = sum(1 for issue in issues if issue["type"] == "epic")
+stories = sum(1 for issue in issues if issue["type"] == "story")
+tasks = sum(1 for issue in issues if issue["type"] == "task")
+with_comments = sum(1 for issue in issues if issue["has_comments"])
+testing_required = sum(1 for issue in issues if issue["testing_matrix_required"])
+testing_closed = sum(
+    1
+    for issue in issues
+    if issue["testing_matrix_required"] and issue["state"] == "closed"
+)
+
+reports_path = pathlib.Path(reports_dir)
+local_artifacts = []
+if reports_path.exists() and reports_path.is_dir():
+    for artifact_path in sorted(reports_path.iterdir(), key=lambda item: item.name):
+        if not artifact_path.is_file():
+            continue
+        if artifact_path.suffix not in {".json", ".md"}:
+            continue
+        stat = artifact_path.stat()
+        local_artifacts.append(
+            {
+                "path": str(artifact_path),
+                "name": artifact_path.name,
+                "bytes": stat.st_size,
+                "modified_at": datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status": "present",
+            }
+        )
+
+matrix = {
+    "schema_version": 1,
+    "generated_at": generated_at,
+    "repository": repo_slug,
+    "schema_path": schema_path,
+    "milestone": {
+        "number": int(milestone_number),
+        "title": milestone_raw.get("title", ""),
+        "state": milestone_raw.get("state", ""),
+        "open_issues": int(milestone_raw.get("open_issues", 0) or 0),
+        "closed_issues": int(milestone_raw.get("closed_issues", 0) or 0),
+        "due_on": milestone_raw.get("due_on"),
+    },
+    "summary": {
+        "total_issues": total,
+        "open_issues": open_count,
+        "closed_issues": closed,
+        "completion_percent": completion_percent(closed, total),
+        "epics": epics,
+        "stories": stories,
+        "tasks": tasks,
+        "with_comments": with_comments,
+        "testing_matrix_required": testing_required,
+        "testing_matrix_closed": testing_closed,
+        "local_artifacts_total": len(local_artifacts),
+    },
+    "local_artifacts": local_artifacts,
+    "issues": issues,
+}
+
+with open(output_json, "w", encoding="utf-8") as handle:
+    json.dump(matrix, handle, indent=2)
+    handle.write("\n")
+
+lines = []
+lines.append("# M21 Validation Matrix")
+lines.append("")
+lines.append(f"- Generated: {matrix['generated_at']}")
+lines.append(f"- Repository: {matrix['repository']}")
+lines.append(
+    f"- Milestone: #{matrix['milestone']['number']} {matrix['milestone']['title']}".rstrip()
+)
+lines.append(
+    f"- Progress: {matrix['summary']['closed_issues']}/{matrix['summary']['total_issues']} "
+    f"closed ({matrix['summary']['completion_percent']:.2f}%)"
+)
+lines.append("")
+lines.append("## Summary")
+lines.append("")
+lines.append("| Metric | Value |")
+lines.append("| --- | ---: |")
+for metric, value in (
+    ("Open issues", matrix["summary"]["open_issues"]),
+    ("Closed issues", matrix["summary"]["closed_issues"]),
+    ("Epics", matrix["summary"]["epics"]),
+    ("Stories", matrix["summary"]["stories"]),
+    ("Tasks", matrix["summary"]["tasks"]),
+    ("Issues with comments", matrix["summary"]["with_comments"]),
+    ("Testing-matrix required", matrix["summary"]["testing_matrix_required"]),
+    ("Testing-matrix closed", matrix["summary"]["testing_matrix_closed"]),
+    ("Local artifacts", matrix["summary"]["local_artifacts_total"]),
+):
+    lines.append(f"| {metric} | {value} |")
+lines.append("")
+
+lines.append("## Issue Matrix")
+lines.append("")
+lines.append("| Issue | State | Type | Labels | Comments | Testing Matrix |")
+lines.append("| --- | --- | --- | --- | ---: | --- |")
+for issue in issues:
+    labels = ", ".join(issue["labels"]) if issue["labels"] else "-"
+    testing_required_cell = "required" if issue["testing_matrix_required"] else "-"
+    lines.append(
+        f"| #{issue['number']} | {issue['state']} | {issue['type']} | "
+        f"{labels} | {issue['comments']} | {testing_required_cell} |"
+    )
+lines.append("")
+
+lines.append("## Local Artifacts")
+lines.append("")
+lines.append("| Artifact | Bytes | Modified (UTC) | Status |")
+lines.append("| --- | ---: | --- | --- |")
+for artifact in local_artifacts:
+    lines.append(
+        f"| `{artifact['path']}` | {artifact['bytes']} | "
+        f"{artifact['modified_at']} | {artifact['status']} |"
+    )
+if not local_artifacts:
+    lines.append("| (none) | 0 | n/a | n/a |")
+lines.append("")
+
+with open(output_md, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(lines))
+    handle.write("\n")
+PY
+
+log_info "wrote validation matrix artifacts:"
+log_info "- ${OUTPUT_JSON}"
+log_info "- ${OUTPUT_MD}"

--- a/scripts/dev/test-m21-validation-matrix.sh
+++ b/scripts/dev/test-m21-validation-matrix.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MATRIX_SCRIPT="${SCRIPT_DIR}/m21-validation-matrix.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for test-m21-validation-matrix.sh" >&2
+  exit 1
+fi
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fixture_milestone="${tmp_dir}/milestone.json"
+fixture_issues="${tmp_dir}/issues.json"
+fixture_reports="${tmp_dir}/reports"
+output_json="${tmp_dir}/matrix.json"
+output_md="${tmp_dir}/matrix.md"
+
+mkdir -p "${fixture_reports}"
+cat >"${fixture_reports}/proof-a.json" <<'EOF'
+{
+  "schema_version": 1
+}
+EOF
+cat >"${fixture_reports}/proof-b.md" <<'EOF'
+# Proof B
+EOF
+
+cat >"${fixture_milestone}" <<'EOF'
+{
+  "number": 21,
+  "title": "Gap Closure Wave 2026-03: Structural Runtime Hardening",
+  "state": "open",
+  "open_issues": 2,
+  "closed_issues": 1,
+  "due_on": "2026-03-30T00:00:00Z"
+}
+EOF
+
+cat >"${fixture_issues}" <<'EOF'
+[
+  {
+    "number": 1741,
+    "title": "Subtask: Automated aggregation script for M21 validation matrix generation",
+    "state": "open",
+    "html_url": "https://github.com/njfio/Tau/issues/1741",
+    "labels": [{"name": "task"}, {"name": "testing-matrix"}],
+    "comments": 1
+  },
+  {
+    "number": 1742,
+    "title": "Subtask: Standard artifact manifest template for M21 live proof pack",
+    "state": "closed",
+    "html_url": "https://github.com/njfio/Tau/issues/1742",
+    "labels": [{"name": "task"}, {"name": "testing-matrix"}],
+    "comments": 2
+  },
+  {
+    "number": 1759,
+    "title": "Story: Cross-Wave Dependency Graph and Critical Path Control",
+    "state": "open",
+    "html_url": "https://github.com/njfio/Tau/issues/1759",
+    "labels": [{"name": "story"}],
+    "comments": 0
+  },
+  {
+    "number": 9999,
+    "title": "Synthetic PR record that should be excluded",
+    "state": "closed",
+    "html_url": "https://github.com/njfio/Tau/pull/9999",
+    "labels": [{"name": "task"}],
+    "comments": 0,
+    "pull_request": {"url": "https://api.github.com/repos/njfio/Tau/pulls/9999"}
+  }
+]
+EOF
+
+bash -n "${MATRIX_SCRIPT}"
+
+"${MATRIX_SCRIPT}" \
+  --quiet \
+  --repo "fixture/repository" \
+  --milestone-number 21 \
+  --fixture-milestone-json "${fixture_milestone}" \
+  --fixture-issues-json "${fixture_issues}" \
+  --reports-dir "${fixture_reports}" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}" \
+  --generated-at "2026-02-15T12:00:00Z"
+
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional): missing output JSON" >&2
+  exit 1
+fi
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional): missing output Markdown" >&2
+  exit 1
+fi
+
+assert_equals "1" "$(jq -r '.schema_version' "${output_json}")" "functional schema version"
+assert_equals "3" "$(jq -r '.summary.total_issues' "${output_json}")" "functional total issues"
+assert_equals "1" "$(jq -r '.summary.closed_issues' "${output_json}")" "functional closed issues"
+assert_equals "2" "$(jq -r '.summary.open_issues' "${output_json}")" "functional open issues"
+assert_equals "2" "$(jq -r '.summary.testing_matrix_required' "${output_json}")" "functional testing required"
+assert_equals "1" "$(jq -r '.summary.testing_matrix_closed' "${output_json}")" "functional testing closed"
+assert_equals "2" "$(jq -r '.summary.local_artifacts_total' "${output_json}")" "functional local artifacts"
+assert_equals "1741" "$(jq -r '.issues[0].number' "${output_json}")" "functional sorted issue order"
+assert_equals "1759" "$(jq -r '.issues[2].number' "${output_json}")" "functional sorted issue order tail"
+assert_contains "$(cat "${output_md}")" "## Issue Matrix" "functional markdown issue table"
+assert_contains "$(cat "${output_md}")" "## Local Artifacts" "functional markdown artifact section"
+
+set +e
+missing_fixture_output="$(
+  "${MATRIX_SCRIPT}" \
+    --fixture-milestone-json "${fixture_milestone}" \
+    --output-json "${tmp_dir}/missing.json" \
+    --output-md "${tmp_dir}/missing.md" 2>&1
+)"
+missing_fixture_code=$?
+set -e
+assert_equals "1" "${missing_fixture_code}" "regression fixture pair requirement"
+assert_contains "${missing_fixture_output}" "must be provided together" "regression fixture pair message"
+
+set +e
+invalid_number_output="$("${MATRIX_SCRIPT}" --milestone-number invalid 2>&1)"
+invalid_number_code=$?
+set -e
+assert_equals "1" "${invalid_number_code}" "regression milestone number validation"
+assert_contains "${invalid_number_output}" "must be a non-negative integer" "regression milestone number message"
+
+set +e
+unknown_option_output="$("${MATRIX_SCRIPT}" --unknown-flag 2>&1)"
+unknown_option_code=$?
+set -e
+assert_equals "1" "${unknown_option_code}" "regression unknown option exit"
+assert_contains "${unknown_option_output}" "unknown option '--unknown-flag'" "regression unknown option message"
+
+echo "m21-validation-matrix tests passed"

--- a/tasks/reports/m21-validation-matrix.json
+++ b/tasks/reports/m21-validation-matrix.json
@@ -1,0 +1,1616 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-02-15T12:32:53Z",
+  "repository": "njfio/Tau",
+  "schema_path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/schemas/m21-validation-matrix.schema.json",
+  "milestone": {
+    "number": 21,
+    "title": "Gap Closure Wave 2026-03: Structural Runtime Hardening",
+    "state": "open",
+    "open_issues": 78,
+    "closed_issues": 10,
+    "due_on": "2026-03-30T00:00:00Z"
+  },
+  "summary": {
+    "total_issues": 88,
+    "open_issues": 78,
+    "closed_issues": 10,
+    "completion_percent": 11.36,
+    "epics": 3,
+    "stories": 12,
+    "tasks": 73,
+    "with_comments": 11,
+    "testing_matrix_required": 88,
+    "testing_matrix_closed": 10,
+    "local_artifacts_total": 6
+  },
+  "local_artifacts": [
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/m21-validation-matrix.json",
+      "name": "m21-validation-matrix.json",
+      "bytes": 48225,
+      "modified_at": "2026-02-15T12:32:30Z",
+      "status": "present"
+    },
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/m21-validation-matrix.md",
+      "name": "m21-validation-matrix.md",
+      "bytes": 9729,
+      "modified_at": "2026-02-15T12:32:30Z",
+      "status": "present"
+    },
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-baseline.json",
+      "name": "pr-throughput-baseline.json",
+      "bytes": 22890,
+      "modified_at": "2026-02-15T12:29:27Z",
+      "status": "present"
+    },
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-baseline.md",
+      "name": "pr-throughput-baseline.md",
+      "bytes": 6515,
+      "modified_at": "2026-02-15T12:29:27Z",
+      "status": "present"
+    },
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-delta.json",
+      "name": "pr-throughput-delta.json",
+      "bytes": 2533,
+      "modified_at": "2026-02-15T12:29:27Z",
+      "status": "present"
+    },
+    {
+      "path": "/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-delta.md",
+      "name": "pr-throughput-delta.md",
+      "bytes": 1285,
+      "modified_at": "2026-02-15T12:29:27Z",
+      "status": "present"
+    }
+  ],
+  "issues": [
+    {
+      "number": 1605,
+      "title": "Epic: Merge or Remove Scaffold Crates (Current-State Audit + Execution)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1605",
+      "labels": [
+        "area:memory",
+        "area:runtime",
+        "area:tools",
+        "enhancement",
+        "epic",
+        "roadmap",
+        "testing-matrix"
+      ],
+      "type": "epic",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1606,
+      "title": "Epic: Split tools.rs and 10 Other Oversized Production Files",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1606",
+      "labels": [
+        "area:cli",
+        "area:runtime",
+        "area:tools",
+        "enhancement",
+        "epic",
+        "roadmap",
+        "testing-matrix"
+      ],
+      "type": "epic",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1607,
+      "title": "Epic: Merge tau-safety to Mainline Runtime Enforcement",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1607",
+      "labels": [
+        "area:providers",
+        "area:runtime",
+        "area:tools",
+        "enhancement",
+        "epic",
+        "roadmap",
+        "testing-matrix"
+      ],
+      "type": "epic",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1610,
+      "title": "Story: Scaffold-Crate Inventory and Merge/Remove Decision Matrix",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1610",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1605"
+    },
+    {
+      "number": 1611,
+      "title": "Story: Execute Scaffold Merge/Remove Decisions Across Runtime Crates",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1611",
+      "labels": [
+        "area:memory",
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1605"
+    },
+    {
+      "number": 1612,
+      "title": "Story: Live Validation and Rollout Hardening After Scaffold Consolidation",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1612",
+      "labels": [
+        "area:observability",
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1605"
+    },
+    {
+      "number": 1613,
+      "title": "Story: Split `tau-tools/src/tools.rs` Below Maintainability Budget",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1613",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1606"
+    },
+    {
+      "number": 1614,
+      "title": "Story: Split Oversized Production Files Cohort A (Files 2-6)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1614",
+      "labels": [
+        "area:cli",
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1606"
+    },
+    {
+      "number": 1615,
+      "title": "Story: Split Oversized Production Files Cohort B (Files 7-11) + File-Size Guardrails",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1615",
+      "labels": [
+        "area:ci-cd",
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1606"
+    },
+    {
+      "number": 1616,
+      "title": "Story: Wire `tau-safety` Policy into Mainline Startup and Runtime Context",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1616",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1607"
+    },
+    {
+      "number": 1617,
+      "title": "Story: Enforce Safety Scanning Across Inbound, Tool Output, and Outbound Payload Paths",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1617",
+      "labels": [
+        "area:providers",
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1607"
+    },
+    {
+      "number": 1618,
+      "title": "Story: Safety Observability, Operator Diagnostics, and Live-Run Proofs",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1618",
+      "labels": [
+        "area:observability",
+        "area:runtime",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1607"
+    },
+    {
+      "number": 1626,
+      "title": "Task: Build scaffold inventory script and ownership map",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1626",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1610"
+    },
+    {
+      "number": 1627,
+      "title": "Task: Publish merge/remove decision rubric and scoring sheet",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1627",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1610"
+    },
+    {
+      "number": 1628,
+      "title": "Task: Consolidate or justify retention of training micro-crates",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1628",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1611"
+    },
+    {
+      "number": 1629,
+      "title": "Task: Resolve scaffolded memory postgres backend path (implement or remove)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1629",
+      "labels": [
+        "area:memory",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1611"
+    },
+    {
+      "number": 1630,
+      "title": "Task: Remove dead contract-runner and scaffold remnants across retained crates",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1630",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1611"
+    },
+    {
+      "number": 1631,
+      "title": "Task: Execute live proof matrix for retained consolidated capabilities",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1631",
+      "labels": [
+        "area:observability",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1612"
+    },
+    {
+      "number": 1632,
+      "title": "Task: Align runbooks and CLI/help docs to post-consolidation ownership",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1632",
+      "labels": [
+        "area:runtime",
+        "documentation",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1612"
+    },
+    {
+      "number": 1633,
+      "title": "Task: Extract tool domains from `tools.rs` into focused modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1633",
+      "labels": [
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1613"
+    },
+    {
+      "number": 1634,
+      "title": "Task: Validate tool behavior parity and latency after `tools.rs` split",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1634",
+      "labels": [
+        "area:observability",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1613"
+    },
+    {
+      "number": 1635,
+      "title": "Task: Split `tau-cli/src/cli_args.rs` and `tau-github-issues-runtime/src/github_issues_runtime.rs`",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1635",
+      "labels": [
+        "area:cli",
+        "area:transports",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1614"
+    },
+    {
+      "number": 1636,
+      "title": "Task: Split `tau-skills/src/package_manifest.rs`, `tau-agent-core/src/lib.rs`, and `tau-ops/src/channel_store_admin.rs`",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1636",
+      "labels": [
+        "area:runtime",
+        "area:skills",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1614"
+    },
+    {
+      "number": 1637,
+      "title": "Task: Split `auth_commands_runtime.rs` and `rpc_protocol_runtime.rs`",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1637",
+      "labels": [
+        "area:providers",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1615"
+    },
+    {
+      "number": 1638,
+      "title": "Task: Split `tau-memory/src/runtime.rs`, `tau-multi-channel/src/multi_channel_runtime.rs`, and `tau-skills/src/lib.rs`",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1638",
+      "labels": [
+        "area:memory",
+        "area:transports",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1615"
+    },
+    {
+      "number": 1639,
+      "title": "Task: Add CI guardrail for oversized production files",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1639",
+      "labels": [
+        "area:ci-cd",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1615"
+    },
+    {
+      "number": 1640,
+      "title": "Task: Unify safety policy resolution across CLI, profile, and startup context",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1640",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1616"
+    },
+    {
+      "number": 1641,
+      "title": "Task: Remove or close safety bypass paths with explicit fail-closed behavior",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1641",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1616"
+    },
+    {
+      "number": 1642,
+      "title": "Task: Add integration tests for inbound prompt and tool-output safety enforcement",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1642",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1617"
+    },
+    {
+      "number": 1643,
+      "title": "Task: Add integration tests for outbound HTTP payload leak/safety enforcement",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1643",
+      "labels": [
+        "area:providers",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1617"
+    },
+    {
+      "number": 1644,
+      "title": "Task: Expose safety diagnostics and enforcement telemetry to operators",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1644",
+      "labels": [
+        "area:observability",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1618"
+    },
+    {
+      "number": 1645,
+      "title": "Task: Add safety live-run validation to demo/CI smoke matrix",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1645",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1618"
+    },
+    {
+      "number": 1679,
+      "title": "Subtask: Split `tau-cli/src/cli_args.rs` into argument-domain modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1679",
+      "labels": [
+        "area:cli",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1635"
+    },
+    {
+      "number": 1680,
+      "title": "Subtask: Split `tau-github-issues-runtime/src/github_issues_runtime.rs` into runtime domains",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1680",
+      "labels": [
+        "area:runtime",
+        "area:transports",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1635"
+    },
+    {
+      "number": 1681,
+      "title": "Subtask: Split `tau-skills/src/package_manifest.rs` by schema/validation/IO boundaries",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1681",
+      "labels": [
+        "area:skills",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1636"
+    },
+    {
+      "number": 1682,
+      "title": "Subtask: Split `tau-agent-core/src/lib.rs` into runtime lifecycle modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1682",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1636"
+    },
+    {
+      "number": 1683,
+      "title": "Subtask: Split `tau-ops/src/channel_store_admin.rs` into command/report/repair modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1683",
+      "labels": [
+        "area:observability",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1636"
+    },
+    {
+      "number": 1684,
+      "title": "Subtask: Split `tau-provider/src/auth_commands_runtime.rs` by provider and shared runtime core",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1684",
+      "labels": [
+        "area:providers",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1637"
+    },
+    {
+      "number": 1685,
+      "title": "Subtask: Split `tau-runtime/src/rpc_protocol_runtime.rs` by protocol parsing/dispatch/transport",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1685",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1637"
+    },
+    {
+      "number": 1686,
+      "title": "Subtask: Split `tau-memory/src/runtime.rs` into backend/query/ranking modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1686",
+      "labels": [
+        "area:memory",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1638"
+    },
+    {
+      "number": 1687,
+      "title": "Subtask: Split `tau-multi-channel/src/multi_channel_runtime.rs` into ingress/routing/outbound orchestration modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1687",
+      "labels": [
+        "area:runtime",
+        "area:transports",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1638"
+    },
+    {
+      "number": 1688,
+      "title": "Subtask: Split `tau-skills/src/lib.rs` into command/load/trust orchestration modules",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1688",
+      "labels": [
+        "area:skills",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1638"
+    },
+    {
+      "number": 1699,
+      "title": "Story: Gate M21 Structural Hardening Exit (Merge/Remove + Splits + Safety)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1699",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1703,
+      "title": "Task: Compile milestone #21 consolidated validation matrix",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1703",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1699"
+    },
+    {
+      "number": 1704,
+      "title": "Task: Execute milestone #21 live-run proof pack",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1704",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1699"
+    },
+    {
+      "number": 1711,
+      "title": "Subtask: Training micro-crate boundary decision implementation plan",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1711",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1628"
+    },
+    {
+      "number": 1712,
+      "title": "Subtask: Remove stale training flag/docs references after crate boundary updates",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1712",
+      "labels": [
+        "area:runtime",
+        "documentation",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1628"
+    },
+    {
+      "number": 1713,
+      "title": "Subtask: Decide postgres backend disposition for tau-memory (implement vs remove)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1713",
+      "labels": [
+        "area:memory",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1629"
+    },
+    {
+      "number": 1714,
+      "title": "Subtask: Purge removed contract-runner flags from startup dispatch and CLI validation",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1714",
+      "labels": [
+        "area:cli",
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1630"
+    },
+    {
+      "number": 1715,
+      "title": "Subtask: Centralize safety policy precedence contract (CLI/profile/env)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1715",
+      "labels": [
+        "area:runtime",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1640"
+    },
+    {
+      "number": 1716,
+      "title": "Subtask: Add fail-closed safety gate tests for bypass attempts",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1716",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1641"
+    },
+    {
+      "number": 1717,
+      "title": "Subtask: Safety diagnostics schema versioning and backward-compat tests",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1717",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1644"
+    },
+    {
+      "number": 1728,
+      "title": "Subtask: Inbound safety fixture corpus for transport-sourced prompt injection cases",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1728",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1642"
+    },
+    {
+      "number": 1729,
+      "title": "Subtask: Tool-output reinjection safety regression suite",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1729",
+      "labels": [
+        "area:runtime",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1642"
+    },
+    {
+      "number": 1730,
+      "title": "Subtask: Outbound HTTP payload secret-leak fixture matrix",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1730",
+      "labels": [
+        "area:providers",
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1643"
+    },
+    {
+      "number": 1731,
+      "title": "Subtask: Safety smoke scenario in demo index and CI-light lane",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1731",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1645"
+    },
+    {
+      "number": 1741,
+      "title": "Subtask: Automated aggregation script for M21 validation matrix generation",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1741",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 1,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1703"
+    },
+    {
+      "number": 1742,
+      "title": "Subtask: Standard artifact manifest template for M21 live proof pack",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1742",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1704"
+    },
+    {
+      "number": 1745,
+      "title": "Subtask: Define retained-capability live-proof matrix and artifact checklist",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1745",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1631"
+    },
+    {
+      "number": 1746,
+      "title": "Subtask: Automate retained-capability proof execution summary generation",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1746",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1631"
+    },
+    {
+      "number": 1747,
+      "title": "Subtask: Runbook ownership map update for consolidated crate boundaries",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1747",
+      "labels": [
+        "documentation",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1632"
+    },
+    {
+      "number": 1748,
+      "title": "Subtask: Add rollback simulation checklist for consolidated runtime surfaces",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1748",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1632"
+    },
+    {
+      "number": 1749,
+      "title": "Subtask: Split tools.rs into registry/core + domain modules first pass",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1749",
+      "labels": [
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1633"
+    },
+    {
+      "number": 1750,
+      "title": "Subtask: Split tools.rs domain modules second pass (fs/shell/session/http)",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1750",
+      "labels": [
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 1,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1633"
+    },
+    {
+      "number": 1751,
+      "title": "Subtask: Create before/after behavior parity checklist for tool dispatch",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1751",
+      "labels": [
+        "area:tools",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1634"
+    },
+    {
+      "number": 1752,
+      "title": "Subtask: Add lightweight performance smoke for tool split regressions",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1752",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1634"
+    },
+    {
+      "number": 1753,
+      "title": "Subtask: Define oversized-file threshold policy and exemption process doc",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1753",
+      "labels": [
+        "area:ci-cd",
+        "documentation",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1639"
+    },
+    {
+      "number": 1754,
+      "title": "Subtask: Add CI output annotation for oversized-file threshold failures",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1754",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 3,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1639"
+    },
+    {
+      "number": 1759,
+      "title": "Story: Cross-Wave Dependency Graph and Critical Path Control",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1759",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1760,
+      "title": "Story: Parallel Execution Batching and PR Merge Throughput Plan",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1760",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "story",
+        "testing-matrix"
+      ],
+      "type": "story",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1678"
+    },
+    {
+      "number": 1761,
+      "title": "Task: Generate machine-readable dependency graph for #1678 hierarchy",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1761",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1759"
+    },
+    {
+      "number": 1762,
+      "title": "Task: Publish critical-path dashboard comment template with blocker states",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1762",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1759"
+    },
+    {
+      "number": 1763,
+      "title": "Task: Add dependency drift check to prevent orphaned tasks",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1763",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1759"
+    },
+    {
+      "number": 1764,
+      "title": "Task: Define PR batch policy by lane (structural/docs/rl) with conflict boundaries",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1764",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1760"
+    },
+    {
+      "number": 1765,
+      "title": "Task: Add merge-throughput telemetry (PR age, review latency, merge interval)",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1765",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1760"
+    },
+    {
+      "number": 1766,
+      "title": "Task: Create stale-branch and merge-conflict fast-response playbook",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1766",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1760"
+    },
+    {
+      "number": 1767,
+      "title": "Subtask: Implement hierarchy graph extractor script (JSON + Markdown outputs)",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1767",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1761"
+    },
+    {
+      "number": 1768,
+      "title": "Subtask: Add graph artifact publication workflow and retention convention",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1768",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1761"
+    },
+    {
+      "number": 1769,
+      "title": "Subtask: Author critical-path update template with risk scoring rubric",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1769",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1762"
+    },
+    {
+      "number": 1770,
+      "title": "Subtask: Add critical-path update cadence policy and enforcement checklist",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1770",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1762"
+    },
+    {
+      "number": 1771,
+      "title": "Subtask: Define orphan-task detection rules and expected metadata",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1771",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1763"
+    },
+    {
+      "number": 1772,
+      "title": "Subtask: Implement drift-check command dry-run mode for local validation",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1772",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1763"
+    },
+    {
+      "number": 1773,
+      "title": "Subtask: Define lane-specific file ownership boundaries for PR batching",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1773",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1764"
+    },
+    {
+      "number": 1774,
+      "title": "Subtask: Create batch-size and review-SLA matrix for lane policy",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1774",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1764"
+    },
+    {
+      "number": 1775,
+      "title": "Subtask: Build PR throughput baseline report from recent merged history",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1775",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1765"
+    },
+    {
+      "number": 1776,
+      "title": "Subtask: Add periodic throughput delta report against baseline",
+      "state": "closed",
+      "url": "https://github.com/njfio/Tau/issues/1776",
+      "labels": [
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 2,
+      "has_comments": true,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1765"
+    },
+    {
+      "number": 1777,
+      "title": "Subtask: Define stale-branch thresholds and automated alert conditions",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1777",
+      "labels": [
+        "area:ci-cd",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1766"
+    },
+    {
+      "number": 1778,
+      "title": "Subtask: Create fast conflict-resolution playbook with rollback criteria",
+      "state": "open",
+      "url": "https://github.com/njfio/Tau/issues/1778",
+      "labels": [
+        "area:ci-cd",
+        "area:observability",
+        "roadmap",
+        "task",
+        "testing-matrix"
+      ],
+      "type": "task",
+      "comments": 0,
+      "has_comments": false,
+      "testing_matrix_required": true,
+      "parent_issue_url": "https://api.github.com/repos/njfio/Tau/issues/1766"
+    }
+  ]
+}

--- a/tasks/reports/m21-validation-matrix.md
+++ b/tasks/reports/m21-validation-matrix.md
@@ -1,0 +1,125 @@
+# M21 Validation Matrix
+
+- Generated: 2026-02-15T12:32:53Z
+- Repository: njfio/Tau
+- Milestone: #21 Gap Closure Wave 2026-03: Structural Runtime Hardening
+- Progress: 10/88 closed (11.36%)
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| Open issues | 78 |
+| Closed issues | 10 |
+| Epics | 3 |
+| Stories | 12 |
+| Tasks | 73 |
+| Issues with comments | 11 |
+| Testing-matrix required | 88 |
+| Testing-matrix closed | 10 |
+| Local artifacts | 6 |
+
+## Issue Matrix
+
+| Issue | State | Type | Labels | Comments | Testing Matrix |
+| --- | --- | --- | --- | ---: | --- |
+| #1605 | open | epic | area:memory, area:runtime, area:tools, enhancement, epic, roadmap, testing-matrix | 0 | required |
+| #1606 | open | epic | area:cli, area:runtime, area:tools, enhancement, epic, roadmap, testing-matrix | 0 | required |
+| #1607 | open | epic | area:providers, area:runtime, area:tools, enhancement, epic, roadmap, testing-matrix | 0 | required |
+| #1610 | open | story | area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1611 | open | story | area:memory, area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1612 | open | story | area:observability, area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1613 | open | story | area:runtime, area:tools, roadmap, story, testing-matrix | 0 | required |
+| #1614 | open | story | area:cli, area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1615 | open | story | area:ci-cd, area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1616 | open | story | area:runtime, area:tools, roadmap, story, testing-matrix | 0 | required |
+| #1617 | open | story | area:providers, area:runtime, area:tools, roadmap, story, testing-matrix | 0 | required |
+| #1618 | open | story | area:observability, area:runtime, roadmap, story, testing-matrix | 0 | required |
+| #1626 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1627 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1628 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1629 | open | task | area:memory, roadmap, task, testing-matrix | 0 | required |
+| #1630 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1631 | open | task | area:observability, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1632 | open | task | area:runtime, documentation, roadmap, task, testing-matrix | 0 | required |
+| #1633 | open | task | area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1634 | open | task | area:observability, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1635 | open | task | area:cli, area:transports, roadmap, task, testing-matrix | 0 | required |
+| #1636 | open | task | area:runtime, area:skills, roadmap, task, testing-matrix | 0 | required |
+| #1637 | open | task | area:providers, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1638 | open | task | area:memory, area:transports, roadmap, task, testing-matrix | 0 | required |
+| #1639 | open | task | area:ci-cd, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1640 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1641 | open | task | area:runtime, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1642 | open | task | area:runtime, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1643 | open | task | area:providers, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1644 | open | task | area:observability, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1645 | open | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1679 | open | task | area:cli, roadmap, task, testing-matrix | 0 | required |
+| #1680 | open | task | area:runtime, area:transports, roadmap, task, testing-matrix | 0 | required |
+| #1681 | open | task | area:skills, roadmap, task, testing-matrix | 0 | required |
+| #1682 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1683 | open | task | area:observability, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1684 | open | task | area:providers, roadmap, task, testing-matrix | 0 | required |
+| #1685 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1686 | open | task | area:memory, roadmap, task, testing-matrix | 0 | required |
+| #1687 | open | task | area:runtime, area:transports, roadmap, task, testing-matrix | 0 | required |
+| #1688 | open | task | area:skills, roadmap, task, testing-matrix | 0 | required |
+| #1699 | open | story | area:observability, roadmap, story, testing-matrix | 0 | required |
+| #1703 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1704 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1711 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1712 | open | task | area:runtime, documentation, roadmap, task, testing-matrix | 0 | required |
+| #1713 | open | task | area:memory, roadmap, task, testing-matrix | 0 | required |
+| #1714 | open | task | area:cli, area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1715 | open | task | area:runtime, roadmap, task, testing-matrix | 0 | required |
+| #1716 | open | task | area:runtime, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1717 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1728 | open | task | area:runtime, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1729 | open | task | area:runtime, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1730 | open | task | area:providers, area:tools, roadmap, task, testing-matrix | 0 | required |
+| #1731 | open | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1741 | open | task | area:ci-cd, roadmap, task, testing-matrix | 1 | required |
+| #1742 | closed | task | area:observability, roadmap, task, testing-matrix | 2 | required |
+| #1745 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1746 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1747 | open | task | documentation, roadmap, task, testing-matrix | 0 | required |
+| #1748 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1749 | closed | task | area:tools, roadmap, task, testing-matrix | 2 | required |
+| #1750 | closed | task | area:tools, roadmap, task, testing-matrix | 1 | required |
+| #1751 | closed | task | area:tools, roadmap, task, testing-matrix | 2 | required |
+| #1752 | closed | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 2 | required |
+| #1753 | closed | task | area:ci-cd, documentation, roadmap, task, testing-matrix | 2 | required |
+| #1754 | closed | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 3 | required |
+| #1759 | open | story | area:observability, roadmap, story, testing-matrix | 0 | required |
+| #1760 | open | story | area:ci-cd, area:observability, roadmap, story, testing-matrix | 0 | required |
+| #1761 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1762 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1763 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1764 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1765 | closed | task | area:observability, roadmap, task, testing-matrix | 2 | required |
+| #1766 | open | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1767 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1768 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1769 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1770 | open | task | area:observability, roadmap, task, testing-matrix | 0 | required |
+| #1771 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1772 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1773 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1774 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1775 | closed | task | area:observability, roadmap, task, testing-matrix | 2 | required |
+| #1776 | closed | task | area:observability, roadmap, task, testing-matrix | 2 | required |
+| #1777 | open | task | area:ci-cd, roadmap, task, testing-matrix | 0 | required |
+| #1778 | open | task | area:ci-cd, area:observability, roadmap, task, testing-matrix | 0 | required |
+
+## Local Artifacts
+
+| Artifact | Bytes | Modified (UTC) | Status |
+| --- | ---: | --- | --- |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/m21-validation-matrix.json` | 48225 | 2026-02-15T12:32:30Z | present |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/m21-validation-matrix.md` | 9729 | 2026-02-15T12:32:30Z | present |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-baseline.json` | 22890 | 2026-02-15T12:29:27Z | present |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-baseline.md` | 6515 | 2026-02-15T12:29:27Z | present |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-delta.json` | 2533 | 2026-02-15T12:29:27Z | present |
+| `/Users/n/RustroverProjects/rust_pi_issue1741/tasks/reports/pr-throughput-delta.md` | 1285 | 2026-02-15T12:29:27Z | present |
+

--- a/tasks/schemas/m21-validation-matrix.schema.json
+++ b/tasks/schemas/m21-validation-matrix.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "M21 Validation Matrix",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "repository",
+    "schema_path",
+    "milestone",
+    "summary",
+    "local_artifacts",
+    "issues"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "schema_path": {
+      "type": "string"
+    },
+    "milestone": {
+      "type": "object",
+      "required": ["number", "title", "state", "open_issues", "closed_issues"],
+      "properties": {
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "state": { "type": "string" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "due_on": { "type": ["string", "null"] }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "total_issues",
+        "open_issues",
+        "closed_issues",
+        "completion_percent",
+        "epics",
+        "stories",
+        "tasks",
+        "with_comments",
+        "testing_matrix_required",
+        "testing_matrix_closed",
+        "local_artifacts_total"
+      ],
+      "properties": {
+        "total_issues": { "type": "integer" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "completion_percent": { "type": "number" },
+        "epics": { "type": "integer" },
+        "stories": { "type": "integer" },
+        "tasks": { "type": "integer" },
+        "with_comments": { "type": "integer" },
+        "testing_matrix_required": { "type": "integer" },
+        "testing_matrix_closed": { "type": "integer" },
+        "local_artifacts_total": { "type": "integer" }
+      }
+    },
+    "local_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "name", "bytes", "modified_at", "status"],
+        "properties": {
+          "path": { "type": "string" },
+          "name": { "type": "string" },
+          "bytes": { "type": "integer" },
+          "modified_at": { "type": "string" },
+          "status": { "type": "string" }
+        }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "title",
+          "state",
+          "url",
+          "labels",
+          "type",
+          "comments",
+          "has_comments",
+          "testing_matrix_required"
+        ],
+        "properties": {
+          "number": { "type": "integer" },
+          "title": { "type": "string" },
+          "state": { "type": "string" },
+          "url": { "type": "string" },
+          "labels": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "type": { "type": "string" },
+          "comments": { "type": "integer" },
+          "has_comments": { "type": "boolean" },
+          "testing_matrix_required": { "type": "boolean" },
+          "parent_issue_url": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `scripts/dev/m21-validation-matrix.sh` to automatically generate milestone validation matrix artifacts (JSON + Markdown)
- add `tasks/schemas/m21-validation-matrix.schema.json` as the canonical matrix schema contract
- add `scripts/dev/test-m21-validation-matrix.sh` functional/regression script coverage
- publish generated default artifacts to:
  - `tasks/reports/m21-validation-matrix.json`
  - `tasks/reports/m21-validation-matrix.md`

## Behavior Changes
- M21 matrix generation is now reproducible from issue state + local report artifacts via one command
- collector supports both live GitHub API mode and deterministic fixture mode
- matrix output includes:
  - milestone metadata
  - issue-state matrix (type, labels, comments, testing-matrix requirement)
  - summary rollups (open/closed/progress/testing coverage)
  - local artifact inventory from `tasks/reports/`

## Risks & Compatibility
- low runtime risk: changes are limited to ops/reporting scripts and artifacts
- generated matrix report is snapshot-based and expected to change as milestone issue state evolves

## Validation Evidence
- `bash -n scripts/dev/m21-validation-matrix.sh scripts/dev/test-m21-validation-matrix.sh`
- `./scripts/dev/test-m21-validation-matrix.sh`
- `./scripts/dev/m21-validation-matrix.sh --repo njfio/Tau --milestone-number 21`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`

## Issue
Closes #1741
