### PR TITLE
refactor(skills): split tau-skills lib load/trust orchestration

### DIFF
--- a/crates/tau-skills/src/commands.rs
+++ b/crates/tau-skills/src/commands.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
 use tau_core::{current_unix_timestamp, is_expired_unix};
 

--- a/crates/tau-skills/src/lib.rs
+++ b/crates/tau-skills/src/lib.rs
@@ -3,21 +3,15 @@
 //! Handles skill manifest parsing, install/update/remove, lockfile sync, trust
 //! records, and signature verification workflows.
 
-use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use ed25519_dalek::{Signature, VerifyingKey};
-use reqwest::Url;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 mod commands;
+mod load_registry;
 mod package_manifest;
+mod trust_policy;
 pub mod trust_roots;
 
 pub use commands::*;
@@ -176,100 +170,18 @@ pub struct SkillRegistryManifest {
 }
 
 pub fn load_catalog(dir: &Path) -> Result<Vec<Skill>> {
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    if !dir.is_dir() {
-        bail!("skills path '{}' is not a directory", dir.display());
-    }
-
-    let mut skills = Vec::new();
-    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
-            continue;
-        }
-
-        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
-            continue;
-        };
-        let content = fs::read_to_string(&path)
-            .with_context(|| format!("failed to read skill file {}", path.display()))?;
-        skills.push(Skill {
-            name: stem.to_string(),
-            content,
-            path,
-        });
-    }
-
-    skills.sort_by(|left, right| left.name.cmp(&right.name));
-    Ok(skills)
+    load_registry::load_catalog(dir)
 }
 
 pub fn install_skills(sources: &[PathBuf], destination_dir: &Path) -> Result<SkillInstallReport> {
-    if sources.is_empty() {
-        return Ok(SkillInstallReport::default());
-    }
-
-    fs::create_dir_all(destination_dir)
-        .with_context(|| format!("failed to create {}", destination_dir.display()))?;
-
-    let mut report = SkillInstallReport::default();
-    for source in sources {
-        if source.extension().and_then(|ext| ext.to_str()) != Some("md") {
-            bail!("skill source '{}' must be a .md file", source.display());
-        }
-
-        let file_name = source
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("invalid skill source '{}'", source.display()))?;
-        let destination = destination_dir.join(file_name);
-
-        let content = fs::read_to_string(source)
-            .with_context(|| format!("failed to read skill source {}", source.display()))?;
-        upsert_skill_file(&destination, &content, &mut report)?;
-    }
-
-    Ok(report)
+    load_registry::install_skills(sources, destination_dir)
 }
 
 pub fn resolve_remote_skill_sources(
     urls: &[String],
     sha256_values: &[String],
 ) -> Result<Vec<RemoteSkillSource>> {
-    if sha256_values.is_empty() {
-        return Ok(urls
-            .iter()
-            .map(|url| RemoteSkillSource {
-                url: url.clone(),
-                sha256: None,
-                signing_key_id: None,
-                signature: None,
-                signer_public_key: None,
-            })
-            .collect());
-    }
-
-    if urls.len() != sha256_values.len() {
-        bail!(
-            "--install-skill-url count ({}) must match --install-skill-sha256 count ({})",
-            urls.len(),
-            sha256_values.len()
-        );
-    }
-
-    Ok(urls
-        .iter()
-        .zip(sha256_values.iter())
-        .map(|(url, sha256)| RemoteSkillSource {
-            url: url.clone(),
-            sha256: Some(sha256.clone()),
-            signing_key_id: None,
-            signature: None,
-            signer_public_key: None,
-        })
-        .collect())
+    load_registry::resolve_remote_skill_sources(urls, sha256_values)
 }
 
 pub async fn install_remote_skills_with_cache(
@@ -277,188 +189,23 @@ pub async fn install_remote_skills_with_cache(
     destination_dir: &Path,
     options: &SkillsDownloadOptions,
 ) -> Result<SkillInstallReport> {
-    if sources.is_empty() {
-        return Ok(SkillInstallReport::default());
-    }
-
-    fs::create_dir_all(destination_dir)
-        .with_context(|| format!("failed to create {}", destination_dir.display()))?;
-
-    let client = reqwest::Client::new();
-    let mut report = SkillInstallReport::default();
-
-    for (index, source) in sources.iter().enumerate() {
-        let url = Url::parse(&source.url)
-            .with_context(|| format!("invalid skill URL '{}'", source.url))?;
-        if !matches!(url.scheme(), "http" | "https") {
-            bail!("unsupported skill URL scheme '{}'", url.scheme());
-        }
-
-        let cache_path = options
-            .cache_dir
-            .as_deref()
-            .map(|cache_dir| remote_skill_cache_path(cache_dir, &source.url));
-        let bytes = fetch_remote_skill_bytes(
-            &client,
-            &url,
-            source,
-            cache_path.as_deref(),
-            options.offline,
-        )
-        .await?;
-
-        let file_name = remote_skill_file_name(&url, index);
-        let destination = destination_dir.join(file_name);
-        let content = String::from_utf8(bytes)
-            .with_context(|| format!("skill content from '{}' is not UTF-8", source.url))?;
-
-        upsert_skill_file(&destination, &content, &mut report)?;
-    }
-
-    Ok(report)
-}
-
-async fn fetch_remote_skill_bytes(
-    client: &reqwest::Client,
-    url: &Url,
-    source: &RemoteSkillSource,
-    cache_path: Option<&Path>,
-    offline: bool,
-) -> Result<Vec<u8>> {
-    validate_remote_skill_source_metadata(source)?;
-    if offline {
-        let cache_path = cache_path
-            .ok_or_else(|| anyhow!("offline mode requires a configured skills cache directory"))?;
-        let bytes = read_cached_payload(cache_path)
-            .with_context(|| format!("offline cache miss for skill URL '{}'", source.url))?;
-        validate_remote_skill_payload(source, &bytes).with_context(|| {
-            format!(
-                "cached skill payload validation failed for '{}'",
-                source.url
-            )
-        })?;
-        return Ok(bytes);
-    }
-
-    if let Some(cache_path) = cache_path {
-        if should_reuse_cached_remote_payload(source) {
-            if let Ok(bytes) = read_cached_payload(cache_path) {
-                if validate_remote_skill_payload(source, &bytes).is_ok() {
-                    return Ok(bytes);
-                }
-            }
-        }
-    }
-
-    let response = client
-        .get(url.clone())
-        .send()
-        .await
-        .with_context(|| format!("failed to fetch skill URL '{}'", source.url))?;
-    if !response.status().is_success() {
-        bail!(
-            "failed to fetch skill URL '{}' with status {}",
-            source.url,
-            response.status()
-        );
-    }
-    let bytes = response
-        .bytes()
-        .await
-        .with_context(|| format!("failed to read skill response '{}'", source.url))?
-        .to_vec();
-
-    validate_remote_skill_payload(source, &bytes)?;
-    if let Some(cache_path) = cache_path {
-        write_cached_payload(cache_path, &bytes)
-            .with_context(|| format!("failed to cache skill URL '{}'", source.url))?;
-    }
-    Ok(bytes)
-}
-
-fn validate_remote_skill_source_metadata(source: &RemoteSkillSource) -> Result<()> {
-    if source.signature.is_some() ^ source.signer_public_key.is_some() {
-        bail!(
-            "incomplete signature metadata for '{}': both signature and signer public key are required",
-            source.url
-        );
-    }
-    Ok(())
-}
-
-fn validate_remote_skill_payload(source: &RemoteSkillSource, bytes: &[u8]) -> Result<()> {
-    if let Some(expected_sha256) = &source.sha256 {
-        let actual_sha256 = sha256_hex(bytes);
-        let expected_sha256 = normalize_sha256(expected_sha256);
-        if actual_sha256 != expected_sha256 {
-            bail!(
-                "sha256 mismatch for '{}': expected {}, got {}",
-                source.url,
-                expected_sha256,
-                actual_sha256
-            );
-        }
-    }
-
-    if let (Some(signature), Some(signer_public_key)) =
-        (&source.signature, &source.signer_public_key)
-    {
-        verify_ed25519_signature(bytes, signature, signer_public_key)
-            .with_context(|| format!("signature verification failed for '{}'", source.url))?;
-    }
-    Ok(())
-}
-
-fn should_reuse_cached_remote_payload(source: &RemoteSkillSource) -> bool {
-    source.sha256.is_some() || source.signature.is_some()
+    load_registry::install_remote_skills_with_cache(sources, destination_dir, options).await
 }
 
 pub fn default_skills_lock_path(skills_dir: &Path) -> PathBuf {
-    skills_dir.join(SKILLS_LOCK_FILE_NAME)
+    load_registry::default_skills_lock_path(skills_dir)
 }
 
 pub fn default_skills_cache_dir(skills_dir: &Path) -> PathBuf {
-    skills_dir.join(SKILLS_CACHE_DIR_NAME)
+    load_registry::default_skills_cache_dir(skills_dir)
 }
 
 pub fn build_local_skill_lock_hints(sources: &[PathBuf]) -> Result<Vec<SkillLockHint>> {
-    let mut hints = Vec::new();
-    for source in sources {
-        if source.extension().and_then(|ext| ext.to_str()) != Some("md") {
-            bail!("skill source '{}' must be a .md file", source.display());
-        }
-        let file = source
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| anyhow!("invalid skill source '{}'", source.display()))?
-            .to_string();
-        hints.push(SkillLockHint {
-            file,
-            source: SkillLockSource::Local {
-                path: source.display().to_string(),
-            },
-        });
-    }
-    Ok(hints)
+    load_registry::build_local_skill_lock_hints(sources)
 }
 
 pub fn build_remote_skill_lock_hints(sources: &[RemoteSkillSource]) -> Result<Vec<SkillLockHint>> {
-    let mut hints = Vec::new();
-    for (index, source) in sources.iter().enumerate() {
-        let file = remote_skill_file_name_for_source(&source.url, index)?;
-        hints.push(SkillLockHint {
-            file,
-            source: SkillLockSource::Remote {
-                url: source.url.clone(),
-                expected_sha256: source.sha256.clone(),
-                signing_key_id: source.signing_key_id.clone(),
-                signature: source.signature.clone(),
-                signer_public_key: source.signer_public_key.clone(),
-                signature_sha256: source.signature.as_deref().map(signature_digest_sha256_hex),
-            },
-        });
-    }
-    Ok(hints)
+    load_registry::build_remote_skill_lock_hints(sources)
 }
 
 pub fn build_registry_skill_lock_hints(
@@ -466,45 +213,15 @@ pub fn build_registry_skill_lock_hints(
     names: &[String],
     sources: &[RemoteSkillSource],
 ) -> Result<Vec<SkillLockHint>> {
-    if names.len() != sources.len() {
-        bail!(
-            "registry lock hint metadata mismatch: names={}, sources={}",
-            names.len(),
-            sources.len()
-        );
-    }
-    let mut hints = Vec::new();
-    for (index, (name, source)) in names.iter().zip(sources.iter()).enumerate() {
-        let file = remote_skill_file_name_for_source(&source.url, index)?;
-        hints.push(SkillLockHint {
-            file,
-            source: SkillLockSource::Registry {
-                registry_url: registry_url.to_string(),
-                name: name.clone(),
-                url: source.url.clone(),
-                expected_sha256: source.sha256.clone(),
-                signing_key_id: source.signing_key_id.clone(),
-                signature: source.signature.clone(),
-                signer_public_key: source.signer_public_key.clone(),
-                signature_sha256: source.signature.as_deref().map(signature_digest_sha256_hex),
-            },
-        });
-    }
-    Ok(hints)
+    load_registry::build_registry_skill_lock_hints(registry_url, names, sources)
 }
 
 pub fn remote_skill_file_name_for_source(url: &str, index: usize) -> Result<String> {
-    let url = Url::parse(url).with_context(|| format!("invalid skill URL '{}'", url))?;
-    Ok(remote_skill_file_name(&url, index))
+    load_registry::remote_skill_file_name_for_source(url, index)
 }
 
 pub fn load_skills_lockfile(path: &Path) -> Result<SkillsLockfile> {
-    let raw = fs::read_to_string(path)
-        .with_context(|| format!("failed to read skills lockfile {}", path.display()))?;
-    let lockfile: SkillsLockfile = serde_json::from_str(&raw)
-        .with_context(|| format!("failed to parse skills lockfile {}", path.display()))?;
-    validate_skills_lockfile(&lockfile, path)?;
-    Ok(lockfile)
+    load_registry::load_skills_lockfile(path)
 }
 
 pub fn write_skills_lockfile(
@@ -512,119 +229,11 @@ pub fn write_skills_lockfile(
     lock_path: &Path,
     hints: &[SkillLockHint],
 ) -> Result<SkillsLockfile> {
-    if !skills_dir.exists() {
-        fs::create_dir_all(skills_dir)
-            .with_context(|| format!("failed to create {}", skills_dir.display()))?;
-    }
-
-    let mut hint_by_file = HashMap::new();
-    for hint in hints {
-        hint_by_file.insert(hint.file.clone(), hint.source.clone());
-    }
-
-    let mut existing_source_by_file = HashMap::new();
-    if lock_path.exists() {
-        let existing = load_skills_lockfile(lock_path)?;
-        for entry in existing.entries {
-            existing_source_by_file.insert(entry.file, entry.source);
-        }
-    }
-
-    let catalog = load_catalog(skills_dir)?;
-    let mut entries = Vec::new();
-    for skill in catalog {
-        let file = skill
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| anyhow!("invalid installed skill path '{}'", skill.path.display()))?
-            .to_string();
-        let source = hint_by_file
-            .get(&file)
-            .cloned()
-            .or_else(|| existing_source_by_file.get(&file).cloned())
-            .unwrap_or(SkillLockSource::Unknown);
-        entries.push(SkillLockEntry {
-            name: skill.name,
-            file,
-            sha256: sha256_hex(skill.content.as_bytes()),
-            source,
-        });
-    }
-    entries.sort_by(|left, right| left.file.cmp(&right.file));
-
-    let lockfile = SkillsLockfile {
-        schema_version: SKILLS_LOCK_SCHEMA_VERSION,
-        entries,
-    };
-    validate_skills_lockfile(&lockfile, lock_path)?;
-
-    if let Some(parent) = lock_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create lockfile directory {}", parent.display())
-            })?;
-        }
-    }
-    let mut encoded = serde_json::to_vec_pretty(&lockfile).context("failed to encode lockfile")?;
-    encoded.push(b'\n');
-    fs::write(lock_path, encoded)
-        .with_context(|| format!("failed to write skills lockfile {}", lock_path.display()))?;
-
-    Ok(lockfile)
+    load_registry::write_skills_lockfile(skills_dir, lock_path, hints)
 }
 
 pub fn sync_skills_with_lockfile(skills_dir: &Path, lock_path: &Path) -> Result<SkillsSyncReport> {
-    let lockfile = load_skills_lockfile(lock_path)?;
-
-    let mut expected = HashMap::new();
-    for entry in &lockfile.entries {
-        expected.insert(entry.file.clone(), entry.sha256.clone());
-    }
-
-    let mut actual = HashMap::new();
-    for skill in load_catalog(skills_dir)? {
-        let file = skill
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| anyhow!("invalid installed skill path '{}'", skill.path.display()))?
-            .to_string();
-        actual.insert(file, sha256_hex(skill.content.as_bytes()));
-    }
-
-    let mut report = SkillsSyncReport {
-        expected_entries: expected.len(),
-        actual_entries: actual.len(),
-        ..SkillsSyncReport::default()
-    };
-    for entry in &lockfile.entries {
-        if let Some(reason) = lock_entry_metadata_mismatch(entry) {
-            report
-                .metadata_mismatch
-                .push(format!("{}: {}", entry.file, reason));
-        }
-    }
-
-    for (file, expected_sha) in &expected {
-        match actual.get(file) {
-            None => report.missing.push(file.clone()),
-            Some(actual_sha) if actual_sha != expected_sha => report.changed.push(file.clone()),
-            Some(_) => {}
-        }
-    }
-    for file in actual.keys() {
-        if !expected.contains_key(file) {
-            report.extra.push(file.clone());
-        }
-    }
-
-    report.missing.sort();
-    report.extra.sort();
-    report.changed.sort();
-    report.metadata_mismatch.sort();
-
-    Ok(report)
+    load_registry::sync_skills_with_lockfile(skills_dir, lock_path)
 }
 
 pub async fn fetch_registry_manifest_with_cache(
@@ -632,93 +241,7 @@ pub async fn fetch_registry_manifest_with_cache(
     expected_sha256: Option<&str>,
     options: &SkillsDownloadOptions,
 ) -> Result<SkillRegistryManifest> {
-    let url = Url::parse(registry_url)
-        .with_context(|| format!("invalid registry URL '{}'", registry_url))?;
-    if !matches!(url.scheme(), "http" | "https") {
-        bail!("unsupported registry URL scheme '{}'", url.scheme());
-    }
-
-    let cache_path = options
-        .cache_dir
-        .as_deref()
-        .map(|cache_dir| registry_manifest_cache_path(cache_dir, registry_url));
-    if options.offline {
-        let cache_path = cache_path
-            .ok_or_else(|| anyhow!("offline mode requires a configured skills cache directory"))?;
-        let bytes = read_cached_payload(&cache_path)
-            .with_context(|| format!("offline cache miss for registry '{}'", registry_url))?;
-        validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)?;
-        return parse_registry_manifest(registry_url, &bytes);
-    }
-
-    if let Some(cache_path) = cache_path.as_deref() {
-        if expected_sha256.is_some() {
-            if let Ok(bytes) = read_cached_payload(cache_path) {
-                if validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)
-                    .is_ok()
-                {
-                    if let Ok(manifest) = parse_registry_manifest(registry_url, &bytes) {
-                        return Ok(manifest);
-                    }
-                }
-            }
-        }
-    }
-
-    let response = reqwest::Client::new()
-        .get(url)
-        .send()
-        .await
-        .with_context(|| format!("failed to fetch registry '{}'", registry_url))?;
-    if !response.status().is_success() {
-        bail!(
-            "failed to fetch registry '{}' with status {}",
-            registry_url,
-            response.status()
-        );
-    }
-    let bytes = response
-        .bytes()
-        .await
-        .with_context(|| format!("failed to read registry response '{}'", registry_url))?
-        .to_vec();
-
-    validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)?;
-    let manifest = parse_registry_manifest(registry_url, &bytes)?;
-    if let Some(cache_path) = cache_path.as_deref() {
-        write_cached_payload(cache_path, &bytes)
-            .with_context(|| format!("failed to cache registry '{}'", registry_url))?;
-    }
-    Ok(manifest)
-}
-
-fn parse_registry_manifest(registry_url: &str, bytes: &[u8]) -> Result<SkillRegistryManifest> {
-    let manifest = serde_json::from_slice::<SkillRegistryManifest>(bytes)
-        .with_context(|| format!("failed to parse registry '{}'", registry_url))?;
-    if manifest.version == 0 {
-        bail!("registry '{}' has invalid version 0", registry_url);
-    }
-    Ok(manifest)
-}
-
-fn validate_registry_manifest_checksum(
-    registry_url: &str,
-    expected_sha256: Option<&str>,
-    bytes: &[u8],
-) -> Result<()> {
-    if let Some(expected_sha256) = expected_sha256 {
-        let actual_sha256 = sha256_hex(bytes);
-        let expected_sha256 = normalize_sha256(expected_sha256);
-        if actual_sha256 != expected_sha256 {
-            bail!(
-                "registry sha256 mismatch for '{}': expected {}, got {}",
-                registry_url,
-                expected_sha256,
-                actual_sha256
-            );
-        }
-    }
-    Ok(())
+    load_registry::fetch_registry_manifest_with_cache(registry_url, expected_sha256, options).await
 }
 
 pub fn resolve_registry_skill_sources(
@@ -727,420 +250,35 @@ pub fn resolve_registry_skill_sources(
     trust_roots: &[TrustedKey],
     require_signed: bool,
 ) -> Result<Vec<RemoteSkillSource>> {
-    let now_unix = current_unix_timestamp();
-    let trusted_keys = build_trusted_key_map(manifest, trust_roots)?;
-    let mut resolved = Vec::new();
-    for name in selected_names {
-        let entry = manifest
-            .skills
-            .iter()
-            .find(|entry| entry.name == *name)
-            .ok_or_else(|| anyhow!("registry does not contain skill '{}'", name))?;
-
-        if entry.revoked {
-            bail!("registry skill '{}' is revoked", name);
-        }
-        if is_expired(entry.expires_unix, now_unix) {
-            bail!("registry skill '{}' is expired", name);
-        }
-
-        let has_signature = entry.signature.is_some() || entry.signing_key.is_some();
-        if require_signed && !has_signature {
-            bail!(
-                "registry skill '{}' is unsigned but signatures are required",
-                name
-            );
-        }
-
-        if entry.signature.is_some() ^ entry.signing_key.is_some() {
-            bail!(
-                "registry skill '{}' has incomplete signing metadata (both signing_key and signature are required)",
-                name
-            );
-        }
-
-        let (signature, signer_public_key) =
-            if let (Some(signature), Some(signing_key)) = (&entry.signature, &entry.signing_key) {
-                let signer_public_key = trusted_keys.get(signing_key).ok_or_else(|| {
-                    let maybe_signing_key = manifest.keys.iter().find(|key| key.id == *signing_key);
-                    if let Some(signing_key_entry) = maybe_signing_key {
-                        if signing_key_entry.revoked {
-                            anyhow!(
-                                "registry skill '{}' uses revoked signing key '{}'",
-                                name,
-                                signing_key
-                            )
-                        } else if is_expired(signing_key_entry.expires_unix, now_unix) {
-                            anyhow!(
-                                "registry skill '{}' uses expired signing key '{}'",
-                                name,
-                                signing_key
-                            )
-                        } else {
-                            anyhow!(
-                                "registry skill '{}' uses untrusted signing key '{}'",
-                                name,
-                                signing_key
-                            )
-                        }
-                    } else {
-                        anyhow!(
-                            "registry skill '{}' uses untrusted signing key '{}'",
-                            name,
-                            signing_key
-                        )
-                    }
-                })?;
-                (Some(signature.clone()), Some(signer_public_key.clone()))
-            } else {
-                (None, None)
-            };
-
-        resolved.push(RemoteSkillSource {
-            url: entry.url.clone(),
-            sha256: entry.sha256.clone(),
-            signing_key_id: entry.signing_key.clone(),
-            signature,
-            signer_public_key,
-        });
-    }
-
-    Ok(resolved)
+    load_registry::resolve_registry_skill_sources(
+        manifest,
+        selected_names,
+        trust_roots,
+        require_signed,
+    )
 }
 
 pub fn resolve_selected_skills(catalog: &[Skill], selected: &[String]) -> Result<Vec<Skill>> {
-    let mut resolved = Vec::new();
-    for name in selected {
-        let skill = catalog
-            .iter()
-            .find(|skill| skill.name == *name)
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("unknown skill '{}'", name))?;
-        resolved.push(skill);
-    }
-
-    Ok(resolved)
+    load_registry::resolve_selected_skills(catalog, selected)
 }
 
 pub fn augment_system_prompt(base: &str, skills: &[Skill]) -> String {
-    let mut prompt = base.trim_end().to_string();
-    for skill in skills {
-        if !prompt.is_empty() {
-            prompt.push_str("\n\n");
-        }
-
-        prompt.push_str("# Skill: ");
-        prompt.push_str(&skill.name);
-        prompt.push('\n');
-        prompt.push_str(skill.content.trim());
-    }
-
-    prompt
+    load_registry::augment_system_prompt(base, skills)
 }
 
