### PR TITLE
test(m25): add deterministic split-map artifact pipeline

### DIFF
--- a/.github/scripts/test_benchmark_artifact_split_map_contract.py
+++ b/.github/scripts/test_benchmark_artifact_split_map_contract.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+SPLIT_MAP_SCRIPT = REPO_ROOT / "scripts" / "dev" / "benchmark-artifact-split-map.sh"
+SCHEMA_PATH = REPO_ROOT / "tasks" / "schemas" / "m25-benchmark-artifact-split-map.schema.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "benchmark-artifact-split-map.md"
+REPORT_JSON_PATH = REPO_ROOT / "tasks" / "reports" / "m25-benchmark-artifact-split-map.json"
+REPORT_MD_PATH = REPO_ROOT / "tasks" / "reports" / "m25-benchmark-artifact-split-map.md"
+
+REQUIRED_GUIDE_SNIPPETS = (
+    "benchmark-artifact-split-map.sh",
+    "m25-benchmark-artifact-split-map.schema.json",
+    "m25-benchmark-artifact-split-map.json",
+    "m25-benchmark-artifact-split-map.md",
+    "Public API Impact",
+    "Test Migration Plan",
+)
+
+
+class BenchmarkArtifactSplitMapContractTests(unittest.TestCase):
+    def test_unit_required_files_exist(self):
+        self.assertTrue(SPLIT_MAP_SCRIPT.is_file(), msg=f"missing script: {SPLIT_MAP_SCRIPT}")
+        self.assertTrue(SPLIT_MAP_SCRIPT.stat().st_mode & 0o111)
+        self.assertTrue(SCHEMA_PATH.is_file(), msg=f"missing schema: {SCHEMA_PATH}")
+        self.assertTrue(GUIDE_PATH.is_file(), msg=f"missing guide: {GUIDE_PATH}")
+        self.assertTrue(REPORT_JSON_PATH.is_file(), msg=f"missing report json: {REPORT_JSON_PATH}")
+        self.assertTrue(REPORT_MD_PATH.is_file(), msg=f"missing report md: {REPORT_MD_PATH}")
+
+    def test_functional_schema_contract_contains_required_fields(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(schema["$schema"], "https://json-schema.org/draft/2020-12/schema")
+        required = set(schema["required"])
+        self.assertIn("schema_version", required)
+        self.assertIn("generated_at", required)
+        self.assertIn("source_file", required)
+        self.assertIn("target_line_budget", required)
+        self.assertIn("current_line_count", required)
+        self.assertIn("line_gap_to_target", required)
+        self.assertIn("extraction_phases", required)
+        self.assertIn("public_api_impact", required)
+        self.assertIn("test_migration_plan", required)
+
+    def test_integration_guide_references_split_map_contract_artifacts(self):
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        missing = [snippet for snippet in REQUIRED_GUIDE_SNIPPETS if snippet not in guide_text]
+        self.assertEqual(missing, [], msg=f"missing guide snippets: {missing}")
+
+    def test_regression_report_matches_schema_version_and_target_budget(self):
+        payload = json.loads(REPORT_JSON_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["source_file"], "crates/tau-trainer/src/benchmark_artifact.rs")
+        self.assertEqual(payload["target_line_budget"], 3000)
+        self.assertGreater(len(payload["extraction_phases"]), 0)
+        self.assertGreater(len(payload["public_api_impact"]), 0)
+        self.assertGreater(len(payload["test_migration_plan"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_cli_args_split_map_contract.py
+++ b/.github/scripts/test_cli_args_split_map_contract.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+SPLIT_MAP_SCRIPT = REPO_ROOT / "scripts" / "dev" / "cli-args-split-map.sh"
+SCHEMA_PATH = REPO_ROOT / "tasks" / "schemas" / "m25-cli-args-split-map.schema.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "cli-args-split-map.md"
+REPORT_JSON_PATH = REPO_ROOT / "tasks" / "reports" / "m25-cli-args-split-map.json"
+REPORT_MD_PATH = REPO_ROOT / "tasks" / "reports" / "m25-cli-args-split-map.md"
+
+REQUIRED_GUIDE_SNIPPETS = (
+    "cli-args-split-map.sh",
+    "m25-cli-args-split-map.schema.json",
+    "m25-cli-args-split-map.json",
+    "m25-cli-args-split-map.md",
+    "Public API Impact",
+    "Test Migration Plan",
+)
+
+
+class CliArgsSplitMapContractTests(unittest.TestCase):
+    def test_unit_required_files_exist(self):
+        self.assertTrue(SPLIT_MAP_SCRIPT.is_file(), msg=f"missing script: {SPLIT_MAP_SCRIPT}")
+        self.assertTrue(SPLIT_MAP_SCRIPT.stat().st_mode & 0o111)
+        self.assertTrue(SCHEMA_PATH.is_file(), msg=f"missing schema: {SCHEMA_PATH}")
+        self.assertTrue(GUIDE_PATH.is_file(), msg=f"missing guide: {GUIDE_PATH}")
+        self.assertTrue(REPORT_JSON_PATH.is_file(), msg=f"missing report json: {REPORT_JSON_PATH}")
+        self.assertTrue(REPORT_MD_PATH.is_file(), msg=f"missing report md: {REPORT_MD_PATH}")
+
+    def test_functional_schema_contract_contains_required_fields(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(schema["$schema"], "https://json-schema.org/draft/2020-12/schema")
+        required = set(schema["required"])
+        self.assertIn("schema_version", required)
+        self.assertIn("generated_at", required)
+        self.assertIn("source_file", required)
+        self.assertIn("target_line_budget", required)
+        self.assertIn("current_line_count", required)
+        self.assertIn("line_gap_to_target", required)
+        self.assertIn("extraction_phases", required)
+        self.assertIn("public_api_impact", required)
+        self.assertIn("test_migration_plan", required)
+
+    def test_integration_guide_references_split_map_contract_artifacts(self):
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        missing = [snippet for snippet in REQUIRED_GUIDE_SNIPPETS if snippet not in guide_text]
+        self.assertEqual(missing, [], msg=f"missing guide snippets: {missing}")
+
+    def test_regression_report_matches_schema_version_and_target_budget(self):
+        payload = json.loads(REPORT_JSON_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["source_file"], "crates/tau-cli/src/cli_args.rs")
+        self.assertEqual(payload["target_line_budget"], 3000)
+        self.assertGreater(len(payload["extraction_phases"]), 0)
+        self.assertGreater(len(payload["public_api_impact"]), 0)
+        self.assertGreater(len(payload["test_migration_plan"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_github_issues_runtime_split_map_contract.py
+++ b/.github/scripts/test_github_issues_runtime_split_map_contract.py
@@ -1,0 +1,65 @@
+import json
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+SPLIT_MAP_SCRIPT = REPO_ROOT / "scripts" / "dev" / "github-issues-runtime-split-map.sh"
+SCHEMA_PATH = REPO_ROOT / "tasks" / "schemas" / "m25-github-issues-runtime-split-map.schema.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "github-issues-runtime-split-map.md"
+REPORT_JSON_PATH = REPO_ROOT / "tasks" / "reports" / "m25-github-issues-runtime-split-map.json"
+REPORT_MD_PATH = REPO_ROOT / "tasks" / "reports" / "m25-github-issues-runtime-split-map.md"
+
+REQUIRED_GUIDE_SNIPPETS = (
+    "github-issues-runtime-split-map.sh",
+    "m25-github-issues-runtime-split-map.schema.json",
+    "m25-github-issues-runtime-split-map.json",
+    "m25-github-issues-runtime-split-map.md",
+    "Public API Impact",
+    "Test Migration Plan",
+)
+
+
+class GithubIssuesRuntimeSplitMapContractTests(unittest.TestCase):
+    def test_unit_required_files_exist(self):
+        self.assertTrue(SPLIT_MAP_SCRIPT.is_file(), msg=f"missing script: {SPLIT_MAP_SCRIPT}")
+        self.assertTrue(SPLIT_MAP_SCRIPT.stat().st_mode & 0o111)
+        self.assertTrue(SCHEMA_PATH.is_file(), msg=f"missing schema: {SCHEMA_PATH}")
+        self.assertTrue(GUIDE_PATH.is_file(), msg=f"missing guide: {GUIDE_PATH}")
+        self.assertTrue(REPORT_JSON_PATH.is_file(), msg=f"missing report json: {REPORT_JSON_PATH}")
+        self.assertTrue(REPORT_MD_PATH.is_file(), msg=f"missing report md: {REPORT_MD_PATH}")
+
+    def test_functional_schema_contract_contains_required_fields(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(schema["$schema"], "https://json-schema.org/draft/2020-12/schema")
+        required = set(schema["required"])
+        self.assertIn("schema_version", required)
+        self.assertIn("generated_at", required)
+        self.assertIn("source_file", required)
+        self.assertIn("target_line_budget", required)
+        self.assertIn("current_line_count", required)
+        self.assertIn("line_gap_to_target", required)
+        self.assertIn("extraction_phases", required)
+        self.assertIn("public_api_impact", required)
+        self.assertIn("test_migration_plan", required)
+
+    def test_integration_guide_references_split_map_contract_artifacts(self):
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        missing = [snippet for snippet in REQUIRED_GUIDE_SNIPPETS if snippet not in guide_text]
+        self.assertEqual(missing, [], msg=f"missing guide snippets: {missing}")
+
+    def test_regression_report_matches_schema_version_and_target_budget(self):
+        payload = json.loads(REPORT_JSON_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(
+            payload["source_file"], "crates/tau-github-issues-runtime/src/github_issues_runtime.rs"
+        )
+        self.assertEqual(payload["target_line_budget"], 3000)
+        self.assertGreater(len(payload["extraction_phases"]), 0)
+        self.assertGreater(len(payload["public_api_impact"]), 0)
+        self.assertGreater(len(payload["test_migration_plan"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_tools_split_map_contract.py
+++ b/.github/scripts/test_tools_split_map_contract.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+SPLIT_MAP_SCRIPT = REPO_ROOT / "scripts" / "dev" / "tools-split-map.sh"
+SCHEMA_PATH = REPO_ROOT / "tasks" / "schemas" / "m25-tools-split-map.schema.json"
+GUIDE_PATH = REPO_ROOT / "docs" / "guides" / "tools-split-map.md"
+REPORT_JSON_PATH = REPO_ROOT / "tasks" / "reports" / "m25-tools-split-map.json"
+REPORT_MD_PATH = REPO_ROOT / "tasks" / "reports" / "m25-tools-split-map.md"
+
+REQUIRED_GUIDE_SNIPPETS = (
+    "tools-split-map.sh",
+    "m25-tools-split-map.schema.json",
+    "m25-tools-split-map.json",
+    "m25-tools-split-map.md",
+    "Public API Impact",
+    "Test Migration Plan",
+)
+
+
+class ToolsSplitMapContractTests(unittest.TestCase):
+    def test_unit_required_files_exist(self):
+        self.assertTrue(SPLIT_MAP_SCRIPT.is_file(), msg=f"missing script: {SPLIT_MAP_SCRIPT}")
+        self.assertTrue(SPLIT_MAP_SCRIPT.stat().st_mode & 0o111)
+        self.assertTrue(SCHEMA_PATH.is_file(), msg=f"missing schema: {SCHEMA_PATH}")
+        self.assertTrue(GUIDE_PATH.is_file(), msg=f"missing guide: {GUIDE_PATH}")
+        self.assertTrue(REPORT_JSON_PATH.is_file(), msg=f"missing report json: {REPORT_JSON_PATH}")
+        self.assertTrue(REPORT_MD_PATH.is_file(), msg=f"missing report md: {REPORT_MD_PATH}")
+
+    def test_functional_schema_contract_contains_required_fields(self):
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(schema["$schema"], "https://json-schema.org/draft/2020-12/schema")
+        required = set(schema["required"])
+        self.assertIn("schema_version", required)
+        self.assertIn("generated_at", required)
+        self.assertIn("source_file", required)
+        self.assertIn("target_line_budget", required)
+        self.assertIn("current_line_count", required)
+        self.assertIn("line_gap_to_target", required)
+        self.assertIn("extraction_phases", required)
+        self.assertIn("public_api_impact", required)
+        self.assertIn("test_migration_plan", required)
+
+    def test_integration_guide_references_split_map_contract_artifacts(self):
+        guide_text = GUIDE_PATH.read_text(encoding="utf-8")
+        missing = [snippet for snippet in REQUIRED_GUIDE_SNIPPETS if snippet not in guide_text]
+        self.assertEqual(missing, [], msg=f"missing guide snippets: {missing}")
+
+    def test_regression_report_matches_schema_version_and_target_budget(self):
+        payload = json.loads(REPORT_JSON_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["source_file"], "crates/tau-tools/src/tools.rs")
+        self.assertEqual(payload["target_line_budget"], 3000)
+        self.assertGreater(len(payload["extraction_phases"]), 0)
+        self.assertGreater(len(payload["public_api_impact"]), 0)
+        self.assertGreater(len(payload["test_migration_plan"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/guides/benchmark-artifact-split-map.md
+++ b/docs/guides/benchmark-artifact-split-map.md
@@ -1,0 +1,63 @@
+# Benchmark Artifact Split Map (M25)
+
+This guide defines the pre-extraction split plan for:
+
+- `crates/tau-trainer/src/benchmark_artifact.rs`
+
+Goal:
+
+- reduce the primary file below 3000 LOC in `#2041` while preserving benchmark
+  artifact behavior and report contracts.
+
+## Generate Artifacts
+
+```bash
+scripts/dev/benchmark-artifact-split-map.sh
+```
+
+Default outputs:
+
+- `tasks/reports/m25-benchmark-artifact-split-map.json`
+- `tasks/reports/m25-benchmark-artifact-split-map.md`
+
+Schema:
+
+- `tasks/schemas/m25-benchmark-artifact-split-map.schema.json`
+
+Deterministic replay:
+
+```bash
+scripts/dev/benchmark-artifact-split-map.sh \
+  --generated-at 2026-02-16T00:00:00Z \
+  --output-json /tmp/m25-benchmark-artifact-split-map.json \
+  --output-md /tmp/m25-benchmark-artifact-split-map.md
+```
+
+## Validation
+
+```bash
+scripts/dev/test-benchmark-artifact-split-map.sh
+python3 -m unittest discover -s .github/scripts -p "test_benchmark_artifact_split_map_contract.py"
+```
+
+## Public API Impact
+
+- Benchmark artifact struct/serde contracts remain stable during extraction.
+- Existing trainer call signatures for load/render/compare paths remain
+  unchanged.
+- Domain modules become internal organization boundaries behind existing entry
+  points.
+
+## Import Impact
+
+- New domain modules are introduced under `crates/tau-trainer/src/benchmark_artifact/`.
+- Root `benchmark_artifact.rs` keeps explicit re-exports while phases migrate.
+- Cross-module imports are minimized by grouping schema/IO/report/validation
+  concerns.
+
+## Test Migration Plan
+
+- Run `cargo test -p tau-trainer benchmark_artifact` after each phase.
+- Run `cargo test -p tau-trainer` to confirm integration behavior.
+- Run `python3 -m unittest discover -s .github/scripts -p "test_*.py"` to keep
+  governance contracts green.

--- a/docs/guides/cli-args-split-map.md
+++ b/docs/guides/cli-args-split-map.md
@@ -1,0 +1,64 @@
+# CLI Args Split Map (M25)
+
+This guide defines the pre-extraction split plan for:
+
+- `crates/tau-cli/src/cli_args.rs`
+
+Goal:
+
+- reduce the primary file below 3000 LOC in `#2040` while preserving CLI
+  behavior and external parser contract.
+
+## Generate Artifacts
+
+```bash
+scripts/dev/cli-args-split-map.sh
+```
+
+Default outputs:
+
+- `tasks/reports/m25-cli-args-split-map.json`
+- `tasks/reports/m25-cli-args-split-map.md`
+
+Schema:
+
+- `tasks/schemas/m25-cli-args-split-map.schema.json`
+
+Deterministic replay:
+
+```bash
+scripts/dev/cli-args-split-map.sh \
+  --generated-at 2026-02-16T00:00:00Z \
+  --output-json /tmp/m25-cli-args-split-map.json \
+  --output-md /tmp/m25-cli-args-split-map.md
+```
+
+## Validation
+
+```bash
+scripts/dev/test-cli-args-split-map.sh
+python3 -m unittest discover -s .github/scripts -p "test_cli_args_split_map_contract.py"
+```
+
+## Public API Impact
+
+- `pub struct Cli` remains the external parse surface.
+- Existing clap flag names, aliases, defaults, and env bindings are preserved.
+- New internal domain structs are flattened into `Cli`; they are implementation
+  detail boundaries, not external API changes.
+
+## Import Impact
+
+- Domain modules are extracted into `crates/tau-cli/src/cli_args/`.
+- `cli_args.rs` keeps root parser helpers and selective `pub use` re-exports
+  during phased extraction.
+- Each phase minimizes cross-domain import churn before final consolidation.
+
+## Test Migration Plan
+
+- Guardrail update: lower line budget gates from `<4000` to phased thresholds
+  ending at `<3000`.
+- Crate-level validation: run `cargo test -p tau-cli` after each extraction
+  phase.
+- Cross-crate regression: run `cargo test -p tau-coding-agent` after each
+  phase to confirm CLI consumption parity.

--- a/docs/guides/github-issues-runtime-split-map.md
+++ b/docs/guides/github-issues-runtime-split-map.md
@@ -1,0 +1,66 @@
+# GitHub Issues Runtime Split Map (M25)
+
+This guide defines the pre-extraction split plan for:
+
+- `crates/tau-github-issues-runtime/src/github_issues_runtime.rs`
+
+Goal:
+
+- reduce the primary file below 3000 LOC in `#2043` while preserving GitHub
+  Issues bridge behavior and external runtime contracts.
+
+## Generate Artifacts
+
+```bash
+scripts/dev/github-issues-runtime-split-map.sh
+```
+
+Default outputs:
+
+- `tasks/reports/m25-github-issues-runtime-split-map.json`
+- `tasks/reports/m25-github-issues-runtime-split-map.md`
+
+Schema:
+
+- `tasks/schemas/m25-github-issues-runtime-split-map.schema.json`
+
+Deterministic replay:
+
+```bash
+scripts/dev/github-issues-runtime-split-map.sh \
+  --generated-at 2026-02-16T00:00:00Z \
+  --output-json /tmp/m25-github-issues-runtime-split-map.json \
+  --output-md /tmp/m25-github-issues-runtime-split-map.md
+```
+
+## Validation
+
+```bash
+scripts/dev/test-github-issues-runtime-split-map.sh
+python3 -m unittest discover -s .github/scripts -p "test_github_issues_runtime_split_map_contract.py"
+```
+
+## Public API Impact
+
+- GitHub Issues runtime public entrypoints and bridge configuration surfaces
+  remain stable.
+- Webhook ingest and issue-comment processing payload contracts remain
+  unchanged.
+- Reason-code and error-envelope semantics stay behaviorally compatible.
+
+## Import Impact
+
+- Domain modules are extracted into
+  `crates/tau-github-issues-runtime/src/github_issues_runtime/`.
+- `github_issues_runtime.rs` keeps targeted re-exports during phased moves.
+- Each phase minimizes cross-domain import churn and preserves bridge call-site
+  stability.
+
+## Test Migration Plan
+
+- Guardrail update: enforce `github_issues_runtime.rs` split threshold ending
+  at `<3000`.
+- Crate-level validation: run `cargo test -p tau-github-issues-runtime` after
+  each extraction phase.
+- Cross-crate regression: run `cargo test -p tau-coding-agent` after each
+  phase to confirm GitHub Issues bridge consumption parity.

--- a/docs/guides/tools-split-map.md
+++ b/docs/guides/tools-split-map.md
@@ -1,0 +1,64 @@
+# Tools Runtime Split Map (M25)
+
+This guide defines the pre-extraction split plan for:
+
+- `crates/tau-tools/src/tools.rs`
+
+Goal:
+
+- reduce the primary file below 3000 LOC in `#2042` while preserving tool
+  behavior and external runtime contracts.
+
+## Generate Artifacts
+
+```bash
+scripts/dev/tools-split-map.sh
+```
+
+Default outputs:
+
+- `tasks/reports/m25-tools-split-map.json`
+- `tasks/reports/m25-tools-split-map.md`
+
+Schema:
+
+- `tasks/schemas/m25-tools-split-map.schema.json`
+
+Deterministic replay:
+
+```bash
+scripts/dev/tools-split-map.sh \
+  --generated-at 2026-02-16T00:00:00Z \
+  --output-json /tmp/m25-tools-split-map.json \
+  --output-md /tmp/m25-tools-split-map.md
+```
+
+## Validation
+
+```bash
+scripts/dev/test-tools-split-map.sh
+python3 -m unittest discover -s .github/scripts -p "test_tools_split_map_contract.py"
+```
+
+## Public API Impact
+
+- Exported tool type names and trait implementations remain stable for runtime
+  callers.
+- Existing JSON argument/return contracts for moved tools remain unchanged.
+- Policy gate result semantics and error envelopes remain behaviorally
+  compatible.
+
+## Import Impact
+
+- Domain modules are extracted into `crates/tau-tools/src/tools/`.
+- `tools.rs` keeps targeted re-exports while phased moves are applied.
+- Each phase minimizes cross-domain import churn and preserves call-site
+  stability.
+
+## Test Migration Plan
+
+- Guardrail update: enforce `tools.rs` split threshold ending at `<3000`.
+- Crate-level validation: run `cargo test -p tau-tools` after each extraction
+  phase.
+- Cross-crate regression: run `cargo test -p tau-coding-agent` after each
+  phase to confirm runtime tool consumption parity.

--- a/scripts/dev/benchmark-artifact-split-map.sh
+++ b/scripts/dev/benchmark-artifact-split-map.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SOURCE_FILE="crates/tau-trainer/src/benchmark_artifact.rs"
+TARGET_LINES=3000
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m25-benchmark-artifact-split-map.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m25-benchmark-artifact-split-map.md"
+GENERATED_AT=""
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: benchmark-artifact-split-map.sh [options]
+
+Generate M25 split-map artifacts for crates/tau-trainer/src/benchmark_artifact.rs.
+
+Options:
+  --source-file <path>      Source file to analyze (default: crates/tau-trainer/src/benchmark_artifact.rs)
+  --target-lines <n>        Target post-split line budget (default: 3000)
+  --output-json <path>      JSON artifact output path
+  --output-md <path>        Markdown artifact output path
+  --generated-at <iso>      Deterministic generated timestamp (ISO-8601 UTC)
+  --quiet                   Suppress informational output
+  --help                    Show this help text
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-file)
+      SOURCE_FILE="$2"
+      shift 2
+      ;;
+    --target-lines)
+      TARGET_LINES="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${TARGET_LINES}" =~ ^[0-9]+$ ]] || [[ "${TARGET_LINES}" -lt 1 ]]; then
+  echo "error: --target-lines must be an integer >= 1" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+  echo "error: source file not found: ${SOURCE_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${SOURCE_FILE}" \
+  "${TARGET_LINES}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${GENERATED_AT}" \
+  "${QUIET_MODE}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+(
+    source_file_raw,
+    target_lines_raw,
+    output_json_raw,
+    output_md_raw,
+    generated_at_raw,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+source_file = Path(source_file_raw)
+output_json = Path(output_json_raw)
+output_md = Path(output_md_raw)
+target_lines = int(target_lines_raw)
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def parse_iso8601_utc(value: str) -> datetime:
+    candidate = value.strip()
+    if not candidate:
+        fail("generated-at value must not be empty")
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        fail(f"invalid --generated-at timestamp: {value} ({exc})")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+generated_at = (
+    parse_iso8601_utc(generated_at_raw)
+    if generated_at_raw.strip()
+    else datetime.now(timezone.utc).replace(microsecond=0)
+)
+generated_at_iso = iso_utc(generated_at)
+
+line_count = len(source_file.read_text(encoding="utf-8").splitlines())
+line_gap = max(line_count - target_lines, 0)
+
+extraction_phases: list[dict[str, Any]] = [
+    {
+        "id": "phase-1-schema-types",
+        "title": "Benchmark schema/types and serde payload structures",
+        "owner": "trainer-core",
+        "line_reduction_estimate": 220,
+        "modules": [
+            "benchmark_artifact/schema.rs",
+            "benchmark_artifact/types.rs",
+        ],
+        "depends_on": [],
+        "notes": "Preserve externally consumed artifact JSON schema and field names.",
+    },
+    {
+        "id": "phase-2-io-persistence",
+        "title": "Artifact IO, path handling, and persistence utilities",
+        "owner": "trainer-runtime",
+        "line_reduction_estimate": 260,
+        "modules": [
+            "benchmark_artifact/io.rs",
+            "benchmark_artifact/persistence.rs",
+        ],
+        "depends_on": ["phase-1-schema-types"],
+        "notes": "Keep filesystem contracts and error surface stable for callers.",
+    },
+    {
+        "id": "phase-3-report-rendering",
+        "title": "Markdown/JSON reporting and presentation helpers",
+        "owner": "trainer-observability",
+        "line_reduction_estimate": 230,
+        "modules": [
+            "benchmark_artifact/reporting.rs",
+            "benchmark_artifact/render.rs",
+        ],
+        "depends_on": ["phase-2-io-persistence"],
+        "notes": "Separate formatting logic from core benchmark artifact state.",
+    },
+    {
+        "id": "phase-4-validation-compare",
+        "title": "Validation, comparison, and regression guard logic",
+        "owner": "trainer-quality",
+        "line_reduction_estimate": 240,
+        "modules": [
+            "benchmark_artifact/validation.rs",
+            "benchmark_artifact/compare.rs",
+        ],
+        "depends_on": ["phase-3-report-rendering"],
+        "notes": "Retain benchmark conformance semantics and regression reason-code behavior.",
+    },
+]
+
+estimated_lines_to_extract = sum(entry["line_reduction_estimate"] for entry in extraction_phases)
+post_split_estimated_line_count = max(line_count - estimated_lines_to_extract, 0)
+
+public_api_impact = [
+    "Retain current benchmark artifact struct names and serialized field contracts.",
+    "Keep public constructor/loader entrypoints stable for trainer and CLI callers.",
+    "Confine extraction changes behind module boundaries without changing call signatures.",
+]
+
+import_impact = [
+    "Introduce benchmark_artifact module tree under crates/tau-trainer/src/benchmark_artifact/.",
+    "Move domain-specific helpers into phased modules while preserving root re-exports.",
+    "Minimize cross-module imports by grouping schema/IO/report/validation concerns.",
+]
+
+test_migration_plan = [
+    {
+        "order": 1,
+        "id": "benchmark-conformance-suite",
+        "description": "Run benchmark artifact conformance tests after each extraction phase.",
+        "command": "cargo test -p tau-trainer benchmark_artifact",
+        "expected_signal": "benchmark artifact conformance tests remain green",
+    },
+    {
+        "order": 2,
+        "id": "trainer-integration-suite",
+        "description": "Run trainer integration tests that persist/load benchmark artifacts.",
+        "command": "cargo test -p tau-trainer",
+        "expected_signal": "trainer integration flows preserve artifact behavior",
+    },
+    {
+        "order": 3,
+        "id": "workspace-regression-suite",
+        "description": "Run workspace-level governance/contract checks for generated artifacts.",
+        "command": "python3 -m unittest discover -s .github/scripts -p test_*.py",
+        "expected_signal": "contract suite remains green after module extraction",
+    },
+]
+
+payload = {
+    "schema_version": 1,
+    "generated_at": generated_at_iso,
+    "source_file": source_file_raw,
+    "target_line_budget": target_lines,
+    "current_line_count": line_count,
+    "line_gap_to_target": line_gap,
+    "estimated_lines_to_extract": estimated_lines_to_extract,
+    "post_split_estimated_line_count": post_split_estimated_line_count,
+    "extraction_phases": extraction_phases,
+    "public_api_impact": public_api_impact,
+    "import_impact": import_impact,
+    "test_migration_plan": test_migration_plan,
+}
+
+output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+lines: list[str] = [
+    "# Benchmark Artifact Split Map (M25)",
+    "",
+    f"- Generated at (UTC): `{generated_at_iso}`",
+    f"- Source file: `{source_file_raw}`",
+    f"- Target line budget: `{target_lines}`",
+    f"- Current line count: `{line_count}`",
+    f"- Current gap to target: `{line_gap}`",
+    f"- Estimated lines to extract: `{estimated_lines_to_extract}`",
+    f"- Estimated post-split line count: `{post_split_estimated_line_count}`",
+    "",
+    "## Extraction Phases",
+    "",
+    "| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |",
+    "| --- | --- | ---: | --- | --- | --- |",
+]
+
+for phase in extraction_phases:
+    depends_on = ", ".join(phase["depends_on"]) if phase["depends_on"] else "-"
+    modules = ", ".join(phase["modules"])
+    lines.append(
+        "| "
+        f"{phase['id']} ({phase['title']}) | "
+        f"{phase['owner']} | "
+        f"{phase['line_reduction_estimate']} | "
+        f"{depends_on} | "
+        f"{modules} | "
+        f"{phase['notes']} |"
+    )
+
+lines.extend(["", "## Public API Impact", ""])
+for item in public_api_impact:
+    lines.append(f"- {item}")
+
+lines.extend(["", "## Import Impact", ""])
+for item in import_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Test Migration Plan",
+        "",
+        "| Order | Step | Command | Expected Signal |",
+        "| ---: | --- | --- | --- |",
+    ]
+)
+for entry in test_migration_plan:
+    lines.append(
+        "| "
+        f"{entry['order']} | "
+        f"{entry['id']}: {entry['description']} | "
+        f"{entry['command']} | "
+        f"{entry['expected_signal']} |"
+    )
+
+output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+log(
+    "[benchmark-artifact-split-map] "
+    f"source={source_file_raw} current_lines={line_count} target={target_lines} gap={line_gap}"
+)
+PY
+
+log_info "wrote benchmark-artifact split-map artifacts:"
+log_info "  - ${OUTPUT_JSON}"
+log_info "  - ${OUTPUT_MD}"

--- a/scripts/dev/cli-args-split-map.sh
+++ b/scripts/dev/cli-args-split-map.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SOURCE_FILE="crates/tau-cli/src/cli_args.rs"
+TARGET_LINES=3000
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m25-cli-args-split-map.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m25-cli-args-split-map.md"
+GENERATED_AT=""
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: cli-args-split-map.sh [options]
+
+Generate M25 split-map artifacts for crates/tau-cli/src/cli_args.rs.
+
+Options:
+  --source-file <path>      Source file to analyze (default: crates/tau-cli/src/cli_args.rs)
+  --target-lines <n>        Target post-split line budget (default: 3000)
+  --output-json <path>      JSON artifact output path
+  --output-md <path>        Markdown artifact output path
+  --generated-at <iso>      Deterministic generated timestamp (ISO-8601 UTC)
+  --quiet                   Suppress informational output
+  --help                    Show this help text
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-file)
+      SOURCE_FILE="$2"
+      shift 2
+      ;;
+    --target-lines)
+      TARGET_LINES="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${TARGET_LINES}" =~ ^[0-9]+$ ]] || [[ "${TARGET_LINES}" -lt 1 ]]; then
+  echo "error: --target-lines must be an integer >= 1" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+  echo "error: source file not found: ${SOURCE_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${SOURCE_FILE}" \
+  "${TARGET_LINES}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${GENERATED_AT}" \
+  "${QUIET_MODE}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+(
+    source_file_raw,
+    target_lines_raw,
+    output_json_raw,
+    output_md_raw,
+    generated_at_raw,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+source_file = Path(source_file_raw)
+output_json = Path(output_json_raw)
+output_md = Path(output_md_raw)
+target_lines = int(target_lines_raw)
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def parse_iso8601_utc(value: str) -> datetime:
+    candidate = value.strip()
+    if not candidate:
+        fail("generated-at value must not be empty")
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        fail(f"invalid --generated-at timestamp: {value} ({exc})")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+generated_at = (
+    parse_iso8601_utc(generated_at_raw)
+    if generated_at_raw.strip()
+    else datetime.now(timezone.utc).replace(microsecond=0)
+)
+generated_at_iso = iso_utc(generated_at)
+
+line_count = len(source_file.read_text(encoding="utf-8").splitlines())
+line_gap = max(line_count - target_lines, 0)
+
+extraction_phases: list[dict[str, Any]] = [
+    {
+        "id": "phase-1-provider-auth",
+        "title": "Provider/auth and model catalog flags",
+        "owner": "cli-platform",
+        "line_reduction_estimate": 300,
+        "modules": [
+            "cli_args/provider_model_flags.rs",
+            "cli_args/provider_auth_flags.rs",
+        ],
+        "depends_on": [],
+        "notes": "Preserve Cli top-level field names via #[command(flatten)] wrappers.",
+    },
+    {
+        "id": "phase-2-gateway-runtime",
+        "title": "Gateway remote/service and transport flags",
+        "owner": "runtime-gateway",
+        "line_reduction_estimate": 260,
+        "modules": [
+            "cli_args/gateway_remote_flags.rs",
+            "cli_args/gateway_service_flags.rs",
+        ],
+        "depends_on": ["phase-1-provider-auth"],
+        "notes": "Keep existing gateway daemon sub-struct wiring intact and additive.",
+    },
+    {
+        "id": "phase-3-package-events-extension",
+        "title": "Package/events/extensions and skill policy flags",
+        "owner": "runtime-packaging",
+        "line_reduction_estimate": 230,
+        "modules": [
+            "cli_args/package_flags.rs",
+            "cli_args/events_flags.rs",
+            "cli_args/extension_flags.rs",
+            "cli_args/skills_flags.rs",
+        ],
+        "depends_on": ["phase-2-gateway-runtime"],
+        "notes": "Group related command surfaces to reduce import fan-out in cli_args.rs.",
+    },
+    {
+        "id": "phase-4-multichannel-dashboard-voice",
+        "title": "Multi-channel, dashboard, memory, and voice surfaces",
+        "owner": "runtime-integrations",
+        "line_reduction_estimate": 280,
+        "modules": [
+            "cli_args/multi_channel_flags.rs",
+            "cli_args/dashboard_flags.rs",
+            "cli_args/memory_flags.rs",
+            "cli_args/voice_flags.rs",
+        ],
+        "depends_on": ["phase-3-package-events-extension"],
+        "notes": "Final phase targets high-volume flag groups to push below the 3000 line budget.",
+    },
+]
+
+estimated_lines_to_extract = sum(entry["line_reduction_estimate"] for entry in extraction_phases)
+post_split_estimated_line_count = max(line_count - estimated_lines_to_extract, 0)
+
+public_api_impact = [
+    "Keep pub struct Cli as the single externally consumed parser type.",
+    "Retain existing flag names, clap aliases, defaults, and env bindings.",
+    "Introduce internal flattened sub-structs only; no external crate API renames.",
+]
+
+import_impact = [
+    "Add new module declarations under crates/tau-cli/src/cli_args/ with targeted pub re-exports.",
+    "Move domain-specific clap argument definitions from cli_args.rs into phase modules.",
+    "Keep root-level helper parsers in cli_args.rs until all phases are complete to avoid churn.",
+]
+
+test_migration_plan = [
+    {
+        "order": 1,
+        "id": "update-guardrail-threshold",
+        "description": "Lower cli_args split guardrail from <4000 to staged thresholds ending at <3000.",
+        "command": "scripts/dev/test-cli-args-domain-split.sh",
+        "expected_signal": "line budget checks enforce progressive reduction and final <3000 gate",
+    },
+    {
+        "order": 2,
+        "id": "cli-crate-coverage",
+        "description": "Run crate-scoped CLI parsing and validation tests after each phase extraction.",
+        "command": "cargo test -p tau-cli",
+        "expected_signal": "all clap parser and validation tests pass",
+    },
+    {
+        "order": 3,
+        "id": "workspace-integration",
+        "description": "Run cross-crate runtime command integration tests that consume Cli fields.",
+        "command": "cargo test -p tau-coding-agent",
+        "expected_signal": "no regressions in command wiring and runtime behavior",
+    },
+]
+
+payload = {
+    "schema_version": 1,
+    "generated_at": generated_at_iso,
+    "source_file": source_file_raw,
+    "target_line_budget": target_lines,
+    "current_line_count": line_count,
+    "line_gap_to_target": line_gap,
+    "estimated_lines_to_extract": estimated_lines_to_extract,
+    "post_split_estimated_line_count": post_split_estimated_line_count,
+    "extraction_phases": extraction_phases,
+    "public_api_impact": public_api_impact,
+    "import_impact": import_impact,
+    "test_migration_plan": test_migration_plan,
+}
+
+output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+lines: list[str] = [
+    "# CLI Args Split Map (M25)",
+    "",
+    f"- Generated at (UTC): `{generated_at_iso}`",
+    f"- Source file: `{source_file_raw}`",
+    f"- Target line budget: `{target_lines}`",
+    f"- Current line count: `{line_count}`",
+    f"- Current gap to target: `{line_gap}`",
+    f"- Estimated lines to extract: `{estimated_lines_to_extract}`",
+    f"- Estimated post-split line count: `{post_split_estimated_line_count}`",
+    "",
+    "## Extraction Phases",
+    "",
+    "| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |",
+    "| --- | --- | ---: | --- | --- | --- |",
+]
+
+for phase in extraction_phases:
+    depends_on = ", ".join(phase["depends_on"]) if phase["depends_on"] else "-"
+    modules = ", ".join(phase["modules"])
+    lines.append(
+        "| "
+        f"{phase['id']} ({phase['title']}) | "
+        f"{phase['owner']} | "
+        f"{phase['line_reduction_estimate']} | "
+        f"{depends_on} | "
+        f"{modules} | "
+        f"{phase['notes']} |"
+    )
+
+lines.extend(
+    [
+        "",
+        "## Public API Impact",
+        "",
+    ]
+)
+for item in public_api_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Import Impact",
+        "",
+    ]
+)
+for item in import_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Test Migration Plan",
+        "",
+        "| Order | Step | Command | Expected Signal |",
+        "| ---: | --- | --- | --- |",
+    ]
+)
+for entry in test_migration_plan:
+    lines.append(
+        "| "
+        f"{entry['order']} | "
+        f"{entry['id']}: {entry['description']} | "
+        f"{entry['command']} | "
+        f"{entry['expected_signal']} |"
+    )
+
+output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+log(
+    "[cli-args-split-map] "
+    f"source={source_file_raw} current_lines={line_count} target={target_lines} gap={line_gap}"
+)
+PY
+
+log_info "wrote cli-args split-map artifacts:"
+log_info "  - ${OUTPUT_JSON}"
+log_info "  - ${OUTPUT_MD}"

--- a/scripts/dev/github-issues-runtime-split-map.sh
+++ b/scripts/dev/github-issues-runtime-split-map.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SOURCE_FILE="crates/tau-github-issues-runtime/src/github_issues_runtime.rs"
+TARGET_LINES=3000
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m25-github-issues-runtime-split-map.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m25-github-issues-runtime-split-map.md"
+GENERATED_AT=""
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: github-issues-runtime-split-map.sh [options]
+
+Generate M25 split-map artifacts for crates/tau-github-issues-runtime/src/github_issues_runtime.rs.
+
+Options:
+  --source-file <path>      Source file to analyze (default: crates/tau-github-issues-runtime/src/github_issues_runtime.rs)
+  --target-lines <n>        Target post-split line budget (default: 3000)
+  --output-json <path>      JSON artifact output path
+  --output-md <path>        Markdown artifact output path
+  --generated-at <iso>      Deterministic generated timestamp (ISO-8601 UTC)
+  --quiet                   Suppress informational output
+  --help                    Show this help text
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-file)
+      SOURCE_FILE="$2"
+      shift 2
+      ;;
+    --target-lines)
+      TARGET_LINES="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${TARGET_LINES}" =~ ^[0-9]+$ ]] || [[ "${TARGET_LINES}" -lt 1 ]]; then
+  echo "error: --target-lines must be an integer >= 1" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+  echo "error: source file not found: ${SOURCE_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${SOURCE_FILE}" \
+  "${TARGET_LINES}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${GENERATED_AT}" \
+  "${QUIET_MODE}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+(
+    source_file_raw,
+    target_lines_raw,
+    output_json_raw,
+    output_md_raw,
+    generated_at_raw,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+source_file = Path(source_file_raw)
+output_json = Path(output_json_raw)
+output_md = Path(output_md_raw)
+target_lines = int(target_lines_raw)
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def parse_iso8601_utc(value: str) -> datetime:
+    candidate = value.strip()
+    if not candidate:
+        fail("generated-at value must not be empty")
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        fail(f"invalid --generated-at timestamp: {value} ({exc})")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+generated_at = (
+    parse_iso8601_utc(generated_at_raw)
+    if generated_at_raw.strip()
+    else datetime.now(timezone.utc).replace(microsecond=0)
+)
+generated_at_iso = iso_utc(generated_at)
+
+line_count = len(source_file.read_text(encoding="utf-8").splitlines())
+line_gap = max(line_count - target_lines, 0)
+
+extraction_phases: list[dict[str, Any]] = [
+    {
+        "id": "phase-1-webhook-validation-ingest",
+        "title": "Webhook payload validation and ingest normalization",
+        "owner": "github-issues-ingest",
+        "line_reduction_estimate": 170,
+        "modules": [
+            "github_issues_runtime/webhook_validation.rs",
+            "github_issues_runtime/ingest.rs",
+        ],
+        "depends_on": [],
+        "notes": "Preserve webhook signature/shape validation and deterministic ingest diagnostics.",
+    },
+    {
+        "id": "phase-2-session-sync-routing",
+        "title": "Session projection, comment sync, and routing helpers",
+        "owner": "github-issues-sync",
+        "line_reduction_estimate": 150,
+        "modules": [
+            "github_issues_runtime/session_projection.rs",
+            "github_issues_runtime/comment_sync.rs",
+            "github_issues_runtime/routing.rs",
+        ],
+        "depends_on": ["phase-1-webhook-validation-ingest"],
+        "notes": "Keep issue-to-session mapping and message emission order stable.",
+    },
+    {
+        "id": "phase-3-error-policy-rate-limit",
+        "title": "Policy guards, rate-limits, and error-envelope mapping",
+        "owner": "github-issues-policy",
+        "line_reduction_estimate": 130,
+        "modules": [
+            "github_issues_runtime/policy.rs",
+            "github_issues_runtime/rate_limit.rs",
+            "github_issues_runtime/errors.rs",
+        ],
+        "depends_on": ["phase-2-session-sync-routing"],
+        "notes": "Retain fail-closed behavior and reason-code mapping for moderation and retry signals.",
+    },
+]
+
+estimated_lines_to_extract = sum(entry["line_reduction_estimate"] for entry in extraction_phases)
+post_split_estimated_line_count = max(line_count - estimated_lines_to_extract, 0)
+
+public_api_impact = [
+    "Keep GitHub Issues runtime public entrypoints and bridge configuration surfaces stable.",
+    "Preserve webhook ingest and issue-comment processing payload contracts.",
+    "Maintain existing reason-code/error-envelope behavior exposed to callers.",
+]
+
+import_impact = [
+    "Introduce module declarations under crates/tau-github-issues-runtime/src/github_issues_runtime/ with selective re-exports.",
+    "Move ingest/sync/policy helper domains out of github_issues_runtime.rs in phases.",
+    "Keep shared bridge utility helpers centralized to minimize cross-module import churn.",
+]
+
+test_migration_plan = [
+    {
+        "order": 1,
+        "id": "guardrail-threshold-enforcement",
+        "description": "Introduce and enforce github_issues_runtime.rs split guardrail ending at <3000.",
+        "command": "scripts/dev/test-github-issues-runtime-domain-split.sh",
+        "expected_signal": "github_issues_runtime.rs threshold checks fail closed until split target is reached",
+    },
+    {
+        "order": 2,
+        "id": "runtime-crate-coverage",
+        "description": "Run crate-scoped GitHub Issues runtime tests after each extraction phase.",
+        "command": "cargo test -p tau-github-issues-runtime",
+        "expected_signal": "bridge ingest/sync behavior and reason-code tests stay green",
+    },
+    {
+        "order": 3,
+        "id": "runtime-integration",
+        "description": "Run cross-crate integration suites that consume GitHub Issues runtime surfaces.",
+        "command": "cargo test -p tau-coding-agent",
+        "expected_signal": "no regressions in issue bridge wiring and end-to-end command flows",
+    },
+]
+
+payload = {
+    "schema_version": 1,
+    "generated_at": generated_at_iso,
+    "source_file": source_file_raw,
+    "target_line_budget": target_lines,
+    "current_line_count": line_count,
+    "line_gap_to_target": line_gap,
+    "estimated_lines_to_extract": estimated_lines_to_extract,
+    "post_split_estimated_line_count": post_split_estimated_line_count,
+    "extraction_phases": extraction_phases,
+    "public_api_impact": public_api_impact,
+    "import_impact": import_impact,
+    "test_migration_plan": test_migration_plan,
+}
+
+output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+lines: list[str] = [
+    "# GitHub Issues Runtime Split Map (M25)",
+    "",
+    f"- Generated at (UTC): `{generated_at_iso}`",
+    f"- Source file: `{source_file_raw}`",
+    f"- Target line budget: `{target_lines}`",
+    f"- Current line count: `{line_count}`",
+    f"- Current gap to target: `{line_gap}`",
+    f"- Estimated lines to extract: `{estimated_lines_to_extract}`",
+    f"- Estimated post-split line count: `{post_split_estimated_line_count}`",
+    "",
+    "## Extraction Phases",
+    "",
+    "| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |",
+    "| --- | --- | ---: | --- | --- | --- |",
+]
+
+for phase in extraction_phases:
+    depends_on = ", ".join(phase["depends_on"]) if phase["depends_on"] else "-"
+    modules = ", ".join(phase["modules"])
+    lines.append(
+        "| "
+        f"{phase['id']} ({phase['title']}) | "
+        f"{phase['owner']} | "
+        f"{phase['line_reduction_estimate']} | "
+        f"{depends_on} | "
+        f"{modules} | "
+        f"{phase['notes']} |"
+    )
+
+lines.extend(
+    [
+        "",
+        "## Public API Impact",
+        "",
+    ]
+)
+for item in public_api_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Import Impact",
+        "",
+    ]
+)
+for item in import_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Test Migration Plan",
+        "",
+        "| Order | Step | Command | Expected Signal |",
+        "| ---: | --- | --- | --- |",
+    ]
+)
+for entry in test_migration_plan:
+    lines.append(
+        "| "
+        f"{entry['order']} | "
+        f"{entry['id']}: {entry['description']} | "
+        f"{entry['command']} | "
+        f"{entry['expected_signal']} |"
+    )
+
+output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+log(
+    "[github-issues-runtime-split-map] "
+    f"source={source_file_raw} current_lines={line_count} target={target_lines} gap={line_gap}"
+)
+PY
+
+log_info "wrote github issues runtime split-map artifacts:"
+log_info "  - ${OUTPUT_JSON}"
+log_info "  - ${OUTPUT_MD}"

