### PR TITLE
Add consolidated runtime rollback drill checklist and tests

### DIFF
--- a/.github/scripts/runbook_ownership_docs_check.py
+++ b/.github/scripts/runbook_ownership_docs_check.py
@@ -67,6 +67,15 @@ OWNERSHIP_SPECS: tuple[OwnershipSpec, ...] = (
         ),
     ),
     OwnershipSpec(
+        path="docs/guides/consolidated-runtime-rollback-drill.md",
+        required_tokens=(
+            "## Ownership",
+            "`scripts/demo/rollback-drill-checklist.sh`",
+            "`scripts/dev/m21-retained-capability-proof-summary.sh`",
+            "docs/guides/runbook-ownership-map.md",
+        ),
+    ),
+    OwnershipSpec(
         path="docs/guides/runbook-ownership-map.md",
         required_tokens=(
             "# Runbook Ownership Map",
@@ -75,6 +84,7 @@ OWNERSHIP_SPECS: tuple[OwnershipSpec, ...] = (
             "docs/guides/training-proxy-ops.md",
             "docs/guides/transports.md",
             "docs/guides/memory-ops.md",
+            "docs/guides/consolidated-runtime-rollback-drill.md",
         ),
     ),
 )

--- a/.github/scripts/test_runbook_ownership_docs_check.py
+++ b/.github/scripts/test_runbook_ownership_docs_check.py
@@ -29,7 +29,7 @@ class RunbookOwnershipDocsCheckTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(completed.returncode, 0, msg=completed.stdout + completed.stderr)
-        self.assertIn("checked_docs=7", completed.stdout)
+        self.assertIn("checked_docs=8", completed.stdout)
         self.assertIn("issues=0", completed.stdout)
 
     def test_integration_collect_ownership_issues_returns_empty_for_repository(self):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
               - "scripts/demo/m21-retained-capability-proof-matrix.json"
               - "scripts/demo/validate-m21-retained-capability-proof-matrix.sh"
               - "scripts/demo/test-m21-retained-capability-proof-matrix.sh"
+              - "scripts/demo/rollback-drill-checklist.sh"
+              - "scripts/demo/test-rollback-drill-checklist.sh"
               - "scripts/demo/index.sh"
               - "scripts/demo/all.sh"
               - "scripts/demo/proof-pack-manifest.sh"
@@ -298,6 +300,10 @@ jobs:
       - name: Validate retained-capability proof matrix/checklist contracts
         if: steps.retained_proof_summary_scope.outputs.retained_proof_summary_tests_needed == 'true'
         run: ./scripts/demo/test-m21-retained-capability-proof-matrix.sh
+
+      - name: Validate rollback drill checklist script
+        if: steps.retained_proof_summary_scope.outputs.retained_proof_summary_tests_needed == 'true'
+        run: ./scripts/demo/test-rollback-drill-checklist.sh
 
       - name: Determine tool split performance smoke scope
         id: tool_perf_scope

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This index maps Tau documentation by audience and task.
 | Runtime contributor | [Contract Pattern Lifecycle](guides/contract-pattern-lifecycle.md) | Shared fixture lifecycle, compatibility gates, extension checklist, anti-patterns |
 | Runtime contributor | [Tool Name Registry](guides/tool-name-registry.md) | Reserved built-in tool-name catalog and registration conflict behavior for extension + MCP external tools |
 | Runtime contributor / doc maintainer | [Runbook Ownership Map](guides/runbook-ownership-map.md) | Post-consolidation runbook-to-crate ownership matrix and update policy |
+| Runtime operator / release manager | [Consolidated Runtime Rollback Drill](guides/consolidated-runtime-rollback-drill.md) | Trigger conditions, rollback simulation checklist, and required artifact capture flow |
 | Runtime operator / integration engineer | [MCP Client Operations Guide](guides/mcp-client-ops.md) | MCP client transport config (stdio + HTTP/SSE), OAuth PKCE token handling, inspect diagnostics, and live validation flow |
 | Runtime contributor | [Tool Policy Sandbox Mode](guides/tool-policy-sandbox-mode.md) | Fail-closed sandbox posture (`best-effort` vs `required`), preset defaults, and operator diagnostics |
 | Runtime contributor | [Tool Policy HTTP Client](guides/tool-policy-http-client.md) | `HttpTool` controls, SSRF/redirect guardrails, caps, and deterministic reason codes |

