### PR TITLE
Define retained-capability proof matrix and artifact checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
             retained_proof_summary:
               - "scripts/dev/m21-retained-capability-proof-summary.sh"
               - "scripts/dev/test-m21-retained-capability-proof-summary.sh"
+              - "scripts/demo/m21-retained-capability-proof-matrix.json"
+              - "scripts/demo/validate-m21-retained-capability-proof-matrix.sh"
+              - "scripts/demo/test-m21-retained-capability-proof-matrix.sh"
               - "scripts/demo/index.sh"
               - "scripts/demo/all.sh"
               - "scripts/demo/proof-pack-manifest.sh"
@@ -291,6 +294,10 @@ jobs:
       - name: Validate retained-capability proof summary script
         if: steps.retained_proof_summary_scope.outputs.retained_proof_summary_tests_needed == 'true'
         run: ./scripts/dev/test-m21-retained-capability-proof-summary.sh
+
+      - name: Validate retained-capability proof matrix/checklist contracts
+        if: steps.retained_proof_summary_scope.outputs.retained_proof_summary_tests_needed == 'true'
+        run: ./scripts/demo/test-m21-retained-capability-proof-matrix.sh
 
       - name: Determine tool split performance smoke scope
         id: tool_perf_scope

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -145,6 +145,19 @@ Example with explicit binary:
   --binary ./target/debug/tau-coding-agent
 ```
 
+Canonical retained-capability matrix and artifact checklist:
+- `scripts/demo/m21-retained-capability-proof-matrix.json`
+- capability IDs: `onboarding`, `gateway-auth`, `gateway-remote-access`,
+  `multi-channel-live`, `deployment-wasm`
+- checklist contract fields for each required artifact:
+  `name`, `path`, `required`, `status`
+
+Validate matrix/checklist contracts before live-proof runs:
+
+```bash
+./scripts/demo/validate-m21-retained-capability-proof-matrix.sh
+```
+
 Default report path conventions:
 - JSON summary: `tasks/reports/m21-retained-capability-proof-summary.json`
 - Markdown summary: `tasks/reports/m21-retained-capability-proof-summary.md`

--- a/scripts/demo/m21-retained-capability-proof-matrix.json
+++ b/scripts/demo/m21-retained-capability-proof-matrix.json
@@ -1,0 +1,233 @@
+{
+  "schema_version": 1,
+  "name": "m21-retained-capability-proof-matrix",
+  "milestone": "Gap Closure Wave 2026-03: Structural Runtime Hardening",
+  "issues": ["#1631", "#1704", "#1745", "#1746"],
+  "artifact_checklist": {
+    "required_fields": ["name", "path", "required", "status"],
+    "required_status_values": ["present"],
+    "required_artifacts": [
+      {
+        "name": "demo-index-report",
+        "path_token": "{reports_dir}/demo-index-retained-summary.json",
+        "producer": "scripts/demo/index.sh"
+      },
+      {
+        "name": "demo-index-manifest",
+        "path_token": "{reports_dir}/demo-index-retained-summary.manifest.json",
+        "producer": "scripts/demo/index.sh"
+      },
+      {
+        "name": "demo-all-report",
+        "path_token": "{reports_dir}/demo-all-retained-summary.json",
+        "producer": "scripts/demo/all.sh"
+      },
+      {
+        "name": "demo-all-manifest",
+        "path_token": "{reports_dir}/demo-all-retained-summary.manifest.json",
+        "producer": "scripts/demo/all.sh"
+      },
+      {
+        "name": "proof-pack-rollup-manifest",
+        "path_token": "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+        "producer": "scripts/demo/proof-pack-manifest.sh"
+      }
+    ],
+    "reviewer_checks": [
+      "All required artifact entries include name/path/required/status fields.",
+      "All required artifacts resolve to status=present in generated manifests.",
+      "Per-run summary status is pass and failed count is zero.",
+      "Rollup manifest includes linked issue references and producer metadata."
+    ]
+  },
+  "capabilities": [
+    {
+      "id": "onboarding",
+      "wrapper": "scripts/demo/local.sh",
+      "proof_step": "demo-index-retained-scenarios",
+      "expected_markers": [
+        "[demo:local] PASS onboard-non-interactive",
+        "[demo:local] summary: total="
+      ],
+      "required_artifacts": ["demo-index-report", "demo-index-manifest"]
+    },
+    {
+      "id": "gateway-auth",
+      "wrapper": "scripts/demo/gateway-auth.sh",
+      "proof_step": "demo-index-retained-scenarios",
+      "expected_markers": [
+        "[demo:gateway-auth] PASS gateway-remote-profile-token-mode",
+        "[demo:gateway-auth] PASS gateway-remote-profile-password-session-mode"
+      ],
+      "required_artifacts": ["demo-index-report", "demo-index-manifest"]
+    },
+    {
+      "id": "gateway-remote-access",
+      "wrapper": "scripts/demo/gateway-remote-access.sh",
+      "proof_step": "demo-index-retained-scenarios",
+      "expected_markers": [
+        "[demo:gateway-remote-access] PASS gateway-remote-plan-export-tailscale-serve",
+        "[demo:gateway-remote-access] PASS gateway-remote-plan-fails-closed-for-missing-password"
+      ],
+      "required_artifacts": ["demo-index-report", "demo-index-manifest"]
+    },
+    {
+      "id": "multi-channel-live",
+      "wrapper": "scripts/demo/multi-channel.sh",
+      "proof_step": "demo-index-retained-scenarios",
+      "expected_markers": [
+        "[demo:multi-channel] PASS multi-channel-live-ingest-telegram",
+        "[demo:multi-channel] PASS multi-channel-live-ingest-discord",
+        "[demo:multi-channel] PASS multi-channel-live-ingest-whatsapp"
+      ],
+      "required_artifacts": ["demo-index-report", "demo-index-manifest"]
+    },
+    {
+      "id": "deployment-wasm",
+      "wrapper": "scripts/demo/deployment.sh",
+      "proof_step": "demo-index-retained-scenarios",
+      "expected_markers": [
+        "[demo:deployment] PASS deployment-wasm-package",
+        "[demo:deployment] PASS channel-store-inspect-deployment-edge-wasm"
+      ],
+      "required_artifacts": ["demo-index-report", "demo-index-manifest"]
+    }
+  ],
+  "runs": [
+    {
+      "name": "demo-index-retained-scenarios",
+      "description": "Run retained scenario subset via demo index wrapper and emit report/manifest artifacts.",
+      "command": [
+        "./scripts/demo/index.sh",
+        "--skip-build",
+        "--repo-root",
+        "{repo_root}",
+        "--binary",
+        "{binary}",
+        "--only",
+        "onboarding,gateway-auth,gateway-remote-access,multi-channel-live,deployment-wasm",
+        "--json",
+        "--report-file",
+        "{reports_dir}/demo-index-retained-summary.json",
+        "--manifest-file",
+        "{reports_dir}/demo-index-retained-summary.manifest.json"
+      ],
+      "expected_exit_code": 0,
+      "markers": [
+        {
+          "id": "index-summary-json",
+          "source": "stdout",
+          "contains": "\"summary\":{\"total\":"
+        },
+        {
+          "id": "index-summary-failed-zero",
+          "source": "stdout",
+          "contains": "\"failed\":0"
+        },
+        {
+          "id": "index-report-artifact",
+          "source": "file",
+          "path": "{reports_dir}/demo-index-retained-summary.json",
+          "contains": "\"summary\":{\"total\":"
+        },
+        {
+          "id": "index-manifest-artifact",
+          "source": "file",
+          "path": "{reports_dir}/demo-index-retained-summary.manifest.json",
+          "contains": "\"pack_name\": \"demo-index-live-proof-pack\""
+        }
+      ]
+    },
+    {
+      "name": "demo-all-retained-demos",
+      "description": "Run retained demo subset via all.sh wrapper and emit report/manifest artifacts.",
+      "command": [
+        "./scripts/demo/all.sh",
+        "--skip-build",
+        "--repo-root",
+        "{repo_root}",
+        "--binary",
+        "{binary}",
+        "--only",
+        "local,multi-channel,gateway-auth,gateway-remote-access,deployment",
+        "--json",
+        "--report-file",
+        "{reports_dir}/demo-all-retained-summary.json",
+        "--manifest-file",
+        "{reports_dir}/demo-all-retained-summary.manifest.json"
+      ],
+      "expected_exit_code": 0,
+      "markers": [
+        {
+          "id": "all-summary-json",
+          "source": "stdout",
+          "contains": "\"summary\":{\"total\":"
+        },
+        {
+          "id": "all-summary-failed-zero",
+          "source": "stdout",
+          "contains": "\"failed\":0"
+        },
+        {
+          "id": "all-report-artifact",
+          "source": "file",
+          "path": "{reports_dir}/demo-all-retained-summary.json",
+          "contains": "\"summary\":{\"total\":"
+        },
+        {
+          "id": "all-manifest-artifact",
+          "source": "file",
+          "path": "{reports_dir}/demo-all-retained-summary.manifest.json",
+          "contains": "\"pack_name\": \"demo-all-live-proof-pack\""
+        }
+      ]
+    },
+    {
+      "name": "proof-pack-rollup-manifest",
+      "description": "Emit rollup manifest for retained-capability proof artifacts.",
+      "command": [
+        "./scripts/demo/proof-pack-manifest.sh",
+        "--output",
+        "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+        "--pack-name",
+        "m21-retained-capability-live-proof-pack",
+        "--producer-script",
+        "scripts/dev/m21-retained-capability-proof-summary.sh",
+        "--mode",
+        "run",
+        "--report-file",
+        "{reports_dir}/demo-all-retained-summary.json",
+        "--artifact",
+        "index-report={reports_dir}/demo-index-retained-summary.json",
+        "--artifact",
+        "index-manifest={reports_dir}/demo-index-retained-summary.manifest.json",
+        "--artifact",
+        "all-manifest={reports_dir}/demo-all-retained-summary.manifest.json",
+        "--issue",
+        "#1745",
+        "--issue",
+        "#1746"
+      ],
+      "expected_exit_code": 0,
+      "markers": [
+        {
+          "id": "rollup-manifest-log",
+          "source": "stderr",
+          "contains": "wrote proof-pack manifest:"
+        },
+        {
+          "id": "rollup-manifest-pack-name",
+          "source": "file",
+          "path": "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+          "contains": "\"pack_name\": \"m21-retained-capability-live-proof-pack\""
+        },
+        {
+          "id": "rollup-manifest-status-pass",
+          "source": "file",
+          "path": "{reports_dir}/m21-retained-capability-proof-pack.manifest.json",
+          "contains": "\"status\": \"pass\""
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/demo/test-m21-retained-capability-proof-matrix.sh
+++ b/scripts/demo/test-m21-retained-capability-proof-matrix.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MATRIX_JSON="${SCRIPT_DIR}/m21-retained-capability-proof-matrix.json"
+VALIDATE_SCRIPT="${SCRIPT_DIR}/validate-m21-retained-capability-proof-matrix.sh"
+SUMMARY_SCRIPT="${REPO_ROOT}/scripts/dev/m21-retained-capability-proof-summary.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+require_cmd jq
+require_cmd python3
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+# Functional: matrix/checklist contract validates and enumerates retained capabilities.
+validation_output="$("${VALIDATE_SCRIPT}" --repo-root "${REPO_ROOT}" --matrix-json "${MATRIX_JSON}")"
+assert_contains "${validation_output}" "validation passed" "functional validation output"
+assert_equals "5" "$(jq -r '.capabilities | length' "${MATRIX_JSON}")" "functional capability count"
+assert_equals "3" "$(jq -r '.runs | length' "${MATRIX_JSON}")" "functional run count"
+assert_equals "5" "$(jq -r '.artifact_checklist.required_artifacts | length' "${MATRIX_JSON}")" "functional artifact checklist count"
+assert_equals "demo-index-retained-scenarios" "$(jq -r '.capabilities[] | select(.id == "onboarding") | .proof_step' "${MATRIX_JSON}")" "functional capability mapping"
+
+# Regression: invalid matrix should fail with actionable diagnostics.
+bad_matrix="${tmp_dir}/bad-matrix.json"
+cat >"${bad_matrix}" <<'EOF'
+{
+  "schema_version": 1,
+  "name": "bad-matrix",
+  "artifact_checklist": {
+    "required_fields": ["name", "path", "required", "status"],
+    "required_artifacts": [
+      { "name": "artifact-a", "path_token": "{reports_dir}/a.json", "producer": "scripts/demo/index.sh" }
+    ]
+  },
+  "capabilities": [
+    {
+      "id": "broken-capability",
+      "wrapper": "scripts/demo/does-not-exist.sh",
+      "proof_step": "missing-run",
+      "expected_markers": ["x"],
+      "required_artifacts": ["artifact-a"]
+    }
+  ],
+  "runs": [
+    {
+      "name": "run-a",
+      "command": ["bash", "-lc", "echo ok"]
+    }
+  ]
+}
+EOF
+
+set +e
+bad_output="$("${VALIDATE_SCRIPT}" --repo-root "${REPO_ROOT}" --matrix-json "${bad_matrix}" 2>&1)"
+bad_rc=$?
+set -e
+assert_equals "1" "${bad_rc}" "regression invalid matrix exit code"
+assert_contains "${bad_output}" "wrapper does not exist" "regression invalid matrix message"
+
+# Live-run proof: matrix is runnable by the retained-capability summary collector.
+mock_binary="${tmp_dir}/mock-tau-coding-agent.py"
+cat >"${mock_binary}" <<'PY'
+#!/usr/bin/env python3
+import sys
+print("mock-ok " + " ".join(sys.argv[1:]))
+PY
+chmod +x "${mock_binary}"
+
+live_reports_dir="${tmp_dir}/live/reports"
+live_logs_dir="${tmp_dir}/live/logs"
+live_json="${tmp_dir}/live/summary.json"
+live_md="${tmp_dir}/live/summary.md"
+
+"${SUMMARY_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --binary "${mock_binary}" \
+  --matrix-json "${MATRIX_JSON}" \
+  --reports-dir "${live_reports_dir}" \
+  --logs-dir "${live_logs_dir}" \
+  --output-json "${live_json}" \
+  --output-md "${live_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+
+assert_equals "pass" "$(jq -r '.summary.status' "${live_json}")" "live-run summary status"
+assert_equals "3" "$(jq -r '.summary.total_runs' "${live_json}")" "live-run total runs"
+assert_equals "3" "$(jq -r '.summary.passed_runs' "${live_json}")" "live-run passed runs"
+assert_contains "$(cat "${live_md}")" "## Run Matrix" "live-run markdown matrix section"
+
+echo "m21-retained-capability-proof-matrix tests passed"

--- a/scripts/demo/validate-m21-retained-capability-proof-matrix.sh
+++ b/scripts/demo/validate-m21-retained-capability-proof-matrix.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MATRIX_JSON="${REPO_ROOT}/scripts/demo/m21-retained-capability-proof-matrix.json"
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: validate-m21-retained-capability-proof-matrix.sh [options]
+
+Validate retained-capability live-proof matrix/checklist contracts.
+
+Options:
+  --repo-root <path>    Repository root (default: detected from script location).
+  --matrix-json <path>  Matrix JSON path.
+  --quiet               Suppress informational output.
+  --help                Show this help text.
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --matrix-json)
+      MATRIX_JSON="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+if [[ ! -f "${MATRIX_JSON}" ]]; then
+  echo "error: matrix JSON not found: ${MATRIX_JSON}" >&2
+  exit 1
+fi
+
+python3 - "${REPO_ROOT}" "${MATRIX_JSON}" "${QUIET_MODE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1]).resolve()
+matrix_path = Path(sys.argv[2]).resolve()
+quiet_mode = sys.argv[3] == "true"
+
+
+def log_info(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"error: {message}")
+
+
+with matrix_path.open(encoding="utf-8") as handle:
+    matrix = json.load(handle)
+
+require(isinstance(matrix, dict), "matrix JSON must decode to an object")
+require(matrix.get("schema_version") == 1, "schema_version must be 1")
+
+required_top_level = {"artifact_checklist", "capabilities", "runs"}
+missing = sorted(key for key in required_top_level if key not in matrix)
+require(not missing, f"missing top-level keys: {', '.join(missing)}")
+
+artifact_checklist = matrix["artifact_checklist"]
+require(isinstance(artifact_checklist, dict), "artifact_checklist must be an object")
+required_fields = artifact_checklist.get("required_fields")
+require(
+    required_fields == ["name", "path", "required", "status"],
+    "artifact_checklist.required_fields must equal ['name', 'path', 'required', 'status']",
+)
+required_artifacts = artifact_checklist.get("required_artifacts")
+require(
+    isinstance(required_artifacts, list) and len(required_artifacts) > 0,
+    "artifact_checklist.required_artifacts must be a non-empty array",
+)
+artifact_names = set()
+for index, artifact in enumerate(required_artifacts):
+    require(isinstance(artifact, dict), f"required_artifacts[{index}] must be an object")
+    name = artifact.get("name")
+    path_token = artifact.get("path_token")
+    producer = artifact.get("producer")
+    require(isinstance(name, str) and name.strip(), f"required_artifacts[{index}].name must be non-empty")
+    require(
+        isinstance(path_token, str) and path_token.strip(),
+        f"required_artifacts[{index}].path_token must be non-empty",
+    )
+    require(
+        isinstance(producer, str) and producer.strip(),
+        f"required_artifacts[{index}].producer must be non-empty",
+    )
+    artifact_names.add(name.strip())
+
+capabilities = matrix["capabilities"]
+require(isinstance(capabilities, list) and len(capabilities) > 0, "capabilities must be a non-empty array")
+runs = matrix["runs"]
+require(isinstance(runs, list) and len(runs) > 0, "runs must be a non-empty array")
+
+run_names = set()
+for index, run in enumerate(runs):
+    require(isinstance(run, dict), f"runs[{index}] must be an object")
+    run_name = run.get("name")
+    require(isinstance(run_name, str) and run_name.strip(), f"runs[{index}].name must be non-empty")
+    require(run_name not in run_names, f"runs[{index}].name must be unique")
+    run_names.add(run_name)
+    command = run.get("command")
+    require(isinstance(command, list) and len(command) > 0, f"runs[{index}].command must be a non-empty array")
+
+for index, capability in enumerate(capabilities):
+    require(isinstance(capability, dict), f"capabilities[{index}] must be an object")
+    cap_id = capability.get("id")
+    wrapper = capability.get("wrapper")
+    proof_step = capability.get("proof_step")
+    expected_markers = capability.get("expected_markers")
+    required = capability.get("required_artifacts")
+    require(isinstance(cap_id, str) and cap_id.strip(), f"capabilities[{index}].id must be non-empty")
+    require(isinstance(wrapper, str) and wrapper.strip(), f"capabilities[{index}].wrapper must be non-empty")
+    require(
+        isinstance(proof_step, str) and proof_step.strip(),
+        f"capabilities[{index}].proof_step must be non-empty",
+    )
+    require(
+        isinstance(expected_markers, list) and len(expected_markers) > 0,
+        f"capabilities[{index}].expected_markers must be a non-empty array",
+    )
+    require(
+        isinstance(required, list) and len(required) > 0,
+        f"capabilities[{index}].required_artifacts must be a non-empty array",
+    )
+
+    wrapper_path = repo_root / wrapper
+    require(wrapper_path.is_file(), f"capabilities[{index}].wrapper does not exist: {wrapper_path}")
+    require(
+        proof_step in run_names,
+        f"capabilities[{index}].proof_step '{proof_step}' does not map to any run name",
+    )
+    for artifact_name in required:
+        require(
+            isinstance(artifact_name, str) and artifact_name in artifact_names,
+            f"capabilities[{index}] references unknown artifact '{artifact_name}'",
+        )
+
+log_info(
+    "[retained-proof-matrix] validation passed: "
+    f"capabilities={len(capabilities)} runs={len(runs)} required_artifacts={len(required_artifacts)}"
+)
+PY
+
+log_info "retained-capability proof matrix contract is valid"


### PR DESCRIPTION
## Summary
- define canonical retained-capability live-proof matrix + artifact checklist in:
  - `scripts/demo/m21-retained-capability-proof-matrix.json`
- add matrix/checklist contract validator:
  - `scripts/demo/validate-m21-retained-capability-proof-matrix.sh`
- add functional/regression/live-run proof tests:
  - `scripts/demo/test-m21-retained-capability-proof-matrix.sh`
- update retained proof summary collector to auto-load canonical matrix by default when present:
  - `scripts/dev/m21-retained-capability-proof-summary.sh`
- extend targeted CI validation scope to run matrix/checklist contract tests for related changes
- update `docs/guides/demo-index.md` with canonical matrix/checklist references and validation command

Closes #1745.

## Risks and Compatibility
- matrix/checklist validation is strict by design (wrapper existence, run mapping, required artifact names); edits to retained capability definitions must update matrix and tests together
- retained proof summary collector now prefers the canonical matrix file; if file is removed, it falls back to embedded defaults
- CI gains one targeted script test when retained-proof paths change

## Validation Evidence
- `./scripts/dev/test-m21-retained-capability-proof-summary.sh`
- `./scripts/demo/test-m21-retained-capability-proof-matrix.sh`
- `python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'`
- `bash -n scripts/dev/m21-retained-capability-proof-summary.sh scripts/dev/test-m21-retained-capability-proof-summary.sh scripts/demo/validate-m21-retained-capability-proof-matrix.sh scripts/demo/test-m21-retained-capability-proof-matrix.sh`
- `cargo fmt`, strict `clippy`, and Rust test matrix not run (no Rust/Cargo source changes in this PR)
