### PR TITLE
docs(roadmap): define orphan-task drift rules for #1771

### DIFF
--- a/.github/scripts/test_issue_hierarchy_drift_rules.py
+++ b/.github/scripts/test_issue_hierarchy_drift_rules.py
@@ -1,0 +1,54 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_PATH = REPO_ROOT / "tasks" / "policies" / "issue-hierarchy-drift-rules.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "issue-hierarchy-drift-rules.md"
+SYNC_GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "roadmap-status-sync.md"
+
+
+def load_rules() -> dict:
+    return json.loads(RULES_PATH.read_text(encoding="utf-8"))
+
+
+class IssueHierarchyDriftRulesTests(unittest.TestCase):
+    def test_functional_rules_file_has_required_contract_sections(self):
+        rules = load_rules()
+        self.assertEqual(rules["schema_version"], 1)
+        self.assertIn("required_metadata", rules)
+        self.assertIn("orphan_conditions", rules)
+        self.assertIn("drift_conditions", rules)
+        self.assertIn("remediation", rules)
+
+        required_labels = set(rules["required_metadata"]["required_labels"])
+        self.assertIn("roadmap", required_labels)
+        self.assertIn("testing-matrix", required_labels)
+        self.assertIn("epic", rules["required_metadata"]["hierarchy_labels"])
+        self.assertIn("story", rules["required_metadata"]["hierarchy_labels"])
+        self.assertIn("task", rules["required_metadata"]["hierarchy_labels"])
+
+    def test_regression_condition_ids_are_unique_and_fully_remediated(self):
+        rules = load_rules()
+        orphan_ids = [entry["id"] for entry in rules["orphan_conditions"]]
+        drift_ids = [entry["id"] for entry in rules["drift_conditions"]]
+        all_condition_ids = orphan_ids + drift_ids
+
+        self.assertEqual(len(all_condition_ids), len(set(all_condition_ids)))
+        remediation_ids = {entry["condition_id"] for entry in rules["remediation"]}
+        self.assertEqual(set(all_condition_ids), remediation_ids)
+
+    def test_regression_docs_reference_policy_and_condition_ids(self):
+        rules = load_rules()
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        sync_guide_text = SYNC_GUIDE_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("issue-hierarchy-drift-rules.json", guide_text)
+        self.assertIn("issue-hierarchy-drift-rules.json", sync_guide_text)
+        for entry in rules["orphan_conditions"] + rules["drift_conditions"]:
+            self.assertIn(entry["id"], guide_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ This index maps Tau documentation by audience and task.
 | Runtime maintainer | [Doc Density Scorecard](guides/doc-density-scorecard.md) | Baseline/targets for public API docs coverage and CI regression guard policy |
 | Roadmap operator | [Roadmap Execution Index](guides/roadmap-execution-index.md) | End-to-end mapping from `tasks/todo.md` items to milestones/issues and execution wave ordering |
 | Roadmap operator | [Roadmap Status Sync](guides/roadmap-status-sync.md) | Generate/check roadmap status snapshots from tracked GitHub issue state |
+| Roadmap operator | [Issue Hierarchy Drift Rules](guides/issue-hierarchy-drift-rules.md) | Required hierarchy metadata, orphan/drift condition IDs, and remediation contract |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/gateway/deployment/voice), dashboard diagnostics/API, memory diagnostics, custom-command diagnostics, RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/issue-hierarchy-drift-rules.md
+++ b/docs/guides/issue-hierarchy-drift-rules.md
@@ -1,0 +1,73 @@
+# Issue Hierarchy Drift Rules
+
+This guide defines the repository contract for detecting orphaned roadmap tasks and hierarchy drift across epics, stories, and tasks.
+
+Machine-readable source of truth: `tasks/policies/issue-hierarchy-drift-rules.json`
+
+## Required Metadata
+
+Issues participating in roadmap hierarchy checks must satisfy:
+
+- Required labels: `roadmap`, `testing-matrix`
+- Hierarchy labels: one of `epic`, `story`, `task`
+- Milestone required when hierarchy label is present
+- Parent link field: `parent_issue_url`
+
+Parent compatibility contract:
+
+- `story` issues must link to an `epic` parent
+- `task` issues must link to a `story` or `epic` parent
+
+## Orphan Conditions
+
+| Condition ID | Severity | Trigger |
+| --- | --- | --- |
+| `orphan.missing_parent_link` | error | Child issue has hierarchy label but no `parent_issue_url` |
+| `orphan.parent_issue_not_found` | error | `parent_issue_url` cannot be resolved to an accessible issue |
+| `orphan.parent_label_incompatible` | error | Child label and parent label violate allowed hierarchy mapping |
+
+## Drift Conditions
+
+| Condition ID | Severity | Trigger |
+| --- | --- | --- |
+| `drift.missing_required_labels` | warning | Required labels are missing |
+| `drift.missing_milestone` | error | Hierarchy-labeled issue has no milestone |
+| `drift.parent_milestone_mismatch` | warning | Parent/child milestones diverge without explicit waiver |
+| `drift.parent_child_state_mismatch` | warning | Parent/child open/closed state indicates lifecycle drift |
+
+## Remediation Playbook
+
+`orphan.missing_parent_link`
+
+- Add `parent_issue_url` in the tracked hierarchy source.
+- Confirm the parent URL resolves with repository permissions.
+
+`orphan.parent_issue_not_found`
+
+- Replace stale parent link with canonical issue URL.
+- If parent was intentionally removed, re-parent or close child with disposition notes.
+
+`orphan.parent_label_incompatible`
+
+- Correct child hierarchy label (`story`/`task`) to intended level.
+- Re-link child to an allowed parent label type.
+
+`drift.missing_required_labels`
+
+- Reapply required labels (`roadmap`, `testing-matrix`).
+- Re-run hierarchy drift checks after metadata correction.
+
+`drift.missing_milestone`
+
+- Assign current execution-wave milestone.
+- Escalate to roadmap owner if no valid milestone exists.
+
+`drift.parent_milestone_mismatch`
+
+- Move child to parent milestone unless explicit cross-wave exception is approved.
+- Document approved exception in tracker comments.
+
+`drift.parent_child_state_mismatch`
+
+- Align child state with lifecycle intent.
+- If parent is closed and child remains active, re-parent child to active owner issue.