--- a/docs/guides/consolidated-runtime-rollback-drill.md
+++ b/docs/guides/consolidated-runtime-rollback-drill.md
@@ -1,0 +1,73 @@
+# Consolidated Runtime Rollback Drill
+
+Use this runbook to execute a deterministic rollback simulation for consolidated runtime surfaces.
+
+## Trigger conditions
+
+Rollback is required when any high/medium trigger is active.
+
+| Trigger ID | Severity | Condition |
+| --- | --- | --- |
+| `proof-summary-missing` | high | Retained-capability proof summary artifact is missing. |
+| `proof-runs-failed` | high | `failed_runs > 0` in retained-capability proof summary. |
+| `proof-markers-missing` | high | Any run reports missing output/artifact markers. |
+| `validation-matrix-missing` | medium | Validation matrix artifact is missing. |
+| `validation-open-issues` | medium | Validation matrix still reports open tracked issues. |
+| `validation-completion-below-100` | low | Validation matrix completion percent is below 100%. |
+
+## Step-by-step rollback drill
+
+1. Freeze promotion and generate rollback checklist artifacts:
+   ```bash
+   ./scripts/demo/rollback-drill-checklist.sh
+   ```
+2. Archive required rollback evidence before any revert:
+   - retained-capability proof summary (JSON + Markdown)
+   - proof logs + generated proof artifacts
+   - validation matrix JSON/Markdown
+3. Execute bounded rollback:
+   ```bash
+   git revert <commit-sha>
+   ./scripts/dev/m21-retained-capability-proof-summary.sh --binary ./target/debug/tau-coding-agent
+   ```
+4. Validate rollback exit criteria:
+   - proof summary reports `failed_runs == 0`
+   - proof marker missing count is `0`
+   - no active high/medium rollback triggers remain
+
+## Artifact capture checklist
+
+`scripts/demo/rollback-drill-checklist.sh` emits:
+
+- `tasks/reports/m21-rollback-drill-checklist.json`
+- `tasks/reports/m21-rollback-drill-checklist.md`
+
+Checklist artifacts include:
+
+- proof summary JSON path + presence status
+- validation matrix JSON path + presence status
+- proof Markdown/log/artifact directory pointers (when present)
+
+## Deterministic simulation commands
+
+Generate retained-capability proof artifacts:
+
+```bash
+./scripts/dev/m21-retained-capability-proof-summary.sh \
+  --binary ./target/debug/tau-coding-agent
+```
+
+Generate rollback drill report and fail closed when rollback triggers are active:
+
+```bash
+./scripts/demo/rollback-drill-checklist.sh --fail-on-trigger
+```
+
+## Ownership
+
+Primary ownership surfaces:
+- `scripts/demo/rollback-drill-checklist.sh` (rollback trigger + checklist generation)
+- `scripts/dev/m21-retained-capability-proof-summary.sh` (proof-run input artifacts)
+- `docs/guides/runbook-ownership-map.md` (consolidated runbook ownership map)
+
+Ownership map: `docs/guides/runbook-ownership-map.md`.

--- a/docs/guides/runbook-ownership-map.md
+++ b/docs/guides/runbook-ownership-map.md
@@ -11,6 +11,7 @@ Use this map when triaging drift between documentation and runtime behavior.
 | `docs/guides/training-proxy-ops.md` | `crates/tau-training-proxy`, `crates/tau-gateway`, `crates/tau-provider`, `crates/tau-coding-agent` | Proxy attribution + upstream routing ownership boundaries. |
 | `docs/guides/transports.md` | `crates/tau-coding-agent`, `crates/tau-github-issues-runtime`, `crates/tau-slack-runtime`, `crates/tau-multi-channel`, `crates/tau-gateway`, `crates/tau-memory` | Transport entrypoints and per-surface runtime ownership map. |
 | `docs/guides/memory-ops.md` | `crates/tau-agent-core`, `crates/tau-memory`, `crates/tau-tools`, `crates/tau-coding-agent` | Runtime memory behavior is owned by `tau-agent-core`; `tau-memory` owns shared storage helpers/contracts. |
+| `docs/guides/consolidated-runtime-rollback-drill.md` | `scripts/demo/rollback-drill-checklist.sh`, `scripts/dev/m21-retained-capability-proof-summary.sh`, `docs/guides/runbook-ownership-map.md` | Rollback trigger contract + artifact capture drill for consolidated runtime surfaces. |
 
 ## Ownership update policy
 

