### PR TITLE
spec(2114): close task with second-wave rustdoc conformance (#2114)

### DIFF
--- a/specs/2114/plan.md
+++ b/specs/2114/plan.md
@@ -1,0 +1,41 @@
+# Plan #2114
+
+Status: Implemented
+Spec: specs/2114/spec.md
+
+## Approach
+
+1. Use merged subtask `#2113` implementation as source of truth.
+2. Add task-level lifecycle artifacts with AC/conformance mapping.
+3. Re-run scoped guard + compile + targeted test matrix.
+4. Close task and hand off to story roll-up.
+
+## Affected Modules
+
+- `specs/2114/spec.md`
+- `specs/2114/plan.md`
+- `specs/2114/tasks.md`
+- `scripts/dev/test-split-module-rustdoc.sh`
+- `crates/tau-github-issues/src/github_transport_helpers.rs`
+- `crates/tau-github-issues/src/issue_filter.rs`
+- `crates/tau-events/src/events_cli_commands.rs`
+- `crates/tau-deployment/src/deployment_wasm_runtime.rs`
+
+## Risks and Mitigations
+
+- Risk: task roll-up drifts from merged subtask evidence.
+  - Mitigation: rerun mapped command set on latest `master`.
+- Risk: expanded guard assertions regress later unnoticed.
+  - Mitigation: keep guard script in conformance matrix.
+
+## Interfaces and Contracts
+
+- `bash scripts/dev/test-split-module-rustdoc.sh`
+- `cargo check -p tau-github-issues --target-dir target-fast`
+- `cargo check -p tau-events --target-dir target-fast`
+- `cargo check -p tau-deployment --target-dir target-fast`
+- targeted tests from subtask plan
+
+## ADR References
+
+- Not required.

--- a/specs/2114/spec.md
+++ b/specs/2114/spec.md
@@ -1,0 +1,44 @@
+# Spec #2114
+
+Status: Implemented
+Milestone: specs/milestones/m29/index.md
+Issue: https://github.com/njfio/Tau/issues/2114
+
+## Problem Statement
+
+Task M29.1.1 tracks second-wave split-module rustdoc coverage and guardrail
+expansion. Subtask `#2113` delivered this in PR `#2116`; this task closes by
+validating AC/conformance evidence at task scope.
+
+## Acceptance Criteria
+
+- AC-1: Second-wave helper modules have baseline rustdoc coverage.
+- AC-2: Guard script assertions are expanded for second-wave modules.
+- AC-3: Affected crate compile/tests remain green.
+
+## Scope
+
+In:
+
+- consume merged subtask output from `#2113` / PR `#2116`
+- map task ACs to conformance evidence
+- publish task closure artifacts
+
+Out:
+
+- additional documentation waves beyond scoped second-wave files
+- non-documentation behavior changes
+
+## Conformance Cases
+
+- C-01 (AC-1, functional): second-wave files contain required rustdoc markers.
+- C-02 (AC-2, regression): `bash scripts/dev/test-split-module-rustdoc.sh` passes.
+- C-03 (AC-3, functional): compile checks pass for
+  `tau-github-issues`, `tau-events`, `tau-deployment`.
+- C-04 (AC-3, integration): targeted tests pass for touched modules.
+
+## Success Metrics
+
+- Task issue `#2114` closes with linked subtask evidence.
+- `specs/2114/{spec,plan,tasks}.md` lifecycle is complete.
+- Story `#2115` roll-up is unblocked.

--- a/specs/2114/tasks.md
+++ b/specs/2114/tasks.md
@@ -1,0 +1,12 @@
+# Tasks #2114
+
+Status: Implemented
+Spec: specs/2114/spec.md
+Plan: specs/2114/plan.md
+
+## Ordered Tasks
+
+- T1 (RED): carry RED evidence from subtask `#2113` pre-doc guard failure.
+- T2 (GREEN): consume merged implementation from PR `#2116`.
+- T3 (VERIFY): rerun scoped guard, compile checks, and targeted tests.
+- T4 (CLOSE): set task status done and close issue `#2114` with evidence.


### PR DESCRIPTION
## Summary
Closes task `#2114` with task-level lifecycle artifacts (`specs/2114/{spec,plan,tasks}.md`) and verifies merged subtask delivery (`#2113` / PR `#2116`) against AC/conformance criteria.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/29
- Closes #2114
- Spec: `specs/2114/spec.md`
- Plan: `specs/2114/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: second-wave helper modules documented | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` |
| AC-2: guard assertions expanded | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` |
| AC-3: compile/tests remain green | ✅ | compile checks + targeted module tests for touched crates |

## TDD Evidence
- RED:
  - Carried from subtask `#2113`: guard failed before second-wave docs.
- GREEN:
  - Guard script and scoped compile/test matrix rerun on latest `master` and green.
- REGRESSION summary:
  - Guard script now covers M28+M29 module sets.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | targeted tests for `github_transport_helpers`, `issue_filter`, `deployment_wasm_runtime` | |
| Property | N/A | | No property-based behavior changes in task roll-up. |
| Contract/DbC | N/A | | No API contract changes. |
| Snapshot | N/A | | No snapshot outputs changed. |
| Functional | ✅ | guard script + targeted tests | |
| Conformance | ✅ | mapped C-01..C-04 command set | |
| Integration | ✅ | targeted deployment/runtime integration tests in scoped command set | |
| Fuzz | N/A | | No new parser/untrusted-input logic. |
| Mutation | N/A | | Task roll-up closure; no new critical-path logic. |
| Regression | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` | |
| Performance | N/A | | No performance-sensitive changes. |

## Mutation
- N/A for task roll-up closure.

## Risks/Rollback
- Risk: roll-up evidence drift from merged subtask behavior.
- Mitigation: reran mapped command set on latest `master`.
- Rollback: revert commit `9f6ed186`.

## Docs/ADR
- Updated: `specs/2114/spec.md`, `specs/2114/plan.md`, `specs/2114/tasks.md`
- ADR: Not required.
