### PR TITLE
feat(release): ship bash/zsh/fish completion assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,6 +476,7 @@ jobs:
         if: steps.release_helper_scope.outputs.release_helper_tests_needed == 'true'
         run: |
           ./scripts/release/test-install-helpers.sh
+          ./scripts/release/test-shell-completions.sh
           ./scripts/release/test-homebrew-formula.sh
           ./scripts/release/test-release-workflow-contract.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,16 @@ jobs:
             dist/SHA256SUMS \
             "${GITHUB_REPOSITORY}" > dist/tau.rb
 
+      - name: Generate shell completions
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf "dist/${APP_NAME}-linux-amd64.tar.gz" -C dist
+          chmod +x "dist/${APP_NAME}-linux-amd64"
+          scripts/release/generate-shell-completions.sh \
+            "dist/${APP_NAME}-linux-amd64" \
+            dist/completions
+
       - name: Verify staged files
         shell: bash
         run: |
@@ -281,6 +291,9 @@ jobs:
             dist/*.sha256
             dist/SHA256SUMS
             dist/tau.rb
+            dist/completions/tau-coding-agent.bash
+            dist/completions/tau-coding-agent.zsh
+            dist/completions/tau-coding-agent.fish
 
       - name: Publish release assets
         uses: softprops/action-gh-release@v2
@@ -293,6 +306,9 @@ jobs:
             dist/*.sha256
             dist/SHA256SUMS
             dist/tau.rb
+            dist/completions/tau-coding-agent.bash
+            dist/completions/tau-coding-agent.zsh
+            dist/completions/tau-coding-agent.fish
 
   publish-container:
     name: Publish container image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3339,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "serde",
  "serde_json",
  "tau-gateway",

--- a/README.md
+++ b/README.md
@@ -150,6 +150,28 @@ brew upgrade tau
 brew uninstall tau
 ```
 
+## Shell Completions
+
+Each tagged release also publishes shell completion assets:
+
+- `tau-coding-agent.bash`
+- `tau-coding-agent.zsh`
+- `tau-coding-agent.fish`
+
+```bash
+# Bash
+curl -fsSL -o ~/.local/share/bash-completion/completions/tau-coding-agent \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.bash
+
+# Zsh
+curl -fsSL -o ~/.zsh/completions/_tau-coding-agent \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.zsh
+
+# Fish
+curl -fsSL -o ~/.config/fish/completions/tau-coding-agent.fish \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.fish
+```
+
 ## Demo Commands
 
 Fresh-clone validation index:
@@ -241,6 +263,7 @@ Contributor references:
   - Linux/macOS/Windows artifacts (`amd64`, `arm64`)
   - GHCR Docker image publish (`ghcr.io/<owner>/tau-coding-agent:<release-tag>`, `latest`)
   - Homebrew formula asset publish (`tau.rb`) derived from `SHA256SUMS`
+  - shell completion assets (`tau-coding-agent.bash`, `.zsh`, `.fish`)
   - optional signing/notarization hooks (`scripts/release/hooks/*`)
   - installer/update scripts for Unix and PowerShell
 - Dependabot: [`.github/dependabot.yml`](.github/dependabot.yml)

--- a/crates/tau-cli/Cargo.toml
+++ b/crates/tau-cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tau-session = { path = "../tau-session" }

--- a/crates/tau-cli/src/cli_args.rs
+++ b/crates/tau-cli/src/cli_args.rs
@@ -6,7 +6,8 @@ use crate::{
     CliCommandFileErrorMode, CliCredentialStoreEncryptionMode, CliDeploymentWasmBrowserDidMethod,
     CliDeploymentWasmRuntimeProfile, CliGatewayOpenResponsesAuthMode, CliGatewayRemoteProfile,
     CliMultiChannelLiveConnectorMode, CliMultiChannelOutboundMode, CliMultiChannelTransport,
-    CliOrchestratorMode, CliPromptSanitizerMode, CliProviderAuthMode, CliWebhookSignatureAlgorithm,
+    CliOrchestratorMode, CliPromptSanitizerMode, CliProviderAuthMode, CliShellCompletion,
+    CliWebhookSignatureAlgorithm,
 };
 
 mod execution_domain_flags;
@@ -67,6 +68,13 @@ fn parse_threshold_percent(value: &str) -> Result<u8, String> {
 )]
 /// Public struct `Cli` used across Tau components.
 pub struct Cli {
+    #[arg(
+        long = "shell-completion",
+        value_enum,
+        help = "Print shell completion script to stdout and exit (supported: bash, zsh, fish)"
+    )]
+    pub shell_completion: Option<CliShellCompletion>,
+
     #[arg(
         long,
         env = "TAU_MODEL",

--- a/crates/tau-cli/src/cli_types.rs
+++ b/crates/tau-cli/src/cli_types.rs
@@ -191,6 +191,14 @@ pub enum CliOrchestratorMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Enumerates supported `CliShellCompletion` values.
+pub enum CliShellCompletion {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 /// Enumerates supported `CliMultiChannelTransport` values.
 pub enum CliMultiChannelTransport {
     Telegram,

--- a/crates/tau-cli/src/lib.rs
+++ b/crates/tau-cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod command_file;
 pub mod command_text;
 pub mod gateway_remote_profile;
 pub mod legacy_aliases;
+pub mod shell_completion;
 pub mod validation;
 
 pub use cli_args::Cli;
@@ -17,4 +18,5 @@ pub use command_file::*;
 pub use command_text::*;
 pub use gateway_remote_profile::*;
 pub use legacy_aliases::normalize_legacy_training_aliases;
+pub use shell_completion::*;
 pub use validation::*;

--- a/crates/tau-cli/src/shell_completion.rs
+++ b/crates/tau-cli/src/shell_completion.rs
@@ -1,0 +1,41 @@
+use std::io::{self, Write};
+
+use clap::CommandFactory;
+use clap_complete::{
+    generate,
+    shells::{Bash, Fish, Zsh},
+};
+
+use crate::{Cli, CliShellCompletion};
+
+/// Canonical binary name used in generated completion scripts.
+pub const SHELL_COMPLETION_COMMAND_NAME: &str = "tau-coding-agent";
+
+/// Render a shell completion script for the requested shell.
+pub fn render_shell_completion(
+    shell: CliShellCompletion,
+    mut writer: impl Write,
+) -> io::Result<()> {
+    let mut command = Cli::command();
+    match shell {
+        CliShellCompletion::Bash => generate(
+            Bash,
+            &mut command,
+            SHELL_COMPLETION_COMMAND_NAME,
+            &mut writer,
+        ),
+        CliShellCompletion::Zsh => generate(
+            Zsh,
+            &mut command,
+            SHELL_COMPLETION_COMMAND_NAME,
+            &mut writer,
+        ),
+        CliShellCompletion::Fish => generate(
+            Fish,
+            &mut command,
+            SHELL_COMPLETION_COMMAND_NAME,
+            &mut writer,
+        ),
+    }
+    Ok(())
+}

--- a/crates/tau-coding-agent/src/startup_dispatch.rs
+++ b/crates/tau-coding-agent/src/startup_dispatch.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use tau_ai::ModelRef;
+use tau_cli::render_shell_completion;
 use tau_cli::validation::validate_removed_contract_runner_flags_cli;
 use tau_cli::Cli;
 use tau_onboarding::startup_dispatch::{
@@ -24,6 +25,11 @@ use crate::training_proxy_runtime::run_prompt_optimization_proxy_mode_if_request
 use crate::training_runtime::run_prompt_optimization_mode_if_requested;
 
 pub(crate) async fn run_cli(cli: Cli) -> Result<()> {
+    if let Some(shell) = cli.shell_completion {
+        render_shell_completion(shell, std::io::stdout())?;
+        return Ok(());
+    }
+
     if execute_startup_preflight(&cli)? {
         return Ok(());
     }

--- a/crates/tau-coding-agent/src/tests.rs
+++ b/crates/tau-coding-agent/src/tests.rs
@@ -326,6 +326,7 @@ fn test_chat_request() -> ChatRequest {
 
 pub(crate) fn test_cli() -> Cli {
     Cli {
+        shell_completion: None,
         model: "openai/gpt-4o-mini".to_string(),
         fallback_model: vec![],
         api_base: "https://api.openai.com/v1".to_string(),

--- a/docs/guides/release-automation-ops.md
+++ b/docs/guides/release-automation-ops.md
@@ -26,6 +26,10 @@ The workflow publishes release archives plus checksum manifests to GitHub Releas
 - `*.sha256`
 - `SHA256SUMS`
 - `tau.rb` (Homebrew formula rendered from `SHA256SUMS`)
+- shell completions:
+  - `tau-coding-agent.bash`
+  - `tau-coding-agent.zsh`
+  - `tau-coding-agent.fish`
 
 The workflow also publishes a GHCR container image:
 
@@ -52,6 +56,28 @@ brew install --formula https://github.com/<owner>/Tau/releases/download/<release
 # Upgrade/remove
 brew upgrade tau
 brew uninstall tau
+```
+
+### Shell completion publishing
+
+The publish job extracts the Linux amd64 release binary and runs
+[`scripts/release/generate-shell-completions.sh`](../../scripts/release/generate-shell-completions.sh)
+to generate completion files under `dist/completions/`.
+
+Operator usage:
+
+```bash
+# Bash
+curl -fsSL -o ~/.local/share/bash-completion/completions/tau-coding-agent \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.bash
+
+# Zsh (rename to leading underscore for autoload)
+curl -fsSL -o ~/.zsh/completions/_tau-coding-agent \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.zsh
+
+# Fish
+curl -fsSL -o ~/.config/fish/completions/tau-coding-agent.fish \
+  https://github.com/<owner>/Tau/releases/download/<release-tag>/tau-coding-agent.fish
 ```
 
 ### Cross-arch smoke policy
@@ -169,8 +195,10 @@ Run helper-script tests:
 
 ```bash
 ./scripts/release/test-install-helpers.sh
+./scripts/release/test-shell-completions.sh
 ./scripts/release/test-homebrew-formula.sh
 ./scripts/release/render-homebrew-formula.sh v0.1.0 dist/SHA256SUMS <owner>/Tau > dist/tau.rb
+./scripts/release/generate-shell-completions.sh ./target/release/tau-coding-agent dist/completions
 ```
 
 Run release workflow lint/validation via PR CI:

--- a/scripts/release/generate-shell-completions.sh
+++ b/scripts/release/generate-shell-completions.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <tau-binary-path> <output-dir>" >&2
+  exit 1
+fi
+
+tau_binary="$1"
+output_dir="$2"
+
+if [[ ! -x "${tau_binary}" ]]; then
+  echo "error: tau binary is not executable: ${tau_binary}" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+
+"${tau_binary}" --shell-completion bash > "${output_dir}/tau-coding-agent.bash"
+"${tau_binary}" --shell-completion zsh > "${output_dir}/tau-coding-agent.zsh"
+"${tau_binary}" --shell-completion fish > "${output_dir}/tau-coding-agent.fish"
+
+for completion_file in \
+  "${output_dir}/tau-coding-agent.bash" \
+  "${output_dir}/tau-coding-agent.zsh" \
+  "${output_dir}/tau-coding-agent.fish"; do
+  if [[ ! -s "${completion_file}" ]]; then
+    echo "error: generated completion file is empty: ${completion_file}" >&2
+    exit 1
+  fi
+done
+
+echo "generated shell completions in ${output_dir}"

--- a/scripts/release/test-release-workflow-contract.sh
+++ b/scripts/release/test-release-workflow-contract.sh
@@ -50,4 +50,11 @@ assert_contains_file "${RELEASE_WORKFLOW}" "Render Homebrew formula" "homebrew f
 assert_contains_file "${RELEASE_WORKFLOW}" "scripts/release/render-homebrew-formula.sh" "homebrew render script invocation"
 assert_contains_file "${RELEASE_WORKFLOW}" "dist/tau.rb" "homebrew formula release asset"
 
+# Conformance: release workflow must generate/publish shell completion assets.
+assert_contains_file "${RELEASE_WORKFLOW}" "Generate shell completions" "shell completion generation step"
+assert_contains_file "${RELEASE_WORKFLOW}" "scripts/release/generate-shell-completions.sh" "shell completion script invocation"
+assert_contains_file "${RELEASE_WORKFLOW}" "dist/completions/tau-coding-agent.bash" "bash completion asset"
+assert_contains_file "${RELEASE_WORKFLOW}" "dist/completions/tau-coding-agent.zsh" "zsh completion asset"
+assert_contains_file "${RELEASE_WORKFLOW}" "dist/completions/tau-coding-agent.fish" "fish completion asset"
+
 echo "release workflow contract tests passed"

--- a/scripts/release/test-shell-completions.sh
+++ b/scripts/release/test-shell-completions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+GENERATOR_SCRIPT="scripts/release/generate-shell-completions.sh"
+
+assert_file_exists() {
+  local file_path="$1"
+  if [[ ! -f "${file_path}" ]]; then
+    echo "assertion failed: expected file to exist: ${file_path}" >&2
+    exit 1
+  fi
+}
+
+assert_contains_file() {
+  local file_path="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq "${needle}" "${file_path}"; then
+    echo "assertion failed (${label}): '${needle}' not found in ${file_path}" >&2
+    exit 1
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+mock_binary="${temp_dir}/mock-tau.sh"
+output_dir="${temp_dir}/completions"
+
+cat > "${mock_binary}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -ne 2 || "$1" != "--shell-completion" ]]; then
+  echo "unexpected args: $*" >&2
+  exit 1
+fi
+printf 'completion-%s\n' "$2"
+EOF
+
+chmod +x "${mock_binary}"
+
+"${GENERATOR_SCRIPT}" "${mock_binary}" "${output_dir}"
+
+assert_file_exists "${output_dir}/tau-coding-agent.bash"
+assert_file_exists "${output_dir}/tau-coding-agent.zsh"
+assert_file_exists "${output_dir}/tau-coding-agent.fish"
+
+assert_contains_file "${output_dir}/tau-coding-agent.bash" "completion-bash" "bash output"
+assert_contains_file "${output_dir}/tau-coding-agent.zsh" "completion-zsh" "zsh output"
+assert_contains_file "${output_dir}/tau-coding-agent.fish" "completion-fish" "fish output"
+
+echo "shell completion generation contract tests passed"

--- a/specs/2265/plan.md
+++ b/specs/2265/plan.md
@@ -1,0 +1,51 @@
+# Plan #2265
+
+Status: Reviewed
+Spec: specs/2265/spec.md
+
+## Approach
+
+1. Add CLI completion rendering path:
+   - introduce `CliShellCompletion` value enum (`bash|zsh|fish`)
+   - add `--shell-completion` flag
+   - render completion via `clap_complete` and exit before runtime startup.
+2. Add release completion generator tooling:
+   - script to invoke binary completion output and write deterministic files.
+3. Wire release workflow:
+   - extract Linux amd64 artifact
+   - generate completion files
+   - publish completion assets in release upload step.
+4. Add release-helper contract tests:
+   - generator script behavior/outputs
+   - workflow step/file assertions.
+5. Update docs:
+   - completion asset locations and install snippets for bash/zsh/fish.
+
+## Affected Modules
+
+- `crates/tau-cli/*` (CLI flag + completion renderer)
+- `crates/tau-coding-agent/src/startup_dispatch.rs` (early completion dispatch)
+- `scripts/release/*` (generation + tests)
+- `.github/workflows/release.yml`
+- `.github/workflows/ci.yml`
+- `README.md`
+- `docs/guides/release-automation-ops.md`
+- `specs/2265/*`
+
+## Risks and Mitigations
+
+- Risk: completion generation path accidentally triggers runtime startup.
+  - Mitigation: short-circuit dispatch before preflight/runtime model setup.
+- Risk: release workflow completion files drift from expected names.
+  - Mitigation: contract test asserts exact output filenames and publish list.
+- Risk: shell-specific generation regressions.
+  - Mitigation: direct per-shell assertions in script tests plus runtime smoke
+    execution of `--shell-completion`.
+
+## Interfaces / Contracts
+
+- New CLI contract:
+  - `tau-coding-agent --shell-completion <bash|zsh|fish>` prints completion
+    script to stdout and exits successfully.
+- New release delivery contract:
+  - release assets include shell completion files for bash/zsh/fish.

--- a/specs/2265/spec.md
+++ b/specs/2265/spec.md
@@ -1,0 +1,57 @@
+# Spec #2265
+
+Status: Accepted
+Milestone: specs/milestones/m46/index.md
+Issue: https://github.com/njfio/Tau/issues/2265
+
+## Problem Statement
+
+Tau currently ships binary artifacts but does not ship first-party shell
+completion scripts. Operators using bash/zsh/fish must discover and type large
+flag surfaces manually, reducing CLI usability and increasing command mistakes.
+
+## Scope
+
+In scope:
+
+- Add CLI completion rendering for bash/zsh/fish.
+- Add release automation to generate and publish completion assets.
+- Add contract tests for generation scripts and release workflow wiring.
+- Add operator documentation for completion download/install usage.
+
+Out of scope:
+
+- Installing completions automatically into user shell config files.
+- Supporting additional shells beyond bash/zsh/fish in this slice.
+- Changing runtime command behavior unrelated to completion generation.
+
+## Acceptance Criteria
+
+- AC-1: Given `tau-coding-agent --shell-completion <shell>`, when shell is one
+  of `bash|zsh|fish`, then valid completion content is emitted to stdout.
+- AC-2: Given release workflow execution for a tag, when artifacts are staged,
+  then bash/zsh/fish completion files are generated and published as release
+  assets.
+- AC-3: Given completion script/workflow changes, when CI release-helper scope
+  runs, then completion generation contract tests and workflow contract tests
+  pass.
+- AC-4: Given operator docs, when onboarding shell completion usage, then docs
+  include deterministic download/install commands for bash/zsh/fish.
+
+## Conformance Cases
+
+- C-01 (AC-1, conformance): CLI completion flag emits deterministic script
+  output for bash/zsh/fish using command name `tau-coding-agent`.
+- C-02 (AC-2, integration): release workflow generates completion assets and
+  includes them in release publish files.
+- C-03 (AC-3, functional): release helper contract scripts verify completion
+  generator behavior and workflow step/file assertions.
+- C-04 (AC-4, documentation): docs include completion asset paths and install
+  command examples for bash/zsh/fish.
+
+## Success Metrics / Observable Signals
+
+- `scripts/release/test-shell-completions.sh` passes locally and in CI.
+- `scripts/release/test-release-workflow-contract.sh` includes shell completion
+  checks and passes.
+- Release docs and README include shell completion usage paths and commands.

--- a/specs/2265/tasks.md
+++ b/specs/2265/tasks.md
@@ -1,0 +1,22 @@
+# Tasks #2265
+
+Status: In Progress
+Spec: specs/2265/spec.md
+Plan: specs/2265/plan.md
+
+- T1 (tests first): add RED completion contract tests for C-01..C-04
+  (`scripts/release/test-shell-completions.sh` + workflow contract assertions).
+- T2: add CLI completion flag/type and completion renderer helper.
+- T3: add startup dispatch short-circuit for completion generation.
+- T4: add release completion generation script and make RED tests pass.
+- T5: wire release workflow + CI release-helper scope for completion assets.
+- T6: update docs (`README.md`, `docs/guides/release-automation-ops.md`) for
+  completion install guidance.
+- T7: run scoped verification and collect PR evidence:
+  - `./scripts/release/test-shell-completions.sh`
+  - `./scripts/release/test-release-workflow-contract.sh`
+  - `./scripts/release/test-install-helpers.sh`
+  - `CARGO_TARGET_DIR=target-fast-2265 cargo check -p tau-cli`
+  - `CARGO_TARGET_DIR=target-fast-2265 cargo test -p tau-coding-agent unit_normalize_daemon_subcommand_args_maps_action_and_alias_flags`
+  - `CARGO_TARGET_DIR=target-fast-2265 cargo run -q -p tau-coding-agent -- --shell-completion bash`
+  - `cargo fmt --check`.


### PR DESCRIPTION
## Summary
Ships first-party bash/zsh/fish shell completions for Tau by adding a CLI completion mode, release automation generation/publish wiring, release-helper contract tests, and operator install docs.

## Links
- Milestone: `specs/milestones/m46/index.md`
- Closes: #2265
- Spec: `specs/2265/spec.md`
- Plan: `specs/2265/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: `--shell-completion <bash|zsh|fish>` emits completion content to stdout | ✅ | `CARGO_TARGET_DIR=target-fast-2265 cargo run -q -p tau-coding-agent -- --shell-completion bash > /tmp/tau-completion-bash.txt` (+ non-empty + `grep "tau-coding-agent"`) |
| AC-2: release workflow generates/publishes completion assets | ✅ | `./scripts/release/test-release-workflow-contract.sh` |
| AC-3: release-helper scope validates completion generation/workflow contracts | ✅ | `./scripts/release/test-shell-completions.sh`, `.github/workflows/ci.yml` release-helper step includes new test |
| AC-4: docs include deterministic download/install commands for bash/zsh/fish | ✅ | `README.md`, `docs/guides/release-automation-ops.md` |

## TDD Evidence
RED:
- `./scripts/release/test-shell-completions.sh`
  - `scripts/release/generate-shell-completions.sh: No such file or directory`
- `./scripts/release/test-release-workflow-contract.sh`
  - `assertion failed (shell completion generation step): 'Generate shell completions' not found in .github/workflows/release.yml`

GREEN:
- `./scripts/release/test-shell-completions.sh`
  - `shell completion generation contract tests passed`
- `./scripts/release/test-release-workflow-contract.sh`
  - `release workflow contract tests passed`
- `./scripts/release/test-homebrew-formula.sh`
  - `homebrew formula contract tests passed`
- `./scripts/release/test-install-helpers.sh`
  - `release install/update helper tests passed`
- `CARGO_TARGET_DIR=target-fast-2265 cargo check -p tau-cli`
  - pass
- `CARGO_TARGET_DIR=target-fast-2265 cargo test -p tau-coding-agent unit_normalize_daemon_subcommand_args_maps_action_and_alias_flags`
  - pass
- `CARGO_TARGET_DIR=target-fast-2265 cargo run -q -p tau-coding-agent -- --shell-completion bash > /tmp/tau-completion-bash.txt`
  - `shell-completion-smoke:pass`
- `cargo fmt --check`
  - pass

REGRESSION summary:
- Existing release helper regressions remain green (`test-install-helpers`, `test-homebrew-formula`).

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `CARGO_TARGET_DIR=target-fast-2265 cargo test -p tau-coding-agent unit_normalize_daemon_subcommand_args_maps_action_and_alias_flags` | |
| Property | N/A | | No randomized invariant surface changed in this delivery slice. |
| Contract/DbC | N/A | | No new Rust DbC contract annotations introduced. |
| Snapshot | N/A | | No snapshot-based outputs were added. |
| Functional | ✅ | `./scripts/release/test-shell-completions.sh` | |
| Conformance | ✅ | `./scripts/release/test-shell-completions.sh`, `./scripts/release/test-release-workflow-contract.sh` | |
| Integration | ✅ | `./scripts/release/test-release-workflow-contract.sh`, completion runtime smoke command | |
| Fuzz | N/A | | Shell/workflow path only; no untrusted parser fuzz target added in this issue. |
| Mutation | N/A | | `cargo-mutants` not applicable for this shell/workflow-focused change set. |
| Regression | ✅ | `./scripts/release/test-install-helpers.sh`, `./scripts/release/test-homebrew-formula.sh` | |
| Performance | N/A | | No runtime hotspot/perf-sensitive path changed. |

## Mutation
- N/A for this change set (no Rust critical-path mutation target in scope).

## Risks / Rollback
- Risk: completion generation step can fail if Linux amd64 archive naming drifts.
- Rollback: revert this PR to restore prior release behavior without completion assets.

## Docs / ADR
- Updated:
  - `README.md`
  - `docs/guides/release-automation-ops.md`
- ADR: not required (no architecture/protocol/dependency decision requiring ADR beyond existing release flow).