--- a/scripts/dev/test-benchmark-artifact-domain-split.sh
+++ b/scripts/dev/test-benchmark-artifact-domain-split.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+artifact_file="crates/tau-trainer/src/benchmark_artifact.rs"
+tests_file="crates/tau-trainer/src/benchmark_artifact/tests.rs"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected to find '${needle}'" >&2
+    exit 1
+  fi
+}
+
+artifact_line_count="$(wc -l < "${artifact_file}" | tr -d ' ')"
+if (( artifact_line_count >= 3000 )); then
+  echo "assertion failed (line budget): expected ${artifact_file} < 3000 lines, got ${artifact_line_count}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${tests_file}" ]]; then
+  echo "assertion failed (tests extraction file): missing ${tests_file}" >&2
+  exit 1
+fi
+
+artifact_contents="$(cat "${artifact_file}")"
+tests_contents="$(cat "${tests_file}")"
+
+assert_contains "${artifact_contents}" "#[cfg(test)]" "artifact cfg-test marker"
+assert_contains "${artifact_contents}" "mod tests;" "artifact external tests module marker"
+assert_contains "${tests_contents}" "fn sample_policy_report()" "tests helper marker"
+assert_contains "${tests_contents}" "fn spec_1980_c02_gate_report_summary_manifest_records_invalid_files_without_abort()" "tests regression marker"
+
+echo "benchmark-artifact-domain-split tests passed"

