### PR TITLE
M27 scaffolding: add milestone and subtask lifecycle artifacts

### DIFF
--- a/specs/2097/plan.md
+++ b/specs/2097/plan.md
@@ -1,0 +1,41 @@
+# Plan #2097
+
+Status: Reviewed
+Spec: specs/2097/spec.md
+
+## Approach
+
+1. Identify a contiguous execution-domain flag slice suitable for first
+   migration.
+2. Add/normalize `crates/tau-cli/src/cli_args/execution_domain_flags.rs` and
+   wire it into `cli_args.rs`.
+3. Migrate the selected slice with minimal behavior drift and compile impact.
+4. Run targeted regression checks for parsing/help compatibility and task-level
+   verification.
+
+## Affected Modules
+
+- `crates/tau-cli/src/cli_args.rs`
+- `crates/tau-cli/src/cli_args/execution_domain_flags.rs`
+- `specs/2097/spec.md`
+- `specs/2097/plan.md`
+- `specs/2097/tasks.md`
+- `specs/milestones/m27/index.md`
+
+## Risks and Mitigations
+
+- Risk: clap flatten/field migration breaks parsing behavior.
+  - Mitigation: test-first regression checks and bounded first slice.
+- Risk: downstream call-sites assume flat field ownership in `Cli`.
+  - Mitigation: choose migration strategy that preserves field-level API or
+    updates call-sites in same PR with compile checks.
+
+## Interfaces and Contracts
+
+- `cargo test -p tau-cli`
+- targeted cli parsing/help regression tests under tau-cli/tau-coding-agent
+- task-scoped `cargo check` for affected crates
+
+## ADR References
+
+- Not required.

--- a/specs/2097/spec.md
+++ b/specs/2097/spec.md
@@ -1,0 +1,50 @@
+# Spec #2097
+
+Status: Accepted
+Milestone: specs/milestones/m27/index.md
+Issue: https://github.com/njfio/Tau/issues/2097
+
+## Problem Statement
+
+`crates/tau-cli/src/cli_args.rs` concentrates large execution-related flag
+blocks in a single file, reducing maintainability. We need initial module
+scaffolding plus migration of a first execution-domain flag slice with
+regression checks to ensure CLI compatibility.
+
+## Acceptance Criteria
+
+- AC-1: Execution-domain module scaffolding is added under
+  `crates/tau-cli/src/cli_args/`.
+- AC-2: A first coherent execution flag slice is migrated out of
+  `cli_args.rs` without breaking compile/CLI behavior.
+- AC-3: Focused regression checks validate parsing/help compatibility for the
+  migrated slice.
+
+## Scope
+
+In:
+
+- add execution-domain module file(s) and wire into `cli_args.rs`
+- migrate an initial, bounded flag slice
+- run targeted regression checks
+
+Out:
+
+- full cli_args decomposition in one subtask
+- semantic changes to existing CLI flags
+
+## Conformance Cases
+
+- C-01 (AC-1, integration): new execution-domain module file is present and
+  referenced by `cli_args.rs`.
+- C-02 (AC-2, functional): migrated CLI flag slice compiles and parses via
+  existing CLI tests/checks.
+- C-03 (AC-3, regression): help/flag compatibility checks pass for migrated
+  fields.
+- C-04 (AC-2/AC-3, regression): task-scoped test command set passes with no new
+  clap parse failures.
+
+## Success Metrics
+
+- Subtask `#2097` merges with a bounded migration and green regressions.
+- `cli_args.rs` line count is reduced versus pre-change baseline.

--- a/specs/2097/tasks.md
+++ b/specs/2097/tasks.md
@@ -1,0 +1,14 @@
+# Tasks #2097
+
+Status: Ready
+Spec: specs/2097/spec.md
+Plan: specs/2097/plan.md
+
+## Ordered Tasks
+
+- T1 (RED): add/identify failing regression checks for migrated execution-domain
+  flag slice.
+- T2 (GREEN): scaffold execution-domain module wiring and migrate first flag
+  slice from `cli_args.rs`.
+- T3 (VERIFY): run task-scoped compile/tests and CLI regression commands.
+- T4 (CLOSE): mark `specs/2097/*` implemented and close subtask issue.

--- a/specs/milestones/m27/index.md
+++ b/specs/milestones/m27/index.md
@@ -1,0 +1,48 @@
+# Milestone M27: CLI Args Maintainability Decomposition
+
+Status: Draft
+
+## Objective
+
+Reduce `tau-cli` CLI argument-surface complexity by extracting coherent domain
+slices from `crates/tau-cli/src/cli_args.rs` while preserving flag behavior and
+compatibility.
+
+## Scope
+
+In scope:
+
+- execution-domain flag extraction from `cli_args.rs`
+- clap compatibility regression checks for migrated slices
+- maintainability-driven decomposition with no user-facing flag removals
+
+Out of scope:
+
+- unrelated runtime feature additions
+- protocol/wire format changes
+
+## Success Signals
+
+- M27 hierarchy exists and is active with epic/story/task/subtask labels.
+- `cli_args.rs` complexity is reduced via modular extraction.
+- regression suites confirm no CLI contract drift.
+
+## Issue Hierarchy
+
+Milestone: GitHub milestone `M27 CLI Args Maintainability Decomposition`
+
+Epic:
+
+- `#2094` Epic: M27 CLI Args Domain Decomposition
+
+Story:
+
+- `#2095` Story: M27.1 Extract CLI execution-domain flag groups
+
+Task:
+
+- `#2096` Task: M27.1.1 Extract execution-domain flags from cli_args.rs into dedicated module
+
+Subtask:
+
+- `#2097` Subtask: M27.1.1a Scaffold execution-domain module and migrate first flag slice with regression checks


### PR DESCRIPTION
## Summary
Adds M27 milestone spec container and subtask `#2097` lifecycle artifacts through PLAN (Accepted spec, Reviewed plan, Ready tasks) so implementation can proceed under AGENTS.md gating.

## Links
- Milestone: `specs/milestones/m27/index.md`
- Refs #2097
- Spec: `specs/2097/spec.md`
- Plan: `specs/2097/plan.md`

## Notes
This PR intentionally does not implement code changes yet; it establishes required spec-driven artifacts before entering implementation phase.

## Validation
- Artifact presence validated in git:
  - `specs/milestones/m27/index.md`
  - `specs/2097/spec.md`
  - `specs/2097/plan.md`
  - `specs/2097/tasks.md`

## Risks/Rollback
- Risk: none beyond planning artifact drift.
- Rollback: revert added spec files.
