### PR TITLE
Version safety diagnostics schema with backward-compat tests (#1717)

### DIFF
--- a/docs/guides/operator-control-summary.md
+++ b/docs/guides/operator-control-summary.md
@@ -73,6 +73,21 @@ When `--operator-control-summary-compare` is used:
 - `changed_components[]`: per-component drift rows (`severity`, before/after state, queue/failure counters)
 - `unchanged_component_count`: stable component count
 
+## Safety Diagnostics Schema Contract
+
+Prompt telemetry records written by runtime observability use:
+- `record_type=prompt_telemetry_v1`
+- `schema_version=1`
+
+Compatibility behavior for diagnostics consumers:
+- Legacy records with `record_type=prompt_telemetry` and missing (or `0`) `schema_version` remain accepted.
+- Unknown future prompt telemetry schema versions are ignored by summary aggregation until explicit support is added.
+
+Migration guidance:
+1. Producers should emit only `prompt_telemetry_v1` with `schema_version=1`.
+2. Consumers should keep compatibility acceptance for legacy v0 records during rollout windows.
+3. When introducing v2+, ship consumer support before enabling producers to emit the new schema.
+
 ## Troubleshooting map
 
 Common hold reason codes and actions:


### PR DESCRIPTION
Closes #1717

## Summary of behavior changes
- Added explicit prompt telemetry diagnostics schema contract constants in:
  - `crates/tau-runtime/src/observability_loggers_runtime.rs`
  - `crates/tau-diagnostics/src/lib.rs`
- Updated runtime prompt telemetry emission to use the contract constants (`record_type=prompt_telemetry_v1`, `schema_version=1`).
- Added backward-compat parsing in `tau-diagnostics` so audit summaries accept:
  - current v1 records (`prompt_telemetry_v1`, schema `1`)
  - legacy v0 records (`prompt_telemetry`, missing or schema `0`)
- Added regression handling for forward-schema records (future versions are ignored by summary aggregation, not treated as parse failures).
- Added schema compatibility tests in `tau-diagnostics` and schema contract emission tests in `tau-runtime`.
- Documented migration and compatibility behavior in `docs/guides/operator-control-summary.md`.

## Risks and compatibility notes
- Diagnostics aggregation now explicitly ignores unknown future prompt telemetry schema versions instead of accidentally treating all `record_type` matches as equivalent.
- Legacy `prompt_telemetry` records remain supported for backward compatibility during rollout windows.
- No runtime behavior changes to agent execution or tool safety enforcement paths.

## Validation evidence
- `cargo fmt --all`
- `cargo test -p tau-diagnostics summarize_audit_file_ -- --test-threads=1`
- `cargo test -p tau-runtime prompt_telemetry_logger_ -- --test-threads=1`
- `cargo clippy -p tau-runtime -p tau-diagnostics --all-targets -- -D warnings`
