### PR TITLE
feat(training): derive model-aware preflight token limits (#2255)

### DIFF
--- a/specs/2255/plan.md
+++ b/specs/2255/plan.md
@@ -1,0 +1,39 @@
+# Plan #2255
+
+Status: Reviewed
+Spec: specs/2255/spec.md
+
+## Approach
+
+1. Add a shared helper in onboarding runtime assembly to derive pre-flight token
+   limits from model metadata and existing defaults.
+2. Extend `LocalRuntimeAgentSettings` and `build_local_runtime_agent` to carry
+   and apply derived pre-flight limits to `AgentConfig`.
+3. Wire local runtime startup and training executor startup to use the same
+   derivation helper.
+4. Add targeted tests:
+   - derivation helper behavior
+   - local runtime pre-flight rejection behavior
+   - training executor path wiring/behavior
+
+## Affected Modules
+
+- `crates/tau-onboarding/src/startup_local_runtime.rs`
+- `crates/tau-onboarding/src/startup_local_runtime/tests.rs`
+- `crates/tau-coding-agent/src/startup_local_runtime.rs`
+- `crates/tau-coding-agent/src/training_runtime.rs`
+- `crates/tau-coding-agent/src/tests/auth_provider/runtime_and_startup.rs`
+
+## Risks and Mitigations
+
+- Risk: over-restrictive limits for models with missing catalog metadata.
+  - Mitigation: preserve existing defaults when metadata is unavailable.
+- Risk: divergence between local runtime and training runtime behavior.
+  - Mitigation: centralize derivation logic and reuse in both paths.
+
+## Interfaces / Contracts
+
+- `LocalRuntimeAgentSettings` gains explicit pre-flight limit fields.
+- `build_local_runtime_agent` applies pre-flight limits directly to
+  `AgentConfig`.
+- Derivation helper is deterministic and saturating for edge arithmetic.

--- a/specs/2255/spec.md
+++ b/specs/2255/spec.md
@@ -1,0 +1,54 @@
+# Spec #2255
+
+Status: Implemented
+Milestone: specs/milestones/m46/index.md
+Issue: https://github.com/njfio/Tau/issues/2255
+
+## Problem Statement
+
+Token pre-flight checks exist in `tau-agent-core`, but runtime startup does not
+derive those limits from provider/model catalog metadata. Large prompts can
+reach provider APIs and fail there instead of being rejected early with a local,
+actionable `TokenBudgetExceeded` error.
+
+## Scope
+
+In scope:
+
+- Derive token pre-flight limits from model catalog metadata:
+  - `context_window_tokens`
+  - `max_output_tokens`
+- Apply derived limits to local runtime and training executor agent settings.
+- Add tests proving provider/model-aware pre-flight rejection behavior.
+
+Out of scope:
+
+- Changes to provider-side token counting algorithms.
+- New CLI flags for token budgets.
+
+## Acceptance Criteria
+
+- AC-1: Runtime startup computes model-aware token pre-flight limits from model
+  catalog metadata and passes them into `AgentConfig`.
+- AC-2: When estimated input/total tokens exceed derived limits, prompt
+  execution fails locally with `TokenBudgetExceeded` before provider request
+  completion.
+- AC-3: Training executor path uses the same derived pre-flight logic as local
+  runtime path.
+
+## Conformance Cases
+
+- C-01 (AC-1, unit): limit-derivation helper returns expected
+  `max_estimated_input_tokens` and `max_estimated_total_tokens` for representative
+  model metadata.
+- C-02 (AC-2, functional): a runtime agent configured with tight derived limits
+  returns `TokenBudgetExceeded` for oversized prompt.
+- C-03 (AC-3, integration): training executor build path sets derived limits and
+  rejects oversized prompt in executor flow.
+
+## Success Metrics / Observable Signals
+
+- No provider call required to observe over-limit rejection for oversized
+  prompts.
+- Derived limits track model catalog entries instead of static defaults.
+- Conformance tests pass in `tau-onboarding` and `tau-coding-agent`.

--- a/specs/2255/tasks.md
+++ b/specs/2255/tasks.md
@@ -1,0 +1,12 @@
+# Tasks #2255
+
+Status: Done
+Spec: specs/2255/spec.md
+Plan: specs/2255/plan.md
+
+- T1 (tests first): add failing conformance tests for token limit derivation and
+  pre-flight rejection behavior (C-01, C-02, C-03).
+- T2: add shared model-aware pre-flight token limit derivation helper.
+- T3: wire derived limits into local runtime startup and training executor.
+- T4: apply derived limits in onboarding agent builder settings/config mapping.
+- T5: run scoped fmt/clippy/tests and verify conformance mappings.


### PR DESCRIPTION
## Summary
This change makes token pre-flight enforcement model-aware by deriving `max_estimated_input_tokens` and `max_estimated_total_tokens` from model catalog metadata (`context_window_tokens`, `max_output_tokens`).
It wires the derived ceilings through both local runtime startup and prompt-optimization executor startup, and adds conformance tests proving oversized prompts fail locally with `TokenBudgetExceeded` semantics.

## Links
- Milestone: `specs/milestones/m46/index.md`
- Closes #2255
- Spec: `specs/2255/spec.md`
- Plan: `specs/2255/plan.md`
- Tasks: `specs/2255/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: runtime computes model-aware pre-flight limits and applies to `AgentConfig` | ✅ | `startup_local_runtime::tests::unit_derive_preflight_token_limits_prefers_model_context_window`; `startup_local_runtime::tests::regression_derive_preflight_token_limits_falls_back_to_defaults_without_context_window`; `training_runtime::tests::integration_build_executor_enforces_model_derived_preflight_limits` |
| AC-2: over-limit prompt fails locally before provider completion | ✅ | `startup_local_runtime::tests::functional_build_local_runtime_agent_enforces_preflight_token_limits` |
| AC-3: training executor path reuses same derivation logic | ✅ | `training_runtime::tests::integration_build_executor_enforces_model_derived_preflight_limits` |

## TDD Evidence
- RED:
  - Command: `cargo test -p tau-coding-agent integration_build_executor_enforces_model_derived_preflight_limits -- --exact`
  - Output excerpt:
    - `error[E0432]: unresolved import 'tau_training_tracer'`
    - `error[E0432]: unresolved import 'tau_training_types'`
- GREEN:
  - Command: `cargo test -p tau-onboarding startup_local_runtime::tests::unit_derive_preflight_token_limits_prefers_model_context_window -- --exact && cargo test -p tau-onboarding startup_local_runtime::tests::regression_derive_preflight_token_limits_falls_back_to_defaults_without_context_window -- --exact && cargo test -p tau-onboarding startup_local_runtime::tests::functional_build_local_runtime_agent_enforces_preflight_token_limits -- --exact && cargo test -p tau-coding-agent training_runtime::tests::integration_build_executor_enforces_model_derived_preflight_limits -- --exact`
  - Output excerpt:
    - `test startup_local_runtime::tests::unit_derive_preflight_token_limits_prefers_model_context_window ... ok`
    - `test startup_local_runtime::tests::regression_derive_preflight_token_limits_falls_back_to_defaults_without_context_window ... ok`
    - `test startup_local_runtime::tests::functional_build_local_runtime_agent_enforces_preflight_token_limits ... ok`
    - `test training_runtime::tests::integration_build_executor_enforces_model_derived_preflight_limits ... ok`
- REGRESSION:
  - `cargo test -p tau-coding-agent training_runtime::tests::`
  - Result: 15 passed, 0 failed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `startup_local_runtime::tests::unit_derive_preflight_token_limits_prefers_model_context_window`; `training_runtime::tests::unit_build_trainer_config_applies_overrides` (regression run) | |
| Property | N/A | | No parser/serde/invariant surface changed in this diff. |
| Contract/DbC | N/A | | `contracts` annotations are not used in touched modules; behavior validated via conformance tests. |
| Snapshot | N/A | | No stable structured renderer/output introduced. |
| Functional | ✅ | `startup_local_runtime::tests::functional_build_local_runtime_agent_enforces_preflight_token_limits` | |
| Conformance | ✅ | C-01/C-02/C-03 mapped in `specs/2255/spec.md` and implemented by new tests above | |
| Integration | ✅ | `training_runtime::tests::integration_build_executor_enforces_model_derived_preflight_limits`; `training_runtime::tests::integration_prompt_optimization_mode_executes_rollouts_and_persists_sqlite` | |
| Fuzz | N/A | | Change does not add/modify untrusted-input parser boundaries. |
| Mutation | N/A | | `cargo-mutants` is not installed in this environment (`cargo mutants --version` -> `no such command: mutants`). |
| Regression | ✅ | `training_runtime::tests::` suite | |
| Performance | N/A | | No hot-path algorithmic change; only config derivation and guards. |

## Mutation
- Not run locally: `cargo-mutants` missing in toolchain (`cargo mutants --version` fails with `no such command: mutants`).

## Risks / Rollback
- Risk: models missing `context_window_tokens` could over-constrain if defaults were not preserved.
- Mitigation implemented: explicit fallback to existing defaults when metadata is missing.
- Rollback: revert commit `6f7c94cf`.

## Docs / ADR
- Updated specs:
  - `specs/2255/spec.md`
  - `specs/2255/plan.md`
  - `specs/2255/tasks.md`
- ADR: not required (no new dependency/protocol/architecture decision).