--- a/scripts/dev/test-benchmark-artifact-split-map.sh
+++ b/scripts/dev/test-benchmark-artifact-split-map.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPLIT_MAP_SCRIPT="${SCRIPT_DIR}/benchmark-artifact-split-map.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "${SPLIT_MAP_SCRIPT}" ]]; then
+  echo "assertion failed (unit executable): missing executable ${SPLIT_MAP_SCRIPT}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+source_file="${tmp_dir}/benchmark_artifact.rs"
+missing_source_file="${tmp_dir}/missing.rs"
+output_json="${tmp_dir}/split-map.json"
+output_md="${tmp_dir}/split-map.md"
+
+cat >"${source_file}" <<'EOF'
+pub fn render_report() {}
+pub fn write_artifact() {}
+pub fn validate_benchmark() {}
+EOF
+
+# Functional: generator emits JSON + markdown contract fields.
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional output json): missing ${output_json}" >&2
+  exit 1
+fi
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional output md): missing ${output_md}" >&2
+  exit 1
+fi
+
+assert_equals "1" "$(jq -r '.schema_version' "${output_json}")" "functional schema_version"
+assert_equals "2026-02-16T00:00:00Z" "$(jq -r '.generated_at' "${output_json}")" "functional generated_at"
+assert_equals "3" "$(jq -r '.current_line_count' "${output_json}")" "functional current line count"
+assert_equals "1" "$(jq -r '.line_gap_to_target' "${output_json}")" "functional line gap"
+assert_equals "true" "$(jq -r '(.extraction_phases | length) > 0' "${output_json}")" "functional extraction phases non-empty"
+assert_equals "true" "$(jq -r '(.public_api_impact | length) > 0' "${output_json}")" "functional api impact non-empty"
+assert_equals "true" "$(jq -r '(.test_migration_plan | length) > 0' "${output_json}")" "functional test migration non-empty"
+assert_contains "$(cat "${output_md}")" "Benchmark Artifact Split Map" "functional markdown title"
+
+# Regression: missing source file fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${missing_source_file}" --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression missing source): expected failure" >&2
+  exit 1
+fi
+
+# Regression: invalid target lines fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${source_file}" --target-lines 0 --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression invalid target): expected failure" >&2
+  exit 1
+fi
+
+# Functional regression: deterministic output for identical input and timestamp.
+hash_before="$(shasum "${output_json}" "${output_md}")"
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+hash_after="$(shasum "${output_json}" "${output_md}")"
+assert_equals "${hash_before}" "${hash_after}" "functional deterministic hash"
+
+echo "benchmark-artifact-split-map tests passed"