-fn validate_skills_lockfile(lockfile: &SkillsLockfile, path: &Path) -> Result<()> {
-    if lockfile.schema_version != SKILLS_LOCK_SCHEMA_VERSION {
-        bail!(
-            "unsupported skills lockfile schema_version {} in {} (expected {})",
-            lockfile.schema_version,
-            path.display(),
-            SKILLS_LOCK_SCHEMA_VERSION
-        );
-    }
-
-    let mut seen_files = HashSet::new();
-    for entry in &lockfile.entries {
-        if entry.file.trim().is_empty() {
-            bail!(
-                "skills lockfile {} contains an entry with empty file name",
-                path.display()
-            );
-        }
-        if !entry.file.ends_with(".md") {
-            bail!(
-                "skills lockfile {} contains non-markdown entry '{}'",
-                path.display(),
-                entry.file
-            );
-        }
-        if !seen_files.insert(entry.file.clone()) {
-            bail!(
-                "skills lockfile {} contains duplicate entry '{}'",
-                path.display(),
-                entry.file
-            );
-        }
-        if entry.sha256.trim().is_empty() {
-            bail!(
-                "skills lockfile {} contains empty sha256 for '{}'",
-                path.display(),
-                entry.file
-            );
-        }
-    }
-
-    Ok(())
-}
-
-fn lock_entry_metadata_mismatch(entry: &SkillLockEntry) -> Option<String> {
-    match &entry.source {
-        SkillLockSource::Remote {
-            expected_sha256,
-            signature,
-            signature_sha256,
-            ..
-        }
-        | SkillLockSource::Registry {
-            expected_sha256,
-            signature,
-            signature_sha256,
-            ..
-        } => {
-            if let Some(expected_sha256) = expected_sha256 {
-                let normalized_expected = normalize_sha256(expected_sha256);
-                if normalized_expected != entry.sha256 {
-                    return Some(format!(
-                        "expected_sha256 {} does not match lockfile sha256 {}",
-                        normalized_expected, entry.sha256
-                    ));
-                }
-            }
-
-            match (signature.as_deref(), signature_sha256.as_deref()) {
-                (Some(signature), Some(signature_sha256)) => {
-                    let expected_digest = normalize_sha256(signature_sha256);
-                    let actual_digest = signature_digest_sha256_hex(signature);
-                    if expected_digest != actual_digest {
-                        return Some(format!(
-                            "signature_sha256 {} does not match computed digest {}",
-                            expected_digest, actual_digest
-                        ));
-                    }
-                }
-                (Some(_), None) => {
-                    return Some("signature_sha256 missing for signed source".to_string())
-                }
-                (None, Some(_)) => {
-                    return Some("signature_sha256 is present without signature".to_string())
-                }
-                (None, None) => {}
-            }
-        }
-        SkillLockSource::Unknown | SkillLockSource::Local { .. } => {}
-    }
-    None
-}
-
-fn build_trusted_key_map(
-    manifest: &SkillRegistryManifest,
-    trust_roots: &[TrustedKey],
-) -> Result<HashMap<String, String>> {
-    let now_unix = current_unix_timestamp();
-    let mut trusted = HashMap::new();
-    for root in trust_roots {
-        let root_public_key = root.public_key.trim().to_string();
-        let root_key_bytes =
-            decode_base64_fixed::<32>("trusted root public key", &root_public_key)?;
-        let _ = VerifyingKey::from_bytes(&root_key_bytes)
-            .with_context(|| format!("invalid trusted root key '{}'", root.id))?;
-
-        if let Some(existing) = trusted.get(&root.id) {
-            if existing != &root_public_key {
-                bail!(
-                    "duplicate trusted root id '{}' has conflicting keys",
-                    root.id
-                );
-            }
-            continue;
-        }
-        trusted.insert(root.id.clone(), root_public_key);
-    }
-
-    let mut manifest_keys = HashMap::new();
-    for key in &manifest.keys {
-        if manifest_keys.insert(key.id.clone(), key).is_some() {
-            bail!("registry contains duplicate key id '{}'", key.id);
-        }
-        if key.signed_by.is_some() ^ key.signature.is_some() {
-            bail!(
-                "registry key '{}' has incomplete signing metadata (signed_by and signature are required together)",
-                key.id
-            );
-        }
-    }
-
-    for root in trust_roots {
-        if let Some(manifest_root) = manifest_keys.get(&root.id) {
-            if manifest_root.revoked {
-                bail!("trusted root '{}' is revoked in registry manifest", root.id);
-            }
-            if is_expired(manifest_root.expires_unix, now_unix) {
-                bail!("trusted root '{}' is expired in registry manifest", root.id);
-            }
-            if manifest_root.public_key.trim() != root.public_key.trim() {
-                bail!(
-                    "trusted root '{}' does not match registry key material",
-                    root.id
-                );
-            }
-        }
-    }
-
-    loop {
-        let mut progressed = false;
-        for key in &manifest.keys {
-            if trusted.contains_key(&key.id) {
-                continue;
-            }
-            if key.revoked || is_expired(key.expires_unix, now_unix) {
-                continue;
-            }
-
-            let (Some(signed_by), Some(signature)) = (&key.signed_by, &key.signature) else {
-                continue;
-            };
-            let Some(signer_public_key) = trusted.get(signed_by).cloned() else {
-                continue;
-            };
-
-            verify_ed25519_signature(
-                key_certificate_payload(key).as_bytes(),
-                signature,
-                &signer_public_key,
-            )
-            .with_context(|| {
-                format!(
-                    "failed to verify registry key '{}' signed by '{}'",
-                    key.id, signed_by
-                )
-            })?;
-
-            trusted.insert(key.id.clone(), key.public_key.trim().to_string());
-            progressed = true;
-        }
-
-        if !progressed {
-            break;
-        }
-    }
-
-    Ok(trusted)
-}
-
-fn verify_ed25519_signature(
-    message: &[u8],
-    signature_base64: &str,
-    public_key_base64: &str,
-) -> Result<()> {
-    let public_key_bytes = decode_base64_fixed::<32>("public key", public_key_base64)?;
-    let signature_bytes = decode_base64_fixed::<64>("signature", signature_base64)?;
-    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
-        .context("failed to decode ed25519 public key bytes")?;
-    let signature = Signature::from_bytes(&signature_bytes);
-    verifying_key
-        .verify_strict(message, &signature)
-        .map_err(|error| anyhow!("invalid ed25519 signature: {error}"))?;
-    Ok(())
-}
-
-fn decode_base64_fixed<const N: usize>(label: &str, value: &str) -> Result<[u8; N]> {
-    let decoded = BASE64
-        .decode(value.trim())
-        .with_context(|| format!("failed to decode {label} from base64"))?;
-    let bytes: [u8; N] = decoded
-        .try_into()
-        .map_err(|_| anyhow!("{label} must decode to {N} bytes"))?;
-    Ok(bytes)
-}
-
-fn key_certificate_payload(key: &RegistryKeyEntry) -> String {
-    format!("tau-skill-key-v1:{}:{}", key.id, key.public_key.trim())
-}
-
+#[cfg(test)]
 fn current_unix_timestamp() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
