### PR TITLE
Add runbook ownership map and documentation guard checks

### DIFF
--- a/.github/scripts/runbook_ownership_docs_check.py
+++ b/.github/scripts/runbook_ownership_docs_check.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class OwnershipSpec:
+    path: str
+    required_tokens: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OwnershipIssue:
+    category: str
+    subject: str
+    detail: str
+
+
+OWNERSHIP_SPECS: tuple[OwnershipSpec, ...] = (
+    OwnershipSpec(
+        path="docs/guides/demo-index.md",
+        required_tokens=(
+            "## Ownership",
+            "`crates/tau-coding-agent`",
+            "`scripts/demo/`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
+        path="docs/guides/training-ops.md",
+        required_tokens=(
+            "## Ownership",
+            "`crates/tau-trainer`",
+            "`crates/tau-training-runner`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
+        path="docs/guides/training-proxy-ops.md",
+        required_tokens=(
+            "## Ownership",
+            "`crates/tau-training-proxy`",
+            "`crates/tau-gateway`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
+        path="docs/guides/transports.md",
+        required_tokens=(
+            "## Ownership",
+            "`crates/tau-github-issues-runtime`",
+            "`crates/tau-slack-runtime`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
+        path="docs/guides/memory-ops.md",
+        required_tokens=(
+            "## Ownership",
+            "`crates/tau-agent-core`",
+            "`crates/tau-memory`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
+        path="docs/guides/runbook-ownership-map.md",
+        required_tokens=(
+            "# Runbook Ownership Map",
+            "docs/guides/demo-index.md",
+            "docs/guides/training-ops.md",
+            "docs/guides/training-proxy-ops.md",
+            "docs/guides/transports.md",
+            "docs/guides/memory-ops.md",
+        ),
+    ),
+)
+
+
+README_EXPECTED_LINK = "guides/runbook-ownership-map.md"
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def collect_ownership_issues(repo_root: Path) -> list[OwnershipIssue]:
+    issues: list[OwnershipIssue] = []
+
+    readme_path = repo_root / "docs" / "README.md"
+    readme = read_text_if_exists(readme_path)
+    if readme is None:
+        issues.append(
+            OwnershipIssue(
+                category="missing_doc",
+                subject="docs/README.md",
+                detail="documentation index file is missing",
+            )
+        )
+    elif README_EXPECTED_LINK not in readme:
+        issues.append(
+            OwnershipIssue(
+                category="missing_readme_link",
+                subject="docs/README.md",
+                detail=f"missing docs index link '{README_EXPECTED_LINK}'",
+            )
+        )
+
+    for spec in OWNERSHIP_SPECS:
+        path = repo_root / spec.path
+        content = read_text_if_exists(path)
+        if content is None:
+            issues.append(
+                OwnershipIssue(
+                    category="missing_doc",
+                    subject=spec.path,
+                    detail="runbook ownership file is missing",
+                )
+            )
+            continue
+
+        for token in spec.required_tokens:
+            if token not in content:
+                issues.append(
+                    OwnershipIssue(
+                        category="missing_token",
+                        subject=spec.path,
+                        detail=f"missing ownership token '{token}'",
+                    )
+                )
+
+    return issues
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate runbook ownership sections and ownership map links."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root path",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    issues = collect_ownership_issues(repo_root)
+    checked = len(OWNERSHIP_SPECS) + 1
+
+    print(f"checked_docs={checked} issues={len(issues)}")
+    for issue in issues:
+        print(f"[{issue.category}] {issue.subject}: {issue.detail}")
+
+    return 0 if not issues else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_runbook_ownership_docs_check.py
+++ b/.github/scripts/test_runbook_ownership_docs_check.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import runbook_ownership_docs_check  # noqa: E402
+
+
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+
+class RunbookOwnershipDocsCheckTests(unittest.TestCase):
+    def test_functional_cli_reports_success_for_repository(self):
+        script_path = SCRIPT_DIR / "runbook_ownership_docs_check.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--repo-root",
+                str(REPO_ROOT),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
+        self.assertIn("checked_docs=7", completed.stdout)
+        self.assertIn("issues=0", completed.stdout)
+
+    def test_integration_collect_ownership_issues_returns_empty_for_repository(self):
+        issues = runbook_ownership_docs_check.collect_ownership_issues(REPO_ROOT)
+        self.assertEqual(issues, [])
+
+    def test_regression_collect_ownership_issues_reports_missing_tokens(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "docs" / "guides").mkdir(parents=True, exist_ok=True)
+            (root / "docs" / "README.md").write_text(
+                "# Documentation Index\n",
+                encoding="utf-8",
+            )
+
+            for spec in runbook_ownership_docs_check.OWNERSHIP_SPECS:
+                path = root / spec.path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                # Deliberately omit required ownership content.
+                path.write_text("# Stub\n", encoding="utf-8")
+
+            issues = runbook_ownership_docs_check.collect_ownership_issues(root)
+            categories = {issue.category for issue in issues}
+            self.assertIn("missing_readme_link", categories)
+            self.assertIn("missing_token", categories)
+            self.assertGreater(len(issues), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -12,6 +12,8 @@ on:
       - ".github/scripts/test_docs_link_check.py"
       - ".github/scripts/architecture_docs_check.py"
       - ".github/scripts/test_architecture_docs_check.py"
+      - ".github/scripts/runbook_ownership_docs_check.py"
+      - ".github/scripts/test_runbook_ownership_docs_check.py"
       - ".github/workflows/docs-quality.yml"
       - "README.md"
       - "crates/tau-startup/src/lib.rs"
@@ -41,6 +43,9 @@ jobs:
 
       - name: Check architecture docs freshness
         run: python3 .github/scripts/architecture_docs_check.py --repo-root .
+
+      - name: Check runbook ownership docs freshness
+        run: python3 .github/scripts/runbook_ownership_docs_check.py --repo-root .
 
       - name: Validate roadmap status sync script
         run: scripts/dev/test-roadmap-status-sync.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This index maps Tau documentation by audience and task.
 | Runtime contributor | [Startup DI Pipeline](guides/startup-di-pipeline.md) | 3-stage startup resolution: preflight gate, dependency/context composition, mode dispatch |
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
 | Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |
+| Runtime contributor / doc maintainer | [Runbook Ownership Map](guides/runbook-ownership-map.md) | Post-consolidation runbook-to-crate ownership matrix and update policy |
 | Runtime operator / integration engineer | [MCP Client Operations Guide](guides/mcp-client-ops.md) | MCP client transport config (stdio + HTTP/SSE), OAuth PKCE token handling, inspect diagnostics, and live validation flow |
 | Runtime contributor | [Tool Policy Sandbox Mode](guides/tool-policy-sandbox-mode.md) | Fail-closed sandbox posture (`best-effort` vs `required`), preset defaults, and operator diagnostics |
 | Runtime contributor | [Tool Policy HTTP Client](guides/tool-policy-http-client.md) | `HttpTool` controls, SSRF/redirect guardrails, caps, and deterministic reason codes |

--- a/docs/guides/demo-index.md
+++ b/docs/guides/demo-index.md
@@ -170,3 +170,12 @@ Each run entry in the JSON summary includes:
 - pass/fail status
 - marker match results (`stdout`, `stderr`, `file`)
 - stdout/stderr log paths for direct triage
+
+## Ownership
+
+Primary ownership surfaces:
+- `crates/tau-coding-agent` (CLI flags and runtime mode dispatch)
+- `scripts/demo/` (retained-capability proof wrappers and matrix contracts)
+- `crates/tau-gateway`, `crates/tau-multi-channel`, `crates/tau-deployment` (scenario-backed runtime surfaces)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.

--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -120,3 +120,13 @@ Primary state files:
   Action: treat as rollout gate failure; pause promotion and investigate repeated runtime failures in active memory producers.
 - Symptom: non-zero `queue_depth`.
   Action: investigate upstream producers writing memory health artifacts and reduce backlog before promotion.
+
+## Ownership
+
+Primary ownership surfaces:
+- `crates/tau-agent-core` (runtime memory behavior, recall, ranking, embedding usage)
+- `crates/tau-memory` (shared storage/runtime helpers and fixture schema contracts)
+- `crates/tau-tools` (memory tool interfaces and policy wiring)
+- `crates/tau-coding-agent` (CLI transport diagnostics and operational entrypoints)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.

--- a/docs/guides/runbook-ownership-map.md
+++ b/docs/guides/runbook-ownership-map.md
@@ -1,0 +1,22 @@
+# Runbook Ownership Map
+
+This guide defines post-consolidation ownership for operator-facing runbooks.
+
+Use this map when triaging drift between documentation and runtime behavior.
+
+| Runbook | Primary ownership surfaces | Notes |
+| --- | --- | --- |
+| `docs/guides/demo-index.md` | `crates/tau-coding-agent`, `scripts/demo/`, `crates/tau-gateway`, `crates/tau-multi-channel`, `crates/tau-deployment` | Demo wrappers prove retained runtime capabilities after consolidation waves. |
+| `docs/guides/training-ops.md` | `crates/tau-trainer`, `crates/tau-training-runner`, `crates/tau-training-store`, `crates/tau-algorithm`, `crates/tau-coding-agent` | Prompt optimization control plane and store ownership boundaries. |
+| `docs/guides/training-proxy-ops.md` | `crates/tau-training-proxy`, `crates/tau-gateway`, `crates/tau-provider`, `crates/tau-coding-agent` | Proxy attribution + upstream routing ownership boundaries. |
+| `docs/guides/transports.md` | `crates/tau-coding-agent`, `crates/tau-github-issues-runtime`, `crates/tau-slack-runtime`, `crates/tau-multi-channel`, `crates/tau-gateway`, `crates/tau-memory` | Transport entrypoints and per-surface runtime ownership map. |
+| `docs/guides/memory-ops.md` | `crates/tau-agent-core`, `crates/tau-memory`, `crates/tau-tools`, `crates/tau-coding-agent` | Runtime memory behavior is owned by `tau-agent-core`; `tau-memory` owns shared storage helpers/contracts. |
+
+## Ownership update policy
+
+When crate boundaries change:
+
+1. Update this table first.
+2. Update the affected runbook `## Ownership` sections.
+3. Run `.github/scripts/runbook_ownership_docs_check.py`.
+4. Include ownership updates in the linked issue/PR acceptance evidence.

--- a/docs/guides/training-ops.md
+++ b/docs/guides/training-ops.md
@@ -86,3 +86,13 @@ Gateway dashboard endpoints (`/dashboard/health`, `/dashboard/widgets`,
 - `--train-config` -> `--prompt-optimization-config`
 - `--train-store-sqlite` -> `--prompt-optimization-store-sqlite`
 - `--train-json` -> `--prompt-optimization-json`
+
+## Ownership
+
+Primary ownership surfaces:
+- `crates/tau-trainer` (top-level orchestration lifecycle)
+- `crates/tau-training-runner` and `crates/tau-training-store` (rollout execution + persistence)
+- `crates/tau-algorithm` (prompt optimization strategy)
+- `crates/tau-coding-agent` (CLI flag wiring and startup dispatch)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.

--- a/docs/guides/training-proxy-ops.md
+++ b/docs/guides/training-proxy-ops.md
@@ -55,3 +55,13 @@ counts, latency, and upstream status/error outcome.
 - `--training-proxy-upstream-url` -> `--prompt-optimization-proxy-upstream-url`
 - `--training-proxy-state-dir` -> `--prompt-optimization-proxy-state-dir`
 - `--training-proxy-timeout-ms` -> `--prompt-optimization-proxy-timeout-ms`
+
+## Ownership
+
+Primary ownership surfaces:
+- `crates/tau-training-proxy` (attribution proxy runtime and log emission)
+- `crates/tau-gateway` (HTTP server integration boundary)
+- `crates/tau-provider` (upstream model/provider routing contracts)
+- `crates/tau-coding-agent` (CLI mode routing and startup surface)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -756,3 +756,13 @@ cat /tmp/rpc-frames.ndjson | cargo run -p tau-coding-agent -- --rpc-serve-ndjson
 ```
 
 RPC schema compatibility fixtures live under `crates/tau-coding-agent/testdata/rpc-schema-compat/`.
+
+## Ownership
+
+Primary ownership surfaces:
+- `crates/tau-coding-agent` (transport command dispatch and shared runtime entrypoints)
+- `crates/tau-github-issues-runtime`, `crates/tau-slack-runtime`, `crates/tau-multi-channel` (channel-specific runtimes)
+- `crates/tau-gateway` (gateway transport, auth, and remote access flows)
+- `crates/tau-memory` + `crates/tau-agent-core` (memory transport diagnostics and runtime ownership boundaries)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.


### PR DESCRIPTION
## Summary
- add centralized runbook ownership map: `docs/guides/runbook-ownership-map.md`
- add explicit `## Ownership` sections (with crate/surface links) to key runbooks:
  - `docs/guides/demo-index.md`
  - `docs/guides/training-ops.md`
  - `docs/guides/training-proxy-ops.md`
  - `docs/guides/transports.md`
  - `docs/guides/memory-ops.md`
- update docs index (`docs/README.md`) with ownership map entry
- add ownership drift checker + tests:
  - `.github/scripts/runbook_ownership_docs_check.py`
  - `.github/scripts/test_runbook_ownership_docs_check.py`
- wire `docs-quality.yml` to execute ownership freshness checks in CI

Closes #1747.

## Risks and Compatibility
- docs quality now enforces ownership tokens for selected runbooks; edits to ownership sections must keep required crate tokens and ownership-map links
- docs workflow path filters now include the new ownership checker files
- no runtime behavior changes; documentation/process guard only

## Validation Evidence
- `python3 -m unittest discover -s .github/scripts -p 'test_*docs*_check.py'`
- `python3 .github/scripts/runbook_ownership_docs_check.py --repo-root .`
- `python3 .github/scripts/docs_link_check.py --repo-root .`
- `python3 .github/scripts/architecture_docs_check.py --repo-root .`
- `cargo fmt`, strict `clippy`, and Rust test matrix not run (docs/workflow/script-only changes)
