### PR TITLE
issue-1774: add batch-size and review-SLA lane matrix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,9 @@
 - Boundary Map (`tasks/policies/pr-batch-lane-boundaries.json`):
 - Boundary Paths (list concrete files/paths touched):
 - Hotspot Mitigation (`none` if no hotspot path touched):
+- Batch Size (`<open PR count in lane>` / `<lane max>`):
+- Review SLA (first review and merge target windows):
+- Exception Reference (`none` or `tasks/policies/pr-batch-exceptions.json#<exception_id>`):
 
 ## Validation Evidence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ This index maps Tau documentation by audience and task.
 | Roadmap operator | [Roadmap Execution Index](guides/roadmap-execution-index.md) | End-to-end mapping from `tasks/todo.md` items to milestones/issues and execution wave ordering |
 | Roadmap operator | [Roadmap Status Sync](guides/roadmap-status-sync.md) | Generate/check roadmap status snapshots from tracked GitHub issue state |
 | Roadmap operator | [Issue Hierarchy Drift Rules](guides/issue-hierarchy-drift-rules.md) | Required hierarchy metadata, orphan/drift condition IDs, and remediation contract |
-| Roadmap operator | [PR Batch Lane Boundaries](guides/pr-batch-lane-boundaries.md) | Lane ownership boundaries, hotspot mitigation rules, and PR reference contract for batching |
+| Roadmap operator | [PR Batch Lane Boundaries](guides/pr-batch-lane-boundaries.md) | Lane boundaries, batch-size/review-SLA matrix, hotspot mitigation rules, and exception workflow |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/gateway/deployment/voice), dashboard diagnostics/API, memory diagnostics, custom-command diagnostics, RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/pr-batch-lane-boundaries.md
+++ b/docs/guides/pr-batch-lane-boundaries.md
@@ -2,7 +2,10 @@
 
 This guide defines lane-specific file ownership boundaries for parallel PR batching.
 
-Machine-readable source of truth: `tasks/policies/pr-batch-lane-boundaries.json`
+Machine-readable source of truth:
+
+- `tasks/policies/pr-batch-lane-boundaries.json`
+- `tasks/policies/pr-batch-exceptions.json`
 
 ## Lane Boundary Map
 
@@ -24,6 +27,36 @@ Use one lane per PR unless there is an explicit cross-lane exception in issue co
 | `hotspot.roadmap-doc-blocks` | `tasks/todo.md` | Generated status blocks reflow on sync | Run `scripts/dev/roadmap-status-sync.sh` before final push; avoid manual edits in generated blocks. |
 | `hotspot.runbook-ownership-map` | `docs/guides/runbook-ownership-map.md` | Structural and RL runbook updates collide | Prefer docs-lane ownership-map batching; run `.github/scripts/runbook_ownership_docs_check.py`. |
 
+## Batch Size And Review SLA Matrix
+
+| Lane | Max open PRs per batch | Max hotspot paths per PR | First-review SLA | Merge SLA | Required reviewers |
+| --- | --- | --- | --- | --- | --- |
+| `structural` | 2 | 1 | 24h | 72h | 2 |
+| `docs` | 4 | 2 | 12h | 48h | 1 |
+| `rl` | 2 | 1 | 24h | 96h | 2 |
+
+## Exception Workflow
+
+If lane matrix limits must be exceeded, track exceptions in `tasks/policies/pr-batch-exceptions.json`.
+
+Required exception fields:
+
+- `exception_id`
+- `lane`
+- `issue_url`
+- `rationale`
+- `approved_by`
+- `approved_at`
+- `expires_on`
+- `mitigation`
+
+Escalation path:
+
+1. Open/reference a blocking issue that explains why matrix limits are insufficient.
+2. Add an exception record with rationale and mitigation.
+3. Obtain runtime maintainer approval before merge.
+4. Remove or expire the exception after merge.
+
 ## Active PR Reference Contract
 
 All active PRs must reference the boundary map and lane in the PR description using `.github/pull_request_template.md`.
@@ -34,6 +67,9 @@ Required fields:
 - `Boundary Map`
 - `Boundary Paths`
 - `Hotspot Mitigation`
+- `Batch Size`
+- `Review SLA`
+- `Exception Reference`
 
 Example:
 
