### PR TITLE
issue-1773: define lane-specific file ownership boundaries for PR batching

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- Behavior changes:
+- Risks / compatibility notes:
+
+## Lane Boundary Contract
+
+- Lane (`structural` | `docs` | `rl`):
+- Boundary Map (`tasks/policies/pr-batch-lane-boundaries.json`):
+- Boundary Paths (list concrete files/paths touched):
+- Hotspot Mitigation (`none` if no hotspot path touched):
+
+## Validation Evidence
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] Additional issue-specific tests (list):
+
+Closes #<issue-id>

--- a/.github/scripts/test_pr_batch_lane_boundaries_contract.py
+++ b/.github/scripts/test_pr_batch_lane_boundaries_contract.py
@@ -1,0 +1,82 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "tasks" / "policies" / "pr-batch-lane-boundaries.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "pr-batch-lane-boundaries.md"
+SYNC_GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "roadmap-status-sync.md"
+PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
+
+
+def load_policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def find_missing_snippets(text: str, required_snippets: tuple[str, ...]) -> list[str]:
+    return [snippet for snippet in required_snippets if snippet not in text]
+
+
+class PrBatchLaneBoundariesContractTests(unittest.TestCase):
+    def test_functional_policy_has_required_lane_boundary_contract(self):
+        policy = load_policy()
+
+        self.assertEqual(policy["schema_version"], 1)
+        self.assertIn("lanes", policy)
+        self.assertIn("high_conflict_hotspots", policy)
+        self.assertIn("pr_reference_contract", policy)
+
+        lane_ids = {lane["id"] for lane in policy["lanes"]}
+        self.assertEqual(lane_ids, {"structural", "docs", "rl"})
+        for lane in policy["lanes"]:
+            self.assertGreater(len(lane["owned_path_prefixes"]), 0)
+            self.assertGreater(len(lane["shared_paths"]), 0)
+
+    def test_regression_hotspot_ids_and_lane_ownership_are_consistent(self):
+        policy = load_policy()
+        lane_ids = {lane["id"] for lane in policy["lanes"]}
+        hotspots = policy["high_conflict_hotspots"]
+        hotspot_ids = [entry["id"] for entry in hotspots]
+
+        self.assertEqual(len(hotspot_ids), len(set(hotspot_ids)))
+        self.assertGreaterEqual(len(hotspots), 4)
+        for entry in hotspots:
+            self.assertIn(entry["preferred_owner_lane"], lane_ids)
+            self.assertGreater(len(entry["mitigation_steps"]), 0)
+
+    def test_integration_docs_and_template_reference_policy_and_ids(self):
+        policy = load_policy()
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        sync_guide_text = SYNC_GUIDE_PATH.read_text(encoding="utf-8")
+        template_text = PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("pr-batch-lane-boundaries.json", guide_text)
+        self.assertIn("pr-batch-lane-boundaries.json", sync_guide_text)
+
+        required_template_fields = tuple(
+            policy["pr_reference_contract"]["required_pr_template_fields"]
+        )
+        missing_template_fields = find_missing_snippets(template_text, required_template_fields)
+        self.assertEqual(
+            missing_template_fields,
+            [],
+            msg=f"missing PR template lane fields: {missing_template_fields}",
+        )
+
+        for lane in policy["lanes"]:
+            self.assertIn(lane["id"], guide_text)
+            self.assertIn(lane["id"], template_text)
+
+        for hotspot in policy["high_conflict_hotspots"]:
+            self.assertIn(hotspot["id"], guide_text)
+
+    def test_regression_pr_template_references_boundary_map_file(self):
+        policy = load_policy()
+        template_text = PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+        boundary_map = policy["pr_reference_contract"]["boundary_map_reference"]
+        self.assertIn(boundary_map, template_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This index maps Tau documentation by audience and task.
 | Roadmap operator | [Roadmap Execution Index](guides/roadmap-execution-index.md) | End-to-end mapping from `tasks/todo.md` items to milestones/issues and execution wave ordering |
 | Roadmap operator | [Roadmap Status Sync](guides/roadmap-status-sync.md) | Generate/check roadmap status snapshots from tracked GitHub issue state |
 | Roadmap operator | [Issue Hierarchy Drift Rules](guides/issue-hierarchy-drift-rules.md) | Required hierarchy metadata, orphan/drift condition IDs, and remediation contract |
+| Roadmap operator | [PR Batch Lane Boundaries](guides/pr-batch-lane-boundaries.md) | Lane ownership boundaries, hotspot mitigation rules, and PR reference contract for batching |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/gateway/deployment/voice), dashboard diagnostics/API, memory diagnostics, custom-command diagnostics, RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/pr-batch-lane-boundaries.md
+++ b/docs/guides/pr-batch-lane-boundaries.md
@@ -1,0 +1,45 @@
+# PR Batch Lane Boundaries
+
+This guide defines lane-specific file ownership boundaries for parallel PR batching.
+
+Machine-readable source of truth: `tasks/policies/pr-batch-lane-boundaries.json`
+
+## Lane Boundary Map
+
+Use one lane per PR unless there is an explicit cross-lane exception in issue comments.
+
+| Lane | Primary ownership boundaries | Shared paths (hotspot rules apply) |
+| --- | --- | --- |
+| `structural` | `crates/tau-cli/`, `crates/tau-coding-agent/`, `crates/tau-tools/`, `crates/tau-channel-store/`, `crates/tau-github-issues-runtime/`, `crates/tau-slack-runtime/`, `crates/tau-safety/` | `Cargo.toml`, `Cargo.lock`, `.github/workflows/ci.yml` |
+| `docs` | `docs/`, `tasks/todo.md`, `tasks/tau-vs-ironclaw-gap-list.md`, `tasks/reports/`, docs link-check scripts/workflow | `README.md`, `docs/README.md`, `docs/guides/runbook-ownership-map.md` |
+| `rl` | `crates/tau-algorithm/`, `crates/tau-trainer/`, `crates/tau-training-*`, training runbooks | `crates/tau-cli/src/cli_args.rs`, `Cargo.toml`, `Cargo.lock`, `.github/workflows/ci.yml` |
+
+## Conflict Hotspots And Mitigation Notes
+
+| Hotspot ID | Path | Why it conflicts | Mitigation |
+| --- | --- | --- | --- |
+| `hotspot.workspace-manifests` | `Cargo.toml` | Cross-lane dependency edits | Rebase before merge; queue one manifest-changing PR at a time; include dependency delta summary. |
+| `hotspot.workspace-lockfile` | `Cargo.lock` | Lockfile churn from concurrent dependency updates | Regenerate only after rebase; avoid lockfile-only drift commits; rerun `cargo check` after merge conflict resolution. |
+| `hotspot.quality-workflow` | `.github/workflows/ci.yml` | Multiple lanes patch same workflow jobs | Keep lane-local scope and ordering; update contract tests in same PR; keep path filters narrow. |
+| `hotspot.roadmap-doc-blocks` | `tasks/todo.md` | Generated status blocks reflow on sync | Run `scripts/dev/roadmap-status-sync.sh` before final push; avoid manual edits in generated blocks. |
+| `hotspot.runbook-ownership-map` | `docs/guides/runbook-ownership-map.md` | Structural and RL runbook updates collide | Prefer docs-lane ownership-map batching; run `.github/scripts/runbook_ownership_docs_check.py`. |
+
+## Active PR Reference Contract
+
+All active PRs must reference the boundary map and lane in the PR description using `.github/pull_request_template.md`.
+
+Required fields:
+
+- `Lane`
+- `Boundary Map`
+- `Boundary Paths`
+- `Hotspot Mitigation`
+
+Example:
+
+```text
+Lane: structural
+Boundary Map: tasks/policies/pr-batch-lane-boundaries.json
+Boundary Paths: crates/tau-tools/src/tools.rs; crates/tau-tools/src/registry.rs
+Hotspot Mitigation: none (no hotspot files changed)
+```