--- a/scripts/dev/test-cli-args-split-map.sh
+++ b/scripts/dev/test-cli-args-split-map.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPLIT_MAP_SCRIPT="${SCRIPT_DIR}/cli-args-split-map.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "${SPLIT_MAP_SCRIPT}" ]]; then
+  echo "assertion failed (unit executable): missing executable ${SPLIT_MAP_SCRIPT}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+source_file="${tmp_dir}/cli_args.rs"
+missing_source_file="${tmp_dir}/missing.rs"
+output_json="${tmp_dir}/split-map.json"
+output_md="${tmp_dir}/split-map.md"
+
+cat >"${source_file}" <<'EOF'
+pub struct Cli {
+    pub model: String,
+    pub api_key: Option<String>,
+    pub gateway_service_start: bool,
+}
+EOF
+
+# Functional: generator emits JSON + markdown contract fields.
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional output json): missing ${output_json}" >&2
+  exit 1
+fi
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional output md): missing ${output_md}" >&2
+  exit 1
+fi
+
+assert_equals "1" "$(jq -r '.schema_version' "${output_json}")" "functional schema_version"
+assert_equals "2026-02-16T00:00:00Z" "$(jq -r '.generated_at' "${output_json}")" "functional generated_at"
+assert_equals "5" "$(jq -r '.current_line_count' "${output_json}")" "functional current line count"
+assert_equals "3" "$(jq -r '.line_gap_to_target' "${output_json}")" "functional line gap"
+assert_equals "true" "$(jq -r '(.extraction_phases | length) > 0' "${output_json}")" "functional extraction phases non-empty"
+assert_equals "true" "$(jq -r '(.public_api_impact | length) > 0' "${output_json}")" "functional api impact non-empty"
+assert_equals "true" "$(jq -r '(.test_migration_plan | length) > 0' "${output_json}")" "functional test migration non-empty"
+assert_contains "$(cat "${output_md}")" "CLI Args Split Map" "functional markdown title"
+
+# Regression: missing source file fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${missing_source_file}" --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression missing source): expected failure" >&2
+  exit 1
+fi
+
+# Regression: invalid target lines fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${source_file}" --target-lines 0 --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression invalid target): expected failure" >&2
+  exit 1
+fi
+
+# Functional regression: deterministic output for identical input and timestamp.
+hash_before="$(shasum "${output_json}" "${output_md}")"
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+hash_after="$(shasum "${output_json}" "${output_md}")"
+assert_equals "${hash_before}" "${hash_after}" "functional deterministic hash"
+
+echo "cli-args-split-map tests passed"

