### PR TITLE
Add fail-closed bypass safety tests and adversarial fixtures (#1716)

### DIFF
--- a/crates/tau-tools/src/tools/tests.rs
+++ b/crates/tau-tools/src/tools/tests.rs
@@ -3026,6 +3026,12 @@ fn redact_secrets_replaces_known_secret_token_patterns() {
 }
 
 #[test]
+fn regression_redact_secrets_replaces_project_scoped_openai_tokens() {
+    let redacted = redact_secrets("openai=sk-proj-AbCdEf0123456789_uvWXyZ9876543210");
+    assert_eq!(redacted, "openai=[REDACTED]");
+}
+
+#[test]
 fn canonicalize_best_effort_handles_non_existing_child() {
     let temp = tempdir().expect("tempdir");
     let target = temp.path().join("a/b/c.txt");


### PR DESCRIPTION
Closes #1716

## Summary of behavior changes
- Adds shared adversarial safety fixtures in `tau-safety` for multiline prompt-injection/exfiltration and modern project-scoped OpenAI key material.
- Hardens prompt-injection regex rules to match multiline bypass attempts (`(?is)`), so newline-delimited payloads are detected.
- Expands OpenAI key leak detection regex to include modern key shapes (including `sk-proj-...` style values).
- Adds regression tests in `tau-agent-core` for fail-closed bypass scenarios:
  - inbound multiline prompt injection blocked in `SafetyMode::Block`
  - multiline malicious tool output blocked with explicit no-pass-through assertion
  - outbound project-scoped key payload blocked in `secret_leak_mode = Block`
- Adds tau-tools regression coverage to ensure `redact_secrets` redacts project-scoped OpenAI token formats.

## Risks and compatibility notes
- Prompt regexes now match across newlines; this intentionally increases detection sensitivity and may catch additional multi-line instruction payloads that previously passed.
- OpenAI leak detection now accepts `_` and `-` after `sk-` with existing minimum length guard, improving modern key detection while preserving redaction behavior.
- Changes are limited to safety scanning and tests; no API shape changes.

## Validation evidence
- `cargo fmt --all`
- `cargo test -p tau-safety regression_scans_multiline_prompt_injection_fixture -- --test-threads=1`
- `cargo test -p tau-safety regression_scans_multiline_prompt_exfiltration_fixture -- --test-threads=1`
- `cargo test -p tau-safety regression_leak_detector_matches_project_scoped_openai_key_fixture -- --test-threads=1`
- `cargo test -p tau-agent-core safety_pipeline::regression_ -- --test-threads=1`
- `cargo test -p tau-agent-core safety_pipeline::integration_ -- --test-threads=1`
- `cargo test -p tau-tools regression_redact_secrets_replaces_project_scoped_openai_tokens -- --test-threads=1`
- `cargo clippy -p tau-safety -p tau-agent-core -p tau-tools --all-targets -- -D warnings`