### PR TITLE
spec(epic): close M42 epic roll-up evidence (#2216)

### DIFF
--- a/specs/2216/plan.md
+++ b/specs/2216/plan.md
@@ -1,6 +1,6 @@
 # Plan #2216
 
-Status: Draft
+Status: Implemented
 Spec: specs/2216/spec.md
 
 ## Approach

--- a/specs/2216/spec.md
+++ b/specs/2216/spec.md
@@ -1,6 +1,6 @@
 # Spec #2216
 
-Status: Draft
+Status: Implemented
 Milestone: specs/milestones/m42/index.md
 Issue: https://github.com/njfio/Tau/issues/2216
 

--- a/specs/2216/tasks.md
+++ b/specs/2216/tasks.md
@@ -1,6 +1,6 @@
 # Tasks #2216
 
-Status: Draft
+Status: Implemented
 Spec: specs/2216/spec.md
 Plan: specs/2216/plan.md
 

--- a/specs/milestones/m42/index.md
+++ b/specs/milestones/m42/index.md
@@ -1,6 +1,6 @@
 # Milestone M42: Resolution Roadmap P0 Provider Execution
 
-Status: Draft
+Status: Implemented
 
 ## Objective
 


### PR DESCRIPTION
## Summary
Marks Epic #2216 and milestone spec container status as implemented after story/task/subtask closure.

## Links
- Closes #2216
- Milestone: `M42 Resolution Roadmap P0 Provider Execution`
- Spec: `specs/2216/spec.md`
- Plan: `specs/2216/plan.md`

## Verification
- `gh issue view 2217 --json state,labels`
- `gh issue view 2218 --json state,labels`
- `gh issue view 2219 --json state,labels`
- `cargo fmt --check`

## Notes
No runtime code changes; epic-level closure traceability only.