--- a/scripts/dev/test-github-issues-runtime-split-map.sh
+++ b/scripts/dev/test-github-issues-runtime-split-map.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPLIT_MAP_SCRIPT="${SCRIPT_DIR}/github-issues-runtime-split-map.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "${SPLIT_MAP_SCRIPT}" ]]; then
+  echo "assertion failed (unit executable): missing executable ${SPLIT_MAP_SCRIPT}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+source_file="${tmp_dir}/github_issues_runtime.rs"
+missing_source_file="${tmp_dir}/missing.rs"
+output_json="${tmp_dir}/split-map.json"
+output_md="${tmp_dir}/split-map.md"
+
+cat >"${source_file}" <<'EOF'
+pub struct GithubIssuesRuntime;
+pub fn ingest_event() {}
+pub fn sync_comment() {}
+EOF
+
+# Functional: generator emits JSON + markdown contract fields.
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional output json): missing ${output_json}" >&2
+  exit 1
+fi
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional output md): missing ${output_md}" >&2
+  exit 1
+fi
+
+assert_equals "1" "$(jq -r '.schema_version' "${output_json}")" "functional schema_version"
+assert_equals "2026-02-16T00:00:00Z" "$(jq -r '.generated_at' "${output_json}")" "functional generated_at"
+assert_equals "3" "$(jq -r '.current_line_count' "${output_json}")" "functional current line count"
+assert_equals "1" "$(jq -r '.line_gap_to_target' "${output_json}")" "functional line gap"
+assert_equals "true" "$(jq -r '(.extraction_phases | length) > 0' "${output_json}")" "functional extraction phases non-empty"
+assert_equals "true" "$(jq -r '(.public_api_impact | length) > 0' "${output_json}")" "functional api impact non-empty"
+assert_equals "true" "$(jq -r '(.test_migration_plan | length) > 0' "${output_json}")" "functional test migration non-empty"
+assert_contains "$(cat "${output_md}")" "GitHub Issues Runtime Split Map" "functional markdown title"
+
+# Regression: missing source file fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${missing_source_file}" --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression missing source): expected failure" >&2
+  exit 1
+fi
+
+# Regression: invalid target lines fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${source_file}" --target-lines 0 --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression invalid target): expected failure" >&2
+  exit 1
+fi
+
+# Functional regression: deterministic output for identical input and timestamp.
+hash_before="$(shasum "${output_json}" "${output_md}")"
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+hash_after="$(shasum "${output_json}" "${output_md}")"
+assert_equals "${hash_before}" "${hash_after}" "functional deterministic hash"
+
+echo "github-issues-runtime-split-map tests passed"

--- a/scripts/dev/test-tools-domain-split.sh
+++ b/scripts/dev/test-tools-domain-split.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+tools_file="crates/tau-tools/src/tools.rs"
+bash_module_file="crates/tau-tools/src/tools/bash_tool.rs"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected to find '${needle}'" >&2
+    exit 1
+  fi
+}
+
+tools_line_count="$(wc -l < "${tools_file}" | tr -d ' ')"
+if (( tools_line_count >= 3000 )); then
+  echo "assertion failed (line budget): expected ${tools_file} < 3000 lines, got ${tools_line_count}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${bash_module_file}" ]]; then
+  echo "assertion failed (domain extraction file): missing ${bash_module_file}" >&2
+  exit 1
+fi
+
+tools_contents="$(cat "${tools_file}")"
+bash_contents="$(cat "${bash_module_file}")"
+
+assert_contains "${tools_contents}" "mod bash_tool;" "tools module marker"
+assert_contains "${tools_contents}" "pub use bash_tool::BashTool;" "tools re-export marker"
+assert_contains "${tools_contents}" "#[cfg(test)]" "tools cfg-test marker"
+assert_contains "${tools_contents}" "mod tests;" "tools tests module marker"
+
+assert_contains "${bash_contents}" "pub struct BashTool {" "bash module struct marker"
+assert_contains "${bash_contents}" "impl AgentTool for BashTool {" "bash module impl marker"
+assert_contains "${bash_contents}" "fn evaluate_tool_rate_limit_gate(" "bash module policy helper marker"
+
+echo "tools-domain-split tests passed"

--- a/scripts/dev/test-tools-split-map.sh
+++ b/scripts/dev/test-tools-split-map.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPLIT_MAP_SCRIPT="${SCRIPT_DIR}/tools-split-map.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected output to contain '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "${SPLIT_MAP_SCRIPT}" ]]; then
+  echo "assertion failed (unit executable): missing executable ${SPLIT_MAP_SCRIPT}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+source_file="${tmp_dir}/tools.rs"
+missing_source_file="${tmp_dir}/missing.rs"
+output_json="${tmp_dir}/split-map.json"
+output_md="${tmp_dir}/split-map.md"
+
+cat >"${source_file}" <<'EOF'
+pub struct ReadTool;
+pub struct WriteTool;
+pub struct BashTool;
+EOF
+
+# Functional: generator emits JSON + markdown contract fields.
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+
+if [[ ! -f "${output_json}" ]]; then
+  echo "assertion failed (functional output json): missing ${output_json}" >&2
+  exit 1
+fi
+if [[ ! -f "${output_md}" ]]; then
+  echo "assertion failed (functional output md): missing ${output_md}" >&2
+  exit 1
+fi
+
+assert_equals "1" "$(jq -r '.schema_version' "${output_json}")" "functional schema_version"
+assert_equals "2026-02-16T00:00:00Z" "$(jq -r '.generated_at' "${output_json}")" "functional generated_at"
+assert_equals "3" "$(jq -r '.current_line_count' "${output_json}")" "functional current line count"
+assert_equals "1" "$(jq -r '.line_gap_to_target' "${output_json}")" "functional line gap"
+assert_equals "true" "$(jq -r '(.extraction_phases | length) > 0' "${output_json}")" "functional extraction phases non-empty"
+assert_equals "true" "$(jq -r '(.public_api_impact | length) > 0' "${output_json}")" "functional api impact non-empty"
+assert_equals "true" "$(jq -r '(.test_migration_plan | length) > 0' "${output_json}")" "functional test migration non-empty"
+assert_contains "$(cat "${output_md}")" "Tools Runtime Split Map" "functional markdown title"
+
+# Regression: missing source file fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${missing_source_file}" --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression missing source): expected failure" >&2
+  exit 1
+fi
+
+# Regression: invalid target lines fails closed.
+if "${SPLIT_MAP_SCRIPT}" --quiet --source-file "${source_file}" --target-lines 0 --output-json "${output_json}" --output-md "${output_md}" >/dev/null 2>&1; then
+  echo "assertion failed (regression invalid target): expected failure" >&2
+  exit 1
+fi
+
+# Functional regression: deterministic output for identical input and timestamp.
+hash_before="$(shasum "${output_json}" "${output_md}")"
+"${SPLIT_MAP_SCRIPT}" \
+  --quiet \
+  --source-file "${source_file}" \
+  --target-lines 2 \
+  --generated-at "2026-02-16T00:00:00Z" \
+  --output-json "${output_json}" \
+  --output-md "${output_md}"
+hash_after="$(shasum "${output_json}" "${output_md}")"
+assert_equals "${hash_before}" "${hash_after}" "functional deterministic hash"
+
+echo "tools-split-map tests passed"

