### PR TITLE
issue-1778: add fast conflict-resolution playbook with rollback criteria

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,8 @@
 - Exception Reference (`none` or `tasks/policies/pr-batch-exceptions.json#<exception_id>`):
 - Branch Freshness (`age_days`, `behind_commits`, `ok|warning|critical`):
 - Stale Alert Acknowledgement (`none` or link to acknowledgement comment/workflow update):
+- Conflict Response Decision (`merge` | `rebase` | `abandon` | `n/a`):
+- Rollback Trigger Check (`none` or rollback trigger id + mitigation link):
 
 ## Validation Evidence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ This index maps Tau documentation by audience and task.
 | Roadmap operator | [Roadmap Status Sync](guides/roadmap-status-sync.md) | Generate/check roadmap status snapshots from tracked GitHub issue state |
 | Roadmap operator | [Issue Hierarchy Drift Rules](guides/issue-hierarchy-drift-rules.md) | Required hierarchy metadata, orphan/drift condition IDs, and remediation contract |
 | Roadmap operator | [PR Batch Lane Boundaries](guides/pr-batch-lane-boundaries.md) | Lane boundaries, batch-size/review-SLA matrix, hotspot mitigation rules, and exception workflow |
-| Roadmap operator | [Stale Branch Response Playbook](guides/stale-branch-response-playbook.md) | Stale thresholds, alert channel rules, and acknowledgement/resolve workflow |
+| Roadmap operator | [Stale Branch Response Playbook](guides/stale-branch-response-playbook.md) | Stale thresholds, alert channels, conflict triage criteria, and rollback triggers |
 | Gateway auth operator | [Gateway Auth Session Smoke](guides/gateway-auth-session-smoke.md) | End-to-end password-session issuance, authorized status call, invalid/expired fail-closed checks |
 | Platform / integration engineer | [Transport Guide](guides/transports.md) | GitHub Issues bridge, Slack bridge, contract runners (multi-channel/multi-agent/gateway/deployment/voice), dashboard diagnostics/API, memory diagnostics, custom-command diagnostics, RPC, ChannelStore admin |
 | Package and extension author | [Packages Guide](guides/packages.md) | Extension manifests, package lifecycle, activation, signing |

--- a/docs/guides/stale-branch-response-playbook.md
+++ b/docs/guides/stale-branch-response-playbook.md
@@ -1,6 +1,6 @@
 # Stale Branch Response Playbook
 
-This guide defines stale-branch thresholds, automated alert conditions, and the acknowledge/resolve workflow.
+This guide defines stale-branch thresholds, automated alert conditions, conflict triage flow, and rollback criteria.
 
 Machine-readable source of truth: `tasks/policies/stale-branch-alert-policy.json`
 
@@ -45,9 +45,50 @@ Suggested response steps:
 3. Post next-update timestamp and execute mitigation plan.
 4. Clear stale status only after one resolve state is reached.
 
+## Conflict Triage Flow
+
+Use this triage flow for high-conflict branches:
+
+1. Classify conflict scope (`manifest`, `workflow`, `runtime module`, `docs-only`).
+2. Estimate resolution effort and blast radius within 30 minutes.
+3. Select one decision path and record rationale in PR comments:
+   - `merge`
+   - `rebase`
+   - `abandon`
+
+## Merge/Rebase/Abandon Criteria
+
+`merge` when:
+
+- Branch is <= 10 commits behind `master`.
+- Conflict scope is docs-only or low-risk non-hotspot changes.
+- No rollback trigger is active.
+
+`rebase` when:
+
+- Branch is > 10 commits behind `master`.
+- Conflict scope includes hotspot paths or generated artifacts.
+- Rebase can complete in one review cycle.
+
+`abandon` when:
+
+- Branch is > 21 days old with unresolved conflicts.
+- PR is superseded or roadmap scope is obsolete.
+- Two failed rebases occurred within 48 hours.
+
+## Rollback Trigger Conditions
+
+| Trigger ID | Trigger | Required actions |
+| --- | --- | --- |
+| `rollback.conflict_churn` | Same conflict appears in two consecutive rebases | Pause impacted lane; escalate; open rollback/disposition issue |
+| `rollback.red_ci_after_resolution` | Quality checks fail after conflict resolution without source changes | Revert resolution commit; restore last green; rerun validation matrix |
+| `rollback.hotspot_collision` | Hotspot files conflict across more than one active lane | Freeze non-owner merges; serialize hotspot owner PRs; rebaseline stale branches |
+
 ## Active PR Usage
 
 Active PRs must include stale-branch status fields in `.github/pull_request_template.md`:
 
 - `Branch Freshness`
 - `Stale Alert Acknowledgement`
