### PR TITLE
issue-1777: define stale-branch thresholds and alert conditions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,8 @@
 - Batch Size (`<open PR count in lane>` / `<lane max>`):
 - Review SLA (first review and merge target windows):
 - Exception Reference (`none` or `tasks/policies/pr-batch-exceptions.json#<exception_id>`):
+- Branch Freshness (`age_days`, `behind_commits`, `ok|warning|critical`):
+- Stale Alert Acknowledgement (`none` or link to acknowledgement comment/workflow update):
 
 ## Validation Evidence
 

--- a/.github/scripts/test_stale_branch_alert_policy.py
+++ b/.github/scripts/test_stale_branch_alert_policy.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "tasks" / "policies" / "stale-branch-alert-policy.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "stale-branch-response-playbook.md"
+SYNC_GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "roadmap-status-sync.md"
+PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
+
+
+def load_policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+class StaleBranchAlertPolicyTests(unittest.TestCase):
+    def test_functional_policy_has_required_threshold_and_alert_sections(self):
+        policy = load_policy()
+
+        self.assertEqual(policy["schema_version"], 1)
+        self.assertIn("thresholds", policy)
+        self.assertIn("alert_conditions", policy)
+        self.assertIn("acknowledge_resolve_workflow", policy)
+        self.assertIn("pr_reference_fields", policy)
+
+        warning = policy["thresholds"]["warning"]
+        critical = policy["thresholds"]["critical"]
+        self.assertLess(warning["age_days"], critical["age_days"])
+        self.assertLess(warning["behind_commits"], critical["behind_commits"])
+        self.assertGreater(policy["thresholds"]["unresolved_conflict_warning_hours"], 0)
+
+    def test_regression_alert_condition_ids_are_unique_and_actionable(self):
+        policy = load_policy()
+        conditions = policy["alert_conditions"]
+        condition_ids = [entry["id"] for entry in conditions]
+
+        self.assertEqual(len(condition_ids), len(set(condition_ids)))
+        self.assertGreaterEqual(len(conditions), 3)
+        for entry in conditions:
+            self.assertIn(entry["severity"], {"warning", "error"})
+            self.assertGreater(len(entry["channels"]), 0)
+
+    def test_integration_docs_and_template_reference_policy_contract(self):
+        policy = load_policy()
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        sync_text = SYNC_GUIDE_PATH.read_text(encoding="utf-8")
+        template_text = PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("stale-branch-alert-policy.json", guide_text)
+        self.assertIn("stale-branch-alert-policy.json", sync_text)
+
+        for condition in policy["alert_conditions"]:
+            self.assertIn(condition["id"], guide_text)
+
+        for field in policy["acknowledge_resolve_workflow"]["required_ack_fields"]:
+            self.assertIn(field, guide_text)
+
+        for field in policy["pr_reference_fields"]:
+            self.assertIn(field, guide_text)
+            self.assertIn(field, template_text)
+
+    def test_regression_resolve_states_are_documented_in_playbook(self):
+        policy = load_policy()
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        for state in policy["acknowledge_resolve_workflow"]["resolve_states"]:
+            self.assertIn(state, guide_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This index maps Tau documentation by audience and task.
 | Roadmap operator | [Roadmap Status Sync](guides/roadmap-status-sync.md) | Generate/check roadmap status snapshots from tracked GitHub issue state |
 | Roadmap operator | [Issue Hierarchy Drift Rules](guides/issue-hierarchy-drift-rules.md) | Required hierarchy metadata, orphan/drift condition IDs, and remediation contract |
 | Roadmap operator | [PR Batch Lane Boundaries](guides/pr-batch-lane-boundaries.md) | Lane boundaries, batch-size/review-SLA matrix, hotspot mitigation rules, and exception workflow |
+| Roadmap operator | [Stale Branch Response Playbook](guides/stale-branch-response-playbook.md) | Stale thresholds, alert channel rules, and acknowledgement/resolve workflow |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/gateway/deployment/voice), dashboard diagnostics/API, memory diagnostics, custom-command diagnostics, RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/roadmap-status-sync.md
+++ b/docs/guides/roadmap-status-sync.md
@@ -20,6 +20,11 @@ PR batch lane ownership boundaries are defined in:
 - `tasks/policies/pr-batch-exceptions.json`
 - `docs/guides/pr-batch-lane-boundaries.md`
 