--- a/scripts/dev/tools-split-map.sh
+++ b/scripts/dev/tools-split-map.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SOURCE_FILE="crates/tau-tools/src/tools.rs"
+TARGET_LINES=3000
+OUTPUT_JSON="${REPO_ROOT}/tasks/reports/m25-tools-split-map.json"
+OUTPUT_MD="${REPO_ROOT}/tasks/reports/m25-tools-split-map.md"
+GENERATED_AT=""
+QUIET_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage: tools-split-map.sh [options]
+
+Generate M25 split-map artifacts for crates/tau-tools/src/tools.rs.
+
+Options:
+  --source-file <path>      Source file to analyze (default: crates/tau-tools/src/tools.rs)
+  --target-lines <n>        Target post-split line budget (default: 3000)
+  --output-json <path>      JSON artifact output path
+  --output-md <path>        Markdown artifact output path
+  --generated-at <iso>      Deterministic generated timestamp (ISO-8601 UTC)
+  --quiet                   Suppress informational output
+  --help                    Show this help text
+EOF
+}
+
+log_info() {
+  if [[ "${QUIET_MODE}" != "true" ]]; then
+    echo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-file)
+      SOURCE_FILE="$2"
+      shift 2
+      ;;
+    --target-lines)
+      TARGET_LINES="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --generated-at)
+      GENERATED_AT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET_MODE="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${TARGET_LINES}" =~ ^[0-9]+$ ]] || [[ "${TARGET_LINES}" -lt 1 ]]; then
+  echo "error: --target-lines must be an integer >= 1" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+  echo "error: source file not found: ${SOURCE_FILE}" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: required command 'python3' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+python3 - \
+  "${SOURCE_FILE}" \
+  "${TARGET_LINES}" \
+  "${OUTPUT_JSON}" \
+  "${OUTPUT_MD}" \
+  "${GENERATED_AT}" \
+  "${QUIET_MODE}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+(
+    source_file_raw,
+    target_lines_raw,
+    output_json_raw,
+    output_md_raw,
+    generated_at_raw,
+    quiet_mode_raw,
+) = sys.argv[1:]
+
+source_file = Path(source_file_raw)
+output_json = Path(output_json_raw)
+output_md = Path(output_md_raw)
+target_lines = int(target_lines_raw)
+quiet_mode = quiet_mode_raw == "true"
+
+
+def log(message: str) -> None:
+    if not quiet_mode:
+        print(message)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def parse_iso8601_utc(value: str) -> datetime:
+    candidate = value.strip()
+    if not candidate:
+        fail("generated-at value must not be empty")
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        fail(f"invalid --generated-at timestamp: {value} ({exc})")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+generated_at = (
+    parse_iso8601_utc(generated_at_raw)
+    if generated_at_raw.strip()
+    else datetime.now(timezone.utc).replace(microsecond=0)
+)
+generated_at_iso = iso_utc(generated_at)
+
+line_count = len(source_file.read_text(encoding="utf-8").splitlines())
+line_gap = max(line_count - target_lines, 0)
+
+extraction_phases: list[dict[str, Any]] = [
+    {
+        "id": "phase-1-fs-edit-memory",
+        "title": "Filesystem/edit and memory domain tools",
+        "owner": "tools-runtime",
+        "line_reduction_estimate": 410,
+        "modules": [
+            "tools/fs_tools.rs",
+            "tools/edit_tools.rs",
+            "tools/memory_tools.rs",
+        ],
+        "depends_on": [],
+        "notes": "Keep read/write/edit/memory tool JSON contracts and policy hooks stable.",
+    },
+    {
+        "id": "phase-2-jobs-history-http",
+        "title": "Jobs/history/http command tool surfaces",
+        "owner": "tools-orchestration",
+        "line_reduction_estimate": 320,
+        "modules": [
+            "tools/jobs_tools.rs",
+            "tools/history_tools.rs",
+            "tools/http_tools.rs",
+        ],
+        "depends_on": ["phase-1-fs-edit-memory"],
+        "notes": "Preserve queue/status/cancel behavior and HTTP safety options across call sites.",
+    },
+    {
+        "id": "phase-3-bash-policy-gates",
+        "title": "Bash execution and policy/approval gate logic",
+        "owner": "tools-safety",
+        "line_reduction_estimate": 260,
+        "modules": [
+            "tools/bash_tool.rs",
+            "tools/policy_gates.rs",
+        ],
+        "depends_on": ["phase-2-jobs-history-http"],
+        "notes": "Keep approval, RBAC, protected-path, and rate-limit gates behaviorally identical.",
+    },
+]
+
+estimated_lines_to_extract = sum(entry["line_reduction_estimate"] for entry in extraction_phases)
+post_split_estimated_line_count = max(line_count - estimated_lines_to_extract, 0)
+
+public_api_impact = [
+    "Keep exported tool type names and trait implementations stable for runtime callers.",
+    "Preserve JSON argument/return contracts for all moved tools.",
+    "Maintain existing policy gate result semantics and error envelopes.",
+]
+
+import_impact = [
+    "Introduce module declarations under crates/tau-tools/src/tools/ with selective re-exports.",
+    "Move domain-specific tool implementations from tools.rs into phased modules.",
+    "Keep shared helper functions centralized to reduce import fan-out during phased extraction.",
+]
+
+test_migration_plan = [
+    {
+        "order": 1,
+        "id": "guardrail-threshold-enforcement",
+        "description": "Introduce and enforce tools.rs split guardrail ending at <3000.",
+        "command": "scripts/dev/test-tools-domain-split.sh",
+        "expected_signal": "tools.rs threshold checks fail closed until split target is reached",
+    },
+    {
+        "order": 2,
+        "id": "tools-crate-coverage",
+        "description": "Run crate-scoped tau-tools tests after each extraction phase.",
+        "command": "cargo test -p tau-tools",
+        "expected_signal": "tool behavior, safety checks, and serialization tests stay green",
+    },
+    {
+        "order": 3,
+        "id": "runtime-integration",
+        "description": "Run cross-crate runtime integration suites that consume tau-tools surfaces.",
+        "command": "cargo test -p tau-coding-agent",
+        "expected_signal": "no regressions in tool wiring and end-to-end command flows",
+    },
+]
+
+payload = {
+    "schema_version": 1,
+    "generated_at": generated_at_iso,
+    "source_file": source_file_raw,
+    "target_line_budget": target_lines,
+    "current_line_count": line_count,
+    "line_gap_to_target": line_gap,
+    "estimated_lines_to_extract": estimated_lines_to_extract,
+    "post_split_estimated_line_count": post_split_estimated_line_count,
+    "extraction_phases": extraction_phases,
+    "public_api_impact": public_api_impact,
+    "import_impact": import_impact,
+    "test_migration_plan": test_migration_plan,
+}
+
+output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+lines: list[str] = [
+    "# Tools Runtime Split Map (M25)",
+    "",
+    f"- Generated at (UTC): `{generated_at_iso}`",
+    f"- Source file: `{source_file_raw}`",
+    f"- Target line budget: `{target_lines}`",
+    f"- Current line count: `{line_count}`",
+    f"- Current gap to target: `{line_gap}`",
+    f"- Estimated lines to extract: `{estimated_lines_to_extract}`",
+    f"- Estimated post-split line count: `{post_split_estimated_line_count}`",
+    "",
+    "## Extraction Phases",
+    "",
+    "| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |",
+    "| --- | --- | ---: | --- | --- | --- |",
+]
+
+for phase in extraction_phases:
+    depends_on = ", ".join(phase["depends_on"]) if phase["depends_on"] else "-"
+    modules = ", ".join(phase["modules"])
+    lines.append(
+        "| "
+        f"{phase['id']} ({phase['title']}) | "
+        f"{phase['owner']} | "
+        f"{phase['line_reduction_estimate']} | "
+        f"{depends_on} | "
+        f"{modules} | "
+        f"{phase['notes']} |"
+    )
+
+lines.extend(
+    [
+        "",
+        "## Public API Impact",
+        "",
+    ]
+)
+for item in public_api_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Import Impact",
+        "",
+    ]
+)
+for item in import_impact:
+    lines.append(f"- {item}")
+
+lines.extend(
+    [
+        "",
+        "## Test Migration Plan",
+        "",
+        "| Order | Step | Command | Expected Signal |",
+        "| ---: | --- | --- | --- |",
+    ]
+)
+for entry in test_migration_plan:
+    lines.append(
+        "| "
+        f"{entry['order']} | "
+        f"{entry['id']}: {entry['description']} | "
+        f"{entry['command']} | "
+        f"{entry['expected_signal']} |"
+    )
+
+output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+log(
+    "[tools-split-map] "
+    f"source={source_file_raw} current_lines={line_count} target={target_lines} gap={line_gap}"
+)
+PY
+
+log_info "wrote tools split-map artifacts:"
+log_info "  - ${OUTPUT_JSON}"
+log_info "  - ${OUTPUT_MD}"

--- a/tasks/reports/m25-benchmark-artifact-split-map.json
+++ b/tasks/reports/m25-benchmark-artifact-split-map.json
@@ -1,0 +1,99 @@
+{
+  "current_line_count": 3868,
+  "estimated_lines_to_extract": 950,
+  "extraction_phases": [
+    {
+      "depends_on": [],
+      "id": "phase-1-schema-types",
+      "line_reduction_estimate": 220,
+      "modules": [
+        "benchmark_artifact/schema.rs",
+        "benchmark_artifact/types.rs"
+      ],
+      "notes": "Preserve externally consumed artifact JSON schema and field names.",
+      "owner": "trainer-core",
+      "title": "Benchmark schema/types and serde payload structures"
+    },
+    {
+      "depends_on": [
+        "phase-1-schema-types"
+      ],
+      "id": "phase-2-io-persistence",
+      "line_reduction_estimate": 260,
+      "modules": [
+        "benchmark_artifact/io.rs",
+        "benchmark_artifact/persistence.rs"
+      ],
+      "notes": "Keep filesystem contracts and error surface stable for callers.",
+      "owner": "trainer-runtime",
+      "title": "Artifact IO, path handling, and persistence utilities"
+    },
+    {
+      "depends_on": [
+        "phase-2-io-persistence"
+      ],
+      "id": "phase-3-report-rendering",
+      "line_reduction_estimate": 230,
+      "modules": [
+        "benchmark_artifact/reporting.rs",
+        "benchmark_artifact/render.rs"
+      ],
+      "notes": "Separate formatting logic from core benchmark artifact state.",
+      "owner": "trainer-observability",
+      "title": "Markdown/JSON reporting and presentation helpers"
+    },
+    {
+      "depends_on": [
+        "phase-3-report-rendering"
+      ],
+      "id": "phase-4-validation-compare",
+      "line_reduction_estimate": 240,
+      "modules": [
+        "benchmark_artifact/validation.rs",
+        "benchmark_artifact/compare.rs"
+      ],
+      "notes": "Retain benchmark conformance semantics and regression reason-code behavior.",
+      "owner": "trainer-quality",
+      "title": "Validation, comparison, and regression guard logic"
+    }
+  ],
+  "generated_at": "2026-02-16T09:21:38Z",
+  "import_impact": [
+    "Introduce benchmark_artifact module tree under crates/tau-trainer/src/benchmark_artifact/.",
+    "Move domain-specific helpers into phased modules while preserving root re-exports.",
+    "Minimize cross-module imports by grouping schema/IO/report/validation concerns."
+  ],
+  "line_gap_to_target": 868,
+  "post_split_estimated_line_count": 2918,
+  "public_api_impact": [
+    "Retain current benchmark artifact struct names and serialized field contracts.",
+    "Keep public constructor/loader entrypoints stable for trainer and CLI callers.",
+    "Confine extraction changes behind module boundaries without changing call signatures."
+  ],
+  "schema_version": 1,
+  "source_file": "crates/tau-trainer/src/benchmark_artifact.rs",
+  "target_line_budget": 3000,
+  "test_migration_plan": [
+    {
+      "command": "cargo test -p tau-trainer benchmark_artifact",
+      "description": "Run benchmark artifact conformance tests after each extraction phase.",
+      "expected_signal": "benchmark artifact conformance tests remain green",
+      "id": "benchmark-conformance-suite",
+      "order": 1
+    },
+    {
+      "command": "cargo test -p tau-trainer",
+      "description": "Run trainer integration tests that persist/load benchmark artifacts.",
+      "expected_signal": "trainer integration flows preserve artifact behavior",
+      "id": "trainer-integration-suite",
+      "order": 2
+    },
+    {
+      "command": "python3 -m unittest discover -s .github/scripts -p test_*.py",
+      "description": "Run workspace-level governance/contract checks for generated artifacts.",
+      "expected_signal": "contract suite remains green after module extraction",
+      "id": "workspace-regression-suite",
+      "order": 3
+    }
+  ]
+}

--- a/tasks/reports/m25-benchmark-artifact-split-map.md
+++ b/tasks/reports/m25-benchmark-artifact-split-map.md
@@ -1,0 +1,38 @@
+# Benchmark Artifact Split Map (M25)
+
+- Generated at (UTC): `2026-02-16T09:21:38Z`
+- Source file: `crates/tau-trainer/src/benchmark_artifact.rs`
+- Target line budget: `3000`
+- Current line count: `3868`
+- Current gap to target: `868`
+- Estimated lines to extract: `950`
+- Estimated post-split line count: `2918`
+
+## Extraction Phases
+
+| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| phase-1-schema-types (Benchmark schema/types and serde payload structures) | trainer-core | 220 | - | benchmark_artifact/schema.rs, benchmark_artifact/types.rs | Preserve externally consumed artifact JSON schema and field names. |
+| phase-2-io-persistence (Artifact IO, path handling, and persistence utilities) | trainer-runtime | 260 | phase-1-schema-types | benchmark_artifact/io.rs, benchmark_artifact/persistence.rs | Keep filesystem contracts and error surface stable for callers. |
+| phase-3-report-rendering (Markdown/JSON reporting and presentation helpers) | trainer-observability | 230 | phase-2-io-persistence | benchmark_artifact/reporting.rs, benchmark_artifact/render.rs | Separate formatting logic from core benchmark artifact state. |
+| phase-4-validation-compare (Validation, comparison, and regression guard logic) | trainer-quality | 240 | phase-3-report-rendering | benchmark_artifact/validation.rs, benchmark_artifact/compare.rs | Retain benchmark conformance semantics and regression reason-code behavior. |
+
+## Public API Impact
+
+- Retain current benchmark artifact struct names and serialized field contracts.
+- Keep public constructor/loader entrypoints stable for trainer and CLI callers.
+- Confine extraction changes behind module boundaries without changing call signatures.
+
+## Import Impact
+
+- Introduce benchmark_artifact module tree under crates/tau-trainer/src/benchmark_artifact/.
+- Move domain-specific helpers into phased modules while preserving root re-exports.
+- Minimize cross-module imports by grouping schema/IO/report/validation concerns.
+
+## Test Migration Plan
+
+| Order | Step | Command | Expected Signal |
+| ---: | --- | --- | --- |
+| 1 | benchmark-conformance-suite: Run benchmark artifact conformance tests after each extraction phase. | cargo test -p tau-trainer benchmark_artifact | benchmark artifact conformance tests remain green |
+| 2 | trainer-integration-suite: Run trainer integration tests that persist/load benchmark artifacts. | cargo test -p tau-trainer | trainer integration flows preserve artifact behavior |
+| 3 | workspace-regression-suite: Run workspace-level governance/contract checks for generated artifacts. | python3 -m unittest discover -s .github/scripts -p test_*.py | contract suite remains green after module extraction |

