### PR TITLE
Purge removed contract-runner startup dispatch wiring

### DIFF
--- a/crates/tau-cli/src/validation.rs
+++ b/crates/tau-cli/src/validation.rs
@@ -9,6 +9,15 @@ const CUSTOM_COMMAND_CONTRACT_RUNNER_REMOVED_MESSAGE: &str = "--custom-command-c
 const BROWSER_AUTOMATION_CONTRACT_RUNNER_REMOVED_MESSAGE: &str = "--browser-automation-contract-runner has been removed; use --browser-automation-live-runner with --browser-automation-live-fixture and --browser-automation-playwright-cli";
 const DASHBOARD_CONTRACT_RUNNER_REMOVED_MESSAGE: &str = "--dashboard-contract-runner has been removed; use --gateway-openresponses-server for dashboard API/webchat surfaces and --dashboard-status-inspect plus --transport-health-inspect dashboard for diagnostics";
 
+/// Rejects removed contract-runner flags before any runtime dispatch or mode-specific validation.
+pub fn validate_removed_contract_runner_flags_cli(cli: &Cli) -> Result<()> {
+    validate_browser_automation_contract_runner_cli(cli)?;
+    validate_memory_contract_runner_cli(cli)?;
+    validate_dashboard_contract_runner_cli(cli)?;
+    validate_custom_command_contract_runner_cli(cli)?;
+    Ok(())
+}
+
 fn resolve_non_empty_cli_value(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)

