### PR TITLE
spec(epic): close M43 epic roll-up evidence (#2224)

### DIFF
--- a/specs/2224/plan.md
+++ b/specs/2224/plan.md
@@ -1,6 +1,6 @@
 # Plan #2224
 
-Status: Draft
+Status: Implemented
 Spec: specs/2224/spec.md
 
 ## Approach

--- a/specs/2224/spec.md
+++ b/specs/2224/spec.md
@@ -1,6 +1,6 @@
 # Spec #2224
 
-Status: Draft
+Status: Implemented
 Milestone: specs/milestones/m43/index.md
 Issue: https://github.com/njfio/Tau/issues/2224
 

--- a/specs/2224/tasks.md
+++ b/specs/2224/tasks.md
@@ -1,6 +1,6 @@
 # Tasks #2224
 
-Status: Draft
+Status: Implemented
 Spec: specs/2224/spec.md
 Plan: specs/2224/plan.md
 

--- a/specs/milestones/m43/index.md
+++ b/specs/milestones/m43/index.md
@@ -1,6 +1,6 @@
 # Milestone M43: Gemini Live Provider Compatibility Fix
 
-Status: Draft
+Status: Implemented
 
 ## Objective
 


### PR DESCRIPTION
## Summary
Marks Epic #2224 and milestone M43 spec container as implemented after story/task/subtask closure.

## Links
- Closes #2224
- Milestone: `M43 Gemini Live Provider Compatibility Fix`
- Spec: `specs/2224/spec.md`
- Plan: `specs/2224/plan.md`

## Verification
- `gh issue view 2225 --json state,labels`
- `gh issue view 2226 --json state,labels`
- `gh issue view 2227 --json state,labels`
- `cargo fmt --check`

## Notes
No runtime code changes; epic-level closure traceability only.
