### PR TITLE
spec(task): close M43 task roll-up evidence (#2226)

### DIFF
--- a/specs/2226/plan.md
+++ b/specs/2226/plan.md
@@ -1,6 +1,6 @@
 # Plan #2226
 
-Status: Draft
+Status: Implemented
 Spec: specs/2226/spec.md
 
 ## Approach

--- a/specs/2226/spec.md
+++ b/specs/2226/spec.md
@@ -1,6 +1,6 @@
 # Spec #2226
 
-Status: Draft
+Status: Implemented
 Milestone: specs/milestones/m43/index.md
 Issue: https://github.com/njfio/Tau/issues/2226
 

--- a/specs/2226/tasks.md
+++ b/specs/2226/tasks.md
@@ -1,6 +1,6 @@
 # Tasks #2226
 
-Status: Draft
+Status: Implemented
 Spec: specs/2226/spec.md
 Plan: specs/2226/plan.md
 


### PR DESCRIPTION
## Summary
Marks Task #2226 artifacts as implemented after subtask #2227 merged in PR #2228.

## Links
- Closes #2226
- Milestone: `M43 Gemini Live Provider Compatibility Fix`
- Spec: `specs/2226/spec.md`
- Plan: `specs/2226/plan.md`

## Verification
- `gh issue view 2227 --json state,labels` confirms child subtask closed with `status:done`
- `cargo fmt --check`

## Notes
No runtime code changes; task-level closure traceability only.
