### PR TITLE
Resolve tau-memory postgres scaffold backend by removing unsupported path

### DIFF
--- a/docs/guides/memory-ops.md
+++ b/docs/guides/memory-ops.md
@@ -19,9 +19,10 @@ These tools persist under `--memory-state-dir` (default `.tau/memory`).
 
 Persistence backend selection:
 
-- `TAU_MEMORY_BACKEND` (`auto`, `sqlite`, `jsonl`, `postgres`)
+- `TAU_MEMORY_BACKEND` (`auto`, `sqlite`, `jsonl`)
 - `auto` prefers SQLite and imports legacy `entries.jsonl` into `entries.sqlite` on first load
-- `postgres` is scaffolded only (explicit not-implemented path for multi-instance follow-up)
+- invalid backend values fall back to inferred backend with reason
+  `memory_storage_backend_env_invalid_fallback`
 
 Optional real-embedding configuration (runtime env):
 


### PR DESCRIPTION
Closes #1713

## Summary of behavior changes
- Removed the scaffold-only `Postgres` backend variant from `tau-memory` runtime backend selection.
- Removed postgres DSN/env plumbing from `FileMemoryStore` and backend resolution internals.
- Updated backend resolution so `TAU_MEMORY_BACKEND=postgres` is treated as invalid input and cleanly falls back to inferred backend (`memory_storage_backend_env_invalid_fallback`).
- Updated memory ops runbook support matrix to document only currently supported backends (`auto`, `sqlite`, `jsonl`).
- Added regression coverage for the `TAU_MEMORY_BACKEND=postgres` fallback behavior.

## Risks and compatibility notes
- Breaking surface: code that pattern-matched on `tau_memory::runtime::MemoryStorageBackend::Postgres` will no longer compile. In-repo usage is unaffected.
- Runtime behavior change: misconfigured postgres backend no longer enters an explicit scaffold fail path; it now falls back to inferred backend with invalid-fallback reason code.
- This aligns the runbook with actual production support and removes a known scaffold footgun.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-memory --all-targets -- -D warnings`
- `cargo test -p tau-memory -- --test-threads=1`