+- `Conflict Response Decision`
+- `Rollback Trigger Check`

--- a/tasks/policies/stale-branch-alert-policy.json
+++ b/tasks/policies/stale-branch-alert-policy.json
@@ -61,8 +61,63 @@
       "stale-critical"
     ]
   },
+  "conflict_response": {
+    "triage_flow": [
+      "Classify conflict scope (manifest, workflow, runtime module, docs-only).",
+      "Estimate resolution effort and blast radius within 30 minutes.",
+      "Select merge, rebase, or abandon using decision criteria and record rationale."
+    ],
+    "decision_criteria": {
+      "merge": [
+        "Branch is <= 10 commits behind master.",
+        "Conflict scope is docs-only or low-risk non-hotspot changes.",
+        "No rollback trigger is active."
+      ],
+      "rebase": [
+        "Branch is > 10 commits behind master.",
+        "Conflict scope includes hotspot paths or generated artifacts.",
+        "Rebase can be completed within one review cycle."
+      ],
+      "abandon": [
+        "Branch is > 21 days old with unresolved conflicts.",
+        "Superseded by merged replacement PR or obsolete roadmap scope.",
+        "Two failed rebase attempts within 48 hours."
+      ]
+    }
+  },
+  "rollback_triggers": [
+    {
+      "id": "rollback.conflict_churn",
+      "trigger": "same conflict resurfaces in two consecutive rebases",
+      "required_actions": [
+        "pause merge queue for impacted lane",
+        "escalate to runtime maintainer",
+        "open rollback/disposition issue"
+      ]
+    },
+    {
+      "id": "rollback.red_ci_after_resolution",
+      "trigger": "quality checks fail after conflict resolution with no source changes",
+      "required_actions": [
+        "revert resolution commit",
+        "restore last green commit",
+        "rerun validation matrix"
+      ]
+    },
+    {
+      "id": "rollback.hotspot_collision",
+      "trigger": "hotspot files (`Cargo.toml`, `Cargo.lock`, `ci.yml`) conflict across >1 active lane",
+      "required_actions": [
+        "freeze non-owner lane merges",
+        "serialize hotspot owner PRs",
+        "rebaseline stale branches"
+      ]
+    }
+  ],
   "pr_reference_fields": [
     "Branch Freshness",
-    "Stale Alert Acknowledgement"
+    "Stale Alert Acknowledgement",
+    "Conflict Response Decision",
+    "Rollback Trigger Check"
   ]
 }


### PR DESCRIPTION
## Summary of behavior changes
- Extended `tasks/policies/stale-branch-alert-policy.json` with fast conflict-response contracts:
  - triage flow sequence
  - merge/rebase/abandon decision criteria
  - rollback trigger IDs with required actions
- Extended `docs/guides/stale-branch-response-playbook.md` with:
  - conflict triage flow
  - merge/rebase/abandon criteria
  - rollback trigger condition table
- Updated `.github/pull_request_template.md` to require:
  - `Conflict Response Decision`
  - `Rollback Trigger Check`
- Extended `.github/scripts/test_stale_branch_alert_policy.py` to enforce the new policy/playbook contract.
- Updated stale-branch playbook summary in `docs/README.md`.

## Risks and compatibility notes
- PR template now requires conflict-response metadata; contributors must explicitly record resolution strategy.
- Rollback trigger/action contracts are governance controls and may require tuning as incident data accumulates.

## Validation evidence
- `python3 -m unittest discover -s .github/scripts -p "test_stale_branch_alert_policy.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_pr_batch_lane_boundaries_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_issue_hierarchy_drift_rules.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_roadmap_status_workflow_contract.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_docs_link_check.py"`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py"`

Closes #1778
