### PR TITLE
docs: finalize #2260 spec/task lifecycle statuses

### DIFF
--- a/specs/2260/spec.md
+++ b/specs/2260/spec.md
@@ -1,6 +1,6 @@
 # Spec #2260
 
-Status: Accepted
+Status: Implemented
 Milestone: specs/milestones/m46/index.md
 Issue: https://github.com/njfio/Tau/issues/2260
 

--- a/specs/2260/tasks.md
+++ b/specs/2260/tasks.md
@@ -1,6 +1,6 @@
 # Tasks #2260
 
-Status: In Progress
+Status: Completed
 Spec: specs/2260/spec.md
 Plan: specs/2260/plan.md
 


### PR DESCRIPTION
Summary:
- Updates `specs/2260/spec.md` status to `Implemented`.
- Updates `specs/2260/tasks.md` status to `Completed`.

Links:
- Related to #2260 (already delivered via merged PR #2276)
- Spec: specs/2260/spec.md
- Tasks: specs/2260/tasks.md