+    trust_policy::current_unix_timestamp()
 }
 
-fn is_expired(expires_unix: Option<u64>, now_unix: u64) -> bool {
-    matches!(expires_unix, Some(expires_unix) if expires_unix <= now_unix)
-}
-
-fn upsert_skill_file(
-    destination: &Path,
-    content: &str,
-    report: &mut SkillInstallReport,
-) -> Result<()> {
-    if destination.exists() {
-        let existing = fs::read_to_string(destination)
-            .with_context(|| format!("failed to read installed skill {}", destination.display()))?;
-        if existing == content {
-            report.skipped += 1;
-            return Ok(());
-        }
-
-        fs::write(destination, content.as_bytes())
-            .with_context(|| format!("failed to update skill {}", destination.display()))?;
-        report.updated += 1;
-        return Ok(());
-    }
-
-    fs::write(destination, content.as_bytes())
-        .with_context(|| format!("failed to install skill {}", destination.display()))?;
-    report.installed += 1;
-    Ok(())
-}
-
+#[cfg(test)]
 fn remote_skill_cache_path(cache_dir: &Path, source_url: &str) -> PathBuf {
-    cache_dir
-        .join(SKILLS_CACHE_ARTIFACTS_DIR)
-        .join(format!("{}.bin", sha256_hex(source_url.as_bytes())))
+    load_registry::remote_skill_cache_path(cache_dir, source_url)
 }
 
