### PR TITLE
feat(training): wire PPO/GAE into prompt optimization runtime (#2257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,6 +3364,7 @@ dependencies = [
  "tau-access",
  "tau-agent-core",
  "tau-ai",
+ "tau-algorithm",
  "tau-browser-automation",
  "tau-cli",
  "tau-core",

--- a/crates/tau-algorithm/src/apo.rs
+++ b/crates/tau-algorithm/src/apo.rs
@@ -346,6 +346,7 @@ async fn request_text_completion(
         json_mode: false,
         max_tokens,
         temperature,
+        prompt_cache: Default::default(),
     };
 
     let response = client.complete(request).await?;

--- a/crates/tau-coding-agent/Cargo.toml
+++ b/crates/tau-coding-agent/Cargo.toml
@@ -44,6 +44,7 @@ tau-tools = { path = "../tau-tools" }
 tau-onboarding = { path = "../tau-onboarding" }
 tau-agent-core = { path = "../tau-agent-core" }
 tau-ai = { path = "../tau-ai" }
+tau-algorithm = { path = "../tau-algorithm" }
 tau-trainer = { path = "../tau-trainer" }
 tau-training-runner = { path = "../tau-training-runner" }
 tau-training-proxy = { path = "../tau-training-proxy" }

--- a/specs/2257/plan.md
+++ b/specs/2257/plan.md
@@ -1,0 +1,34 @@
+# Plan #2257
+
+Status: Reviewed
+Spec: specs/2257/spec.md
+
+## Approach
+
+1. Extend prompt-optimization config with optional `rl_optimizer` section.
+2. Add validation for RL optimizer config in `build_trainer_config` stage to fail fast.
+3. After trainer completion, collect successful train rollouts and adapt spans to trajectories.
+4. Build GAE batches and PPO samples with deterministic fallback values when logprob/value are missing.
+5. Execute PPO update using `tau_algorithm::compute_ppo_update` and attach summary to persisted runtime status artifact.
+6. Add conformance-first tests for config parsing, fail-closed validation, execution path, and skip behavior.
+
+## Affected Modules
+
+- `crates/tau-coding-agent/src/training_runtime.rs`
+- `crates/tau-algorithm/src/collector.rs` (reuse only, no behavior change expected)
+- `crates/tau-onboarding/src/startup_local_runtime.rs` (none expected)
+
+## Risks and Mitigations
+
+- Risk: trajectory spans may lack logprob/value estimates.
+  - Mitigation: deterministic fallback values (`0.0`) for PPO sample construction; explicit skip reason when sample set is empty.
+- Risk: runtime behavior regressions for existing prompt-optimization users.
+  - Mitigation: optimizer remains optional and defaults disabled; regression tests verify unchanged baseline behavior.
+- Risk: unstable/non-finite optimization math from malformed inputs.
+  - Mitigation: strict config validation + finite checks + fail-closed errors from PPO/GAE utilities surfaced with context.
+
+## Interfaces / Contracts
+
+- `TrainingConfigFile` gains `rl_optimizer: Option<RlOptimizerConfigFile>`.
+- `TrainingStatusFile` gains optional `rl_optimizer` summary block.
+- New helper executes `collect_trajectory_batch` -> GAE -> PPO and returns structured summary or skip reason.

--- a/specs/2257/spec.md
+++ b/specs/2257/spec.md
@@ -1,0 +1,47 @@
+# Spec #2257
+
+Status: Implemented
+Milestone: specs/milestones/m46/index.md
+Issue: https://github.com/njfio/Tau/issues/2257
+
+## Problem Statement
+
+`tau-algorithm` already ships PPO and GAE implementations, but production prompt-optimization runtime never invokes them. As a result, PPO/GAE remains math-only with zero runtime callers and no operational evidence that policy-optimization updates are executed.
+
+## Scope
+
+In scope:
+
+- Add a production call path from `tau-coding-agent` training runtime into PPO/GAE.
+- Add config surface for RL optimizer settings (enable/disable + GAE/PPO knobs).
+- Collect trajectories from completed training rollouts and build PPO samples.
+- Execute GAE + PPO update and persist deterministic optimizer summary in runtime status artifact.
+- Add conformance tests proving the optimizer path is executed and fail-closed on invalid config.
+
+Out of scope:
+
+- Persisting model weights to external model stores.
+- Implementing distributed optimizer workers.
+- Replacing prompt-optimization loop with full actor-learner architecture.
+
+## Acceptance Criteria
+
+- AC-1: Given prompt-optimization runtime is started with RL optimizer enabled, when training rollouts finish, then runtime invokes trajectory collection + GAE + PPO update in the production path.
+- AC-2: Given PPO/GAE runs, when status artifacts are written, then persisted report includes deterministic optimizer summary (trajectory count, sample count, mean PPO loss/kl, early-stop flag).
+- AC-3: Given invalid RL optimizer config, when startup validation runs, then runtime fails closed before worker execution with actionable error text.
+- AC-4: Given RL optimizer is disabled or there are no eligible train rollouts, when runtime completes, then existing behavior remains intact and optimizer summary is omitted or explicitly marked skipped.
+
+## Conformance Cases
+
+- C-01 (AC-1, unit): training config parser accepts `rl_optimizer` object and materializes defaults/overrides.
+- C-02 (AC-1, integration): prompt-optimization runtime with `rl_optimizer.enabled=true` executes optimizer path and returns summary with non-zero trajectory/sample counts.
+- C-03 (AC-2, functional): persisted status artifact includes optimizer summary fields (`trajectories`, `samples`, `mean_total_loss`, `observed_approx_kl`, `early_stop_triggered`).
+- C-04 (AC-3, unit): invalid PPO config (e.g., `mini_batch_size=0` or `epochs=0`) fails config validation with fail-closed error.
+- C-05 (AC-4, regression): disabled optimizer leaves status artifact schema backward-compatible and does not fail training completion.
+- C-06 (AC-4, functional): when train rollouts have no usable trajectories/samples, runtime reports optimizer skipped with explicit reason instead of panic.
+
+## Success Metrics / Observable Signals
+
+- `run_prompt_optimization_mode_if_requested` has a direct production caller path into `compute_gae_*` and `compute_ppo_update`.
+- Runtime status/report exposes optimizer execution evidence for operators.
+- New conformance tests C-01..C-06 pass in CI and guard the call path.

--- a/specs/2257/tasks.md
+++ b/specs/2257/tasks.md
@@ -1,0 +1,11 @@
+# Tasks #2257
+
+Status: Completed
+Spec: specs/2257/spec.md
+Plan: specs/2257/plan.md
+
+- T1 (tests first): add failing conformance tests C-01..C-06 in `training_runtime.rs` test module.
+- T2: add `rl_optimizer` config structs + validation and wire into startup flow.
+- T3: implement trajectory collection + GAE + PPO execution helper in production runtime path.
+- T4: persist optimizer summary/skip reason in status artifact and human/json report.
+- T5: run scoped fmt/clippy/tests and map ACs to conformance tests.


### PR DESCRIPTION
## Summary
Wires PPO/GAE execution into the production prompt-optimization runtime path in `tau-coding-agent` using existing `tau-algorithm` collector + optimizer utilities. Adds `rl_optimizer` config parsing/validation, executes trajectory collection + GAE + PPO after rollout completion, and persists deterministic optimizer status in `status.json`. Includes conformance tests C-01..C-06 proving execution, persistence, fail-closed validation, disabled behavior, and skip behavior.

## Links
- Milestone: M46 Production Readiness Gap Closure Wave 1 (`specs/milestones/m46/index.md`)
- Closes #2257
- Spec: `specs/2257/spec.md`
- Plan: `specs/2257/plan.md`
- Tasks: `specs/2257/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Runtime invokes trajectory collection + GAE + PPO when enabled | ✅ | `training_runtime::tests::spec_c01_build_trainer_config_parses_rl_optimizer_settings`, `training_runtime::tests::spec_c02_integration_prompt_optimization_mode_executes_rl_optimizer_when_enabled` |
| AC-2: Status artifact persists deterministic optimizer summary | ✅ | `training_runtime::tests::spec_c03_functional_status_artifact_persists_rl_optimizer_summary` |
| AC-3: Invalid RL optimizer config fails closed at startup validation | ✅ | `training_runtime::tests::spec_c04_build_trainer_config_rejects_invalid_rl_optimizer_ppo_config` |
| AC-4: Disabled/no-eligible-rollout behavior remains safe and explicit | ✅ | `training_runtime::tests::spec_c05_regression_disabled_rl_optimizer_preserves_baseline_status_shape`, `training_runtime::tests::spec_c06_functional_rl_optimizer_reports_skip_when_no_succeeded_rollouts` |

## TDD Evidence
- RED:
  - `cargo test -p tau-coding-agent spec_c01_build_trainer_config_parses_rl_optimizer_settings -- --exact`
  - failing excerpts before implementation:
    - `cannot find function resolve_rl_optimizer_settings in module super`
    - `no field rl_optimizer on type TrainingConfigFile`
- GREEN:
  - `cargo test -p tau-coding-agent training_runtime::tests::spec_c0 -- --nocapture` -> `6 passed; 0 failed`
  - `cargo test -p tau-coding-agent training_runtime::tests:: -- --nocapture` -> `20 passed; 0 failed`
  - `cargo test -p tau-algorithm -- --nocapture` -> `39 passed; 0 failed`
  - `cargo fmt --check` -> pass
  - `cargo clippy -p tau-coding-agent -p tau-algorithm -- -D warnings` -> pass
- REGRESSION:
  - Existing prompt-optimization control and timeout regressions inside `training_runtime::tests::` remained green.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`, `spec_c04` | |
| Property | N/A | | No new randomized invariants introduced in this slice. |
| Contract/DbC | N/A | | No `contracts` annotations introduced/modified. |
| Snapshot | N/A | | No snapshot-based output introduced. |
| Functional | ✅ | `spec_c03`, `spec_c06` | |
| Conformance | ✅ | `spec_c01`..`spec_c06` | |
| Integration | ✅ | `spec_c02`; `training_runtime::tests::` full suite | |
| Fuzz | N/A | | No new untrusted parser boundary; this change wires existing validated algorithm/data paths. |
| Mutation | N/A | | `cargo-mutants` unavailable (`cargo mutants --version` -> no such command). |
| Regression | ✅ | `spec_c05` + existing regression tests in `training_runtime::tests::` | |
| Performance | N/A | | No benchmarked hotspot target in this slice; runtime adds optional post-run optimizer summary pass. |

## Mutation
- caught/total: N/A (tool unavailable in environment)

## Risks / Rollback
- Risk: optimizer summary execution on succeeded rollouts could fail due malformed trajectories.
- Mitigation: fail-closed config validation, deterministic fallback values for missing logprob/value, and explicit skipped reasons when no eligible data exists.
- Rollback: revert commit `deec9c30`.

## Docs / ADR
- Updated: `specs/2257/spec.md`, `specs/2257/plan.md`, `specs/2257/tasks.md`
- ADR: not required (no external dependency introduction; reused in-repo crate)