--- a/scripts/demo/rollback-drill-checklist.sh
+++ b/scripts/demo/rollback-drill-checklist.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROOF_SUMMARY_JSON="${REPO_ROOT}/tasks/reports/m21-retained-capability-proof-summary.json"
+VALIDATION_MATRIX_JSON="${REPO_ROOT}/tasks/reports/m21-validation-matrix.json"
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m21-rollback-drill-checklist.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m21-rollback-drill-checklist.md"
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+FAIL_ON_TRIGGER="false"
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: rollback-drill-checklist.sh [options]
+
+Generate a standardized rollback drill checklist for consolidated runtime surfaces.
+
+Options:
+  --repo-root <path>              Repository root (default: detected from script location).
+  --proof-summary-json <path>     Retained-capability proof summary JSON.
+  --validation-matrix-json <path> M21 validation matrix JSON.
+  --output-json <path>            Output JSON checklist report path.
+  --output-md <path>              Output Markdown checklist report path.
+  --generated-at <iso>            Override generated timestamp.
+  --fail-on-trigger               Exit non-zero when rollback_required is true.
+  --quiet                         Suppress informational output.
+  --help                          Show this help text.
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --proof-summary-json)
+      PROOF_SUMMARY_JSON="$2"
+      shift 2
+      ;;
+    --validation-matrix-json)
+      VALIDATION_MATRIX_JSON="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --fail-on-trigger)
+      FAIL_ON_TRIGGER="true"
+      shift
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${REPO_ROOT}" \
+  "${PROOF_SUMMARY_JSON}" \
+  "${VALIDATION_MATRIX_JSON}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${GENERATED_AT}" \
+  "${FAIL_ON_TRIGGER}" \
+  "${QUIET_MODE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    repo_root_raw,
+    proof_summary_raw,
+    validation_matrix_raw,
+    output_json_raw,
+    output_md_raw,
+    generated_at,
+    fail_on_trigger_raw,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+repo_root = Path(repo_root_raw).resolve()
+proof_summary_path = Path(proof_summary_raw)
+if not proof_summary_path.is_absolute():
+    proof_summary_path = (repo_root / proof_summary_path).resolve()
+validation_matrix_path = Path(validation_matrix_raw)
+if not validation_matrix_path.is_absolute():
+    validation_matrix_path = (repo_root / validation_matrix_path).resolve()
+output_json = Path(output_json_raw)
+if not output_json.is_absolute():
+    output_json = (repo_root / output_json).resolve()
+output_md = Path(output_md_raw)
+if not output_md.is_absolute():
+    output_md = (repo_root / output_md).resolve()
+fail_on_trigger = fail_on_trigger_raw == "true"
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log_info(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def load_json_if_present(path: Path):
+    if not path.is_file():
+        return None
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+proof_summary = load_json_if_present(proof_summary_path)
+validation_matrix = load_json_if_present(validation_matrix_path)
+
+triggers = []
+
+def add_trigger(trigger_id: str, description: str, severity: str, active: bool, evidence: str):
+    triggers.append(
+        {
+            "id": trigger_id,
+            "description": description,
+            "severity": severity,
+            "active": active,
+            "evidence": evidence,
+        }
+    )
+
+
+if proof_summary is None:
+    add_trigger(
+        "proof-summary-missing",
+        "Retained-capability proof summary artifact is missing.",
+        "high",
+        True,
+        f"missing file: {proof_summary_path}",
+    )
+    proof_failed_runs = None
+    proof_marker_missing = None
+else:
+    summary = proof_summary.get("summary", {})
+    proof_failed_runs = int(summary.get("failed_runs", 0) or 0)
+    proof_marker_missing = sum(
+        int((run.get("marker_summary") or {}).get("missing", 0) or 0)
+        for run in proof_summary.get("runs", [])
+        if isinstance(run, dict)
+    )
+    add_trigger(
+        "proof-runs-failed",
+        "Retained-capability proof run(s) failed.",
+        "high",
+        proof_failed_runs > 0,
+        f"failed_runs={proof_failed_runs}",
+    )
+    add_trigger(
+        "proof-markers-missing",
+        "Expected proof markers were missing in run output/artifacts.",
+        "high",
+        proof_marker_missing > 0,
+        f"marker_missing={proof_marker_missing}",
+    )
+
+if validation_matrix is None:
+    add_trigger(
+        "validation-matrix-missing",
+        "M21 validation matrix artifact is missing.",
+        "medium",
+        True,
+        f"missing file: {validation_matrix_path}",
+    )
+else:
+    summary = validation_matrix.get("summary", {})
+    open_issues = int(summary.get("open_issues", 0) or 0)
+    completion_percent = float(summary.get("completion_percent", 0.0) or 0.0)
+    add_trigger(
+        "validation-open-issues",
+        "Validation matrix still has open tracked issues.",
+        "medium",
+        open_issues > 0,
+        f"open_issues={open_issues}",
+    )
+    add_trigger(
+        "validation-completion-below-100",
+        "Validation matrix completion is below 100%.",
+        "low",
+        completion_percent < 100.0,
+        f"completion_percent={completion_percent:.2f}",
+    )
+
+rollback_required = any(trigger["active"] and trigger["severity"] in {"high", "medium"} for trigger in triggers)
+
+artifact_capture = [
+    {
+        "name": "proof-summary-json",
+        "path": str(proof_summary_path),
+        "required": True,
+        "status": "present" if proof_summary_path.is_file() else "missing",
+    },
+    {
+        "name": "validation-matrix-json",
+        "path": str(validation_matrix_path),
+        "required": True,
+        "status": "present" if validation_matrix_path.is_file() else "missing",
+    },
+]
+
+if isinstance(proof_summary, dict):
+    report_paths = proof_summary.get("report_paths") or {}
+    for key in ("markdown", "logs_dir", "artifacts_dir"):
+        value = report_paths.get(key)
+        if isinstance(value, str) and value:
+            artifact_capture.append(
+                {
+                    "name": f"proof-{key}",
+                    "path": value,
+                    "required": True,
+                    "status": "present" if Path(value).exists() else "missing",
+                }
+            )
+
+steps = [
+    {
+        "order": 1,
+        "title": "Freeze rollout and capture gate state",
+        "action": "Pause promotion and snapshot current rollout gate diagnostics.",
+        "command": "./scripts/demo/rollback-drill-checklist.sh --output-json tasks/reports/m21-rollback-drill-checklist.json --output-md tasks/reports/m21-rollback-drill-checklist.md",
+    },
+    {
+        "order": 2,
+        "title": "Collect required rollback artifacts",
+        "action": "Archive proof summaries, validation matrix output, and per-run logs before any revert.",
+        "command": "tar -czf tasks/reports/m21-rollback-artifacts.tgz tasks/reports/m21-retained-capability-proof-summary.json tasks/reports/m21-validation-matrix.json tasks/reports/m21-retained-capability-proof-logs",
+    },
+    {
+        "order": 3,
+        "title": "Execute bounded rollback",
+        "action": "Revert the candidate consolidation commit(s) and rerun retained-capability proof matrix.",
+        "command": "git revert <commit-sha> && ./scripts/dev/m21-retained-capability-proof-summary.sh --binary ./target/debug/tau-coding-agent",
+    },
+    {
+        "order": 4,
+        "title": "Verify rollback exit criteria",
+        "action": "Confirm proof summary failed_runs=0 and marker_missing=0 before reopening rollout.",
+        "command": "jq '.summary' tasks/reports/m21-retained-capability-proof-summary.json",
+    },
+]
+
+report = {
+    "schema_version": 1,
+    "generated_at": generated_at,
+    "rollback_required": rollback_required,
+    "inputs": {
+        "proof_summary_json": str(proof_summary_path),
+        "validation_matrix_json": str(validation_matrix_path),
+    },
+    "triggers": triggers,
+    "checklist": {
+        "steps": steps,
+        "artifact_capture": artifact_capture,
+        "exit_criteria": [
+            "All high/medium rollback triggers are inactive.",
+            "Retained-capability proof summary reports failed_runs == 0.",
+            "Retained-capability proof summary marker missing count == 0.",
+        ],
+    },
+}
+
+output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+lines = []
+lines.append("# M21 Rollback Drill Checklist")
+lines.append("")
+lines.append(f"- Generated: {generated_at}")
+lines.append(f"- Rollback required: {'yes' if rollback_required else 'no'}")
+lines.append("")
+lines.append("## Trigger Conditions")
+lines.append("")
+lines.append("| Trigger | Severity | Active | Evidence |")
+lines.append("| --- | --- | --- | --- |")
+for trigger in triggers:
+    lines.append(
+        f"| {trigger['id']} | {trigger['severity']} | "
+        f"{'yes' if trigger['active'] else 'no'} | {trigger['evidence']} |"
+    )
+lines.append("")
+lines.append("## Rollback Drill Steps")
+lines.append("")
+for step in steps:
+    lines.append(f"{step['order']}. **{step['title']}**")
+    lines.append(f"   - Action: {step['action']}")
+    lines.append(f"   - Command: `{step['command']}`")
+lines.append("")
+lines.append("## Artifact Capture Checklist")
+lines.append("")
+lines.append("| Artifact | Required | Status | Path |")
+lines.append("| --- | --- | --- | --- |")
+for artifact in artifact_capture:
+    lines.append(
+        f"| {artifact['name']} | {'yes' if artifact['required'] else 'no'} | "
+        f"{artifact['status']} | `{artifact['path']}` |"
+    )
+lines.append("")
+lines.append("## Exit Criteria")
+lines.append("")
+for criterion in report["checklist"]["exit_criteria"]:
+    lines.append(f"- {criterion}")
+lines.append("")
+
+output_md.write_text("\n".join(lines), encoding="utf-8")
+
+log_info(f"[rollback-drill] wrote JSON: {output_json}")
+log_info(f"[rollback-drill] wrote Markdown: {output_md}")
+log_info(f"[rollback-drill] rollback_required={'yes' if rollback_required else 'no'}")
+
+if fail_on_trigger and rollback_required:
+    raise SystemExit(1)
+PY
+
+log_info "rollback drill checklist generation complete"

--- a/scripts/demo/test-rollback-drill-checklist.sh
+++ b/scripts/demo/test-rollback-drill-checklist.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ROLLBACK_SCRIPT="${SCRIPT_DIR}/rollback-drill-checklist.sh"
+SUMMARY_SCRIPT="${REPO_ROOT}/scripts/dev/m21-retained-capability-proof-summary.sh"
+MATRIX_JSON="${SCRIPT_DIR}/m21-retained-capability-proof-matrix.json"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "error: required command '${name}' not found" >&2
+    exit 1
+  fi
+}
+
+require_cmd jq
+require_cmd python3
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+# Functional: pass-state artifacts produce rollback_required=false.
+proof_pass="${tmp_dir}/proof-pass.json"
+matrix_pass="${tmp_dir}/matrix-pass.json"
+output_json="${tmp_dir}/rollback-pass.json"
+output_md="${tmp_dir}/rollback-pass.md"
+
+cat >"${proof_pass}" <<'EOF'
+{
+  "schema_version": 1,
+  "summary": {
+    "total_runs": 3,
+    "passed_runs": 3,
+    "failed_runs": 0,
+    "status": "pass"
+  },
+  "report_paths": {
+    "markdown": "tasks/reports/m21-retained-capability-proof-summary.md",
+    "logs_dir": "tasks/reports/m21-retained-capability-proof-logs",
+    "artifacts_dir": "tasks/reports/m21-retained-capability-artifacts"
+  },
+  "runs": [
+    { "marker_summary": { "total": 3, "matched": 3, "missing": 0 } },
+    { "marker_summary": { "total": 2, "matched": 2, "missing": 0 } }
+  ]
+}
+EOF
+
+cat >"${matrix_pass}" <<'EOF'
+{
+  "schema_version": 1,
+  "summary": {
+    "open_issues": 0,
+    "completion_percent": 100.0
+  }
+}
+EOF
+
+"${ROLLBACK_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --proof-summary-json "${proof_pass}" \
+  --validation-matrix-json "${matrix_pass}" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+
+assert_equals "false" "$(jq -r '.rollback_required' "${output_json}")" "functional rollback not required"
+assert_equals "0" "$(jq -r '[.triggers[] | select(.active == true)] | length' "${output_json}")" "functional active triggers"
+assert_contains "$(cat "${output_md}")" "Rollback required: no" "functional markdown status"
+
+# Regression: failed proof artifacts should trigger rollback and fail with --fail-on-trigger.
+proof_fail="${tmp_dir}/proof-fail.json"
+cat >"${proof_fail}" <<'EOF'
+{
+  "schema_version": 1,
+  "summary": {
+    "total_runs": 3,
+    "passed_runs": 2,
+    "failed_runs": 1,
+    "status": "fail"
+  },
+  "runs": [
+    { "marker_summary": { "total": 3, "matched": 2, "missing": 1 } }
+  ]
+}
+EOF
+
+reg_json="${tmp_dir}/rollback-fail.json"
+reg_md="${tmp_dir}/rollback-fail.md"
+
+set +e
+"${ROLLBACK_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --proof-summary-json "${proof_fail}" \
+  --validation-matrix-json "${matrix_pass}" \
+  --output-json "${reg_json}" \
+  --output-md "${reg_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --fail-on-trigger \
+  --quiet
+reg_rc=$?
+set -e
+
+assert_equals "1" "${reg_rc}" "regression fail-on-trigger exit code"
+assert_equals "true" "$(jq -r '.rollback_required' "${reg_json}")" "regression rollback required"
+assert_equals "true" "$(jq -r '.triggers[] | select(.id == "proof-runs-failed") | .active' "${reg_json}")" "regression failed-runs trigger"
+assert_equals "true" "$(jq -r '.triggers[] | select(.id == "proof-markers-missing") | .active' "${reg_json}")" "regression missing-marker trigger"
+assert_contains "$(cat "${reg_md}")" "Rollback required: yes" "regression markdown status"
+
+# Live-run proof: generate real proof summary via matrix + mock binary, then build rollback checklist.
+mock_binary="${tmp_dir}/mock-tau-coding-agent.py"
+cat >"${mock_binary}" <<'PY'
+#!/usr/bin/env python3
+import sys
+print("mock-ok " + " ".join(sys.argv[1:]))
+PY
+chmod +x "${mock_binary}"
+
+live_reports_dir="${tmp_dir}/live/reports"
+live_logs_dir="${tmp_dir}/live/logs"
+live_proof_json="${tmp_dir}/live/proof-summary.json"
+live_proof_md="${tmp_dir}/live/proof-summary.md"
+
+"${SUMMARY_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --binary "${mock_binary}" \
+  --matrix-json "${MATRIX_JSON}" \
+  --reports-dir "${live_reports_dir}" \
+  --logs-dir "${live_logs_dir}" \
+  --output-json "${live_proof_json}" \
+  --output-md "${live_proof_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+
+live_matrix="${tmp_dir}/live/matrix.json"
+cat >"${live_matrix}" <<'EOF'
+{
+  "schema_version": 1,
+  "summary": {
+    "open_issues": 0,
+    "completion_percent": 100.0
+  }
+}
+EOF
+
+live_roll_json="${tmp_dir}/live/rollback.json"
+live_roll_md="${tmp_dir}/live/rollback.md"
+
+"${ROLLBACK_SCRIPT}" \
+  --repo-root "${REPO_ROOT}" \
+  --proof-summary-json "${live_proof_json}" \
+  --validation-matrix-json "${live_matrix}" \
+  --output-json "${live_roll_json}" \
+  --output-md "${live_roll_md}" \
+  --generated-at "2026-02-15T00:00:00Z" \
+  --quiet
+
+assert_equals "false" "$(jq -r '.rollback_required' "${live_roll_json}")" "live-run rollback not required"
+assert_contains "$(cat "${live_roll_md}")" "## Rollback Drill Steps" "live-run markdown steps"
+
+echo "rollback-drill-checklist tests passed"


### PR DESCRIPTION
## Summary
- add standardized rollback drill generator:
  - `scripts/demo/rollback-drill-checklist.sh`
- add rollback drill contract tests (functional/regression/live-run proof):
  - `scripts/demo/test-rollback-drill-checklist.sh`
- add rollback runbook:
  - `docs/guides/consolidated-runtime-rollback-drill.md`
- update docs index and ownership map for rollback drill ownership boundaries
- extend runbook ownership docs guard coverage for new rollback runbook
- extend CI retained-proof scope to validate rollback drill script contract

Closes #1748.

## Risks and Compatibility
- rollback checklist now introduces optional fail-closed mode (`--fail-on-trigger`) for automation gates
- retained-proof CI scope now includes rollback checklist script/tests
- docs ownership checker enforces rollback runbook ownership tokens and map linkage

## Validation Evidence
- `./scripts/dev/test-m21-retained-capability-proof-summary.sh`
- `./scripts/demo/test-m21-retained-capability-proof-matrix.sh`
- `./scripts/demo/test-rollback-drill-checklist.sh`
- `python3 -m unittest discover -s .github/scripts -p 'test_*docs*_check.py'`
- `python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'`
- `python3 .github/scripts/runbook_ownership_docs_check.py --repo-root .`
- `python3 .github/scripts/docs_link_check.py --repo-root .`
- `python3 .github/scripts/architecture_docs_check.py --repo-root .`
- `cargo fmt`, strict `clippy`, and Rust test matrix not run (docs/script/workflow changes only)