--- a/crates/tau-coding-agent/src/startup_dispatch.rs
+++ b/crates/tau-coding-agent/src/startup_dispatch.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use tau_ai::ModelRef;
+use tau_cli::validation::validate_removed_contract_runner_flags_cli;
 use tau_cli::Cli;
 use tau_onboarding::startup_dispatch::{
     execute_startup_runtime_from_cli_with_modes, ExecuteStartupRuntimeFromCliWithModesRequest,
@@ -21,6 +22,7 @@ pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
     if execute_startup_preflight(&cli)? {
         return Ok(());
     }
+    validate_removed_contract_runner_flags_cli(&cli)?;
 
     execute_startup_runtime_from_cli_with_modes(ExecuteStartupRuntimeFromCliWithModesRequest {
         cli: &cli,

--- a/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages/bridge_and_contract_runners.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages/bridge_and_contract_runners.rs
@@ -3,6 +3,7 @@
 use super::*;
 use tau_cli::{
     validate_browser_automation_contract_runner_cli, validate_browser_automation_live_runner_cli,
+    validate_removed_contract_runner_flags_cli,
 };
 
 #[test]
@@ -922,6 +923,19 @@ fn unit_validate_browser_automation_contract_runner_cli_is_removed() {
     assert!(error
         .to_string()
         .contains("--browser-automation-live-runner"));
+}
+
+#[test]
+fn regression_validate_removed_contract_runner_flags_cli_prefers_removed_guidance_over_conflicts() {
+    let mut cli = test_cli();
+    cli.memory_contract_runner = true;
+    cli.events_runner = true;
+
+    let error = validate_removed_contract_runner_flags_cli(&cli)
+        .expect_err("removed runner guidance should trigger first");
+    assert!(error
+        .to_string()
+        .contains("--memory-contract-runner has been removed"));
 }
 
 #[test]

--- a/crates/tau-onboarding/src/startup_transport_modes.rs
+++ b/crates/tau-onboarding/src/startup_transport_modes.rs
@@ -14,14 +14,13 @@ use tau_browser_automation::browser_automation_live::{
     PlaywrightCliActionExecutor,
 };
 use tau_cli::validation::{
-    validate_browser_automation_contract_runner_cli, validate_browser_automation_live_runner_cli,
-    validate_custom_command_contract_runner_cli, validate_dashboard_contract_runner_cli,
-    validate_deployment_contract_runner_cli, validate_events_runner_cli,
-    validate_gateway_contract_runner_cli, validate_gateway_openresponses_server_cli,
-    validate_github_issues_bridge_cli, validate_memory_contract_runner_cli,
+    validate_browser_automation_live_runner_cli, validate_deployment_contract_runner_cli,
+    validate_events_runner_cli, validate_gateway_contract_runner_cli,
+    validate_gateway_openresponses_server_cli, validate_github_issues_bridge_cli,
     validate_multi_agent_contract_runner_cli, validate_multi_channel_contract_runner_cli,
     validate_multi_channel_live_connectors_runner_cli, validate_multi_channel_live_runner_cli,
-    validate_slack_bridge_cli, validate_voice_contract_runner_cli, validate_voice_live_runner_cli,
+    validate_removed_contract_runner_flags_cli, validate_slack_bridge_cli,
+    validate_voice_contract_runner_cli, validate_voice_live_runner_cli,
 };
 use tau_cli::Cli;
 use tau_cli::CliGatewayOpenResponsesAuthMode;
@@ -189,6 +188,7 @@ where
 }
 
 pub fn validate_transport_mode_cli(cli: &Cli) -> Result<()> {
+    validate_removed_contract_runner_flags_cli(cli)?;
     validate_github_issues_bridge_cli(cli)?;
     validate_slack_bridge_cli(cli)?;
     validate_events_runner_cli(cli)?;
@@ -196,14 +196,10 @@ pub fn validate_transport_mode_cli(cli: &Cli) -> Result<()> {
     validate_multi_channel_live_runner_cli(cli)?;
     validate_multi_channel_live_connectors_runner_cli(cli)?;
     validate_multi_agent_contract_runner_cli(cli)?;
-    validate_browser_automation_contract_runner_cli(cli)?;
     validate_browser_automation_live_runner_cli(cli)?;
-    validate_memory_contract_runner_cli(cli)?;
-    validate_dashboard_contract_runner_cli(cli)?;
     validate_gateway_openresponses_server_cli(cli)?;
     validate_gateway_contract_runner_cli(cli)?;
     validate_deployment_contract_runner_cli(cli)?;
-    validate_custom_command_contract_runner_cli(cli)?;
     validate_voice_contract_runner_cli(cli)?;
     validate_voice_live_runner_cli(cli)?;
     Ok(())

--- a/crates/tau-onboarding/src/startup_transport_modes/tests.rs
+++ b/crates/tau-onboarding/src/startup_transport_modes/tests.rs
@@ -776,6 +776,42 @@ fn regression_validate_transport_mode_cli_rejects_removed_browser_automation_con
 }
 
 #[test]
+fn regression_validate_transport_mode_cli_rejects_removed_memory_contract_runner() {
+    let mut cli = parse_cli_with_stack();
+    cli.memory_contract_runner = true;
+
+    let error =
+        validate_transport_mode_cli(&cli).expect_err("removed memory contract runner should fail");
+    assert!(error
+        .to_string()
+        .contains("--memory-contract-runner has been removed"));
+}
+
+#[test]
+fn regression_validate_transport_mode_cli_rejects_removed_dashboard_contract_runner() {
+    let mut cli = parse_cli_with_stack();
+    cli.dashboard_contract_runner = true;
+
+    let error = validate_transport_mode_cli(&cli)
+        .expect_err("removed dashboard contract runner should fail");
+    assert!(error
+        .to_string()
+        .contains("--dashboard-contract-runner has been removed"));
+}
+
+#[test]
+fn regression_validate_transport_mode_cli_rejects_removed_custom_command_contract_runner() {
+    let mut cli = parse_cli_with_stack();
+    cli.custom_command_contract_runner = true;
+
+    let error = validate_transport_mode_cli(&cli)
+        .expect_err("removed custom-command contract runner should fail");
+    assert!(error
+        .to_string()
+        .contains("--custom-command-contract-runner has been removed"));
+}
+
+#[test]
 fn functional_resolve_gateway_openresponses_auth_trims_non_empty_values() {
     let mut cli = parse_cli_with_stack();
     cli.gateway_openresponses_auth_token = Some(" token-value ".to_string());


### PR DESCRIPTION
Closes #1714

## Summary of behavior changes
- Added `validate_removed_contract_runner_flags_cli` in `tau-cli` to centralize removed-flag rejection (`browser-automation`, `memory`, `dashboard`, `custom-command` contract runners).
- Updated onboarding transport validation to call the centralized removed-flag validator before mode-specific transport checks.
- Added fail-fast checks in startup dispatch entrypoints:
  - `crates/tau-onboarding/src/startup_dispatch.rs`
  - `crates/tau-coding-agent/src/startup_dispatch.rs`
  so removed flags are rejected before transport/local runtime callbacks execute.
- Expanded regression coverage to verify removed flags are blocked in transport validation and startup dispatch.

## Risks and compatibility notes
- User-visible behavior change: removed contract-runner flags now fail earlier in startup dispatch, which may change the exact first error surfaced in mixed-flag invocations.
- Supported transport/runtime modes are unchanged; this only removes dead wiring paths for already-removed flags.
- Compatibility: no new flags introduced, and no active runner mode behavior changed.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-cli -p tau-onboarding -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-onboarding startup_dispatch::tests:: -- --test-threads=1`
- `cargo test -p tau-onboarding startup_transport_modes::tests:: -- --test-threads=1`
- `cargo test -p tau-coding-agent regression_validate_removed_contract_runner_flags_cli_prefers_removed_guidance_over_conflicts -- --test-threads=1`
