### PR TITLE
Centralize startup safety policy precedence resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3820,6 +3820,7 @@ name = "tau-startup"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "serde_json",
  "tau-access",
  "tau-ai",
@@ -3833,6 +3834,7 @@ dependencies = [
  "tau-provider",
  "tau-runtime",
  "tau-session",
+ "tau-tools",
 ]
 
 [[package]]

--- a/crates/tau-coding-agent/src/main.rs
+++ b/crates/tau-coding-agent/src/main.rs
@@ -253,6 +253,10 @@ pub(crate) use crate::tool_policy_config::build_tool_policy;
 #[cfg(test)]
 pub(crate) use crate::tool_policy_config::parse_sandbox_command_tokens;
 #[cfg(test)]
+pub(crate) use crate::tool_policy_config::resolve_startup_safety_policy;
+#[cfg(test)]
+pub(crate) use crate::tool_policy_config::startup_safety_policy_precedence_layers;
+#[cfg(test)]
 pub(crate) use crate::tool_policy_config::tool_policy_to_json;
 #[cfg(test)]
 pub(crate) use crate::transport_health::TransportHealthSnapshot;

--- a/crates/tau-coding-agent/src/tool_policy_config.rs
+++ b/crates/tau-coding-agent/src/tool_policy_config.rs
@@ -1,4 +1,7 @@
 // Re-export retained for startup/runtime tests through `crate::tool_policy_config`.
+pub(crate) use tau_startup::{
+    resolve_startup_safety_policy, startup_safety_policy_precedence_layers,
+};
 pub(crate) use tau_tools::tool_policy_config::{
     build_tool_policy, parse_sandbox_command_tokens, tool_policy_to_json,
 };

