### PR TITLE
test(safety): add outbound payload fixture matrix for #1730

### DIFF
--- a/crates/tau-tools/src/outbound_secret_fixture_matrix.json
+++ b/crates/tau-tools/src/outbound_secret_fixture_matrix.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "case_id": "openai_api_key",
+      "payload": "credential=sk-abc123abc123abc123abc123",
+      "expected_reason_code": "secret_leak.openai_api_key",
+      "marker": "sk-abc123abc123abc123abc123"
+    },
+    {
+      "case_id": "openai_project_key",
+      "payload": "credential=sk-proj-AbCdEf0123456789_uvWXyZ9876543210",
+      "expected_reason_code": "secret_leak.openai_api_key",
+      "marker": "sk-proj-AbCdEf0123456789_uvWXyZ9876543210"
+    },
+    {
+      "case_id": "anthropic_api_key",
+      "payload": "credential=sk-ant-AbCdEf0123456789_zyxWVUT987654321",
+      "expected_reason_code": "secret_leak.anthropic_api_key",
+      "marker": "sk-ant-AbCdEf0123456789_zyxWVUT987654321"
+    },
+    {
+      "case_id": "github_classic_pat",
+      "payload": "credential=ghp_AbCdEf0123456789QwErTyUi",
+      "expected_reason_code": "secret_leak.github_token",
+      "marker": "ghp_AbCdEf0123456789QwErTyUi"
+    },
+    {
+      "case_id": "github_fine_grained_pat",
+      "payload": "credential=github_pat_AbCdEf0123456789_QwErTyUiOp",
+      "expected_reason_code": "secret_leak.github_token",
+      "marker": "github_pat_AbCdEf0123456789_QwErTyUiOp"
+    },
+    {
+      "case_id": "slack_token",
+      "payload": "credential=xoxb-1234567890[TAU-OBFUSCATED]-ABCDEF1234567890",
+      "expected_reason_code": "secret_leak.slack_token",
+      "marker": "xoxb-1234567890[TAU-OBFUSCATED]-ABCDEF1234567890"
+    },
+    {
+      "case_id": "aws_access_key",
+      "payload": "credential=AKIA1234567890ABCDEF",
+      "expected_reason_code": "secret_leak.aws_access_key",
+      "marker": "AKIA1234567890ABCDEF"
+    },
+    {
+      "case_id": "private_key_material",
+      "payload": "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----",
+      "expected_reason_code": "secret_leak.private_key_material",
+      "marker": "BEGIN PRIVATE KEY"
+    },
+    {
+      "case_id": "jwt_token",
+      "payload": "credential=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ZXhhbXBsZV9wYXlsb2Fk.X2V4YW1wbGVfc2lnbmF0dXJl",
+      "expected_reason_code": "secret_leak.jwt_token",
+      "marker": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1730

## Summary
- Added outbound secret fixture matrix artifact at `crates/tau-tools/src/outbound_secret_fixture_matrix.json` with schema versioning and per-case expected reason code markers
- Added matrix-driven outbound safety coverage in `tau-agent-core` for:
  - Integration: block mode rejects every configured fixture payload
  - Functional: redact mode replaces secrets and preserves non-secret payload structure
  - Regression: emitted reason codes stay stable and namespaced
- Added `tau-tools` functional coverage asserting fixture matrix payloads are redacted by `redact_secrets`
- Added `tau-ai` provider integration coverage asserting usage telemetry fields (`input_tokens`, `output_tokens`, `total_tokens`) remain deterministic across fixture payloads
- Added push-protection-safe fixture literal handling using `[TAU-OBFUSCATED]` marker with runtime decode in tests

## Risks and Compatibility
- Low runtime risk: changes are test-only plus new fixture artifact under `src/`
- No API or behavior changes in production code paths
- Fixture schema is explicitly versioned (`schema_version = 1`) for controlled future expansion

## Validation
- `cargo fmt --all`
- `cargo test -p tau-agent-core outbound_secret_fixture_matrix -- --nocapture`
- `cargo test -p tau-tools outbound_fixture_matrix -- --nocapture`
- `cargo test -p tau-ai outbound_secret_fixture_matrix_preserves_usage_telemetry_fields -- --nocapture`
- `cargo clippy -p tau-agent-core -p tau-tools -p tau-ai --all-targets -- -D warnings`
