### PR TITLE
docs(split-modules): extend rustdoc guard for wave 2 helpers (#2113)

### DIFF
--- a/crates/tau-deployment/src/deployment_wasm_runtime.rs
+++ b/crates/tau-deployment/src/deployment_wasm_runtime.rs
@@ -1,16 +1,19 @@
 use anyhow::{Context, Result};
 use tau_cli::Cli;
 
+/// Re-exports for deployment WASM package/inspect command integration.
 pub use crate::deployment_wasm::{
     inspect_deployment_wasm_deliverable, package_deployment_wasm_artifact,
     render_deployment_wasm_inspect_report, render_deployment_wasm_package_report,
     DeploymentWasmPackageConfig,
 };
+/// Re-exports for browser DID initialization command integration.
 pub use crate::deployment_wasm_identity::{
     initialize_deployment_wasm_browser_did, render_deployment_wasm_browser_did_report,
     DeploymentWasmBrowserDidConfig,
 };
 
+/// Execute WASM package command when --deployment-wasm-package-module is set.
 pub fn execute_deployment_wasm_package_command(cli: &Cli) -> Result<()> {
     let Some(module_path) = cli.deployment_wasm_package_module.clone() else {
         return Ok(());
@@ -37,6 +40,7 @@ pub fn execute_deployment_wasm_package_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute WASM inspect command when --deployment-wasm-inspect-manifest is set.
 pub fn execute_deployment_wasm_inspect_command(cli: &Cli) -> Result<()> {
     let Some(manifest_path) = cli.deployment_wasm_inspect_manifest.clone() else {
         return Ok(());
@@ -54,6 +58,7 @@ pub fn execute_deployment_wasm_inspect_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute browser DID initialization command for deployment WASM runtime.
 pub fn execute_deployment_wasm_browser_did_init_command(cli: &Cli) -> Result<()> {
     if !cli.deployment_wasm_browser_did_init {
         return Ok(());

--- a/crates/tau-events/src/events_cli_commands.rs
+++ b/crates/tau-events/src/events_cli_commands.rs
@@ -10,6 +10,7 @@ use crate::{
     EventsValidateReport,
 };
 
+/// Execute events inspect mode and print either JSON or text report.
 pub fn execute_events_inspect_command(cli: &Cli) -> Result<()> {
     let report = inspect_events(
         &EventsInspectConfig {
@@ -33,6 +34,7 @@ pub fn execute_events_inspect_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute events validate mode and fail when invalid definition files are found.
 pub fn execute_events_validate_command(cli: &Cli) -> Result<()> {
     let report = validate_events_definitions(
         &EventsValidateConfig {
@@ -63,6 +65,7 @@ pub fn execute_events_validate_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute events template-write mode and emit generated template metadata.
 pub fn execute_events_template_write_command(cli: &Cli) -> Result<()> {
     let target_path = cli
         .execution_domain
@@ -137,6 +140,7 @@ pub fn execute_events_template_write_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute events simulation mode for due/horizon posture inspection.
 pub fn execute_events_simulate_command(cli: &Cli) -> Result<()> {
     let report = simulate_events(
         &EventsSimulateConfig {
@@ -160,6 +164,7 @@ pub fn execute_events_simulate_command(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+/// Execute events dry-run mode and enforce configured gate thresholds.
 pub fn execute_events_dry_run_command(cli: &Cli) -> Result<()> {
     let report = dry_run_events(
         &EventsDryRunConfig {

--- a/crates/tau-github-issues/src/github_transport_helpers.rs
+++ b/crates/tau-github-issues/src/github_transport_helpers.rs
@@ -1,11 +1,13 @@
 use std::time::Duration;
 
+/// Parse GitHub Retry-After header value as a duration.
 pub fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
     let raw = headers.get("retry-after")?.to_str().ok()?;
     let seconds = raw.trim().parse::<u64>().ok()?;
     Some(Duration::from_secs(seconds))
 }
 
+/// Compute retry delay using either retry-after floor or capped exponential backoff.
 pub fn retry_delay(base_delay_ms: u64, attempt: usize, retry_after: Option<Duration>) -> Duration {
     if let Some(delay) = retry_after {
         return delay.max(Duration::from_millis(base_delay_ms));
@@ -15,14 +17,17 @@ pub fn retry_delay(base_delay_ms: u64, attempt: usize, retry_after: Option<Durat
     Duration::from_millis(scaled.min(30_000))
 }
 
+/// Return true when a reqwest transport failure should be retried.
 pub fn is_retryable_transport_error(error: &reqwest::Error) -> bool {
     error.is_timeout() || error.is_connect() || error.is_request()
 }
 
+/// Determine whether a GitHub HTTP status is retryable.
 pub fn is_retryable_github_status(status: u16) -> bool {
     status == 429 || status >= 500
 }
 
+/// Truncate error text without breaking unicode boundaries and append ellipsis.
 pub fn truncate_for_error(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_string();

--- a/crates/tau-github-issues/src/issue_filter.rs
+++ b/crates/tau-github-issues/src/issue_filter.rs
@@ -1,9 +1,11 @@
 use std::collections::HashSet;
 
+/// Normalize issue label filters for case-insensitive matching.
 pub fn normalize_issue_label(raw: &str) -> String {
     raw.trim().to_ascii_lowercase()
 }
 
+/// Build the normalized set of required labels from CLI or configuration values.
 pub fn build_required_issue_labels<'a>(
     labels: impl IntoIterator<Item = &'a str>,
 ) -> HashSet<String> {
@@ -14,10 +16,12 @@ pub fn build_required_issue_labels<'a>(
         .collect::<HashSet<_>>()
 }
 
+/// Return true when required issue-number filters are empty or contain the issue.
 pub fn issue_matches_required_numbers(issue_number: u64, required: &HashSet<u64>) -> bool {
     required.is_empty() || required.contains(&issue_number)
 }
 
+/// Return true when issue labels satisfy required label filters.
 pub fn issue_matches_required_labels<'a>(
     labels: impl IntoIterator<Item = &'a str>,
     required: &HashSet<String>,

--- a/scripts/dev/test-split-module-rustdoc.sh
+++ b/scripts/dev/test-split-module-rustdoc.sh
@@ -6,8 +6,12 @@ cd "${REPO_ROOT}"
 
 issue_runtime_helpers="crates/tau-github-issues/src/issue_runtime_helpers.rs"
 issue_command_usage="crates/tau-github-issues/src/issue_command_usage.rs"
+github_transport_helpers="crates/tau-github-issues/src/github_transport_helpers.rs"
+issue_filter_file="crates/tau-github-issues/src/issue_filter.rs"
 retry_file="crates/tau-ai/src/retry.rs"
 slack_helpers_file="crates/tau-runtime/src/slack_helpers_runtime.rs"
+events_cli_commands_file="crates/tau-events/src/events_cli_commands.rs"
+deployment_wasm_runtime_file="crates/tau-deployment/src/deployment_wasm_runtime.rs"
 
 assert_contains() {
   local haystack="$1"
@@ -19,7 +23,15 @@ assert_contains() {
   fi
 }
 
-for file in "${issue_runtime_helpers}" "${issue_command_usage}" "${retry_file}" "${slack_helpers_file}"; do
+for file in \
+  "${issue_runtime_helpers}" \
+  "${issue_command_usage}" \
+  "${github_transport_helpers}" \
+  "${issue_filter_file}" \
+  "${retry_file}" \
+  "${slack_helpers_file}" \
+  "${events_cli_commands_file}" \
+  "${deployment_wasm_runtime_file}"; do
   if [[ ! -f "${file}" ]]; then
     echo "assertion failed (missing file): ${file}" >&2
     exit 1
@@ -28,16 +40,28 @@ done
 
 issue_runtime_contents="$(cat "${issue_runtime_helpers}")"
 issue_usage_contents="$(cat "${issue_command_usage}")"
+github_transport_contents="$(cat "${github_transport_helpers}")"
+issue_filter_contents="$(cat "${issue_filter_file}")"
 retry_contents="$(cat "${retry_file}")"
 slack_contents="$(cat "${slack_helpers_file}")"
+events_cli_contents="$(cat "${events_cli_commands_file}")"
+deployment_wasm_runtime_contents="$(cat "${deployment_wasm_runtime_file}")"
 
 assert_contains "${issue_runtime_contents}" "/// Normalize a repository-relative channel artifact path for persisted pointers." "issue runtime normalize doc"
 assert_contains "${issue_runtime_contents}" "/// Render a stable artifact pointer line for issue comments and logs." "issue runtime pointer doc"
 assert_contains "${issue_usage_contents}" "/// Render doctor command usage for GitHub issue transport runtime commands." "issue usage doctor doc"
 assert_contains "${issue_usage_contents}" "/// Render top-level /tau help lines scoped to issue-transport commands." "issue usage root doc"
+assert_contains "${github_transport_contents}" "/// Parse GitHub Retry-After header value as a duration." "github transport retry-after doc"
+assert_contains "${github_transport_contents}" "/// Determine whether a GitHub HTTP status is retryable." "github transport retry-status doc"
+assert_contains "${issue_filter_contents}" "/// Normalize issue label filters for case-insensitive matching." "issue filter normalize doc"
+assert_contains "${issue_filter_contents}" "/// Return true when issue labels satisfy required label filters." "issue filter label-match doc"
 assert_contains "${retry_contents}" "/// Default retry backoff base in milliseconds for provider HTTP requests." "retry base const doc"
 assert_contains "${retry_contents}" "/// Return true when an HTTP status should be retried by provider clients." "retry status doc"
 assert_contains "${slack_contents}" "/// Parse Slack Retry-After header value (seconds) when present." "slack retry-after doc"
 assert_contains "${slack_contents}" "/// Build a deterministic path-safe slug for Slack channel identifiers." "slack sanitize doc"
+assert_contains "${events_cli_contents}" "/// Execute events inspect mode and print either JSON or text report." "events inspect command doc"
+assert_contains "${events_cli_contents}" "/// Execute events dry-run mode and enforce configured gate thresholds." "events dry-run command doc"
+assert_contains "${deployment_wasm_runtime_contents}" "/// Execute WASM package command when --deployment-wasm-package-module is set." "deployment wasm package command doc"
+assert_contains "${deployment_wasm_runtime_contents}" "/// Execute browser DID initialization command for deployment WASM runtime." "deployment wasm did command doc"
 
 echo "split-module-rustdoc tests passed"

--- a/specs/2113/plan.md
+++ b/specs/2113/plan.md
@@ -1,0 +1,49 @@
+# Plan #2113
+
+Status: Implemented
+Spec: specs/2113/spec.md
+
+## Approach
+
+1. Add RED assertions for second-wave files to
+   `scripts/dev/test-split-module-rustdoc.sh`.
+2. Run guard script to capture expected failure before docs are added.
+3. Add concise rustdoc comments to second-wave helper modules.
+4. Run scoped guard + compile + targeted tests.
+
+## Affected Modules
+
+- `specs/milestones/m29/index.md`
+- `specs/2113/spec.md`
+- `specs/2113/plan.md`
+- `specs/2113/tasks.md`
+- `scripts/dev/test-split-module-rustdoc.sh`
+- `crates/tau-github-issues/src/github_transport_helpers.rs`
+- `crates/tau-github-issues/src/issue_filter.rs`
+- `crates/tau-events/src/events_cli_commands.rs`
+- `crates/tau-deployment/src/deployment_wasm_runtime.rs`
+
+## Risks and Mitigations
+
+- Risk: assertions become brittle on string-level doc changes.
+  - Mitigation: use stable, API-specific marker phrases.
+- Risk: broad file edits introduce accidental behavior drift.
+  - Mitigation: docs-only changes + compile/targeted test matrix.
+
+## Interfaces and Contracts
+
+- Guard script:
+  `bash scripts/dev/test-split-module-rustdoc.sh`
+- Compile checks:
+  `cargo check -p tau-github-issues --target-dir target-fast`
+  `cargo check -p tau-events --target-dir target-fast`
+  `cargo check -p tau-deployment --target-dir target-fast`
+- Targeted tests:
+  `cargo test -p tau-github-issues github_transport_helpers --target-dir target-fast`
+  `cargo test -p tau-github-issues issue_filter --target-dir target-fast`
+  `cargo test -p tau-events events_cli_commands --target-dir target-fast`
+  `cargo test -p tau-deployment deployment_wasm_runtime --target-dir target-fast`
+
+## ADR References
+
+- Not required.

--- a/specs/2113/spec.md
+++ b/specs/2113/spec.md
@@ -1,0 +1,53 @@
+# Spec #2113
+
+Status: Implemented
+Milestone: specs/milestones/m29/index.md
+Issue: https://github.com/njfio/Tau/issues/2113
+
+## Problem Statement
+
+A second wave of split helper modules still exposes public APIs without
+rustdoc comments, and the existing guard script does not cover these files.
+We need bounded rustdoc additions plus guardrail expansion to prevent regression.
+
+## Acceptance Criteria
+
+- AC-1: Add `///` rustdoc comments for public helper APIs in:
+  - `crates/tau-github-issues/src/github_transport_helpers.rs`
+  - `crates/tau-github-issues/src/issue_filter.rs`
+  - `crates/tau-events/src/events_cli_commands.rs`
+  - `crates/tau-deployment/src/deployment_wasm_runtime.rs`
+- AC-2: Extend `scripts/dev/test-split-module-rustdoc.sh` with second-wave
+  marker assertions covering these files.
+- AC-3: Scoped compile/test matrix passes for affected crates.
+
+## Scope
+
+In:
+
+- rustdoc additions for second-wave public helper APIs
+- guard script assertion expansion for second-wave files
+- scoped compile/test verification for touched crates
+
+Out:
+
+- broad documentation rewrites outside scoped files
+- non-documentation behavioral changes
+
+## Conformance Cases
+
+- C-01 (AC-1, functional): all four scoped files contain expected rustdoc
+  marker phrases for key public APIs.
+- C-02 (AC-2, regression): `bash scripts/dev/test-split-module-rustdoc.sh`
+  fails when required markers are missing and passes once present.
+- C-03 (AC-3, functional):
+  `cargo check -p tau-github-issues --target-dir target-fast`,
+  `cargo check -p tau-events --target-dir target-fast`,
+  `cargo check -p tau-deployment --target-dir target-fast` pass.
+- C-04 (AC-3, integration): targeted tests for touched modules pass.
+
+## Success Metrics
+
+- Subtask `#2113` merges with bounded doc+guard updates.
+- Second-wave files are no longer zero-doc helper modules.
+- Conformance suite C-01..C-04 passes.

--- a/specs/2113/tasks.md
+++ b/specs/2113/tasks.md
@@ -1,0 +1,16 @@
+# Tasks #2113
+
+Status: Implemented
+Spec: specs/2113/spec.md
+Plan: specs/2113/plan.md
+
+## Ordered Tasks
+
+- T1 (RED): extend guard script assertions for second-wave files and capture
+  expected failure before rustdoc additions.
+- T2 (GREEN): add rustdoc comments to second-wave helper modules.
+- T3 (VERIFY): run
+  `bash scripts/dev/test-split-module-rustdoc.sh`,
+  compile checks for `tau-github-issues`, `tau-events`, `tau-deployment`,
+  and targeted tests listed in plan.
+- T4 (CLOSE): set `specs/2113/*` status Implemented and close issue `#2113`.

--- a/specs/milestones/m29/index.md
+++ b/specs/milestones/m29/index.md
@@ -1,0 +1,47 @@
+# Milestone M29: Split Module Documentation Wave 2
+
+Status: Draft
+
+## Objective
+
+Extend split-module rustdoc baseline coverage to the next scoped helper set and
+strengthen guardrail assertions so coverage regressions fail fast.
+
+## Scope
+
+In scope:
+
+- add concise rustdoc comments to second-wave helper modules
+- extend split-module rustdoc guard script with second-wave assertions
+- run scoped compile/test validation for touched crates
+
+Out of scope:
+
+- repository-wide rustdoc parity in one milestone
+- semantic runtime behavior changes unrelated to documentation
+
+## Success Signals
+
+- M29 hierarchy exists and is active with epic/story/task/subtask linkage.
+- second-wave helper modules gain rustdoc marker coverage.
+- guard script and crate-level validation matrix remain green.
+
+## Issue Hierarchy
+
+Milestone: GitHub milestone `M29 Split Module Documentation Wave 2`
+
+Epic:
+
+- `#2111` Epic: M29 Split-Module Rustdoc Coverage Wave 2
+
+Story:
+
+- `#2115` Story: M29.1 Document second wave of split runtime helpers
+
+Task:
+
+- `#2114` Task: M29.1.1 Add rustdoc coverage to split helper modules and extend guard
+
+Subtask:
+
+- `#2113` Subtask: M29.1.1a Document GitHub/events/deployment helper modules


### PR DESCRIPTION
## Summary
Extends split-module rustdoc baseline to a second scoped wave by documenting helper APIs in `tau-github-issues`, `tau-events`, and `tau-deployment`, and expands `scripts/dev/test-split-module-rustdoc.sh` with guard assertions for those files. Adds M29 milestone/spec artifacts and marks `specs/2113/*` as Implemented.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/29
- Closes #2113
- Spec: `specs/2113/spec.md`
- Plan: `specs/2113/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: add rustdoc comments to second-wave helper files | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` (marker assertions across all scoped files) |
| AC-2: extend split-module rustdoc guard assertions | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` |
| AC-3: scoped compile/test matrix passes | ✅ | `cargo check -p tau-github-issues --target-dir target-fast`; `cargo check -p tau-events --target-dir target-fast`; `cargo check -p tau-deployment --target-dir target-fast`; targeted tests below |

## TDD Evidence
- RED:
  - Command: `bash scripts/dev/test-split-module-rustdoc.sh`
  - Output excerpt: `assertion failed (github transport retry-after doc): expected to find '/// Parse GitHub Retry-After header value as a duration.'`
- GREEN:
  - `bash scripts/dev/test-split-module-rustdoc.sh` -> `split-module-rustdoc tests passed`
  - compile checks for `tau-github-issues`, `tau-events`, `tau-deployment` -> pass
  - targeted tests:
    - `cargo test -p tau-github-issues github_transport_helpers --target-dir target-fast` -> `5 passed; 0 failed`
    - `cargo test -p tau-github-issues issue_filter --target-dir target-fast` -> `4 passed; 0 failed`
    - `cargo test -p tau-events events_cli_commands --target-dir target-fast` -> filtered target compiled/ran clean
    - `cargo test -p tau-deployment deployment_wasm_runtime --target-dir target-fast` -> `6 passed; 0 failed`
- REGRESSION summary:
  - `scripts/dev/test-split-module-rustdoc.sh` now enforces both M28 and M29 doc-marker baselines.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `cargo test -p tau-github-issues github_transport_helpers --target-dir target-fast`; `cargo test -p tau-github-issues issue_filter --target-dir target-fast`; `cargo test -p tau-deployment deployment_wasm_runtime --target-dir target-fast` | |
| Property | N/A | | No randomized invariants introduced; docs/guard assertions only. |
| Contract/DbC | N/A | | No DbC contract surface changes. |
| Snapshot | N/A | | No snapshot outputs changed. |
| Functional | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh`; targeted tests above | |
| Conformance | ✅ | mapped C-01..C-04 commands in spec | |
| Integration | ✅ | `cargo test -p tau-deployment deployment_wasm_runtime --target-dir target-fast` includes integration cases; `tau-events` compile/test path validated | |
| Fuzz | N/A | | No new parser/untrusted-input logic introduced. |
| Mutation | N/A | | Documentation-focused scoped subtask; no critical-path logic change. |
| Regression | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` | |
| Performance | N/A | | No performance-sensitive behavior changes. |

## Mutation
- N/A for this documentation-focused scoped subtask.

## Risks/Rollback
- Risk: marker assertions drift when helper names or wording changes.
- Mitigation: markers anchored to stable API intent phrases and scoped files.
- Rollback: revert commit `6a4e11c3`.

## Docs/ADR
- Updated: `specs/milestones/m29/index.md`, `specs/2113/spec.md`, `specs/2113/plan.md`, `specs/2113/tasks.md`
- ADR: Not required.