--- a/tasks/reports/m25-cli-args-split-map.json
+++ b/tasks/reports/m25-cli-args-split-map.json
@@ -1,0 +1,103 @@
+{
+  "current_line_count": 3954,
+  "estimated_lines_to_extract": 1070,
+  "extraction_phases": [
+    {
+      "depends_on": [],
+      "id": "phase-1-provider-auth",
+      "line_reduction_estimate": 300,
+      "modules": [
+        "cli_args/provider_model_flags.rs",
+        "cli_args/provider_auth_flags.rs"
+      ],
+      "notes": "Preserve Cli top-level field names via #[command(flatten)] wrappers.",
+      "owner": "cli-platform",
+      "title": "Provider/auth and model catalog flags"
+    },
+    {
+      "depends_on": [
+        "phase-1-provider-auth"
+      ],
+      "id": "phase-2-gateway-runtime",
+      "line_reduction_estimate": 260,
+      "modules": [
+        "cli_args/gateway_remote_flags.rs",
+        "cli_args/gateway_service_flags.rs"
+      ],
+      "notes": "Keep existing gateway daemon sub-struct wiring intact and additive.",
+      "owner": "runtime-gateway",
+      "title": "Gateway remote/service and transport flags"
+    },
+    {
+      "depends_on": [
+        "phase-2-gateway-runtime"
+      ],
+      "id": "phase-3-package-events-extension",
+      "line_reduction_estimate": 230,
+      "modules": [
+        "cli_args/package_flags.rs",
+        "cli_args/events_flags.rs",
+        "cli_args/extension_flags.rs",
+        "cli_args/skills_flags.rs"
+      ],
+      "notes": "Group related command surfaces to reduce import fan-out in cli_args.rs.",
+      "owner": "runtime-packaging",
+      "title": "Package/events/extensions and skill policy flags"
+    },
+    {
+      "depends_on": [
+        "phase-3-package-events-extension"
+      ],
+      "id": "phase-4-multichannel-dashboard-voice",
+      "line_reduction_estimate": 280,
+      "modules": [
+        "cli_args/multi_channel_flags.rs",
+        "cli_args/dashboard_flags.rs",
+        "cli_args/memory_flags.rs",
+        "cli_args/voice_flags.rs"
+      ],
+      "notes": "Final phase targets high-volume flag groups to push below the 3000 line budget.",
+      "owner": "runtime-integrations",
+      "title": "Multi-channel, dashboard, memory, and voice surfaces"
+    }
+  ],
+  "generated_at": "2026-02-16T08:47:54Z",
+  "import_impact": [
+    "Add new module declarations under crates/tau-cli/src/cli_args/ with targeted pub re-exports.",
+    "Move domain-specific clap argument definitions from cli_args.rs into phase modules.",
+    "Keep root-level helper parsers in cli_args.rs until all phases are complete to avoid churn."
+  ],
+  "line_gap_to_target": 954,
+  "post_split_estimated_line_count": 2884,
+  "public_api_impact": [
+    "Keep pub struct Cli as the single externally consumed parser type.",
+    "Retain existing flag names, clap aliases, defaults, and env bindings.",
+    "Introduce internal flattened sub-structs only; no external crate API renames."
+  ],
+  "schema_version": 1,
+  "source_file": "crates/tau-cli/src/cli_args.rs",
+  "target_line_budget": 3000,
+  "test_migration_plan": [
+    {
+      "command": "scripts/dev/test-cli-args-domain-split.sh",
+      "description": "Lower cli_args split guardrail from <4000 to staged thresholds ending at <3000.",
+      "expected_signal": "line budget checks enforce progressive reduction and final <3000 gate",
+      "id": "update-guardrail-threshold",
+      "order": 1
+    },
+    {
+      "command": "cargo test -p tau-cli",
+      "description": "Run crate-scoped CLI parsing and validation tests after each phase extraction.",
+      "expected_signal": "all clap parser and validation tests pass",
+      "id": "cli-crate-coverage",
+      "order": 2
+    },
+    {
+      "command": "cargo test -p tau-coding-agent",
+      "description": "Run cross-crate runtime command integration tests that consume Cli fields.",
+      "expected_signal": "no regressions in command wiring and runtime behavior",
+      "id": "workspace-integration",
+      "order": 3
+    }
+  ]
+}

--- a/tasks/reports/m25-cli-args-split-map.md
+++ b/tasks/reports/m25-cli-args-split-map.md
@@ -1,0 +1,38 @@
+# CLI Args Split Map (M25)
+
+- Generated at (UTC): `2026-02-16T08:47:54Z`
+- Source file: `crates/tau-cli/src/cli_args.rs`
+- Target line budget: `3000`
+- Current line count: `3954`
+- Current gap to target: `954`
+- Estimated lines to extract: `1070`
+- Estimated post-split line count: `2884`
+
+## Extraction Phases
+
+| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| phase-1-provider-auth (Provider/auth and model catalog flags) | cli-platform | 300 | - | cli_args/provider_model_flags.rs, cli_args/provider_auth_flags.rs | Preserve Cli top-level field names via #[command(flatten)] wrappers. |
+| phase-2-gateway-runtime (Gateway remote/service and transport flags) | runtime-gateway | 260 | phase-1-provider-auth | cli_args/gateway_remote_flags.rs, cli_args/gateway_service_flags.rs | Keep existing gateway daemon sub-struct wiring intact and additive. |
+| phase-3-package-events-extension (Package/events/extensions and skill policy flags) | runtime-packaging | 230 | phase-2-gateway-runtime | cli_args/package_flags.rs, cli_args/events_flags.rs, cli_args/extension_flags.rs, cli_args/skills_flags.rs | Group related command surfaces to reduce import fan-out in cli_args.rs. |
+| phase-4-multichannel-dashboard-voice (Multi-channel, dashboard, memory, and voice surfaces) | runtime-integrations | 280 | phase-3-package-events-extension | cli_args/multi_channel_flags.rs, cli_args/dashboard_flags.rs, cli_args/memory_flags.rs, cli_args/voice_flags.rs | Final phase targets high-volume flag groups to push below the 3000 line budget. |
+
+## Public API Impact
+
+- Keep pub struct Cli as the single externally consumed parser type.
+- Retain existing flag names, clap aliases, defaults, and env bindings.
+- Introduce internal flattened sub-structs only; no external crate API renames.
+
+## Import Impact
+
+- Add new module declarations under crates/tau-cli/src/cli_args/ with targeted pub re-exports.
+- Move domain-specific clap argument definitions from cli_args.rs into phase modules.
+- Keep root-level helper parsers in cli_args.rs until all phases are complete to avoid churn.
+
+## Test Migration Plan
+
+| Order | Step | Command | Expected Signal |
+| ---: | --- | --- | --- |
+| 1 | update-guardrail-threshold: Lower cli_args split guardrail from <4000 to staged thresholds ending at <3000. | scripts/dev/test-cli-args-domain-split.sh | line budget checks enforce progressive reduction and final <3000 gate |
+| 2 | cli-crate-coverage: Run crate-scoped CLI parsing and validation tests after each phase extraction. | cargo test -p tau-cli | all clap parser and validation tests pass |
+| 3 | workspace-integration: Run cross-crate runtime command integration tests that consume Cli fields. | cargo test -p tau-coding-agent | no regressions in command wiring and runtime behavior |

--- a/tasks/reports/m25-github-issues-runtime-split-map.json
+++ b/tasks/reports/m25-github-issues-runtime-split-map.json
@@ -1,0 +1,87 @@
+{
+  "current_line_count": 3390,
+  "estimated_lines_to_extract": 450,
+  "extraction_phases": [
+    {
+      "depends_on": [],
+      "id": "phase-1-webhook-validation-ingest",
+      "line_reduction_estimate": 170,
+      "modules": [
+        "github_issues_runtime/webhook_validation.rs",
+        "github_issues_runtime/ingest.rs"
+      ],
+      "notes": "Preserve webhook signature/shape validation and deterministic ingest diagnostics.",
+      "owner": "github-issues-ingest",
+      "title": "Webhook payload validation and ingest normalization"
+    },
+    {
+      "depends_on": [
+        "phase-1-webhook-validation-ingest"
+      ],
+      "id": "phase-2-session-sync-routing",
+      "line_reduction_estimate": 150,
+      "modules": [
+        "github_issues_runtime/session_projection.rs",
+        "github_issues_runtime/comment_sync.rs",
+        "github_issues_runtime/routing.rs"
+      ],
+      "notes": "Keep issue-to-session mapping and message emission order stable.",
+      "owner": "github-issues-sync",
+      "title": "Session projection, comment sync, and routing helpers"
+    },
+    {
+      "depends_on": [
+        "phase-2-session-sync-routing"
+      ],
+      "id": "phase-3-error-policy-rate-limit",
+      "line_reduction_estimate": 130,
+      "modules": [
+        "github_issues_runtime/policy.rs",
+        "github_issues_runtime/rate_limit.rs",
+        "github_issues_runtime/errors.rs"
+      ],
+      "notes": "Retain fail-closed behavior and reason-code mapping for moderation and retry signals.",
+      "owner": "github-issues-policy",
+      "title": "Policy guards, rate-limits, and error-envelope mapping"
+    }
+  ],
+  "generated_at": "2026-02-16T00:00:00Z",
+  "import_impact": [
+    "Introduce module declarations under crates/tau-github-issues-runtime/src/github_issues_runtime/ with selective re-exports.",
+    "Move ingest/sync/policy helper domains out of github_issues_runtime.rs in phases.",
+    "Keep shared bridge utility helpers centralized to minimize cross-module import churn."
+  ],
+  "line_gap_to_target": 390,
+  "post_split_estimated_line_count": 2940,
+  "public_api_impact": [
+    "Keep GitHub Issues runtime public entrypoints and bridge configuration surfaces stable.",
+    "Preserve webhook ingest and issue-comment processing payload contracts.",
+    "Maintain existing reason-code/error-envelope behavior exposed to callers."
+  ],
+  "schema_version": 1,
+  "source_file": "crates/tau-github-issues-runtime/src/github_issues_runtime.rs",
+  "target_line_budget": 3000,
+  "test_migration_plan": [
+    {
+      "command": "scripts/dev/test-github-issues-runtime-domain-split.sh",
+      "description": "Introduce and enforce github_issues_runtime.rs split guardrail ending at <3000.",
+      "expected_signal": "github_issues_runtime.rs threshold checks fail closed until split target is reached",
+      "id": "guardrail-threshold-enforcement",
+      "order": 1
+    },
+    {
+      "command": "cargo test -p tau-github-issues-runtime",
+      "description": "Run crate-scoped GitHub Issues runtime tests after each extraction phase.",
+      "expected_signal": "bridge ingest/sync behavior and reason-code tests stay green",
+      "id": "runtime-crate-coverage",
+      "order": 2
+    },
+    {
+      "command": "cargo test -p tau-coding-agent",
+      "description": "Run cross-crate integration suites that consume GitHub Issues runtime surfaces.",
+      "expected_signal": "no regressions in issue bridge wiring and end-to-end command flows",
+      "id": "runtime-integration",
+      "order": 3
+    }
+  ]
+}

--- a/tasks/reports/m25-github-issues-runtime-split-map.md
+++ b/tasks/reports/m25-github-issues-runtime-split-map.md
@@ -1,0 +1,37 @@
+# GitHub Issues Runtime Split Map (M25)
+
+- Generated at (UTC): `2026-02-16T00:00:00Z`
+- Source file: `crates/tau-github-issues-runtime/src/github_issues_runtime.rs`
+- Target line budget: `3000`
+- Current line count: `3390`
+- Current gap to target: `390`
+- Estimated lines to extract: `450`
+- Estimated post-split line count: `2940`
+
+## Extraction Phases
+
+| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| phase-1-webhook-validation-ingest (Webhook payload validation and ingest normalization) | github-issues-ingest | 170 | - | github_issues_runtime/webhook_validation.rs, github_issues_runtime/ingest.rs | Preserve webhook signature/shape validation and deterministic ingest diagnostics. |
+| phase-2-session-sync-routing (Session projection, comment sync, and routing helpers) | github-issues-sync | 150 | phase-1-webhook-validation-ingest | github_issues_runtime/session_projection.rs, github_issues_runtime/comment_sync.rs, github_issues_runtime/routing.rs | Keep issue-to-session mapping and message emission order stable. |
+| phase-3-error-policy-rate-limit (Policy guards, rate-limits, and error-envelope mapping) | github-issues-policy | 130 | phase-2-session-sync-routing | github_issues_runtime/policy.rs, github_issues_runtime/rate_limit.rs, github_issues_runtime/errors.rs | Retain fail-closed behavior and reason-code mapping for moderation and retry signals. |
+
+## Public API Impact
+
+- Keep GitHub Issues runtime public entrypoints and bridge configuration surfaces stable.
+- Preserve webhook ingest and issue-comment processing payload contracts.
+- Maintain existing reason-code/error-envelope behavior exposed to callers.
+
+## Import Impact
+
+- Introduce module declarations under crates/tau-github-issues-runtime/src/github_issues_runtime/ with selective re-exports.
+- Move ingest/sync/policy helper domains out of github_issues_runtime.rs in phases.
+- Keep shared bridge utility helpers centralized to minimize cross-module import churn.
+
+## Test Migration Plan
+
+| Order | Step | Command | Expected Signal |
+| ---: | --- | --- | --- |
+| 1 | guardrail-threshold-enforcement: Introduce and enforce github_issues_runtime.rs split guardrail ending at <3000. | scripts/dev/test-github-issues-runtime-domain-split.sh | github_issues_runtime.rs threshold checks fail closed until split target is reached |
+| 2 | runtime-crate-coverage: Run crate-scoped GitHub Issues runtime tests after each extraction phase. | cargo test -p tau-github-issues-runtime | bridge ingest/sync behavior and reason-code tests stay green |
+| 3 | runtime-integration: Run cross-crate integration suites that consume GitHub Issues runtime surfaces. | cargo test -p tau-coding-agent | no regressions in issue bridge wiring and end-to-end command flows |

