### PR TITLE
Add retained-capability proof summary collector and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
             fast_validate:
               - "scripts/dev/fast-validate.sh"
               - "scripts/dev/test-fast-validate.sh"
+            retained_proof_summary:
+              - "scripts/dev/m21-retained-capability-proof-summary.sh"
+              - "scripts/dev/test-m21-retained-capability-proof-summary.sh"
+              - "scripts/demo/index.sh"
+              - "scripts/demo/all.sh"
+              - "scripts/demo/proof-pack-manifest.sh"
             tool_perf_smoke:
               - "crates/tau-tools/src/tools.rs"
               - "crates/tau-tools/src/tools/**"
@@ -266,6 +272,25 @@ jobs:
       - name: Validate fast-validate script
         if: steps.fast_validate_scope.outputs.fast_validate_tests_needed == 'true'
         run: ./scripts/dev/test-fast-validate.sh
+
+      - name: Determine retained-capability proof summary scope
+        id: retained_proof_summary_scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          retained_proof_summary_tests_needed="${{ steps.change_scope.outputs.retained_proof_summary }}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            retained_proof_summary_tests_needed="true"
+          elif [[ -z "${retained_proof_summary_tests_needed}" ]]; then
+            retained_proof_summary_tests_needed="false"
+          fi
+          echo "retained_proof_summary_tests_needed=${retained_proof_summary_tests_needed}" >> "$GITHUB_OUTPUT"
+          echo "### Retained-Capability Proof Summary Scope" >> "$GITHUB_STEP_SUMMARY"
+          echo "- retained-capability proof summary tests needed: ${retained_proof_summary_tests_needed}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate retained-capability proof summary script
+        if: steps.retained_proof_summary_scope.outputs.retained_proof_summary_tests_needed == 'true'
+        run: ./scripts/dev/test-m21-retained-capability-proof-summary.sh
 
       - name: Determine tool split performance smoke scope
         id: tool_perf_scope

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -131,3 +131,29 @@ Reviewer checklist:
 - confirm each required artifact entry is `present`
 - confirm `summary.status == "pass"` for closure-ready proof packs
 - verify `issues[]` links and `producer` metadata match the reviewed run
+
+## Retained-capability proof summary collector
+
+Use `scripts/dev/m21-retained-capability-proof-summary.sh` to execute the retained
+proof run matrix and emit a machine-readable summary with exit/status/marker diagnostics.
+
+Example with explicit binary:
+
+```bash
+./scripts/dev/m21-retained-capability-proof-summary.sh \
+  --repo-root . \
+  --binary ./target/debug/tau-coding-agent
+```
+
+Default report path conventions:
+- JSON summary: `tasks/reports/m21-retained-capability-proof-summary.json`
+- Markdown summary: `tasks/reports/m21-retained-capability-proof-summary.md`
+- Per-run logs: `tasks/reports/m21-retained-capability-proof-logs/`
+- Generated run artifacts: `tasks/reports/m21-retained-capability-artifacts/`
+
+Each run entry in the JSON summary includes:
+- command line
+- expected vs actual exit code
+- pass/fail status
+- marker match results (`stdout`, `stderr`, `file`)
+- stdout/stderr log paths for direct triage

