### PR TITLE
spec(2115): close story with second-wave rustdoc evidence (#2115)

### DIFF
--- a/specs/2115/plan.md
+++ b/specs/2115/plan.md
@@ -1,0 +1,38 @@
+# Plan #2115
+
+Status: Implemented
+Spec: specs/2115/spec.md
+
+## Approach
+
+1. Aggregate merged evidence from task/subtask (`#2114/#2113`).
+2. Add story-level lifecycle artifacts with AC/conformance mapping.
+3. Re-run scoped guard + compile + targeted tests on latest `master`.
+4. Close story and hand off to epic roll-up.
+
+## Affected Modules
+
+- `specs/2115/spec.md`
+- `specs/2115/plan.md`
+- `specs/2115/tasks.md`
+- `specs/2114/spec.md`
+- `specs/2113/spec.md`
+
+## Risks and Mitigations
+
+- Risk: story traceability drift from lower-level merged evidence.
+  - Mitigation: rerun mapped command set and link PR chain.
+- Risk: guardrail coverage assumptions become stale.
+  - Mitigation: keep guard pass as explicit conformance case.
+
+## Interfaces and Contracts
+
+- `bash scripts/dev/test-split-module-rustdoc.sh`
+- `cargo check -p tau-github-issues --target-dir target-fast`
+- `cargo check -p tau-events --target-dir target-fast`
+- `cargo check -p tau-deployment --target-dir target-fast`
+- targeted tests from task plan
+
+## ADR References
+
+- Not required.

--- a/specs/2115/spec.md
+++ b/specs/2115/spec.md
@@ -1,0 +1,43 @@
+# Spec #2115
+
+Status: Implemented
+Milestone: specs/milestones/m29/index.md
+Issue: https://github.com/njfio/Tau/issues/2115
+
+## Problem Statement
+
+Story M29.1 tracks second-wave split-module rustdoc coverage with guardrail
+expansion. Task/subtask delivery (`#2114/#2113`) merged via PRs `#2117/#2116`.
+This story closes by consolidating AC/conformance evidence.
+
+## Acceptance Criteria
+
+- AC-1: second-wave split helper modules are documented.
+- AC-2: split-module rustdoc guard covers second-wave scope.
+- AC-3: story-level lifecycle artifacts map ACs to test evidence.
+
+## Scope
+
+In:
+
+- consume merged outputs from `#2114/#2113`
+- publish story-level lifecycle artifacts
+- rerun scoped verification commands
+
+Out:
+
+- new documentation waves beyond M29.1
+- non-documentation behavior changes
+
+## Conformance Cases
+
+- C-01 (AC-1, functional): second-wave files contain expected rustdoc markers.
+- C-02 (AC-2, regression): `bash scripts/dev/test-split-module-rustdoc.sh` passes.
+- C-03 (AC-2, functional): compile checks pass for touched crates.
+- C-04 (AC-3, integration): targeted tests pass for touched modules.
+
+## Success Metrics
+
+- Story issue `#2115` closes with linked task/subtask evidence.
+- `specs/2115/{spec,plan,tasks}.md` lifecycle is complete.
+- Epic `#2111` roll-up is unblocked.

--- a/specs/2115/tasks.md
+++ b/specs/2115/tasks.md
@@ -1,0 +1,12 @@
+# Tasks #2115
+
+Status: Implemented
+Spec: specs/2115/spec.md
+Plan: specs/2115/plan.md
+
+## Ordered Tasks
+
+- T1 (RED): carry RED evidence from subtask `#2113` pre-doc guard failure.
+- T2 (GREEN): consume merged outputs from PRs `#2116` and `#2117`.
+- T3 (VERIFY): rerun scoped guard, compile checks, and targeted tests.
+- T4 (CLOSE): set story status done and close issue `#2115` with evidence.


### PR DESCRIPTION
## Summary
Closes story `#2115` by adding story-level lifecycle artifacts in `specs/2115/{spec,plan,tasks}.md` and consolidating AC/conformance evidence from completed task/subtask delivery (`#2114/#2113`, PRs `#2117/#2116`).

## Links
- Milestone: https://github.com/njfio/Tau/milestone/29
- Closes #2115
- Spec: `specs/2115/spec.md`
- Plan: `specs/2115/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: second-wave modules documented | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` |
| AC-2: guard covers second-wave scope | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` |
| AC-3: story-level AC/conformance mapping complete | ✅ | `specs/2115/spec.md` C-01..C-04 + rerun verification commands |

## TDD Evidence
- RED:
  - Carried from subtask `#2113` guard failure before docs existed.
- GREEN:
  - scoped guard + compile + targeted tests rerun and green on latest `master`.
- REGRESSION summary:
  - guard script enforces M28+M29 rustdoc markers.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | targeted tests in `tau-github-issues` and `tau-deployment` | |
| Property | N/A | | No property-focused behavior added in story roll-up. |
| Contract/DbC | N/A | | No contract surface changes. |
| Snapshot | N/A | | No snapshot changes. |
| Functional | ✅ | guard script + targeted tests | |
| Conformance | ✅ | mapped C-01..C-04 command set | |
| Integration | ✅ | targeted deployment/runtime integration tests in command set | |
| Fuzz | N/A | | No untrusted-input parser additions. |
| Mutation | N/A | | Story roll-up closure; no new critical logic. |
| Regression | ✅ | `bash scripts/dev/test-split-module-rustdoc.sh` | |
| Performance | N/A | | No performance changes. |

## Mutation
- N/A for story roll-up closure.

## Risks/Rollback
- Risk: story roll-up drift from task/subtask outputs.
- Mitigation: reran mapped command set and linked merged PR chain.
- Rollback: revert commit `6121a69a`.

## Docs/ADR
- Updated: `specs/2115/spec.md`, `specs/2115/plan.md`, `specs/2115/tasks.md`
- ADR: Not required.