--- a/docs/guides/roadmap-status-sync.md
+++ b/docs/guides/roadmap-status-sync.md
@@ -9,6 +9,11 @@ Use `scripts/dev/roadmap-status-sync.sh` to avoid manual drift between docs and 
 
 Tracked roadmap groups/IDs are configured in `tasks/roadmap-status-config.json`.
 
+Hierarchy drift/orphan detection rules are defined in:
+
+- `tasks/policies/issue-hierarchy-drift-rules.json`
+- `docs/guides/issue-hierarchy-drift-rules.md`
+
 ## Prerequisites
 
 - `gh` authenticated for this repository.

--- a/tasks/policies/issue-hierarchy-drift-rules.json
+++ b/tasks/policies/issue-hierarchy-drift-rules.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 1,
+  "required_metadata": {
+    "required_labels": [
+      "roadmap",
+      "testing-matrix"
+    ],
+    "hierarchy_labels": [
+      "epic",
+      "story",
+      "task"
+    ],
+    "milestone_required_for_hierarchy_labels": true,
+    "parent_link_field": "parent_issue_url",
+    "parent_rules": [
+      {
+        "child_label": "story",
+        "allowed_parent_labels": [
+          "epic"
+        ]
+      },
+      {
+        "child_label": "task",
+        "allowed_parent_labels": [
+          "story",
+          "epic"
+        ]
+      }
+    ]
+  },
+  "orphan_conditions": [
+    {
+      "id": "orphan.missing_parent_link",
+      "severity": "error",
+      "description": "Child issue has a hierarchy label but parent_issue_url metadata is missing."
+    },
+    {
+      "id": "orphan.parent_issue_not_found",
+      "severity": "error",
+      "description": "parent_issue_url points to a missing, inaccessible, or deleted issue."
+    },
+    {
+      "id": "orphan.parent_label_incompatible",
+      "severity": "error",
+      "description": "Child hierarchy label does not match allowed parent label contract."
+    }
+  ],
+  "drift_conditions": [
+    {
+      "id": "drift.missing_required_labels",
+      "severity": "warning",
+      "description": "Issue is missing one or more required labels from required_metadata.required_labels."
+    },
+    {
+      "id": "drift.missing_milestone",
+      "severity": "error",
+      "description": "Issue has a hierarchy label but no milestone assigned."
+    },
+    {
+      "id": "drift.parent_milestone_mismatch",
+      "severity": "warning",
+      "description": "Child and parent issues resolve to different milestones without explicit waiver."
+    },
+    {
+      "id": "drift.parent_child_state_mismatch",
+      "severity": "warning",
+      "description": "Parent and child issue states indicate lifecycle drift (for example, open child under closed parent)."
+    }
+  ],
+  "remediation": [
+    {
+      "condition_id": "orphan.missing_parent_link",
+      "steps": [
+        "Add parent_issue_url metadata in the tracked hierarchy source.",
+        "Confirm the linked parent issue is reachable with repository permissions."
+      ]
+    },
+    {
+      "condition_id": "orphan.parent_issue_not_found",
+      "steps": [
+        "Replace stale parent_issue_url with the canonical issue URL.",
+        "If parent was intentionally removed, re-parent child or close it with disposition notes."
+      ]
+    },
+    {
+      "condition_id": "orphan.parent_label_incompatible",
+      "steps": [
+        "Align child label to the intended hierarchy level (story/task).",
+        "Re-link to a parent issue with an allowed hierarchy label."
+      ]
+    },
+    {
+      "condition_id": "drift.missing_required_labels",
+      "steps": [
+        "Apply missing required labels (`roadmap`, `testing-matrix`) to restore policy baseline.",
+        "Re-run hierarchy drift checks after label correction."
+      ]
+    },
+    {
+      "condition_id": "drift.missing_milestone",
+      "steps": [
+        "Assign milestone matching the active execution wave.",
+        "Escalate to roadmap owner if no valid milestone exists."
+      ]
+    },
+    {
+      "condition_id": "drift.parent_milestone_mismatch",
+      "steps": [
+        "Move child into parent milestone unless explicit cross-wave dependency is approved.",
+        "Document approved exception in tracker comments when mismatch is intentional."
+      ]
+    },
+    {
+      "condition_id": "drift.parent_child_state_mismatch",
+      "steps": [
+        "Close or re-open child issue to match parent lifecycle intent.",
+        "If parent is complete but child remains open, re-parent child to current active story/task owner."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1771

## Summary
- Added machine-readable hierarchy drift policy at `tasks/policies/issue-hierarchy-drift-rules.json` defining:
  - required metadata contract
  - orphan condition IDs
  - drift condition IDs
  - condition-to-remediation mapping
- Added operator guide at `docs/guides/issue-hierarchy-drift-rules.md` with codified rules and remediation playbook
- Linked hierarchy drift policy references from `docs/guides/roadmap-status-sync.md`
- Added docs index entry for the new guide in `docs/README.md`
- Added helper tests in `.github/scripts/test_issue_hierarchy_drift_rules.py` to enforce:
  - policy contract shape
  - unique condition IDs + full remediation coverage
  - policy/doc ID consistency

## Risks and Compatibility
- Low risk: documentation + policy artifact + helper tests only
- No runtime/agent behavior changes
- Introduces explicit condition IDs that downstream drift-check tooling can consume without redefining semantics

## Validation
- `python3 -m unittest discover -s .github/scripts -p "test_issue_hierarchy_drift_rules.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_docs_link_check.py"`