--- a/scripts/dev/m21-retained-capability-proof-summary.sh
+++ b/scripts/dev/m21-retained-capability-proof-summary.sh
@@ -1,0 +1,630 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+BINARY_PATH="${REPO_ROOT}/target/debug/tau-coding-agent"
+REPORTS_DIR="${REPO_ROOT}/tasks/reports/m21-retained-capability-artifacts"
+LOGS_DIR="${REPO_ROOT}/tasks/reports/m21-retained-capability-proof-logs"
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m21-retained-capability-proof-summary.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m21-retained-capability-proof-summary.md"
+MATRIX_JSON=""
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: m21-retained-capability-proof-summary.sh [options]
+
+Execute retained-capability proof runs and emit reproducible JSON/Markdown summaries.
+
+By default this runs a bounded proof matrix based on scripts/demo wrappers and writes:
+  - tasks/reports/m21-retained-capability-proof-summary.json
+  - tasks/reports/m21-retained-capability-proof-summary.md
+  - tasks/reports/m21-retained-capability-proof-logs/
+  - tasks/reports/m21-retained-capability-artifacts/
+
+Options:
+  --repo-root <path>      Repository root (default: detected from script location).
+  --binary <path>         tau-coding-agent binary path used by default matrix runs.
+  --reports-dir <path>    Artifact directory for proof run outputs.
+  --logs-dir <path>       Directory for per-run stdout/stderr logs.
+  --output-json <path>    JSON summary output path.
+  --output-md <path>      Markdown summary output path.
+  --matrix-json <path>    Optional custom proof matrix JSON.
+  --generated-at <iso>    Override generated timestamp.
+  --quiet                 Suppress informational logs.
+  --help                  Show this help text.
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --binary)
+      BINARY_PATH="$2"
+      shift 2
+      ;;
+    --reports-dir)
+      REPORTS_DIR="$2"
+      shift 2
+      ;;
+    --logs-dir)
+      LOGS_DIR="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --matrix-json)
+      MATRIX_JSON="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+if [[ -n "${MATRIX_JSON}" && ! -f "${MATRIX_JSON}" ]]; then
+  echo "error: matrix JSON not found: ${MATRIX_JSON}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")" "${REPORTS_DIR}" "${LOGS_DIR}"
+
+python3 - \
+  "${REPO_ROOT}" \
+  "${BINARY_PATH}" \
+  "${REPORTS_DIR}" \
+  "${LOGS_DIR}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${MATRIX_JSON}" \
+  "${GENERATED_AT}" \
+  "${QUIET_MODE}" <<'PY'
+import json
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+(
+    repo_root_raw,
+    binary_path_raw,
+    reports_dir_raw,
+    logs_dir_raw,
+    output_json_raw,
+    output_md_raw,
+    matrix_json_raw,
+    generated_at,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+repo_root = Path(repo_root_raw).resolve()
+binary_path = Path(binary_path_raw)
+if not binary_path.is_absolute():
+    binary_path = (repo_root / binary_path).resolve()
+reports_dir = Path(reports_dir_raw)
+if not reports_dir.is_absolute():
+    reports_dir = (repo_root / reports_dir).resolve()
+logs_dir = Path(logs_dir_raw)
+if not logs_dir.is_absolute():
+    logs_dir = (repo_root / logs_dir).resolve()
+output_json = Path(output_json_raw)
+if not output_json.is_absolute():
+    output_json = (repo_root / output_json).resolve()
+output_md = Path(output_md_raw)
+if not output_md.is_absolute():
+    output_md = (repo_root / output_md).resolve()
+matrix_json = Path(matrix_json_raw).resolve() if matrix_json_raw else None
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log_info(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def default_matrix() -> dict:
+    return {
+        "schema_version": 1,
+        "name": "m21-retained-capability-proof-matrix",
+        "issues": ["#1746"],
+        "runs": [
+            {
+                "name": "demo-index-retained-scenarios",
+                "description": (
+                    "Run retained scenario subset via demo index wrapper and emit "
+                    "report/manifest artifacts."
+                ),
+                "command": [
+                    "./scripts/demo/index.sh",
+                    "--skip-build",
+                    "--repo-root",
+                    "{repo_root}",
+                    "--binary",
+                    "{binary}",
+                    "--only",
+                    "onboarding,gateway-auth,gateway-remote-access,multi-channel-live,deployment-wasm",
+                    "--json",
+                    "--report-file",
+                    "{reports_dir}/demo-index-retained-summary.json",
+                    "--manifest-file",
+                    "{reports_dir}/demo-index-retained-summary.manifest.json",
+                ],
+                "expected_exit_code": 0,
+                "markers": [
+                    {
+                        "id": "index-summary-json",
+                        "source": "stdout",
+                        "contains": '"summary":{"total":',
+                    },
+                    {
+                        "id": "index-summary-failed-zero",
+                        "source": "stdout",
+                        "contains": '"failed":0',
+                    },
+                    {
+                        "id": "index-report-artifact",
+                        "source": "file",
+                        "path": "{reports_dir}/demo-index-retained-summary.json",
+                        "contains": '"summary":{"total":',
+                    },
+                    {
+                        "id": "index-manifest-artifact",
+                        "source": "file",
+                        "path": "{reports_dir}/demo-index-retained-summary.manifest.json",
+                        "contains": '"pack_name": "demo-index-live-proof-pack"',
+                    },
+                ],
+            },
+            {
+                "name": "demo-all-retained-demos",
+                "description": (
+                    "Run retained demo subset via all.sh wrapper and emit report/manifest artifacts."
+                ),
+                "command": [
+                    "./scripts/demo/all.sh",
+                    "--skip-build",
+                    "--repo-root",
+                    "{repo_root}",
+                    "--binary",
+                    "{binary}",
+                    "--only",
+                    "local,multi-channel,gateway-auth,gateway-remote-access,deployment",
+                    "--json",
+                    "--report-file",
+                    "{reports_dir}/demo-all-retained-summary.json",
+                    "--manifest-file",
+                    "{reports_dir}/demo-all-retained-summary.manifest.json",
+                ],
+                "expected_exit_code": 0,
+                "markers": [
+                    {
+                        "id": "all-summary-json",
+                        "source": "stdout",
+                        "contains": '"summary":{"total":',
+                    },
+                    {
+                        "id": "all-summary-failed-zero",
+                        "source": "stdout",
+                        "contains": '"failed":0',
+                    },
+                    {
+                        "id": "all-report-artifact",
+                        "source": "file",
+                        "path": "{reports_dir}/demo-all-retained-summary.json",
+                        "contains": '"summary":{"total":',
+                    },
+                    {
+                        "id": "all-manifest-artifact",
+                        "source": "file",
+                        "path": "{reports_dir}/demo-all-retained-summary.manifest.json",
+                        "contains": '"pack_name": "demo-all-live-proof-pack"',
+                    },
+                ],
+            },
+            {
+                "name": "proof-pack-rollup-manifest",
+                "description": "Emit rollup manifest for retained-capability proof artifacts.",
+                "command": [
+                    "./scripts/demo/proof-pack-manifest.sh",
+                    "--output",
+                    "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+                    "--pack-name",
+                    "m21-retained-capability-live-proof-pack",
+                    "--producer-script",
+                    "scripts/dev/m21-retained-capability-proof-summary.sh",
+                    "--mode",
+                    "run",
+                    "--report-file",
+                    "{reports_dir}/demo-all-retained-summary.json",
+                    "--artifact",
+                    "index-report={reports_dir}/demo-index-retained-summary.json",
+                    "--artifact",
+                    "index-manifest={reports_dir}/demo-index-retained-summary.manifest.json",
+                    "--artifact",
+                    "all-manifest={reports_dir}/demo-all-retained-summary.manifest.json",
+                    "--issue",
+                    "#1746",
+                ],
+                "expected_exit_code": 0,
+                "markers": [
+                    {
+                        "id": "rollup-manifest-log",
+                        "source": "stderr",
+                        "contains": "wrote proof-pack manifest:",
+                    },
+                    {
+                        "id": "rollup-manifest-pack-name",
+                        "source": "file",
+                        "path": "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+                        "contains": '"pack_name": "m21-retained-capability-live-proof-pack"',
+                    },
+                    {
+                        "id": "rollup-manifest-status-pass",
+                        "source": "file",
+                        "path": "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+                        "contains": '"status": "pass"',
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def load_matrix(path: Path | None) -> dict:
+    if path is None:
+        return default_matrix()
+    with path.open(encoding="utf-8") as handle:
+        matrix = json.load(handle)
+    if not isinstance(matrix, dict):
+        raise SystemExit("error: matrix JSON must decode to an object")
+    return matrix
+
+
+def sanitize_name(raw: str) -> str:
+    sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in raw)
+    sanitized = sanitized.strip("-")
+    return sanitized or "run"
+
+
+def ensure_path(path_text: str) -> Path:
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    return path
+
+
+def render_template(raw: str) -> str:
+    rendered = raw
+    replacements = {
+        "{repo_root}": str(repo_root),
+        "{binary}": str(binary_path),
+        "{reports_dir}": str(reports_dir),
+        "{logs_dir}": str(logs_dir),
+        "{output_json}": str(output_json),
+        "{output_md}": str(output_md),
+    }
+    for token, value in replacements.items():
+        rendered = rendered.replace(token, value)
+    return rendered
+
+
+def render_command(args: list[str]) -> list[str]:
+    return [render_template(item) for item in args]
+
+
+def evaluate_marker(marker: dict, stdout_text: str, stderr_text: str) -> dict:
+    marker_id = marker.get("id") or "marker"
+    source = marker.get("source")
+    contains = marker.get("contains")
+    marker_path_raw = marker.get("path")
+    marker_path = render_template(marker_path_raw) if isinstance(marker_path_raw, str) else None
+    matched = False
+    detail = ""
+
+    if source == "stdout":
+        if not isinstance(contains, str) or not contains:
+            raise SystemExit(f"error: marker '{marker_id}' stdout markers require non-empty contains")
+        matched = contains in stdout_text
+        detail = "matched stdout substring" if matched else "stdout substring missing"
+    elif source == "stderr":
+        if not isinstance(contains, str) or not contains:
+            raise SystemExit(f"error: marker '{marker_id}' stderr markers require non-empty contains")
+        matched = contains in stderr_text
+        detail = "matched stderr substring" if matched else "stderr substring missing"
+    elif source == "file":
+        if not isinstance(marker_path, str) or not marker_path:
+            raise SystemExit(f"error: marker '{marker_id}' file markers require path")
+        path = ensure_path(marker_path)
+        if not path.exists():
+            matched = False
+            detail = f"file missing: {path}"
+        else:
+            if contains is None:
+                matched = True
+                detail = f"file present: {path}"
+            else:
+                if not isinstance(contains, str) or not contains:
+                    raise SystemExit(
+                        f"error: marker '{marker_id}' file marker contains must be non-empty when set"
+                    )
+                text = path.read_text(encoding="utf-8")
+                matched = contains in text
+                detail = (
+                    f"matched file substring in {path}"
+                    if matched
+                    else f"file substring missing in {path}"
+                )
+    else:
+        raise SystemExit(f"error: marker '{marker_id}' has unsupported source '{source}'")
+
+    payload = {
+        "id": marker_id,
+        "source": source,
+        "contains": contains,
+        "path": marker_path,
+        "matched": matched,
+        "detail": detail,
+    }
+    return payload
+
+
+matrix = load_matrix(matrix_json)
+schema_version = matrix.get("schema_version", 1)
+if schema_version != 1:
+    raise SystemExit(
+        f"error: unsupported matrix schema_version {schema_version}; expected 1"
+    )
+
+matrix_name = matrix.get("name", "retained-capability-proof-matrix")
+issues = matrix.get("issues", [])
+if issues is None:
+    issues = []
+if not isinstance(issues, list):
+    raise SystemExit("error: matrix issues must be an array when present")
+issues = [str(issue) for issue in issues if str(issue).strip()]
+
+runs = matrix.get("runs")
+if not isinstance(runs, list) or not runs:
+    raise SystemExit("error: matrix runs must be a non-empty array")
+
+reports_dir.mkdir(parents=True, exist_ok=True)
+logs_dir.mkdir(parents=True, exist_ok=True)
+output_json.parent.mkdir(parents=True, exist_ok=True)
+output_md.parent.mkdir(parents=True, exist_ok=True)
+
+results: list[dict] = []
+for index, run in enumerate(runs, start=1):
+    if not isinstance(run, dict):
+        raise SystemExit(f"error: runs[{index - 1}] must be an object")
+    name = run.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise SystemExit(f"error: runs[{index - 1}].name must be a non-empty string")
+    name = name.strip()
+    description = run.get("description", "")
+    if description is None:
+        description = ""
+    if not isinstance(description, str):
+        raise SystemExit(f"error: runs[{index - 1}].description must be a string when set")
+    command = run.get("command")
+    if not isinstance(command, list) or not command:
+        raise SystemExit(f"error: runs[{index - 1}].command must be a non-empty array")
+    command_rendered: list[str] = []
+    for arg_index, arg in enumerate(command):
+        if not isinstance(arg, str) or not arg:
+            raise SystemExit(
+                f"error: runs[{index - 1}].command[{arg_index}] must be a non-empty string"
+            )
+        command_rendered.append(render_template(arg))
+
+    expected_exit_code = run.get("expected_exit_code", 0)
+    if not isinstance(expected_exit_code, int):
+        raise SystemExit(
+            f"error: runs[{index - 1}].expected_exit_code must be an integer when set"
+        )
+
+    if any("{binary}" in arg for arg in command) and not binary_path.is_file():
+        raise SystemExit(
+            f"error: binary path does not exist for run '{name}': {binary_path}"
+        )
+
+    safe_name = sanitize_name(name)
+    stdout_log = logs_dir / f"{index:02d}-{safe_name}.stdout.log"
+    stderr_log = logs_dir / f"{index:02d}-{safe_name}.stderr.log"
+
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command_rendered,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    duration_ms = int((time.perf_counter() - started) * 1000)
+
+    stdout_log.write_text(completed.stdout, encoding="utf-8")
+    stderr_log.write_text(completed.stderr, encoding="utf-8")
+
+    markers = run.get("markers", [])
+    if not isinstance(markers, list):
+        raise SystemExit(f"error: runs[{index - 1}].markers must be an array when set")
+
+    marker_results = []
+    matched_markers = 0
+    for marker_index, marker in enumerate(markers):
+        if not isinstance(marker, dict):
+            raise SystemExit(
+                f"error: runs[{index - 1}].markers[{marker_index}] must be an object"
+            )
+        if "id" not in marker:
+            marker = dict(marker)
+            marker["id"] = f"{safe_name}-marker-{marker_index + 1}"
+        marker_result = evaluate_marker(marker, completed.stdout, completed.stderr)
+        marker_results.append(marker_result)
+        if marker_result["matched"]:
+            matched_markers += 1
+
+    failure_reasons: list[str] = []
+    if completed.returncode != expected_exit_code:
+        failure_reasons.append(
+            f"exit-code-mismatch expected={expected_exit_code} actual={completed.returncode}"
+        )
+    for marker in marker_results:
+        if not marker["matched"]:
+            failure_reasons.append(f"marker-missing:{marker['id']}")
+
+    status = "pass" if not failure_reasons else "fail"
+    results.append(
+        {
+            "name": name,
+            "description": description,
+            "status": status,
+            "command": command_rendered,
+            "command_line": shlex.join(command_rendered),
+            "expected_exit_code": expected_exit_code,
+            "exit_code": completed.returncode,
+            "duration_ms": duration_ms,
+            "stdout_log": str(stdout_log),
+            "stderr_log": str(stderr_log),
+            "marker_summary": {
+                "total": len(marker_results),
+                "matched": matched_markers,
+                "missing": len(marker_results) - matched_markers,
+            },
+            "markers": marker_results,
+            "failure_reasons": failure_reasons,
+        }
+    )
+
+    log_info(
+        f"[m21-proof-summary] run={name} status={status} "
+        f"exit={completed.returncode} markers={matched_markers}/{len(marker_results)}"
+    )
+
+passed_runs = sum(1 for entry in results if entry["status"] == "pass")
+failed_runs = len(results) - passed_runs
+summary_status = "pass" if failed_runs == 0 else "fail"
+
+payload = {
+    "schema_version": 1,
+    "generated_at": generated_at,
+    "matrix_name": matrix_name,
+    "issues": issues,
+    "repository_root": str(repo_root),
+    "report_paths": {
+        "json": str(output_json),
+        "markdown": str(output_md),
+        "logs_dir": str(logs_dir),
+        "artifacts_dir": str(reports_dir),
+    },
+    "summary": {
+        "total_runs": len(results),
+        "passed_runs": passed_runs,
+        "failed_runs": failed_runs,
+        "status": summary_status,
+    },
+    "runs": results,
+}
+
+output_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+lines: list[str] = []
+lines.append("# M21 Retained-Capability Proof Summary")
+lines.append("")
+lines.append(f"- Generated: {generated_at}")
+lines.append(f"- Matrix: {matrix_name}")
+if issues:
+    lines.append(f"- Issues: {', '.join(issues)}")
+lines.append(f"- Status: {summary_status}")
+lines.append("")
+lines.append("## Report Paths")
+lines.append("")
+lines.append(f"- JSON: `{output_json}`")
+lines.append(f"- Markdown: `{output_md}`")
+lines.append(f"- Logs directory: `{logs_dir}`")
+lines.append(f"- Artifact directory: `{reports_dir}`")
+lines.append("")
+lines.append("## Summary")
+lines.append("")
+lines.append("| Metric | Value |")
+lines.append("| --- | ---: |")
+lines.append(f"| Total runs | {len(results)} |")
+lines.append(f"| Passed runs | {passed_runs} |")
+lines.append(f"| Failed runs | {failed_runs} |")
+lines.append("")
+lines.append("## Run Matrix")
+lines.append("")
+lines.append("| Run | Status | Exit | Markers | Stdout Log | Stderr Log |")
+lines.append("| --- | --- | ---: | ---: | --- | --- |")
+for entry in results:
+    marker_summary = entry["marker_summary"]
+    lines.append(
+        f"| {entry['name']} | {entry['status']} | {entry['exit_code']} | "
+        f"{marker_summary['matched']}/{marker_summary['total']} | "
+        f"`{entry['stdout_log']}` | `{entry['stderr_log']}` |"
+    )
+lines.append("")
+
+failed_entries = [entry for entry in results if entry["status"] == "fail"]
+if failed_entries:
+    lines.append("## Failure Diagnostics")
+    lines.append("")
+    for entry in failed_entries:
+        lines.append(f"### {entry['name']}")
+        lines.append("")
+        lines.append(f"- Command: `{entry['command_line']}`")
+        lines.append(f"- Exit: {entry['exit_code']} (expected {entry['expected_exit_code']})")
+        if entry["failure_reasons"]:
+            lines.append(f"- Reasons: {', '.join(entry['failure_reasons'])}")
+        lines.append(f"- Stdout: `{entry['stdout_log']}`")
+        lines.append(f"- Stderr: `{entry['stderr_log']}`")
+        lines.append("")
+
+output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+log_info(f"[m21-proof-summary] wrote JSON summary: {output_json}")
+log_info(f"[m21-proof-summary] wrote Markdown summary: {output_md}")
+
+if failed_runs > 0:
+    raise SystemExit(1)
+PY
+
+log_info "retained-capability proof summary generation complete"

--- a/scripts/dev/test-m21-retained-capability-proof-summary.sh
+++ b/scripts/dev/test-m21-retained-capability-proof-summary.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SUMMARY_SCRIPT="${SCRIPT_DIR}/m21-retained-capability-proof-summary.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+require_cmd jq
+require_cmd python3
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+mock_binary="${tmp_dir}/mock-tau-coding-agent.py"
+cat >"${mock_binary}" <<'PY'
+#!/usr/bin/env python3
+import sys
+
+print("mock-ok " + " ".join(sys.argv[1:]))
+PY
+chmod +x "${mock_binary}"
+
+# Functional: default proof matrix runs cleanly with a mock binary and writes summary artifacts.
+functional_reports_dir="${tmp_dir}/functional/reports"
+functional_logs_dir="${tmp_dir}/functional/logs"
+functional_json="${tmp_dir}/functional/summary.json"
+functional_md="${tmp_dir}/functional/summary.md"
+
+"${SUMMARY_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --binary "${mock_binary}" \
+  --reports-dir "${functional_reports_dir}" \
+  --logs-dir "${functional_logs_dir}" \
+  --output-json "${functional_json}" \
+  --output-md "${functional_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+
+if [[ ! -f "${functional_json}" ]]; then
+  echo "assertion failed (functional json output): missing ${functional_json}" >&2
+  exit 1
+fi
+if [[ ! -f "${functional_md}" ]]; then
+  echo "assertion failed (functional markdown output): missing ${functional_md}" >&2
+  exit 1
+fi
+
+functional_json_content="$(cat "${functional_json}")"
+functional_md_content="$(cat "${functional_md}")"
+
+assert_equals "1" "$(jq -r '.schema_version' <<<"${functional_json_content}")" "functional schema version"
+assert_equals "pass" "$(jq -r '.summary.status' <<<"${functional_json_content}")" "functional status"
+assert_equals "3" "$(jq -r '.summary.total_runs' <<<"${functional_json_content}")" "functional total runs"
+assert_equals "3" "$(jq -r '.summary.passed_runs' <<<"${functional_json_content}")" "functional passed runs"
+assert_equals "0" "$(jq -r '.summary.failed_runs' <<<"${functional_json_content}")" "functional failed runs"
+assert_equals "true" "$(jq -r '.runs[] | select(.name == "demo-index-retained-scenarios") | .markers[] | select(.id == "index-summary-json") | .matched' <<<"${functional_json_content}")" "functional marker matched"
+assert_equals "6" "$(find "${functional_logs_dir}" -type f | wc -l | tr -d '[:space:]')" "functional log file count"
+assert_contains "${functional_md_content}" "## Run Matrix" "functional markdown matrix section"
+assert_contains "${functional_md_content}" "| demo-index-retained-scenarios | pass |" "functional markdown run row"
+
+# Regression: marker mismatch should fail with diagnosable report output.
+regression_matrix="${tmp_dir}/regression-matrix.json"
+cat >"${regression_matrix}" <<'EOF'
+{
+  "schema_version": 1,
+  "name": "regression-matrix",
+  "issues": ["#1746"],
+  "runs": [
+    {
+      "name": "marker-regression",
+      "description": "Intentional marker miss for regression validation.",
+      "command": ["bash", "-lc", "echo retained-proof-regression"],
+      "expected_exit_code": 0,
+      "markers": [
+        {
+          "id": "missing-stdout-marker",
+          "source": "stdout",
+          "contains": "not-present-token"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+regression_json="${tmp_dir}/regression/summary.json"
+regression_md="${tmp_dir}/regression/summary.md"
+regression_logs_dir="${tmp_dir}/regression/logs"
+regression_reports_dir="${tmp_dir}/regression/reports"
+
+set +e
+"${SUMMARY_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --binary "${mock_binary}" \
+  --matrix-json "${regression_matrix}" \
+  --reports-dir "${regression_reports_dir}" \
+  --logs-dir "${regression_logs_dir}" \
+  --output-json "${regression_json}" \
+  --output-md "${regression_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+regression_rc=$?
+set -e
+
+assert_equals "1" "${regression_rc}" "regression exit code"
+assert_equals "fail" "$(jq -r '.summary.status' "${regression_json}")" "regression summary status"
+assert_equals "1" "$(jq -r '.summary.failed_runs' "${regression_json}")" "regression failed runs"
+assert_equals "marker-missing:missing-stdout-marker" "$(jq -r '.runs[0].failure_reasons[0]' "${regression_json}")" "regression failure reason"
+assert_contains "$(cat "${regression_md}")" "## Failure Diagnostics" "regression markdown failure section"
+assert_contains "$(cat "${regression_md}")" "marker-missing:missing-stdout-marker" "regression markdown reason"
+
+# Regression: default matrix should fail fast when binary is missing.
+missing_binary_json="${tmp_dir}/missing-binary/summary.json"
+missing_binary_md="${tmp_dir}/missing-binary/summary.md"
+missing_binary_logs="${tmp_dir}/missing-binary/logs"
+missing_binary_reports="${tmp_dir}/missing-binary/reports"
+
+set +e
+missing_binary_output="$("${SUMMARY_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --binary "${tmp_dir}/does-not-exist" \
+  --reports-dir "${missing_binary_reports}" \
+  --logs-dir "${missing_binary_logs}" \
+  --output-json "${missing_binary_json}" \
+  --output-md "${missing_binary_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet 2>&1)"
+missing_binary_rc=$?
+set -e
+
+assert_equals "1" "${missing_binary_rc}" "regression missing binary exit code"
+assert_contains "${missing_binary_output}" "binary path does not exist for run" "regression missing binary message"
+
+echo "m21-retained-capability-proof-summary tests passed"


### PR DESCRIPTION
## Summary
- add `scripts/dev/m21-retained-capability-proof-summary.sh` to execute a retained-capability proof matrix and emit machine-readable JSON + Markdown summaries
- include per-run diagnostics in the summary payload: command line, expected/actual exit code, run status, marker evaluations (`stdout`/`stderr`/`file`), and stdout/stderr log artifact paths
- add `scripts/dev/test-m21-retained-capability-proof-summary.sh` with functional and regression checks (marker mismatch and missing-binary fail-fast)
- wire targeted CI verification in `.github/workflows/ci.yml` using a dedicated `retained_proof_summary` paths-filter scope
- document usage + report path conventions in `docs/guides/demo-index.md`

Closes #1746.

## Risks and Compatibility
- default matrix runs depend on `--binary` existing (fails closed with explicit error if missing)
- default marker checks are intentionally strict against current demo wrapper JSON/report contracts; if those contracts change, matrix markers must be updated
- CI adds one additional targeted script-test lane; scope is restricted to retained-proof-summary and related demo files

## Validation Evidence
- `./scripts/dev/test-m21-retained-capability-proof-summary.sh`
- `python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'`
- `bash -n scripts/dev/m21-retained-capability-proof-summary.sh scripts/dev/test-m21-retained-capability-proof-summary.sh`
- `cargo fmt`, strict `clippy`, and Rust test matrix not run (no Rust/Cargo source changes in this PR)