--- a/tasks/reports/m25-tools-split-map.json
+++ b/tasks/reports/m25-tools-split-map.json
@@ -1,0 +1,87 @@
+{
+  "current_line_count": 3646,
+  "estimated_lines_to_extract": 990,
+  "extraction_phases": [
+    {
+      "depends_on": [],
+      "id": "phase-1-fs-edit-memory",
+      "line_reduction_estimate": 410,
+      "modules": [
+        "tools/fs_tools.rs",
+        "tools/edit_tools.rs",
+        "tools/memory_tools.rs"
+      ],
+      "notes": "Keep read/write/edit/memory tool JSON contracts and policy hooks stable.",
+      "owner": "tools-runtime",
+      "title": "Filesystem/edit and memory domain tools"
+    },
+    {
+      "depends_on": [
+        "phase-1-fs-edit-memory"
+      ],
+      "id": "phase-2-jobs-history-http",
+      "line_reduction_estimate": 320,
+      "modules": [
+        "tools/jobs_tools.rs",
+        "tools/history_tools.rs",
+        "tools/http_tools.rs"
+      ],
+      "notes": "Preserve queue/status/cancel behavior and HTTP safety options across call sites.",
+      "owner": "tools-orchestration",
+      "title": "Jobs/history/http command tool surfaces"
+    },
+    {
+      "depends_on": [
+        "phase-2-jobs-history-http"
+      ],
+      "id": "phase-3-bash-policy-gates",
+      "line_reduction_estimate": 260,
+      "modules": [
+        "tools/bash_tool.rs",
+        "tools/policy_gates.rs"
+      ],
+      "notes": "Keep approval, RBAC, protected-path, and rate-limit gates behaviorally identical.",
+      "owner": "tools-safety",
+      "title": "Bash execution and policy/approval gate logic"
+    }
+  ],
+  "generated_at": "2026-02-16T00:00:00Z",
+  "import_impact": [
+    "Introduce module declarations under crates/tau-tools/src/tools/ with selective re-exports.",
+    "Move domain-specific tool implementations from tools.rs into phased modules.",
+    "Keep shared helper functions centralized to reduce import fan-out during phased extraction."
+  ],
+  "line_gap_to_target": 646,
+  "post_split_estimated_line_count": 2656,
+  "public_api_impact": [
+    "Keep exported tool type names and trait implementations stable for runtime callers.",
+    "Preserve JSON argument/return contracts for all moved tools.",
+    "Maintain existing policy gate result semantics and error envelopes."
+  ],
+  "schema_version": 1,
+  "source_file": "crates/tau-tools/src/tools.rs",
+  "target_line_budget": 3000,
+  "test_migration_plan": [
+    {
+      "command": "scripts/dev/test-tools-domain-split.sh",
+      "description": "Introduce and enforce tools.rs split guardrail ending at <3000.",
+      "expected_signal": "tools.rs threshold checks fail closed until split target is reached",
+      "id": "guardrail-threshold-enforcement",
+      "order": 1
+    },
+    {
+      "command": "cargo test -p tau-tools",
+      "description": "Run crate-scoped tau-tools tests after each extraction phase.",
+      "expected_signal": "tool behavior, safety checks, and serialization tests stay green",
+      "id": "tools-crate-coverage",
+      "order": 2
+    },
+    {
+      "command": "cargo test -p tau-coding-agent",
+      "description": "Run cross-crate runtime integration suites that consume tau-tools surfaces.",
+      "expected_signal": "no regressions in tool wiring and end-to-end command flows",
+      "id": "runtime-integration",
+      "order": 3
+    }
+  ]
+}

--- a/tasks/reports/m25-tools-split-map.md
+++ b/tasks/reports/m25-tools-split-map.md
@@ -1,0 +1,37 @@
+# Tools Runtime Split Map (M25)
+
+- Generated at (UTC): `2026-02-16T00:00:00Z`
+- Source file: `crates/tau-tools/src/tools.rs`
+- Target line budget: `3000`
+- Current line count: `3646`
+- Current gap to target: `646`
+- Estimated lines to extract: `990`
+- Estimated post-split line count: `2656`
+
+## Extraction Phases
+
+| Phase | Owner | Est. Reduction | Depends On | Modules | Notes |
+| --- | --- | ---: | --- | --- | --- |
+| phase-1-fs-edit-memory (Filesystem/edit and memory domain tools) | tools-runtime | 410 | - | tools/fs_tools.rs, tools/edit_tools.rs, tools/memory_tools.rs | Keep read/write/edit/memory tool JSON contracts and policy hooks stable. |
+| phase-2-jobs-history-http (Jobs/history/http command tool surfaces) | tools-orchestration | 320 | phase-1-fs-edit-memory | tools/jobs_tools.rs, tools/history_tools.rs, tools/http_tools.rs | Preserve queue/status/cancel behavior and HTTP safety options across call sites. |
+| phase-3-bash-policy-gates (Bash execution and policy/approval gate logic) | tools-safety | 260 | phase-2-jobs-history-http | tools/bash_tool.rs, tools/policy_gates.rs | Keep approval, RBAC, protected-path, and rate-limit gates behaviorally identical. |
+
+## Public API Impact
+
+- Keep exported tool type names and trait implementations stable for runtime callers.
+- Preserve JSON argument/return contracts for all moved tools.
+- Maintain existing policy gate result semantics and error envelopes.
+
+## Import Impact
+
+- Introduce module declarations under crates/tau-tools/src/tools/ with selective re-exports.
+- Move domain-specific tool implementations from tools.rs into phased modules.
+- Keep shared helper functions centralized to reduce import fan-out during phased extraction.
+
+## Test Migration Plan
+
+| Order | Step | Command | Expected Signal |
+| ---: | --- | --- | --- |
+| 1 | guardrail-threshold-enforcement: Introduce and enforce tools.rs split guardrail ending at <3000. | scripts/dev/test-tools-domain-split.sh | tools.rs threshold checks fail closed until split target is reached |
+| 2 | tools-crate-coverage: Run crate-scoped tau-tools tests after each extraction phase. | cargo test -p tau-tools | tool behavior, safety checks, and serialization tests stay green |
+| 3 | runtime-integration: Run cross-crate runtime integration suites that consume tau-tools surfaces. | cargo test -p tau-coding-agent | no regressions in tool wiring and end-to-end command flows |

--- a/tasks/schemas/m25-benchmark-artifact-split-map.schema.json
+++ b/tasks/schemas/m25-benchmark-artifact-split-map.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tau.njf.io/schemas/m25-benchmark-artifact-split-map.schema.json",
+  "title": "M25 Benchmark Artifact Split Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_file",
+    "target_line_budget",
+    "current_line_count",
+    "line_gap_to_target",
+    "estimated_lines_to_extract",
+    "post_split_estimated_line_count",
+    "extraction_phases",
+    "public_api_impact",
+    "import_impact",
+    "test_migration_plan"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_line_budget": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "current_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "line_gap_to_target": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "estimated_lines_to_extract": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "post_split_estimated_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "extraction_phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "owner",
+          "line_reduction_estimate",
+          "modules",
+          "depends_on",
+          "notes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_reduction_estimate": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "modules": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "public_api_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "import_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "test_migration_plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "order",
+          "id",
+          "description",
+          "command",
+          "expected_signal"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_signal": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tasks/schemas/m25-cli-args-split-map.schema.json
+++ b/tasks/schemas/m25-cli-args-split-map.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tau.njf.io/schemas/m25-cli-args-split-map.schema.json",
+  "title": "M25 CLI Args Split Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_file",
+    "target_line_budget",
+    "current_line_count",
+    "line_gap_to_target",
+    "estimated_lines_to_extract",
+    "post_split_estimated_line_count",
+    "extraction_phases",
+    "public_api_impact",
+    "import_impact",
+    "test_migration_plan"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_line_budget": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "current_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "line_gap_to_target": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "estimated_lines_to_extract": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "post_split_estimated_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "extraction_phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "owner",
+          "line_reduction_estimate",
+          "modules",
+          "depends_on",
+          "notes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_reduction_estimate": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "modules": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "public_api_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "import_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "test_migration_plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "order",
+          "id",
+          "description",
+          "command",
+          "expected_signal"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_signal": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tasks/schemas/m25-github-issues-runtime-split-map.schema.json
+++ b/tasks/schemas/m25-github-issues-runtime-split-map.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tau.njf.io/schemas/m25-github-issues-runtime-split-map.schema.json",
+  "title": "M25 GitHub Issues Runtime Split Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_file",
+    "target_line_budget",
+    "current_line_count",
+    "line_gap_to_target",
+    "estimated_lines_to_extract",
+    "post_split_estimated_line_count",
+    "extraction_phases",
+    "public_api_impact",
+    "import_impact",
+    "test_migration_plan"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_line_budget": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "current_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "line_gap_to_target": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "estimated_lines_to_extract": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "post_split_estimated_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "extraction_phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "owner",
+          "line_reduction_estimate",
+          "modules",
+          "depends_on",
+          "notes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_reduction_estimate": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "modules": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "public_api_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "import_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "test_migration_plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "order",
+          "id",
+          "description",
+          "command",
+          "expected_signal"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_signal": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tasks/schemas/m25-tools-split-map.schema.json
+++ b/tasks/schemas/m25-tools-split-map.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tau.njf.io/schemas/m25-tools-split-map.schema.json",
+  "title": "M25 Tools Runtime Split Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_file",
+    "target_line_budget",
+    "current_line_count",
+    "line_gap_to_target",
+    "estimated_lines_to_extract",
+    "post_split_estimated_line_count",
+    "extraction_phases",
+    "public_api_impact",
+    "import_impact",
+    "test_migration_plan"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_line_budget": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "current_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "line_gap_to_target": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "estimated_lines_to_extract": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "post_split_estimated_line_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "extraction_phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "owner",
+          "line_reduction_estimate",
+          "modules",
+          "depends_on",
+          "notes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_reduction_estimate": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "modules": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "public_api_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "import_impact": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "test_migration_plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "order",
+          "id",
+          "description",
+          "command",
+          "expected_signal"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_signal": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds deterministic split-map generation, schemas, reports, and contract tests for the M25 oversized-file decomposition wave.
It covers cli_args, benchmark_artifact, tools, and github_issues_runtime split-map artifacts plus guardrail scripts.

## Links
- Milestone: M25 Governance + Decomposition + Velocity
- Epic: #2029
- Roll-up: #2032
- Planning tasks: #2058, #2060, #2062, #2064
- Specs:
  - specs/2058/spec.md
  - specs/2060/spec.md
  - specs/2062/spec.md
  - specs/2064/spec.md

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: deterministic split-map artifacts emitted for each target file | ✅ | scripts/dev/test-cli-args-split-map.sh, scripts/dev/test-benchmark-artifact-split-map.sh, scripts/dev/test-tools-split-map.sh, scripts/dev/test-github-issues-runtime-split-map.sh |
| AC-2: schema + API/import impact sections are present and validated | ✅ | python3 .github/scripts/test_*_split_map_contract.py |
| AC-3: fail-closed behavior enforced for missing source/report/schema paths | ✅ | split-map shell tests and python contract suites |

## TDD Evidence
- RED: split-map tests fail when report/schema contracts are missing/misaligned.
- GREEN: all split-map suites pass after generator/schema/report wiring.
- REGRESSION: domain split guardrail checks remain green.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | python split-map contract tests per target | |
| Property | N/A | | no property-based invariant changes |
| Contract/DbC | N/A | | no Rust DbC annotations introduced |
| Snapshot | N/A | | outputs are asserted structurally, not via snapshots |
| Functional | ✅ | scripts/dev/test-*-split-map.sh | |
| Conformance | ✅ | specs/2058,2060,2062,2064 mapped in script suites | |
| Integration | ✅ | generator + schema + report + docs path consistency checks | |
| Fuzz | N/A | | no untrusted parser/code-path added |
| Mutation | N/A | | artifact-script layer only |
| Regression | ✅ | scripts/dev/test-benchmark-artifact-domain-split.sh, scripts/dev/test-tools-domain-split.sh | |
| Performance | N/A | | no runtime hotspots touched |

## Risks / Rollback
- Risk: low; additive scripts/docs/schemas/reports.
- Rollback: revert this PR to remove split-map artifact pipeline additions.

## Docs / ADR
- Added docs/guides/*-split-map.md; no ADR required.