@@ -42,4 +78,7 @@ Lane: structural
 Boundary Map: tasks/policies/pr-batch-lane-boundaries.json
 Boundary Paths: crates/tau-tools/src/tools.rs; crates/tau-tools/src/registry.rs
 Hotspot Mitigation: none (no hotspot files changed)
+Batch Size: 1 / 2
+Review SLA: first review <= 24h, merge <= 72h
+Exception Reference: none
 ```

--- a/docs/guides/roadmap-status-sync.md
+++ b/docs/guides/roadmap-status-sync.md
@@ -17,6 +17,7 @@ Hierarchy drift/orphan detection rules are defined in:
 PR batch lane ownership boundaries are defined in:
 
 - `tasks/policies/pr-batch-lane-boundaries.json`
+- `tasks/policies/pr-batch-exceptions.json`
 - `docs/guides/pr-batch-lane-boundaries.md`
 
 To preview hierarchy drift findings locally before CI:

--- a/tasks/policies/pr-batch-exceptions.json
+++ b/tasks/policies/pr-batch-exceptions.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "policy_id": "pr-batch-exceptions",
+  "exceptions": []
+}

--- a/tasks/policies/pr-batch-lane-boundaries.json
+++ b/tasks/policies/pr-batch-lane-boundaries.json
@@ -119,6 +119,51 @@
       ]
     }
   ],
+  "batch_size_review_sla_matrix": [
+    {
+      "lane": "structural",
+      "max_open_prs_per_batch": 2,
+      "max_hotspot_paths_per_pr": 1,
+      "target_first_review_hours": 24,
+      "target_merge_hours": 72,
+      "required_reviewers": 2
+    },
+    {
+      "lane": "docs",
+      "max_open_prs_per_batch": 4,
+      "max_hotspot_paths_per_pr": 2,
+      "target_first_review_hours": 12,
+      "target_merge_hours": 48,
+      "required_reviewers": 1
+    },
+    {
+      "lane": "rl",
+      "max_open_prs_per_batch": 2,
+      "max_hotspot_paths_per_pr": 1,
+      "target_first_review_hours": 24,
+      "target_merge_hours": 96,
+      "required_reviewers": 2
+    }
+  ],
+  "exception_workflow": {
+    "tracking_file": "tasks/policies/pr-batch-exceptions.json",
+    "required_fields": [
+      "exception_id",
+      "lane",
+      "issue_url",
+      "rationale",
+      "approved_by",
+      "approved_at",
+      "expires_on",
+      "mitigation"
+    ],
+    "escalation_path": [
+      "Open or reference the blocking issue that requires exceeding lane matrix limits.",
+      "Record the exception in the tracking file with rationale and mitigation.",
+      "Obtain approval from a runtime maintainer before merging.",
+      "Expire or remove the exception entry after merge completion."
+    ]
+  },
   "pr_reference_contract": {
     "template_path": ".github/pull_request_template.md",
     "boundary_map_reference": "tasks/policies/pr-batch-lane-boundaries.json",
@@ -126,7 +171,10 @@
       "Lane",
       "Boundary Map",
       "Boundary Paths",
-      "Hotspot Mitigation"
+      "Hotspot Mitigation",
+      "Batch Size",
+      "Review SLA",
+      "Exception Reference"
     ]
   }
 }


### PR DESCRIPTION
## Summary of behavior changes
- Extended `tasks/policies/pr-batch-lane-boundaries.json` with a lane-specific batch-size and review-SLA matrix.
- Added exception workflow contract (required fields + escalation path) and tracking artifact `tasks/policies/pr-batch-exceptions.json`.
- Updated `docs/guides/pr-batch-lane-boundaries.md` with matrix and exception workflow sections.
- Updated `.github/pull_request_template.md` to require `Batch Size`, `Review SLA`, and `Exception Reference` for active PR batching.
- Extended `.github/scripts/test_pr_batch_lane_boundaries_contract.py` to enforce matrix/exceptions contract consistency.
- Updated docs references in `docs/README.md` and `docs/guides/roadmap-status-sync.md`.

## Risks and compatibility notes
- PR template now requires additional metadata fields; contributors must provide lane throughput/SLA context in all new PRs.
- SLA values are policy targets, not CI-enforced timers; operational adherence still depends on reviewer discipline.

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_pr_batch_lane_boundaries_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_issue_hierarchy_drift_rules.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_docs_link_check.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`

Closes #1774