+#[cfg(test)]
 fn registry_manifest_cache_path(cache_dir: &Path, registry_url: &str) -> PathBuf {
-    cache_dir
-        .join(SKILLS_CACHE_MANIFESTS_DIR)
-        .join(format!("{}.json", sha256_hex(registry_url.as_bytes())))
-}
-
-fn read_cached_payload(path: &Path) -> Result<Vec<u8>> {
-    fs::read(path).with_context(|| format!("failed to read cache file {}", path.display()))
-}
-
-fn write_cached_payload(path: &Path, bytes: &[u8]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create cache directory {}", parent.display()))?;
-    }
-    fs::write(path, bytes).with_context(|| format!("failed to write cache file {}", path.display()))
-}
-
-fn remote_skill_file_name(url: &Url, index: usize) -> String {
-    let base_name = url
-        .path_segments()
-        .and_then(|mut segments| segments.rfind(|segment| !segment.is_empty()))
-        .map(std::string::ToString::to_string)
-        .unwrap_or_else(|| format!("remote-skill-{}", index + 1));
-
-    if base_name.ends_with(".md") {
-        base_name
-    } else {
-        format!("{base_name}.md")
-    }
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
-}
-
-fn signature_digest_sha256_hex(signature: &str) -> String {
-    sha256_hex(signature.trim().as_bytes())
-}
-
-fn normalize_sha256(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
+    load_registry::registry_manifest_cache_path(cache_dir, registry_url)
 }
 
 #[cfg(test)]

