### PR TITLE
feat(tau-ops): harden systemd-user daemon contract (#2266)

### DIFF
--- a/specs/2266/plan.md
+++ b/specs/2266/plan.md
@@ -1,0 +1,35 @@
+# Plan #2266
+
+Status: Reviewed
+Spec: specs/2266/spec.md
+
+## Approach
+
+1. Add conformance-first tests in `tau-ops` daemon runtime test module:
+   - explicit spec-named coverage for systemd template sections and lifecycle checks.
+   - failing regression for executable-path-with-spaces in `ExecStart`.
+2. Implement minimal rendering fix for systemd executable argument formatting.
+3. Run scoped validation for `tau-ops` (`fmt`, `clippy`, targeted tests, full crate
+   tests).
+
+## Affected Modules
+
+- `crates/tau-ops/src/daemon_runtime.rs`
+- `specs/2266/spec.md`
+- `specs/2266/plan.md`
+- `specs/2266/tasks.md`
+
+## Risks and Mitigations
+
+- Risk: overly aggressive quoting could alter standard service rendering.
+  - Mitigation: preserve existing output for normal paths; add regression tests for
+    both standard and spaced paths.
+- Risk: lifecycle regressions from unrelated daemon behavior.
+  - Mitigation: run existing full `tau-ops` test suite after change.
+
+## Interfaces / Contracts
+
+- Public API remains unchanged:
+  - `render_systemd_user_unit(...) -> String`
+  - daemon lifecycle functions in `tau-ops` (`install/start/stop/uninstall/inspect`)
+- Behavior contract tightened around `ExecStart` binary-path safety.

--- a/specs/2266/spec.md
+++ b/specs/2266/spec.md
@@ -1,0 +1,59 @@
+# Spec #2266
+
+Status: Accepted
+Milestone: specs/milestones/m46/index.md
+Issue: https://github.com/njfio/Tau/issues/2266
+
+## Problem Statement
+
+Tau daemon supports systemd-user profile operations, but the systemd unit contract
+is not tracked with explicit conformance cases and misses edge-case safety for
+`ExecStart` when executable paths include spaces. This risks broken managed runtime
+deployments on hosts with non-trivial install paths.
+
+## Scope
+
+In scope:
+
+- Define explicit conformance coverage for systemd unit rendering and operational
+  daemon lifecycle behavior.
+- Ensure rendered systemd `ExecStart` safely handles executable paths with spaces.
+- Keep launchd and existing daemon lifecycle semantics unchanged.
+
+Out of scope:
+
+- Root/system-wide systemd units (`/etc/systemd/system`).
+- External service manager integration (`systemctl --user` invocation automation).
+- Daemon protocol/runtime behavior unrelated to service unit generation.
+
+## Acceptance Criteria
+
+- AC-1: Given `render_systemd_user_unit`, when called for standard executable/state
+  paths, then output includes required `[Unit]`, `[Service]`, and `[Install]` sections
+  with gateway startup flags.
+- AC-2: Given an executable path containing spaces, when rendering systemd unit,
+  then `ExecStart` encodes executable path safely so systemd tokenization does not
+  split the binary path.
+- AC-3: Given systemd-user daemon lifecycle (`install/start/stop/uninstall`), when
+  operations run, then service files/pid/state transitions are consistent and
+  inspectable.
+- AC-4: Given repeated status inspection after lifecycle changes, when inspecting
+  daemon state, then reports remain deterministic and regression-safe.
+
+## Conformance Cases
+
+- C-01 (AC-1, unit): rendered systemd unit includes expected command and gateway
+  paths.
+- C-02 (AC-2, regression): rendered systemd unit escapes/quotes executable path with
+  spaces in `ExecStart`.
+- C-03 (AC-3, functional): lifecycle install/start/stop/uninstall roundtrip passes
+  for `CliDaemonProfile::SystemdUser`.
+- C-04 (AC-4, integration): status report fields are stable across repeated
+  inspection.
+
+## Success Metrics / Observable Signals
+
+- `tau-ops` tests include explicit `spec_c0x_*` coverage for systemd template and
+  lifecycle behavior.
+- Service unit output remains backward compatible for standard paths while covering
+  path-with-space safety.

--- a/specs/2266/tasks.md
+++ b/specs/2266/tasks.md
@@ -1,0 +1,14 @@
+# Tasks #2266
+
+Status: In Progress
+Spec: specs/2266/spec.md
+Plan: specs/2266/plan.md
+
+- T1 (tests first): add RED conformance tests C-01..C-04 with explicit `spec_c0x`
+  naming, including path-with-space `ExecStart` regression.
+- T2: implement minimal systemd `ExecStart` rendering fix for executable path
+  safety.
+- T3: run scoped verification (`cargo fmt --check`, `cargo clippy -p tau-ops -- -D warnings`,
+  `cargo test -p tau-ops`) and confirm AC mapping.
+- T4: update issue process log, open PR with RED/GREEN evidence, merge, and set
+  spec/tasks statuses to Implemented/Completed.


### PR DESCRIPTION
## Summary
Hardens `tau-ops` systemd-user daemon unit rendering by adding conformance-first coverage and fixing `ExecStart` argument quoting for executable paths containing spaces. Keeps existing lifecycle and launchd behavior unchanged.

## Links
- Milestone: `specs/milestones/m46/index.md`
- Closes #2266
- Spec: `specs/2266/spec.md`
- Plan: `specs/2266/plan.md`
- Tasks: `specs/2266/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: systemd unit includes required sections and gateway flags | ✅ | `daemon_runtime::tests::spec_c01_render_systemd_user_unit_includes_required_sections_and_gateway_flags` |
| AC-2: spaced executable path is safely encoded in `ExecStart` | ✅ | `daemon_runtime::tests::spec_c02_render_systemd_user_unit_escapes_execstart_path_with_spaces` |
| AC-3: systemd-user lifecycle install/start/stop/uninstall remains consistent | ✅ | `daemon_runtime::tests::spec_c03_tau_daemon_lifecycle_roundtrip_systemd_user_profile` |
| AC-4: status reports are deterministic across reloads | ✅ | `daemon_runtime::tests::spec_c04_tau_daemon_status_is_deterministic_across_reloads` |

## TDD Evidence
- RED:
  - Command: `CARGO_TARGET_DIR=target-fast-2266 CARGO_BUILD_JOBS=1 cargo test -p tau-ops spec_c02_render_systemd_user_unit_escapes_execstart_path_with_spaces -- --nocapture`
  - Output excerpt: `FAILED ... expected quoted executable in ExecStart, got: ... ExecStart=/opt/Tau Agent/bin/tau-coding-agent ...`
- GREEN:
  - Command: `CARGO_TARGET_DIR=target-fast-2266 CARGO_BUILD_JOBS=1 cargo test -p tau-ops spec_c02_render_systemd_user_unit_escapes_execstart_path_with_spaces -- --nocapture`
  - Output excerpt: `test ... spec_c02_render_systemd_user_unit_escapes_execstart_path_with_spaces ... ok`
- REGRESSION:
  - Command: `CARGO_TARGET_DIR=target-fast-2266 CARGO_BUILD_JOBS=1 cargo test -p tau-ops`
  - Output excerpt: `test result: ok. 82 passed; 0 failed`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`, `spec_c02`, existing unit daemon render tests | |
| Property | N/A | | No parser/invariant domain added in this issue |
| Contract/DbC | N/A | | No new contract macros or API pre/post conditions introduced |
| Snapshot | N/A | | Output is behavior-asserted with explicit string checks |
| Functional | ✅ | `spec_c03` + existing lifecycle functional tests | |
| Conformance | ✅ | `spec_c01`..`spec_c04` mapped to C-01..C-04 | |
| Integration | ✅ | `spec_c04` + existing integration determinism test | |
| Fuzz | N/A | | No untrusted parser surface changed in this diff |
| Mutation | N/A | | Scoped fix to service-template formatting; no critical path gate requested for this milestone slice |
| Regression | ✅ | RED->GREEN on `spec_c02`; existing daemon regressions still pass | |
| Performance | N/A | | No runtime hot-path/perf-sensitive algorithm changes |

## Mutation
N/A for this milestone slice (non-critical template formatting change; no escaped mutants introduced by known failing paths in this diff).

## Risks / Rollback
- Risk: quoting behavior could alter expected rendering for non-spaced paths.
- Mitigation: preserved non-spaced output shape and validated with existing unit tests + full `tau-ops` suite.
- Rollback: revert commit `fb39ba84`.

## Docs / ADR
- Added and linked issue lifecycle artifacts:
  - `specs/2266/spec.md`
  - `specs/2266/plan.md`
  - `specs/2266/tasks.md`
- ADR not required: no new dependency, protocol, or architecture decision.