--- a/docs/guides/roadmap-status-sync.md
+++ b/docs/guides/roadmap-status-sync.md
@@ -14,6 +14,11 @@ Hierarchy drift/orphan detection rules are defined in:
 - `tasks/policies/issue-hierarchy-drift-rules.json`
 - `docs/guides/issue-hierarchy-drift-rules.md`
 
+PR batch lane ownership boundaries are defined in:
+
+- `tasks/policies/pr-batch-lane-boundaries.json`
+- `docs/guides/pr-batch-lane-boundaries.md`
+
 To preview hierarchy drift findings locally before CI:
 
 ```bash

--- a/tasks/policies/pr-batch-lane-boundaries.json
+++ b/tasks/policies/pr-batch-lane-boundaries.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "policy_id": "pr-batch-lane-boundaries",
+  "description": "Lane ownership boundaries for parallel PR batching during milestone execution waves.",
+  "lanes": [
+    {
+      "id": "structural",
+      "purpose": "Runtime structural refactors, oversized-file decomposition, and crate-boundary hardening.",
+      "owned_path_prefixes": [
+        "crates/tau-cli/",
+        "crates/tau-coding-agent/",
+        "crates/tau-tools/",
+        "crates/tau-channel-store/",
+        "crates/tau-github-issues-runtime/",
+        "crates/tau-slack-runtime/",
+        "crates/tau-safety/"
+      ],
+      "shared_paths": [
+        "Cargo.toml",
+        "Cargo.lock",
+        ".github/workflows/ci.yml"
+      ]
+    },
+    {
+      "id": "docs",
+      "purpose": "Documentation updates, roadmap status artifacts, and operator runbook alignment.",
+      "owned_path_prefixes": [
+        "docs/",
+        "tasks/todo.md",
+        "tasks/tau-vs-ironclaw-gap-list.md",
+        "tasks/reports/",
+        ".github/scripts/docs_link_check.py",
+        ".github/scripts/test_docs_link_check.py",
+        ".github/workflows/docs-quality.yml"
+      ],
+      "shared_paths": [
+        "README.md",
+        "docs/README.md",
+        "docs/guides/runbook-ownership-map.md"
+      ]
+    },
+    {
+      "id": "rl",
+      "purpose": "Training and reinforcement-learning runtime implementation, evaluation, and contract tests.",
+      "owned_path_prefixes": [
+        "crates/tau-algorithm/",
+        "crates/tau-trainer/",
+        "crates/tau-training-types/",
+        "crates/tau-training-store/",
+        "crates/tau-training-tracer/",
+        "crates/tau-training-runner/",
+        "crates/tau-training-proxy/",
+        "docs/guides/training-ops.md",
+        "docs/guides/training-proxy-ops.md",
+        "docs/guides/training-crate-boundary-plan.md"
+      ],
+      "shared_paths": [
+        "crates/tau-cli/src/cli_args.rs",
+        "Cargo.toml",
+        "Cargo.lock",
+        ".github/workflows/ci.yml"
+      ]
+    }
+  ],
+  "high_conflict_hotspots": [
+    {
+      "id": "hotspot.workspace-manifests",
+      "path": "Cargo.toml",
+      "reason": "All lanes change workspace dependencies/features, creating frequent merge conflicts and lockfile churn.",
+      "preferred_owner_lane": "structural",
+      "mitigation_steps": [
+        "Rebase lane branches onto latest master before opening merge-ready PRs.",
+        "Queue one manifest-changing PR at a time; hold others at ready-for-review until merged.",
+        "Include a short dependency delta summary in PR validation evidence."
+      ]
+    },
+    {
+      "id": "hotspot.workspace-lockfile",
+      "path": "Cargo.lock",
+      "reason": "Lockfile regeneration amplifies unrelated diffs when multiple lanes update dependencies in parallel.",
+      "preferred_owner_lane": "structural",
+      "mitigation_steps": [
+        "Regenerate lockfile in the final commit only after rebasing on master.",
+        "Avoid lockfile-only commits detached from dependency manifest updates.",
+        "When conflict markers appear, rerun a clean `cargo check` after resolution."
+      ]
+    },
+    {
+      "id": "hotspot.quality-workflow",
+      "path": ".github/workflows/ci.yml",
+      "reason": "Lane-specific checks are added in the same workflow file, creating rebase friction and accidental step drops.",
+      "preferred_owner_lane": "docs",
+      "mitigation_steps": [
+        "Group workflow edits by lane scope and preserve existing step ordering.",
+        "Keep contract tests in `.github/scripts/test_*.py` updated in the same PR.",
+        "Use focused path filters to avoid expanding quality-runtime cost."
+      ]
+    },
+    {
+      "id": "hotspot.roadmap-doc-blocks",
+      "path": "tasks/todo.md",
+      "reason": "Generated roadmap blocks drift when multiple PRs regenerate status snapshots simultaneously.",
+      "preferred_owner_lane": "docs",
+      "mitigation_steps": [
+        "Run `scripts/dev/roadmap-status-sync.sh` immediately before final push.",
+        "Keep manual edits outside generated marker blocks.",
+        "If conflicts occur, rerun sync instead of hand-merging generated sections."
+      ]
+    },
+    {
+      "id": "hotspot.runbook-ownership-map",
+      "path": "docs/guides/runbook-ownership-map.md",
+      "reason": "Structural and RL changes both require runbook ownership updates, producing frequent table conflicts.",
+      "preferred_owner_lane": "docs",
+      "mitigation_steps": [
+        "Batch ownership-map edits into docs lane PRs whenever feasible.",
+        "For structural/RL PRs, link pending ownership updates if not included directly.",
+        "Run `.github/scripts/runbook_ownership_docs_check.py` in every PR touching runbooks."
+      ]
+    }
+  ],
+  "pr_reference_contract": {
+    "template_path": ".github/pull_request_template.md",
+    "boundary_map_reference": "tasks/policies/pr-batch-lane-boundaries.json",
+    "required_pr_template_fields": [
+      "Lane",
+      "Boundary Map",
+      "Boundary Paths",
+      "Hotspot Mitigation"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary of behavior changes
- Added machine-readable lane boundary policy at `tasks/policies/pr-batch-lane-boundaries.json` with explicit `structural`, `docs`, and `rl` ownership boundaries.
- Added high-conflict hotspot definitions with mitigation playbooks (`Cargo.toml`, `Cargo.lock`, CI workflow, roadmap generated block, runbook ownership map).
- Published the lane boundary map in `docs/guides/pr-batch-lane-boundaries.md`.
- Added `.github/pull_request_template.md` to require active PRs to declare lane, boundary map, boundary paths, and hotspot mitigation notes.
- Added CI contract test coverage in `.github/scripts/test_pr_batch_lane_boundaries_contract.py` and linked the guide/policy from `docs/README.md` and `docs/guides/roadmap-status-sync.md`.

## Risks and compatibility notes
- Introducing a repository-level PR template changes default PR authoring UX; existing open PRs are unaffected, new PRs get required boundary metadata prompts.
- Lane boundaries are policy guidance; edge cases may still require explicit cross-lane exceptions documented in issue/PR comments.

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_pr_batch_lane_boundaries_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_issue_hierarchy_drift_rules.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_docs_link_check.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`

Closes #1773