--- a/crates/tau-onboarding/src/startup_dispatch.rs
+++ b/crates/tau-onboarding/src/startup_dispatch.rs
@@ -91,6 +91,7 @@ where
     let StartupPolicyBundle {
         tool_policy,
         tool_policy_json,
+        precedence_layers: _precedence_layers,
     } = startup_policy;
     if run_transport_mode_if_requested(
         cli,
@@ -565,6 +566,14 @@ mod tests {
         assert_eq!(context.identity_composition.loaded_count, 0);
         assert_eq!(context.identity_composition.missing_count, 3);
         assert!(context.startup_policy.tool_policy_json.is_object());
+        assert_eq!(
+            context.startup_policy.precedence_layers,
+            vec![
+                "profile_preset".to_string(),
+                "cli_flags_and_cli_env".to_string(),
+                "runtime_env_overrides".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/tau-onboarding/src/startup_policy.rs
+++ b/crates/tau-onboarding/src/startup_policy.rs
@@ -1,23 +1,21 @@
 use anyhow::Result;
 use serde_json::Value;
 use tau_cli::Cli;
-use tau_tools::tool_policy_config::{build_tool_policy, tool_policy_to_json};
+use tau_startup::resolve_startup_safety_policy;
 use tau_tools::tools::ToolPolicy;
 
 /// Public struct `StartupPolicyBundle` used across Tau components.
 pub struct StartupPolicyBundle {
     pub tool_policy: ToolPolicy,
     pub tool_policy_json: Value,
+    pub precedence_layers: Vec<String>,
 }
 
 pub fn resolve_startup_policy(cli: &Cli) -> Result<StartupPolicyBundle> {
-    let tool_policy = build_tool_policy(cli)?;
-    let tool_policy_json = tool_policy_to_json(&tool_policy);
-    if cli.print_tool_policy {
-        println!("{tool_policy_json}");
-    }
+    let resolved = resolve_startup_safety_policy(cli)?;
     Ok(StartupPolicyBundle {
-        tool_policy,
-        tool_policy_json,
+        tool_policy: resolved.tool_policy,
+        tool_policy_json: resolved.tool_policy_json,
+        precedence_layers: resolved.precedence_layers,
     })
 }

--- a/crates/tau-startup/Cargo.toml
+++ b/crates/tau-startup/Cargo.toml
@@ -42,3 +42,9 @@ path = "../tau-runtime"
 
 [dependencies.tau-session]
 path = "../tau-session"
+
+[dependencies.tau-tools]
+path = "../tau-tools"
+
+[dev-dependencies]
+clap = { workspace = true }

--- a/crates/tau-startup/src/lib.rs
+++ b/crates/tau-startup/src/lib.rs
@@ -40,6 +40,8 @@ pub mod startup_multi_channel_adapters;
 pub mod startup_multi_channel_commands;
 /// RPC capabilities command rendering and dispatch helpers.
 pub mod startup_rpc_capabilities_command;
+/// Centralized startup safety-policy precedence resolver.
+pub mod startup_safety_policy;
 
 pub use runtime_types::*;
 pub use startup_command_file_runtime::*;
@@ -47,6 +49,7 @@ pub use startup_model_catalog::*;
 pub use startup_multi_channel_adapters::*;
 pub use startup_multi_channel_commands::*;
 pub use startup_rpc_capabilities_command::*;
+pub use startup_safety_policy::*;
 
 /// Trait contract for `StartupPreflightActions` behavior.
 pub trait StartupPreflightActions {

--- a/crates/tau-startup/src/startup_safety_policy.rs
+++ b/crates/tau-startup/src/startup_safety_policy.rs
@@ -1,0 +1,181 @@
+use anyhow::Result;
+use serde_json::Value;
+use tau_cli::Cli;
+use tau_tools::tool_policy_config::{build_tool_policy, tool_policy_to_json};
+use tau_tools::tools::ToolPolicy;
+
+const STARTUP_SAFETY_POLICY_PRECEDENCE: [&str; 3] = [
+    "profile_preset",
+    "cli_flags_and_cli_env",
+    "runtime_env_overrides",
+];
+
+/// Public struct `StartupSafetyPolicyResolution` used across Tau components.
+#[derive(Debug, Clone)]
+pub struct StartupSafetyPolicyResolution {
+    pub tool_policy: ToolPolicy,
+    pub tool_policy_json: Value,
+    pub precedence_layers: Vec<String>,
+}
+
+/// Returns the canonical safety-policy precedence contract.
+pub fn startup_safety_policy_precedence_layers() -> Vec<String> {
+    STARTUP_SAFETY_POLICY_PRECEDENCE
+        .iter()
+        .map(|layer| (*layer).to_string())
+        .collect()
+}
+
+/// Resolves startup safety policy using a single precedence contract.
+pub fn resolve_startup_safety_policy(cli: &Cli) -> Result<StartupSafetyPolicyResolution> {
+    let tool_policy = build_tool_policy(cli)?;
+    let tool_policy_json = tool_policy_to_json(&tool_policy);
+    if cli.print_tool_policy {
+        println!("{tool_policy_json}");
+    }
+    Ok(StartupSafetyPolicyResolution {
+        tool_policy,
+        tool_policy_json,
+        precedence_layers: startup_safety_policy_precedence_layers(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_startup_safety_policy, startup_safety_policy_precedence_layers};
+    use clap::Parser;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+    use tau_cli::Cli;
+    use tau_tools::tools::{BashCommandProfile, ToolPolicyPreset};
+
+    #[test]
+    fn unit_startup_safety_policy_precedence_layers_match_contract() {
+        assert_eq!(
+            startup_safety_policy_precedence_layers(),
+            vec![
+                "profile_preset".to_string(),
+                "cli_flags_and_cli_env".to_string(),
+                "runtime_env_overrides".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn functional_resolve_startup_safety_policy_cli_flag_overrides_env_and_preset() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _snapshot = EnvSnapshot::capture(&["TAU_BASH_PROFILE"]);
+        std::env::set_var("TAU_BASH_PROFILE", "strict");
+
+        let cli = parse_cli_with_stack_args(vec![
+            "tau-rs",
+            "--tool-policy-preset",
+            "hardened",
+            "--bash-profile",
+            "permissive",
+        ]);
+        let resolved = resolve_startup_safety_policy(&cli).expect("resolve startup safety policy");
+
+        assert_eq!(
+            resolved.tool_policy.policy_preset,
+            ToolPolicyPreset::Hardened
+        );
+        assert_eq!(
+            resolved.tool_policy.bash_profile,
+            BashCommandProfile::Permissive
+        );
+    }
+
+    #[test]
+    fn regression_resolve_startup_safety_policy_env_overrides_preset_when_cli_flag_unset() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _snapshot = EnvSnapshot::capture(&["TAU_BASH_PROFILE"]);
+        std::env::set_var("TAU_BASH_PROFILE", "permissive");
+
+        let cli = parse_cli_with_stack_args(vec!["tau-rs", "--tool-policy-preset", "hardened"]);
+        let resolved = resolve_startup_safety_policy(&cli).expect("resolve startup safety policy");
+
+        assert_eq!(
+            resolved.tool_policy.policy_preset,
+            ToolPolicyPreset::Hardened
+        );
+        assert_eq!(
+            resolved.tool_policy.bash_profile,
+            BashCommandProfile::Permissive
+        );
+        assert_eq!(
+            resolved.precedence_layers,
+            startup_safety_policy_precedence_layers()
+        );
+    }
+
+    #[test]
+    fn regression_resolve_startup_safety_policy_applies_runtime_env_overrides() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _snapshot = EnvSnapshot::capture(&["TAU_MEMORY_EMBEDDING_PROVIDER"]);
+        std::env::set_var("TAU_MEMORY_EMBEDDING_PROVIDER", "openai-compatible");
+
+        let cli = parse_cli_with_stack();
+        let resolved = resolve_startup_safety_policy(&cli).expect("resolve startup safety policy");
+
+        assert_eq!(
+            resolved.tool_policy.memory_embedding_provider.as_deref(),
+            Some("openai-compatible")
+        );
+        assert_eq!(
+            resolved.tool_policy_json["memory_embedding_provider"],
+            "openai-compatible"
+        );
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn parse_cli_with_stack() -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::parse_from(["tau-rs"]))
+            .expect("spawn cli parse thread")
+            .join()
+            .expect("join cli parse thread")
+    }
+
+    fn parse_cli_with_stack_args(args: Vec<&'static str>) -> Cli {
+        std::thread::Builder::new()
+            .name("tau-cli-parse-args".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || Cli::parse_from(args))
+            .expect("spawn cli parse args thread")
+            .join()
+            .expect("join cli parse args thread")
+    }
+
+    struct EnvSnapshot {
+        values: Vec<(String, Option<OsString>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(names: &[&str]) -> Self {
+            Self {
+                values: names
+                    .iter()
+                    .map(|name| ((*name).to_string(), std::env::var_os(name)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (name, value) in self.values.drain(..) {
+                match value {
+                    Some(previous) => std::env::set_var(name, previous),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1715

## Summary of behavior changes
- Added a centralized startup safety-policy resolver in `tau-startup`:
  - `resolve_startup_safety_policy`
  - `startup_safety_policy_precedence_layers`
  - `StartupSafetyPolicyResolution`
- Formalized one precedence contract with explicit layers:
  1. `profile_preset`
  2. `cli_flags_and_cli_env`
  3. `runtime_env_overrides`
- Updated onboarding startup policy wiring to consume the centralized resolver instead of calling `build_tool_policy` directly.
- Propagated precedence metadata via `StartupPolicyBundle.precedence_layers` and asserted it in startup dispatch tests.
- Added matrix tests in `tau-startup` and `tau-coding-agent` to verify precedence behavior (CLI over env over preset and runtime env overlays).

## Risks and compatibility notes
- `StartupPolicyBundle` now includes `precedence_layers` (additive field); existing behavior for `tool_policy` and `tool_policy_json` is preserved.
- Safety-policy construction now routes through one startup resolver path, reducing drift risk but changing the internal call graph.
- No CLI flags were added/removed; this is a wiring and contract-hardening change.

## Validation evidence
- `cargo fmt --all`
- `cargo clippy -p tau-startup -p tau-onboarding -p tau-coding-agent --all-targets -- -D warnings`
- `cargo test -p tau-startup startup_safety_policy::tests:: -- --test-threads=1`
- `cargo test -p tau-onboarding startup_dispatch::tests:: -- --test-threads=1`
- `cargo test -p tau-coding-agent regression_resolve_startup_safety_policy_enforces_precedence_contract -- --test-threads=1`