+Stale-branch threshold and alert rules are defined in:
+
+- `tasks/policies/stale-branch-alert-policy.json`
+- `docs/guides/stale-branch-response-playbook.md`
+
 To preview hierarchy drift findings locally before CI:
 
 ```bash

--- a/docs/guides/stale-branch-response-playbook.md
+++ b/docs/guides/stale-branch-response-playbook.md
@@ -1,0 +1,53 @@
+# Stale Branch Response Playbook
+
+This guide defines stale-branch thresholds, automated alert conditions, and the acknowledge/resolve workflow.
+
+Machine-readable source of truth: `tasks/policies/stale-branch-alert-policy.json`
+
+## Threshold Matrix
+
+| Severity | Branch age threshold | Behind-commit threshold |
+| --- | --- | --- |
+| `warning` | `>= 2` days | `>= 25` commits |
+| `critical` | `>= 5` days | `>= 75` commits |
+
+Persistent merge conflict warning threshold: `12` hours unresolved.
+
+## Automated Alert Conditions
+
+| Condition ID | Severity | Trigger | Alert channels |
+| --- | --- | --- | --- |
+| `stale.warning.age_or_behind` | warning | Branch age or behind count reaches warning threshold | `github.pr_comment`, `github.issue_comment:#1678` |
+| `stale.critical.age_or_behind` | error | Branch age or behind count reaches critical threshold | `github.pr_comment`, `github.issue_comment:#1678`, `runtime.maintainer_page` |
+| `stale.warning.unresolved_conflict` | warning | Merge conflict remains unresolved for >= 12 hours | `github.pr_comment`, `github.issue_comment:#1678` |
+
+## Acknowledge/Resolve Workflow
+
+A stale alert must be acknowledged within `4` hours.
+
+Required acknowledgement fields:
+
+- `owner`
+- `acknowledged_at`
+- `next_update_at`
+- `mitigation_plan`
+
+Allowed resolve states:
+
+- `rebased_and_green`
+- `merged`
+- `closed_not_planned`
+
+Suggested response steps:
+
+1. Add/update the acknowledgement comment on the PR with required fields.
+2. Update status tags (`stale-warning` or `stale-critical`) on the tracker issue comment.
+3. Post next-update timestamp and execute mitigation plan.
+4. Clear stale status only after one resolve state is reached.
+
+## Active PR Usage
+
+Active PRs must include stale-branch status fields in `.github/pull_request_template.md`:
+
+- `Branch Freshness`
+- `Stale Alert Acknowledgement`

--- a/tasks/policies/stale-branch-alert-policy.json
+++ b/tasks/policies/stale-branch-alert-policy.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "policy_id": "stale-branch-alert-policy",
+  "description": "Objective stale-branch thresholds and automated alert conditions for merge throughput control.",
+  "thresholds": {
+    "warning": {
+      "age_days": 2,
+      "behind_commits": 25
+    },
+    "critical": {
+      "age_days": 5,
+      "behind_commits": 75
+    },
+    "unresolved_conflict_warning_hours": 12
+  },
+  "alert_conditions": [
+    {
+      "id": "stale.warning.age_or_behind",
+      "severity": "warning",
+      "trigger": "branch age or behind count reaches warning threshold",
+      "channels": [
+        "github.pr_comment",
+        "github.issue_comment:#1678"
+      ]
+    },
+    {
+      "id": "stale.critical.age_or_behind",
+      "severity": "error",
+      "trigger": "branch age or behind count reaches critical threshold",
+      "channels": [
+        "github.pr_comment",
+        "github.issue_comment:#1678",
+        "runtime.maintainer_page"
+      ]
+    },
+    {
+      "id": "stale.warning.unresolved_conflict",
+      "severity": "warning",
+      "trigger": "merge conflict remains unresolved beyond unresolved_conflict_warning_hours",
+      "channels": [
+        "github.pr_comment",
+        "github.issue_comment:#1678"
+      ]
+    }
+  ],
+  "acknowledge_resolve_workflow": {
+    "acknowledge_sla_hours": 4,
+    "required_ack_fields": [
+      "owner",
+      "acknowledged_at",
+      "next_update_at",
+      "mitigation_plan"
+    ],
+    "resolve_states": [
+      "rebased_and_green",
+      "merged",
+      "closed_not_planned"
+    ],
+    "status_tags": [
+      "stale-warning",
+      "stale-critical"
+    ]
+  },
+  "pr_reference_fields": [
+    "Branch Freshness",
+    "Stale Alert Acknowledgement"
+  ]
+}


### PR DESCRIPTION
## Summary of behavior changes
- Added machine-readable stale-branch alert policy in `tasks/policies/stale-branch-alert-policy.json`.
  - warning/critical thresholds for branch age and behind-commit drift
  - explicit automated alert condition IDs and channels
  - acknowledge/resolve workflow contract fields
- Added operator guide `docs/guides/stale-branch-response-playbook.md` with threshold matrix and acknowledgement workflow.
- Added contract tests in `.github/scripts/test_stale_branch_alert_policy.py`.
- Updated `.github/pull_request_template.md` to require `Branch Freshness` and `Stale Alert Acknowledgement` fields.
- Updated documentation index references in `docs/README.md` and `docs/guides/roadmap-status-sync.md`.

## Risks and compatibility notes
- PR template now asks for branch freshness metadata; contributors need to provide stale-status context for active PRs.
- Policy thresholds are governance defaults and may need tuning as merge throughput data evolves.

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_stale_branch_alert_policy.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_pr_batch_lane_boundaries_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_issue_hierarchy_drift_rules.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_docs_link_check.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`

Closes #1777