--- a/crates/tau-skills/src/load_registry.rs
+++ b/crates/tau-skills/src/load_registry.rs
@@ -1,0 +1,819 @@
+//! Skill loading, registry resolution, cache, and lockfile orchestration.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::Url;
+
+use super::trust_policy::{
+    build_trusted_key_map, current_unix_timestamp, is_expired, normalize_sha256, sha256_hex,
+    signature_digest_sha256_hex, validate_remote_skill_payload,
+    validate_remote_skill_source_metadata,
+};
+use super::{
+    RemoteSkillSource, Skill, SkillInstallReport, SkillLockEntry, SkillLockHint, SkillLockSource,
+    SkillRegistryManifest, SkillsDownloadOptions, SkillsLockfile, SkillsSyncReport, TrustedKey,
+    SKILLS_CACHE_ARTIFACTS_DIR, SKILLS_CACHE_DIR_NAME, SKILLS_CACHE_MANIFESTS_DIR,
+    SKILLS_LOCK_FILE_NAME, SKILLS_LOCK_SCHEMA_VERSION,
+};
+
+pub(super) fn load_catalog(dir: &Path) -> Result<Vec<Skill>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    if !dir.is_dir() {
+        bail!("skills path '{}' is not a directory", dir.display());
+    }
+
+    let mut skills = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+
+        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read skill file {}", path.display()))?;
+        skills.push(Skill {
+            name: stem.to_string(),
+            content,
+            path,
+        });
+    }
+
+    skills.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(skills)
+}
+
+pub(super) fn install_skills(
+    sources: &[PathBuf],
+    destination_dir: &Path,
+) -> Result<SkillInstallReport> {
+    if sources.is_empty() {
+        return Ok(SkillInstallReport::default());
+    }
+
+    fs::create_dir_all(destination_dir)
+        .with_context(|| format!("failed to create {}", destination_dir.display()))?;
+
+    let mut report = SkillInstallReport::default();
+    for source in sources {
+        if source.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            bail!("skill source '{}' must be a .md file", source.display());
+        }
+
+        let file_name = source
+            .file_name()
+            .ok_or_else(|| anyhow!("invalid skill source '{}'", source.display()))?;
+        let destination = destination_dir.join(file_name);
+
+        let content = fs::read_to_string(source)
+            .with_context(|| format!("failed to read skill source {}", source.display()))?;
+        upsert_skill_file(&destination, &content, &mut report)?;
+    }
+
+    Ok(report)
+}
+
+pub(super) fn resolve_remote_skill_sources(
+    urls: &[String],
+    sha256_values: &[String],
+) -> Result<Vec<RemoteSkillSource>> {
+    if sha256_values.is_empty() {
+        return Ok(urls
+            .iter()
+            .map(|url| RemoteSkillSource {
+                url: url.clone(),
+                sha256: None,
+                signing_key_id: None,
+                signature: None,
+                signer_public_key: None,
+            })
+            .collect());
+    }
+
+    if urls.len() != sha256_values.len() {
+        bail!(
+            "--install-skill-url count ({}) must match --install-skill-sha256 count ({})",
+            urls.len(),
+            sha256_values.len()
+        );
+    }
+
+    Ok(urls
+        .iter()
+        .zip(sha256_values.iter())
+        .map(|(url, sha256)| RemoteSkillSource {
+            url: url.clone(),
+            sha256: Some(sha256.clone()),
+            signing_key_id: None,
+            signature: None,
+            signer_public_key: None,
+        })
+        .collect())
+}
+
+pub(super) async fn install_remote_skills_with_cache(
+    sources: &[RemoteSkillSource],
+    destination_dir: &Path,
+    options: &SkillsDownloadOptions,
+) -> Result<SkillInstallReport> {
+    if sources.is_empty() {
+        return Ok(SkillInstallReport::default());
+    }
+
+    fs::create_dir_all(destination_dir)
+        .with_context(|| format!("failed to create {}", destination_dir.display()))?;
+
+    let client = reqwest::Client::new();
+    let mut report = SkillInstallReport::default();
+
+    for (index, source) in sources.iter().enumerate() {
+        let url = Url::parse(&source.url)
+            .with_context(|| format!("invalid skill URL '{}'", source.url))?;
+        if !matches!(url.scheme(), "http" | "https") {
+            bail!("unsupported skill URL scheme '{}'", url.scheme());
+        }
+
+        let cache_path = options
+            .cache_dir
+            .as_deref()
+            .map(|cache_dir| remote_skill_cache_path(cache_dir, &source.url));
+        let bytes = fetch_remote_skill_bytes(
+            &client,
+            &url,
+            source,
+            cache_path.as_deref(),
+            options.offline,
+        )
+        .await?;
+
+        let file_name = remote_skill_file_name(&url, index);
+        let destination = destination_dir.join(file_name);
+        let content = String::from_utf8(bytes)
+            .with_context(|| format!("skill content from '{}' is not UTF-8", source.url))?;
+
+        upsert_skill_file(&destination, &content, &mut report)?;
+    }
+
+    Ok(report)
+}
+
+async fn fetch_remote_skill_bytes(
+    client: &reqwest::Client,
+    url: &Url,
+    source: &RemoteSkillSource,
+    cache_path: Option<&Path>,
+    offline: bool,
+) -> Result<Vec<u8>> {
+    validate_remote_skill_source_metadata(source)?;
+    if offline {
+        let cache_path = cache_path
+            .ok_or_else(|| anyhow!("offline mode requires a configured skills cache directory"))?;
+        let bytes = read_cached_payload(cache_path)
+            .with_context(|| format!("offline cache miss for skill URL '{}'", source.url))?;
+        validate_remote_skill_payload(source, &bytes).with_context(|| {
+            format!(
+                "cached skill payload validation failed for '{}'",
+                source.url
+            )
+        })?;
+        return Ok(bytes);
+    }
+
+    if let Some(cache_path) = cache_path {
+        if should_reuse_cached_remote_payload(source) {
+            if let Ok(bytes) = read_cached_payload(cache_path) {
+                if validate_remote_skill_payload(source, &bytes).is_ok() {
+                    return Ok(bytes);
+                }
+            }
+        }
+    }
+
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch skill URL '{}'", source.url))?;
+    if !response.status().is_success() {
+        bail!(
+            "failed to fetch skill URL '{}' with status {}",
+            source.url,
+            response.status()
+        );
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read skill response '{}'", source.url))?
+        .to_vec();
+
+    validate_remote_skill_payload(source, &bytes)?;
+    if let Some(cache_path) = cache_path {
+        write_cached_payload(cache_path, &bytes)
+            .with_context(|| format!("failed to cache skill URL '{}'", source.url))?;
+    }
+    Ok(bytes)
+}
+
+fn should_reuse_cached_remote_payload(source: &RemoteSkillSource) -> bool {
+    source.sha256.is_some() || source.signature.is_some()
+}
+
+pub(super) fn default_skills_lock_path(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(SKILLS_LOCK_FILE_NAME)
+}
+
+pub(super) fn default_skills_cache_dir(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(SKILLS_CACHE_DIR_NAME)
+}
+
+pub(super) fn build_local_skill_lock_hints(sources: &[PathBuf]) -> Result<Vec<SkillLockHint>> {
+    let mut hints = Vec::new();
+    for source in sources {
+        if source.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            bail!("skill source '{}' must be a .md file", source.display());
+        }
+        let file = source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| anyhow!("invalid skill source '{}'", source.display()))?
+            .to_string();
+        hints.push(SkillLockHint {
+            file,
+            source: SkillLockSource::Local {
+                path: source.display().to_string(),
+            },
+        });
+    }
+    Ok(hints)
+}
+
+pub(super) fn build_remote_skill_lock_hints(
+    sources: &[RemoteSkillSource],
+) -> Result<Vec<SkillLockHint>> {
+    let mut hints = Vec::new();
+    for (index, source) in sources.iter().enumerate() {
+        let file = remote_skill_file_name_for_source(&source.url, index)?;
+        hints.push(SkillLockHint {
+            file,
+            source: SkillLockSource::Remote {
+                url: source.url.clone(),
+                expected_sha256: source.sha256.clone(),
+                signing_key_id: source.signing_key_id.clone(),
+                signature: source.signature.clone(),
+                signer_public_key: source.signer_public_key.clone(),
+                signature_sha256: source.signature.as_deref().map(signature_digest_sha256_hex),
+            },
+        });
+    }
+    Ok(hints)
+}
+
+pub(super) fn build_registry_skill_lock_hints(
+    registry_url: &str,
+    names: &[String],
+    sources: &[RemoteSkillSource],
+) -> Result<Vec<SkillLockHint>> {
+    if names.len() != sources.len() {
+        bail!(
+            "registry lock hint metadata mismatch: names={}, sources={}",
+            names.len(),
+            sources.len()
+        );
+    }
+    let mut hints = Vec::new();
+    for (index, (name, source)) in names.iter().zip(sources.iter()).enumerate() {
+        let file = remote_skill_file_name_for_source(&source.url, index)?;
+        hints.push(SkillLockHint {
+            file,
+            source: SkillLockSource::Registry {
+                registry_url: registry_url.to_string(),
+                name: name.clone(),
+                url: source.url.clone(),
+                expected_sha256: source.sha256.clone(),
+                signing_key_id: source.signing_key_id.clone(),
+                signature: source.signature.clone(),
+                signer_public_key: source.signer_public_key.clone(),
+                signature_sha256: source.signature.as_deref().map(signature_digest_sha256_hex),
+            },
+        });
+    }
+    Ok(hints)
+}
+
+pub(super) fn remote_skill_file_name_for_source(url: &str, index: usize) -> Result<String> {
+    let url = Url::parse(url).with_context(|| format!("invalid skill URL '{}'", url))?;
+    Ok(remote_skill_file_name(&url, index))
+}
+
+pub(super) fn load_skills_lockfile(path: &Path) -> Result<SkillsLockfile> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read skills lockfile {}", path.display()))?;
+    let lockfile: SkillsLockfile = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse skills lockfile {}", path.display()))?;
+    validate_skills_lockfile(&lockfile, path)?;
+    Ok(lockfile)
+}
+
+pub(super) fn write_skills_lockfile(
+    skills_dir: &Path,
+    lock_path: &Path,
+    hints: &[SkillLockHint],
+) -> Result<SkillsLockfile> {
+    if !skills_dir.exists() {
+        fs::create_dir_all(skills_dir)
+            .with_context(|| format!("failed to create {}", skills_dir.display()))?;
+    }
+
+    let mut hint_by_file = HashMap::new();
+    for hint in hints {
+        hint_by_file.insert(hint.file.clone(), hint.source.clone());
+    }
+
+    let mut existing_source_by_file = HashMap::new();
+    if lock_path.exists() {
+        let existing = load_skills_lockfile(lock_path)?;
+        for entry in existing.entries {
+            existing_source_by_file.insert(entry.file, entry.source);
+        }
+    }
+
+    let catalog = load_catalog(skills_dir)?;
+    let mut entries = Vec::new();
+    for skill in catalog {
+        let file = skill
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| anyhow!("invalid installed skill path '{}'", skill.path.display()))?
+            .to_string();
+        let source = hint_by_file
+            .get(&file)
+            .cloned()
+            .or_else(|| existing_source_by_file.get(&file).cloned())
+            .unwrap_or(SkillLockSource::Unknown);
+        entries.push(SkillLockEntry {
+            name: skill.name,
+            file,
+            sha256: sha256_hex(skill.content.as_bytes()),
+            source,
+        });
+    }
+    entries.sort_by(|left, right| left.file.cmp(&right.file));
+
+    let lockfile = SkillsLockfile {
+        schema_version: SKILLS_LOCK_SCHEMA_VERSION,
+        entries,
+    };
+    validate_skills_lockfile(&lockfile, lock_path)?;
+
+    if let Some(parent) = lock_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create lockfile directory {}", parent.display())
+            })?;
+        }
+    }
+    let mut encoded = serde_json::to_vec_pretty(&lockfile).context("failed to encode lockfile")?;
+    encoded.push(b'\n');
+    fs::write(lock_path, encoded)
+        .with_context(|| format!("failed to write skills lockfile {}", lock_path.display()))?;
+
+    Ok(lockfile)
+}
+
+pub(super) fn sync_skills_with_lockfile(
+    skills_dir: &Path,
+    lock_path: &Path,
+) -> Result<SkillsSyncReport> {
+    let lockfile = load_skills_lockfile(lock_path)?;
+
+    let mut expected = HashMap::new();
+    for entry in &lockfile.entries {
+        expected.insert(entry.file.clone(), entry.sha256.clone());
+    }
+
+    let mut actual = HashMap::new();
+    for skill in load_catalog(skills_dir)? {
+        let file = skill
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| anyhow!("invalid installed skill path '{}'", skill.path.display()))?
+            .to_string();
+        actual.insert(file, sha256_hex(skill.content.as_bytes()));
+    }
+
+    let mut report = SkillsSyncReport {
+        expected_entries: expected.len(),
+        actual_entries: actual.len(),
+        ..SkillsSyncReport::default()
+    };
+    for entry in &lockfile.entries {
+        if let Some(reason) = lock_entry_metadata_mismatch(entry) {
+            report
+                .metadata_mismatch
+                .push(format!("{}: {}", entry.file, reason));
+        }
+    }
+
+    for (file, expected_sha) in &expected {
+        match actual.get(file) {
+            None => report.missing.push(file.clone()),
+            Some(actual_sha) if actual_sha != expected_sha => report.changed.push(file.clone()),
+            Some(_) => {}
+        }
+    }
+    for file in actual.keys() {
+        if !expected.contains_key(file) {
+            report.extra.push(file.clone());
+        }
+    }
+
+    report.missing.sort();
+    report.extra.sort();
+    report.changed.sort();
+    report.metadata_mismatch.sort();
+
+    Ok(report)
+}
+
+pub(super) async fn fetch_registry_manifest_with_cache(
+    registry_url: &str,
+    expected_sha256: Option<&str>,
+    options: &SkillsDownloadOptions,
+) -> Result<SkillRegistryManifest> {
+    let url = Url::parse(registry_url)
+        .with_context(|| format!("invalid registry URL '{}'", registry_url))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        bail!("unsupported registry URL scheme '{}'", url.scheme());
+    }
+
+    let cache_path = options
+        .cache_dir
+        .as_deref()
+        .map(|cache_dir| registry_manifest_cache_path(cache_dir, registry_url));
+    if options.offline {
+        let cache_path = cache_path
+            .ok_or_else(|| anyhow!("offline mode requires a configured skills cache directory"))?;
+        let bytes = read_cached_payload(&cache_path)
+            .with_context(|| format!("offline cache miss for registry '{}'", registry_url))?;
+        validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)?;
+        return parse_registry_manifest(registry_url, &bytes);
+    }
+
+    if let Some(cache_path) = cache_path.as_deref() {
+        if expected_sha256.is_some() {
+            if let Ok(bytes) = read_cached_payload(cache_path) {
+                if validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)
+                    .is_ok()
+                {
+                    if let Ok(manifest) = parse_registry_manifest(registry_url, &bytes) {
+                        return Ok(manifest);
+                    }
+                }
+            }
+        }
+    }
+
+    let response = reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch registry '{}'", registry_url))?;
+    if !response.status().is_success() {
+        bail!(
+            "failed to fetch registry '{}' with status {}",
+            registry_url,
+            response.status()
+        );
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read registry response '{}'", registry_url))?
+        .to_vec();
+
+    validate_registry_manifest_checksum(registry_url, expected_sha256, &bytes)?;
+    let manifest = parse_registry_manifest(registry_url, &bytes)?;
+    if let Some(cache_path) = cache_path.as_deref() {
+        write_cached_payload(cache_path, &bytes)
+            .with_context(|| format!("failed to cache registry '{}'", registry_url))?;
+    }
+    Ok(manifest)
+}
+
+fn parse_registry_manifest(registry_url: &str, bytes: &[u8]) -> Result<SkillRegistryManifest> {
+    let manifest = serde_json::from_slice::<SkillRegistryManifest>(bytes)
+        .with_context(|| format!("failed to parse registry '{}'", registry_url))?;
+    if manifest.version == 0 {
+        bail!("registry '{}' has invalid version 0", registry_url);
+    }
+    Ok(manifest)
+}
+
+fn validate_registry_manifest_checksum(
+    registry_url: &str,
+    expected_sha256: Option<&str>,
+    bytes: &[u8],
+) -> Result<()> {
+    if let Some(expected_sha256) = expected_sha256 {
+        let actual_sha256 = sha256_hex(bytes);
+        let expected_sha256 = normalize_sha256(expected_sha256);
+        if actual_sha256 != expected_sha256 {
+            bail!(
+                "registry sha256 mismatch for '{}': expected {}, got {}",
+                registry_url,
+                expected_sha256,
+                actual_sha256
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn resolve_registry_skill_sources(
+    manifest: &SkillRegistryManifest,
+    selected_names: &[String],
+    trust_roots: &[TrustedKey],
+    require_signed: bool,
+) -> Result<Vec<RemoteSkillSource>> {
+    let now_unix = current_unix_timestamp();
+    let trusted_keys = build_trusted_key_map(manifest, trust_roots)?;
+    let mut resolved = Vec::new();
+    for name in selected_names {
+        let entry = manifest
+            .skills
+            .iter()
+            .find(|entry| entry.name == *name)
+            .ok_or_else(|| anyhow!("registry does not contain skill '{}'", name))?;
+
+        if entry.revoked {
+            bail!("registry skill '{}' is revoked", name);
+        }
+        if is_expired(entry.expires_unix, now_unix) {
+            bail!("registry skill '{}' is expired", name);
+        }
+
+        let has_signature = entry.signature.is_some() || entry.signing_key.is_some();
+        if require_signed && !has_signature {
+            bail!(
+                "registry skill '{}' is unsigned but signatures are required",
+                name
+            );
+        }
+
+        if entry.signature.is_some() ^ entry.signing_key.is_some() {
+            bail!(
+                "registry skill '{}' has incomplete signing metadata (both signing_key and signature are required)",
+                name
+            );
+        }
+
+        let (signature, signer_public_key) =
+            if let (Some(signature), Some(signing_key)) = (&entry.signature, &entry.signing_key) {
+                let signer_public_key = trusted_keys.get(signing_key).ok_or_else(|| {
+                    let maybe_signing_key = manifest.keys.iter().find(|key| key.id == *signing_key);
+                    if let Some(signing_key_entry) = maybe_signing_key {
+                        if signing_key_entry.revoked {
+                            anyhow!(
+                                "registry skill '{}' uses revoked signing key '{}'",
+                                name,
+                                signing_key
+                            )
+                        } else if is_expired(signing_key_entry.expires_unix, now_unix) {
+                            anyhow!(
+                                "registry skill '{}' uses expired signing key '{}'",
+                                name,
+                                signing_key
+                            )
+                        } else {
+                            anyhow!(
+                                "registry skill '{}' uses untrusted signing key '{}'",
+                                name,
+                                signing_key
+                            )
+                        }
+                    } else {
+                        anyhow!(
+                            "registry skill '{}' uses untrusted signing key '{}'",
+                            name,
+                            signing_key
+                        )
+                    }
+                })?;
+                (Some(signature.clone()), Some(signer_public_key.clone()))
+            } else {
+                (None, None)
+            };
+
+        resolved.push(RemoteSkillSource {
+            url: entry.url.clone(),
+            sha256: entry.sha256.clone(),
+            signing_key_id: entry.signing_key.clone(),
+            signature,
+            signer_public_key,
+        });
+    }
+
+    Ok(resolved)
+}
+
+pub(super) fn resolve_selected_skills(
+    catalog: &[Skill],
+    selected: &[String],
+) -> Result<Vec<Skill>> {
+    let mut resolved = Vec::new();
+    for name in selected {
+        let skill = catalog
+            .iter()
+            .find(|skill| skill.name == *name)
+            .cloned()
+            .ok_or_else(|| anyhow!("unknown skill '{}'", name))?;
+        resolved.push(skill);
+    }
+
+    Ok(resolved)
+}
+
+pub(super) fn augment_system_prompt(base: &str, skills: &[Skill]) -> String {
+    let mut prompt = base.trim_end().to_string();
+    for skill in skills {
+        if !prompt.is_empty() {
+            prompt.push_str("\n\n");
+        }
+
+        prompt.push_str("# Skill: ");
+        prompt.push_str(&skill.name);
+        prompt.push('\n');
+        prompt.push_str(skill.content.trim());
+    }
+
+    prompt
+}
+
+fn validate_skills_lockfile(lockfile: &SkillsLockfile, path: &Path) -> Result<()> {
+    if lockfile.schema_version != SKILLS_LOCK_SCHEMA_VERSION {
+        bail!(
+            "unsupported skills lockfile schema_version {} in {} (expected {})",
+            lockfile.schema_version,
+            path.display(),
+            SKILLS_LOCK_SCHEMA_VERSION
+        );
+    }
+
+    let mut seen_files = HashSet::new();
+    for entry in &lockfile.entries {
+        if entry.file.trim().is_empty() {
+            bail!(
+                "skills lockfile {} contains an entry with empty file name",
+                path.display()
+            );
+        }
+        if !entry.file.ends_with(".md") {
+            bail!(
+                "skills lockfile {} contains non-markdown entry '{}'",
+                path.display(),
+                entry.file
+            );
+        }
+        if !seen_files.insert(entry.file.clone()) {
+            bail!(
+                "skills lockfile {} contains duplicate entry '{}'",
+                path.display(),
+                entry.file
+            );
+        }
+        if entry.sha256.trim().is_empty() {
+            bail!(
+                "skills lockfile {} contains empty sha256 for '{}'",
+                path.display(),
+                entry.file
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn lock_entry_metadata_mismatch(entry: &SkillLockEntry) -> Option<String> {
+    match &entry.source {
+        SkillLockSource::Remote {
+            expected_sha256,
+            signature,
+            signature_sha256,
+            ..
+        }
+        | SkillLockSource::Registry {
+            expected_sha256,
+            signature,
+            signature_sha256,
+            ..
+        } => {
+            if let Some(expected_sha256) = expected_sha256 {
+                let normalized_expected = normalize_sha256(expected_sha256);
+                if normalized_expected != entry.sha256 {
+                    return Some(format!(
+                        "expected_sha256 {} does not match lockfile sha256 {}",
+                        normalized_expected, entry.sha256
+                    ));
+                }
+            }
+
+            match (signature.as_deref(), signature_sha256.as_deref()) {
+                (Some(signature), Some(signature_sha256)) => {
+                    let expected_digest = normalize_sha256(signature_sha256);
+                    let actual_digest = signature_digest_sha256_hex(signature);
+                    if expected_digest != actual_digest {
+                        return Some(format!(
+                            "signature_sha256 {} does not match computed digest {}",
+                            expected_digest, actual_digest
+                        ));
+                    }
+                }
+                (Some(_), None) => {
+                    return Some("signature_sha256 missing for signed source".to_string())
+                }
+                (None, Some(_)) => {
+                    return Some("signature_sha256 is present without signature".to_string())
+                }
+                (None, None) => {}
+            }
+        }
+        SkillLockSource::Unknown | SkillLockSource::Local { .. } => {}
+    }
+    None
+}
+
+fn upsert_skill_file(
+    destination: &Path,
+    content: &str,
+    report: &mut SkillInstallReport,
+) -> Result<()> {
+    if destination.exists() {
+        let existing = fs::read_to_string(destination)
+            .with_context(|| format!("failed to read installed skill {}", destination.display()))?;
+        if existing == content {
+            report.skipped += 1;
+            return Ok(());
+        }
+
+        fs::write(destination, content.as_bytes())
+            .with_context(|| format!("failed to update skill {}", destination.display()))?;
+        report.updated += 1;
+        return Ok(());
+    }
+
+    fs::write(destination, content.as_bytes())
+        .with_context(|| format!("failed to install skill {}", destination.display()))?;
+    report.installed += 1;
+    Ok(())
+}
+
+pub(super) fn remote_skill_cache_path(cache_dir: &Path, source_url: &str) -> PathBuf {
+    cache_dir
+        .join(SKILLS_CACHE_ARTIFACTS_DIR)
+        .join(format!("{}.bin", sha256_hex(source_url.as_bytes())))
+}
+
+pub(super) fn registry_manifest_cache_path(cache_dir: &Path, registry_url: &str) -> PathBuf {
+    cache_dir
+        .join(SKILLS_CACHE_MANIFESTS_DIR)
+        .join(format!("{}.json", sha256_hex(registry_url.as_bytes())))
+}
+
+fn read_cached_payload(path: &Path) -> Result<Vec<u8>> {
+    fs::read(path).with_context(|| format!("failed to read cache file {}", path.display()))
+}
+
+fn write_cached_payload(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create cache directory {}", parent.display()))?;
+    }
+    fs::write(path, bytes).with_context(|| format!("failed to write cache file {}", path.display()))
+}
+
+fn remote_skill_file_name(url: &Url, index: usize) -> String {
+    let base_name = url
+        .path_segments()
+        .and_then(|mut segments| segments.rfind(|segment| !segment.is_empty()))
+        .map(std::string::ToString::to_string)
+        .unwrap_or_else(|| format!("remote-skill-{}", index + 1));
+
+    if base_name.ends_with(".md") {
+        base_name
+    } else {
+        format!("{base_name}.md")
+    }
+}

--- a/crates/tau-skills/src/trust_policy.rs
+++ b/crates/tau-skills/src/trust_policy.rs
@@ -1,0 +1,195 @@
+//! Trust-chain and signature verification policy helpers for skills.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use ed25519_dalek::{Signature, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use super::{RegistryKeyEntry, RemoteSkillSource, SkillRegistryManifest, TrustedKey};
+
+pub(super) fn validate_remote_skill_source_metadata(source: &RemoteSkillSource) -> Result<()> {
+    if source.signature.is_some() ^ source.signer_public_key.is_some() {
+        bail!(
+            "incomplete signature metadata for '{}': both signature and signer public key are required",
+            source.url
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn validate_remote_skill_payload(
+    source: &RemoteSkillSource,
+    bytes: &[u8],
+) -> Result<()> {
+    if let Some(expected_sha256) = &source.sha256 {
+        let actual_sha256 = sha256_hex(bytes);
+        let expected_sha256 = normalize_sha256(expected_sha256);
+        if actual_sha256 != expected_sha256 {
+            bail!(
+                "sha256 mismatch for '{}': expected {}, got {}",
+                source.url,
+                expected_sha256,
+                actual_sha256
+            );
+        }
+    }
+
+    if let (Some(signature), Some(signer_public_key)) =
+        (&source.signature, &source.signer_public_key)
+    {
+        verify_ed25519_signature(bytes, signature, signer_public_key)
+            .with_context(|| format!("signature verification failed for '{}'", source.url))?;
+    }
+    Ok(())
+}
+
+pub(super) fn build_trusted_key_map(
+    manifest: &SkillRegistryManifest,
+    trust_roots: &[TrustedKey],
+) -> Result<HashMap<String, String>> {
+    let now_unix = current_unix_timestamp();
+    let mut trusted = HashMap::new();
+    for root in trust_roots {
+        let root_public_key = root.public_key.trim().to_string();
+        let root_key_bytes =
+            decode_base64_fixed::<32>("trusted root public key", &root_public_key)?;
+        let _ = VerifyingKey::from_bytes(&root_key_bytes)
+            .with_context(|| format!("invalid trusted root key '{}'", root.id))?;
+
+        if let Some(existing) = trusted.get(&root.id) {
+            if existing != &root_public_key {
+                bail!(
+                    "duplicate trusted root id '{}' has conflicting keys",
+                    root.id
+                );
+            }
+            continue;
+        }
+        trusted.insert(root.id.clone(), root_public_key);
+    }
+
+    let mut manifest_keys = HashMap::new();
+    for key in &manifest.keys {
+        if manifest_keys.insert(key.id.clone(), key).is_some() {
+            bail!("registry contains duplicate key id '{}'", key.id);
+        }
+        if key.signed_by.is_some() ^ key.signature.is_some() {
+            bail!(
+                "registry key '{}' has incomplete signing metadata (signed_by and signature are required together)",
+                key.id
+            );
+        }
+    }
+
+    for root in trust_roots {
+        if let Some(manifest_root) = manifest_keys.get(&root.id) {
+            if manifest_root.revoked {
+                bail!("trusted root '{}' is revoked in registry manifest", root.id);
+            }
+            if is_expired(manifest_root.expires_unix, now_unix) {
+                bail!("trusted root '{}' is expired in registry manifest", root.id);
+            }
+            if manifest_root.public_key.trim() != root.public_key.trim() {
+                bail!(
+                    "trusted root '{}' does not match registry key material",
+                    root.id
+                );
+            }
+        }
+    }
+
+    loop {
+        let mut progressed = false;
+        for key in &manifest.keys {
+            if trusted.contains_key(&key.id) {
+                continue;
+            }
+            if key.revoked || is_expired(key.expires_unix, now_unix) {
+                continue;
+            }
+
+            let (Some(signed_by), Some(signature)) = (&key.signed_by, &key.signature) else {
+                continue;
+            };
+            let Some(signer_public_key) = trusted.get(signed_by).cloned() else {
+                continue;
+            };
+
+            verify_ed25519_signature(
+                key_certificate_payload(key).as_bytes(),
+                signature,
+                &signer_public_key,
+            )
+            .with_context(|| {
+                format!(
+                    "failed to verify registry key '{}' signed by '{}'",
+                    key.id, signed_by
+                )
+            })?;
+
+            trusted.insert(key.id.clone(), key.public_key.trim().to_string());
+            progressed = true;
+        }
+
+        if !progressed {
+            break;
+        }
+    }
+
+    Ok(trusted)
+}
+
+pub(super) fn verify_ed25519_signature(
+    message: &[u8],
+    signature_base64: &str,
+    public_key_base64: &str,
+) -> Result<()> {
+    let public_key_bytes = decode_base64_fixed::<32>("public key", public_key_base64)?;
+    let signature_bytes = decode_base64_fixed::<64>("signature", signature_base64)?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+        .context("failed to decode ed25519 public key bytes")?;
+    let signature = Signature::from_bytes(&signature_bytes);
+    verifying_key
+        .verify_strict(message, &signature)
+        .map_err(|error| anyhow!("invalid ed25519 signature: {error}"))?;
+    Ok(())
+}
+
+fn decode_base64_fixed<const N: usize>(label: &str, value: &str) -> Result<[u8; N]> {
+    let decoded = BASE64
+        .decode(value.trim())
+        .with_context(|| format!("failed to decode {label} from base64"))?;
+    let bytes: [u8; N] = decoded
+        .try_into()
+        .map_err(|_| anyhow!("{label} must decode to {N} bytes"))?;
+    Ok(bytes)
+}
+
+fn key_certificate_payload(key: &RegistryKeyEntry) -> String {
+    format!("tau-skill-key-v1:{}:{}", key.id, key.public_key.trim())
+}
+
+pub(super) fn current_unix_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+pub(super) fn is_expired(expires_unix: Option<u64>, now_unix: u64) -> bool {
+    matches!(expires_unix, Some(expires_unix) if expires_unix <= now_unix)
+}
+
+pub(super) fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+pub(super) fn signature_digest_sha256_hex(signature: &str) -> String {
+    sha256_hex(signature.trim().as_bytes())
+}
+
+pub(super) fn normalize_sha256(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}

--- a/scripts/dev/test-skills-lib-domain-split.sh
+++ b/scripts/dev/test-skills-lib-domain-split.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+lib_file="crates/tau-skills/src/lib.rs"
+load_file="crates/tau-skills/src/load_registry.rs"
+trust_file="crates/tau-skills/src/trust_policy.rs"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected to find '${needle}'" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected to NOT find '${needle}'" >&2
+    exit 1
+  fi
+}
+
+line_count="$(wc -l < "${lib_file}" | tr -d ' ')"
+if (( line_count >= 1800 )); then
+  echo "assertion failed (line budget): expected ${lib_file} < 1800 lines, got ${line_count}" >&2
+  exit 1
+fi
+
+for file in "${load_file}" "${trust_file}"; do
+  if [[ ! -f "${file}" ]]; then
+    echo "assertion failed (module file): missing ${file}" >&2
+    exit 1
+  fi
+done
+
+lib_contents="$(cat "${lib_file}")"
+
+assert_contains "${lib_contents}" "mod load_registry;" "module marker: load registry"
+assert_contains "${lib_contents}" "mod trust_policy;" "module marker: trust policy"
+assert_contains "${lib_contents}" "pub fn load_catalog(" "public api: load_catalog"
+assert_contains "${lib_contents}" "pub fn resolve_registry_skill_sources(" "public api: resolve_registry_skill_sources"
+
+assert_not_contains "${lib_contents}" "fn fetch_remote_skill_bytes(" "moved helper: remote fetch"
+assert_not_contains "${lib_contents}" "fn validate_skills_lockfile(" "moved helper: lockfile validation"
+assert_not_contains "${lib_contents}" "fn build_trusted_key_map(" "moved helper: trust map"
+assert_not_contains "${lib_contents}" "fn verify_ed25519_signature(" "moved helper: signature verify"
+
+echo "skills-lib-domain-split tests passed"

--- a/specs/1688/plan.md
+++ b/specs/1688/plan.md
@@ -1,0 +1,32 @@
+# Issue 1688 Plan
+
+Status: Reviewed
+
+## Approach
+
+1. Split orchestration code by domain:
+   - `load_registry.rs`: catalog loading, install/update, remote fetch/cache, lockfile, registry manifest/source resolution, selection and prompt assembly
+   - `trust_policy.rs`: trust root/key-map validation, signature verification, hash/time helpers
+2. Keep all public entry points defined in `lib.rs`, delegating to new modules to preserve API.
+3. Keep internal test coverage stable by exposing only needed `pub(crate)` helpers for existing tests.
+4. Run scoped verification: targeted tests first, then full `tau-skills` test suite, clippy, and fmt.
+
+## Affected Areas
+
+- `crates/tau-skills/src/lib.rs`
+- `crates/tau-skills/src/load_registry.rs` (new)
+- `crates/tau-skills/src/trust_policy.rs` (new)
+- `specs/1688/*`
+
+## Risks And Mitigations
+
+- Risk: subtle behavior drift during function moves.
+  - Mitigation: move code verbatim where possible; preserve error text and call order.
+- Risk: test visibility breakage for internal helpers.
+  - Mitigation: add minimal `pub(crate)` helper exports used by existing tests.
+- Risk: clippy dead-code warnings from duplicated leftovers.
+  - Mitigation: remove superseded root implementations after delegation.
+
+## ADR
+
+No dependency/protocol/architecture decision beyond internal module decomposition. ADR not required.

--- a/specs/1688/spec.md
+++ b/specs/1688/spec.md
@@ -1,0 +1,63 @@
+# Issue 1688 Spec
+
+Status: Implemented
+
+Issue: `#1688`  
+Milestone: `#21`  
+Parent: `#1623`
+
+## Problem Statement
+
+`crates/tau-skills/src/lib.rs` is a large monolith that mixes command-facing API, load/registry orchestration, trust-policy verification, and helper internals in one file. This obscures module boundaries and increases review/maintenance risk.
+
+## Scope
+
+In scope:
+
+- extract loading/registry/cache/lockfile orchestration from `lib.rs` into dedicated module(s)
+- extract trust/policy/signature verification orchestration from `lib.rs` into dedicated module(s)
+- keep `lib.rs` as a composition surface with unchanged public API
+- preserve existing runtime behavior and test outcomes
+
+Out of scope:
+
+- protocol/CLI/wire-format changes
+- dependency changes
+- feature additions
+
+## Acceptance Criteria
+
+AC-1 (composition surface):
+Given `crates/tau-skills/src/lib.rs`,
+when reviewing module structure,
+then orchestration logic is delegated into focused modules and `lib.rs` primarily composes/re-exports API.
+
+AC-2 (public API stability):
+Given existing callers of `tau-skills` public functions,
+when compiling and running tests,
+then signatures and externally visible behavior remain unchanged.
+
+AC-3 (trust and registry behavior parity):
+Given trust/signature and registry resolution flows,
+when running targeted tests,
+then all pre-existing trust/registry conformance behavior remains green.
+
+AC-4 (regression safety):
+Given scoped quality checks,
+when running fmt/clippy/tests,
+then the crate passes with no new warnings or regressions.
+
+## Conformance Cases
+
+| Case | Maps To | Tier | Given / When / Then |
+| --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | Given `tau-skills/src/lib.rs`, when inspected, then `load_registry` and `trust_policy` modules own orchestration bodies while `lib.rs` delegates. |
+| C-02 | AC-2 | Conformance | Given existing public APIs (`load_catalog`, `install_skills`, lockfile and registry helpers), when compiling tests, then signatures remain unchanged and call sites compile without adapter shims. |
+| C-03 | AC-3 | Integration | Given trust-chain and registry tests, when run, then signed/unsigned, revoked/expired, and checksum/signature cases preserve behavior. |
+| C-04 | AC-4 | Regression | Given crate checks, when `cargo fmt --check`, strict clippy, and `cargo test -p tau-skills` run, then all pass. |
+
+## Success Metrics
+
+- `lib.rs` line count reduced with orchestration moved into focused modules
+- no public API breakage in `tau-skills`
+- targeted + full crate tests remain green

--- a/specs/1688/tasks.md
+++ b/specs/1688/tasks.md
@@ -1,0 +1,22 @@
+# Issue 1688 Tasks
+
+Status: Implemented
+
+## Ordered Tasks
+
+T1 (tests-first): run a focused `tau-skills` test selection touching load/registry/trust flows to establish baseline RED/GREEN evidence anchor.
+
+T2: create `load_registry.rs` and move load/registry/cache/lockfile orchestration and helper internals.
+
+T3: create `trust_policy.rs` and move trust/signature/hash/time orchestration and helper internals.
+
+T4: refactor `lib.rs` into composition/delegation surface, preserving public API and required `pub(crate)` helpers.
+
+T5: run verification (`cargo test -p tau-skills`, strict clippy for crate, `cargo fmt --check`) and capture evidence.
+
+## Tier Mapping
+
+- Unit: existing unit tests in `tau-skills` remain green
+- Functional: module split conformance (`lib.rs` delegates)
+- Integration: trust + registry + remote/cache flows
+- Regression: full crate tests + lint/format checks


### PR DESCRIPTION
## Summary
Split `tau-skills` orchestration out of `src/lib.rs` into focused `load_registry` and `trust_policy` modules while preserving public API behavior. `lib.rs` now acts as a composition/delegation surface and the split is guarded by a dedicated harness script.

## Links
- Milestone: #21
- Closes #1688
- Spec: `specs/1688/spec.md`
- Plan: `specs/1688/plan.md`
- Tasks: `specs/1688/tasks.md`

## Spec Verification (AC → tests)

| AC | ✅/❌ | Test(s) |
| --- | --- | --- |
| AC-1: lib.rs is composition surface | ✅ | `scripts/dev/test-skills-lib-domain-split.sh`; structural RED/GREEN line-count + module-marker checks |
| AC-2: public API stability | ✅ | `cargo test -p tau-skills` (all existing call paths compile and pass) |
| AC-3: trust/registry behavior parity | ✅ | `cargo test -p tau-skills resolve_registry_skill_sources`; trust/registry cases in full crate tests |
| AC-4: regression safety | ✅ | `cargo test -p tau-skills`; `cargo clippy -p tau-skills -- -D warnings`; `cargo fmt --check`; `scripts/dev/roadmap-status-sync.sh --check --quiet` |

## TDD Evidence

RED (structural gap before split):
- `git show HEAD^:crates/tau-skills/src/lib.rs | wc -l`
  - `2355` lines (above split budget)
- `git show HEAD^:crates/tau-skills/src/lib.rs | rg 'mod load_registry|mod trust_policy'`
  - no matches

GREEN (post-split):
- `scripts/dev/test-skills-lib-domain-split.sh`
  - `skills-lib-domain-split tests passed`
- `cargo test -p tau-skills resolve_registry_skill_sources`
  - `7 passed; 0 failed`
- `cargo test -p tau-skills`
  - `83 passed; 0 failed`

REGRESSION summary:
- `cargo clippy -p tau-skills -- -D warnings` passed
- `cargo fmt --check` passed
- `scripts/dev/roadmap-status-sync.sh --check --quiet` passed

## Test Tiers

| Tier | ✅/❌/N/A | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | `cargo test -p tau-skills` (unit-prefixed cases) | |
| Property | N/A | None | No property-based invariants were introduced/changed in this refactor. |
| Contract/DbC | N/A | None | No new public contracts or DbC annotations added in this issue. |
| Snapshot | N/A | None | No stable snapshot surface changed. |
| Functional | ✅ | `scripts/dev/test-skills-lib-domain-split.sh`; functional tests in `cargo test -p tau-skills` | |
| Conformance | ✅ | `cargo test -p tau-skills resolve_registry_skill_sources`; conformance mapping in `specs/1688/spec.md` | |
| Integration | ✅ | Integration-prefixed cases in `cargo test -p tau-skills` | |
| Fuzz | N/A | None | No parser/untrusted-input surface changed by this structural split. |
| Mutation | N/A | None | Structural decomposition only; no new algorithmic behavior in critical path for this task. |
| Regression | ✅ | `cargo test -p tau-skills`; targeted trust/registry regression tests | |
| Performance | N/A | None | No hot-path behavioral change; module split only. |

## Mutation
- N/A for this structural refactor issue (no critical-path behavior change).

## Risks / Rollback
- Risk: low; accidental behavior drift from function moves.
- Mitigation: moved implementations preserved verbatim in new modules and validated by full crate tests.
- Rollback: revert this PR commit to restore previous monolithic layout.

## Docs / ADR
- Updated: `specs/1688/spec.md`, `specs/1688/plan.md`, `specs/1688/tasks.md`
- ADR: not required (no dependency/protocol/architecture decision beyond internal file decomposition)
