### PR TITLE
feat(runtime): implement #2268 runtime log rotation policy

### DIFF
--- a/crates/tau-core/src/lib.rs
+++ b/crates/tau-core/src/lib.rs
@@ -5,10 +5,13 @@
 
 /// Atomic file-write helpers for durable state updates.
 pub mod atomic_io;
+/// Size-based NDJSON log rotation helpers for operational runtime files.
+pub mod log_rotation;
 /// Unix timestamp utilities used across runtime policy/state logic.
 pub mod time_utils;
 
 pub use atomic_io::write_text_atomic;
+pub use log_rotation::{append_line_with_rotation, LogRotationPolicy};
 pub use time_utils::{current_unix_timestamp, current_unix_timestamp_ms, is_expired_unix};
 
 #[cfg(test)]

--- a/crates/tau-core/src/log_rotation.rs
+++ b/crates/tau-core/src/log_rotation.rs
@@ -1,0 +1,193 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+const DEFAULT_LOG_ROTATION_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const DEFAULT_LOG_ROTATION_MAX_FILES: usize = 5;
+
+/// Configuration for size-based log rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogRotationPolicy {
+    pub max_bytes: u64,
+    pub max_files: usize,
+}
+
+impl LogRotationPolicy {
+    /// Build policy from env vars with safe defaults.
+    pub fn from_env() -> Self {
+        let max_bytes = std::env::var("TAU_LOG_ROTATION_MAX_BYTES")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_LOG_ROTATION_MAX_BYTES);
+        let max_files = std::env::var("TAU_LOG_ROTATION_MAX_FILES")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_LOG_ROTATION_MAX_FILES);
+        Self {
+            max_bytes,
+            max_files,
+        }
+    }
+
+    /// Returns true when size-based rotation is enabled.
+    pub fn is_enabled(self) -> bool {
+        self.max_bytes > 0 && self.max_files > 0
+    }
+}
+
+/// Append one NDJSON line to `path`, applying size-based rotation policy.
+pub fn append_line_with_rotation(path: &Path, line: &str, policy: LogRotationPolicy) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+
+    if policy.is_enabled() && path.exists() {
+        let current_size = std::fs::metadata(path)
+            .with_context(|| format!("failed to stat {}", path.display()))?
+            .len();
+        let incoming_size = line.len().saturating_add(1).try_into().unwrap_or(u64::MAX);
+        if current_size.saturating_add(incoming_size) > policy.max_bytes {
+            rotate_log_file(path, policy)?;
+        }
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+fn rotated_backup_path(path: &Path, index: usize) -> PathBuf {
+    PathBuf::from(format!("{}.{}", path.display(), index))
+}
+
+fn rotate_log_file(path: &Path, policy: LogRotationPolicy) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    if !policy.is_enabled() {
+        return Ok(());
+    }
+
+    if policy.max_files <= 1 {
+        std::fs::remove_file(path)
+            .with_context(|| format!("failed to rotate {}", path.display()))?;
+        return Ok(());
+    }
+
+    let max_backup_index = policy.max_files.saturating_sub(1);
+    for index in (1..=max_backup_index).rev() {
+        let source = if index == 1 {
+            path.to_path_buf()
+        } else {
+            rotated_backup_path(path, index.saturating_sub(1))
+        };
+        if !source.exists() {
+            continue;
+        }
+        let destination = rotated_backup_path(path, index);
+        if destination.exists() {
+            std::fs::remove_file(&destination).with_context(|| {
+                format!("failed to replace rotated log {}", destination.display())
+            })?;
+        }
+        std::fs::rename(&source, &destination).with_context(|| {
+            format!(
+                "failed to rotate {} to {}",
+                source.display(),
+                destination.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_line_with_rotation, rotated_backup_path, LogRotationPolicy};
+
+    fn read(path: &std::path::Path) -> String {
+        std::fs::read_to_string(path).unwrap_or_default()
+    }
+
+    #[test]
+    fn spec_c01_append_rotation_rotates_when_size_threshold_exceeded() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("runtime-events.jsonl");
+        let policy = LogRotationPolicy {
+            max_bytes: 24,
+            max_files: 3,
+        };
+
+        append_line_with_rotation(path.as_path(), r#"{"seq":1,"msg":"first"}"#, policy)
+            .expect("append first");
+        append_line_with_rotation(path.as_path(), r#"{"seq":2,"msg":"second"}"#, policy)
+            .expect("append second");
+
+        let first_backup = rotated_backup_path(path.as_path(), 1);
+        assert!(
+            first_backup.exists(),
+            "expected first rotated backup to exist"
+        );
+        assert!(
+            read(first_backup.as_path()).contains("\"seq\":1"),
+            "backup should retain first record"
+        );
+        assert!(
+            read(path.as_path()).contains("\"seq\":2"),
+            "active log should contain second record after rotation"
+        );
+    }
+
+    #[test]
+    fn spec_c02_append_rotation_prunes_backups_to_max_files_limit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("runtime-events.jsonl");
+        let policy = LogRotationPolicy {
+            max_bytes: 18,
+            max_files: 2,
+        };
+
+        for seq in 1..=6 {
+            append_line_with_rotation(path.as_path(), &format!(r#"{{"seq":{seq}}}"#), policy)
+                .expect("append line");
+        }
+
+        let backup_1 = rotated_backup_path(path.as_path(), 1);
+        let backup_2 = rotated_backup_path(path.as_path(), 2);
+        assert!(backup_1.exists(), "expected first backup to exist");
+        assert!(
+            !backup_2.exists(),
+            "expected backups older than max_files retention to be pruned"
+        );
+    }
+
+    #[test]
+    fn spec_c03_log_rotation_policy_from_env_uses_valid_values_and_falls_back_on_invalid() {
+        std::env::set_var("TAU_LOG_ROTATION_MAX_BYTES", "4096");
+        std::env::set_var("TAU_LOG_ROTATION_MAX_FILES", "7");
+        let parsed = LogRotationPolicy::from_env();
+        assert_eq!(parsed.max_bytes, 4096);
+        assert_eq!(parsed.max_files, 7);
+
+        std::env::set_var("TAU_LOG_ROTATION_MAX_BYTES", "not-a-number");
+        std::env::set_var("TAU_LOG_ROTATION_MAX_FILES", "0");
+        let fallback = LogRotationPolicy::from_env();
+        assert_eq!(fallback.max_bytes, 10 * 1024 * 1024);
+        assert_eq!(fallback.max_files, 5);
+
+        std::env::remove_var("TAU_LOG_ROTATION_MAX_BYTES");
+        std::env::remove_var("TAU_LOG_ROTATION_MAX_FILES");
+    }
+}

--- a/crates/tau-dashboard/src/dashboard_runtime.rs
+++ b/crates/tau-dashboard/src/dashboard_runtime.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -14,7 +13,9 @@ use crate::dashboard_contract::{
     DASHBOARD_ERROR_EMPTY_INPUT, DASHBOARD_ERROR_INVALID_ACTION, DASHBOARD_ERROR_INVALID_FILTER,
     DASHBOARD_ERROR_INVALID_SCOPE,
 };
-use tau_core::{current_unix_timestamp_ms, write_text_atomic};
+use tau_core::{
+    append_line_with_rotation, current_unix_timestamp_ms, write_text_atomic, LogRotationPolicy,
+};
 use tau_runtime::channel_store::{ChannelContextEntry, ChannelLogEntry, ChannelStore};
 use tau_runtime::transport_health::TransportHealthSnapshot;
 
@@ -562,14 +563,8 @@ fn append_dashboard_cycle_report(
         failure_streak: health.failure_streak,
     };
     let line = serde_json::to_string(&payload).context("serialize dashboard runtime report")?;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
-    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
-    file.flush()
-        .with_context(|| format!("failed to flush {}", path.display()))?;
+    append_line_with_rotation(path, &line, LogRotationPolicy::from_env())
+        .with_context(|| format!("failed to append {}", path.display()))?;
     Ok(())
 }
 

--- a/crates/tau-multi-channel/src/multi_channel_runtime/routing.rs
+++ b/crates/tau-multi-channel/src/multi_channel_runtime/routing.rs
@@ -1,8 +1,8 @@
-use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde_json::Value;
+use tau_core::{append_line_with_rotation, LogRotationPolicy};
 
 use super::{
     current_unix_timestamp_ms, MultiChannelRuntimeCycleReport, MultiChannelRuntimeSummary,
@@ -125,14 +125,8 @@ pub(super) fn append_multi_channel_cycle_report(
         failure_streak: health.failure_streak,
     };
     let line = serde_json::to_string(&payload).context("serialize multi-channel runtime report")?;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
-    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
-    file.flush()
-        .with_context(|| format!("failed to flush {}", path.display()))?;
+    append_line_with_rotation(path, &line, LogRotationPolicy::from_env())
+        .with_context(|| format!("failed to append {}", path.display()))?;
     Ok(())
 }
 
@@ -144,13 +138,7 @@ pub(super) fn append_multi_channel_route_trace(path: &Path, payload: &Value) -> 
         }
     }
     let line = serde_json::to_string(payload).context("serialize multi-channel route trace")?;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
-    writeln!(file, "{line}").with_context(|| format!("failed to append {}", path.display()))?;
-    file.flush()
-        .with_context(|| format!("failed to flush {}", path.display()))?;
+    append_line_with_rotation(path, &line, LogRotationPolicy::from_env())
+        .with_context(|| format!("failed to append {}", path.display()))?;
     Ok(())
 }

--- a/docs/guides/transports.md
+++ b/docs/guides/transports.md
@@ -12,6 +12,28 @@ cargo run -p tau-coding-agent -- \
 
 Troubleshooting map and field details: `docs/guides/operator-control-summary.md`.
 
+## Runtime Log Rotation
+
+Runtime JSONL logs use size-based rotation with bounded retained files.
+
+- `TAU_LOG_ROTATION_MAX_BYTES`: max bytes for active log before rollover
+  (default `10485760` / 10 MiB).
+- `TAU_LOG_ROTATION_MAX_FILES`: retained file count including active file
+  (default `5`).
+
+Retained files are named:
+
+- Active: `<name>.jsonl`
+- Backups: `<name>.jsonl.1`, `<name>.jsonl.2`, ...
+
+Examples:
+
+```bash
+# Keep active + 2 backups, rotate every 2 MiB.
+export TAU_LOG_ROTATION_MAX_BYTES=2097152
+export TAU_LOG_ROTATION_MAX_FILES=3
+```
+
 ## Removed Contract Runner Migration Matrix
 
 | Removed Flag | Status | Replacement Path |

--- a/specs/2268/plan.md
+++ b/specs/2268/plan.md
@@ -1,0 +1,55 @@
+# Plan #2268
+
+Status: Reviewed
+Spec: specs/2268/spec.md
+
+## Approach
+
+1. Add shared low-level log-rotation utility in `tau-core`:
+   - policy struct (`max_bytes`, `max_files`)
+   - env-driven policy resolution with defaults
+   - append-with-rotation helper for NDJSON lines.
+2. Add RED conformance tests for helper behavior (threshold, retention, env
+   parsing).
+3. Integrate helper into runtime operational appenders:
+   - `tau-runtime`: heartbeat, background jobs, tool audit, prompt telemetry.
+   - transport runtimes: dashboard, gateway, deployment, multi-agent,
+     multi-channel, custom-command, voice.
+4. Add integration/regression tests for representative runtime appenders to
+   prove rotation does not break writes.
+5. Update runtime/operator docs with controls, defaults, and retained file
+   naming.
+6. Run scoped verification on touched crates and collect RED/GREEN evidence.
+
+## Affected Modules
+
+- `crates/tau-core/src/*` (new rotation utility)
+- `crates/tau-runtime/src/{observability_loggers_runtime.rs,heartbeat_runtime.rs,background_jobs_runtime.rs}`
+- `crates/tau-dashboard/src/dashboard_runtime.rs`
+- `crates/tau-gateway/src/gateway_runtime.rs`
+- `crates/tau-deployment/src/deployment_runtime.rs`
+- `crates/tau-orchestrator/src/multi_agent_runtime.rs`
+- `crates/tau-multi-channel/src/multi_channel_runtime/routing.rs`
+- `crates/tau-custom-command/src/custom_command_runtime.rs`
+- `crates/tau-voice/src/voice_runtime.rs`
+- `docs/guides/*` (runtime ops guidance)
+- `specs/2268/*`
+
+## Risks and Mitigations
+
+- Risk: rotation integration accidentally changes non-operational transcript
+  behavior.
+  - Mitigation: scope helper calls to runtime/event/audit appenders only.
+- Risk: file rename semantics differ across platforms when destination exists.
+  - Mitigation: remove destination before rename and validate in unit tests.
+- Risk: excessive rotation under low thresholds affects performance.
+  - Mitigation: provide tunable max-bytes/max-files controls with safe defaults.
+
+## Interfaces / Contracts
+
+- New environment controls:
+  - `TAU_LOG_ROTATION_MAX_BYTES` (u64, default documented)
+  - `TAU_LOG_ROTATION_MAX_FILES` (usize, default documented)
+- New retained-file convention:
+  - active: `<name>.jsonl`
+  - backups: `<name>.jsonl.1`, `<name>.jsonl.2`, ...

--- a/specs/2268/spec.md
+++ b/specs/2268/spec.md
@@ -1,0 +1,63 @@
+# Spec #2268
+
+Status: Accepted
+Milestone: specs/milestones/m46/index.md
+Issue: https://github.com/njfio/Tau/issues/2268
+
+## Problem Statement
+
+Tau appends operational JSONL logs across runtime components (runtime cycle
+events, heartbeat events, background job events, tool audit, and prompt
+telemetry) but currently has no built-in size-based rotation. Long-running
+deployments accumulate unbounded files and create disk-growth and operator
+reliability risk.
+
+## Scope
+
+In scope:
+
+- Add shared runtime log rotation policy and append helper for JSONL line writes.
+- Add operator controls for retention via environment variables.
+- Wire rotation into runtime event appenders and telemetry/audit appenders.
+- Add conformance tests for rotation behavior and control handling.
+- Document runtime log rotation controls and retained-file behavior.
+
+Out of scope:
+
+- Compression of rotated files.
+- Time-based rotation schedules.
+- Rotation of session transcript/history stores used as conversational memory.
+
+## Acceptance Criteria
+
+- AC-1: Given runtime JSONL appenders, when append would exceed configured
+  max-bytes, then active log rotates and append continues on a fresh active
+  file.
+- AC-2: Given configured max-files retention, when repeated rotation happens,
+  then only configured retained files remain (`active + numbered backups`) and
+  oldest backups are pruned.
+- AC-3: Given operator environment controls, when values are set, then runtime
+  log rotation policy uses those values; when unset/invalid, safe defaults are
+  used.
+- AC-4: Given runtime and ops documentation, when operators review deployment
+  guidance, then the log rotation controls and retained-file naming are
+  documented.
+
+## Conformance Cases
+
+- C-01 (AC-1, unit): append helper rotates active file when
+  `current_size + incoming_line > max_bytes`.
+- C-02 (AC-2, unit): repeated rotations keep only `max_files - 1` backups and
+  prune older files.
+- C-03 (AC-3, functional): environment control parser applies valid values and
+  falls back for invalid/empty values.
+- C-04 (AC-1, integration): runtime appenders (heartbeat + runtime events +
+  telemetry/audit) continue writing records after rotation.
+- C-05 (AC-4, documentation): operator docs include env vars, defaults, and
+  backup naming convention.
+
+## Success Metrics / Observable Signals
+
+- Rotation helper tests pass for threshold, retention, and env policy controls.
+- Runtime crate tests demonstrate appenders keep writing after rotation.
+- Runtime docs list controls and retention naming (`*.jsonl`, `*.jsonl.1`, ...).

--- a/specs/2268/tasks.md
+++ b/specs/2268/tasks.md
@@ -1,0 +1,22 @@
+# Tasks #2268
+
+Status: Planned
+Spec: specs/2268/spec.md
+Plan: specs/2268/plan.md
+
+- T1 (tests first): add RED conformance tests in `tau-core` for C-01..C-03
+  (threshold rotation, retention pruning, env policy parsing fallbacks).
+- T2: implement shared log rotation policy + append helper in `tau-core`.
+- T3: integrate helper into `tau-runtime` appenders (heartbeat, background jobs,
+  tool audit, prompt telemetry) and add/adjust runtime tests for C-04.
+- T4: integrate helper into transport runtime cycle appenders
+  (dashboard/gateway/deployment/multi-agent/multi-channel/custom-command/voice).
+- T5: add operator docs updates for C-05 (env controls, defaults, file naming).
+- T6: run scoped verification and capture RED/GREEN evidence:
+  - `cargo fmt --check`
+  - `cargo clippy -p tau-core -p tau-runtime -- -D warnings`
+  - `cargo test -p tau-core`
+  - `cargo test -p tau-runtime`
+  - targeted tests for touched transport crates.
+- T7: update issue process log + labels (`status:implementing`), open PR, merge,
+  then set `spec.md` to Implemented and `tasks.md` to Completed.


### PR DESCRIPTION
## Summary
Implements `#2268` by adding shared size-based runtime log rotation and wiring it across operational JSONL appenders (runtime cycle logs, heartbeat/background job events, and telemetry/audit logs). Adds conformance tests for rotation thresholds/retention/env policy parsing and integration tests to prove appenders continue writing after rollover. Updates transport ops docs with operator controls and retained-file naming.

## Links
- Milestone: `specs/milestones/m46/index.md`
- Closes #2268
- Spec: `specs/2268/spec.md`
- Plan: `specs/2268/plan.md`
- Tasks: `specs/2268/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: rotate on max-bytes and continue writing | ✅ | `log_rotation::tests::spec_c01_append_rotation_rotates_when_size_threshold_exceeded`; `observability_loggers_runtime::tests::spec_c04_tool_audit_logger_rotates_and_keeps_writing_after_threshold`; `heartbeat_runtime::tests::spec_c04_runtime_heartbeat_cycle_report_rotates_and_keeps_latest_record`; `gateway_runtime::tests::spec_c04_gateway_cycle_report_rotates_and_keeps_latest_record` |
| AC-2: retain only configured max-files | ✅ | `log_rotation::tests::spec_c02_append_rotation_prunes_backups_to_max_files_limit` |
| AC-3: env controls parse valid values and fallback safely | ✅ | `log_rotation::tests::spec_c03_log_rotation_policy_from_env_uses_valid_values_and_falls_back_on_invalid` |
| AC-4: operator docs include controls/defaults/naming | ✅ | `docs/guides/transports.md` `Runtime Log Rotation` section |

## TDD Evidence
RED:
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-core spec_c01_append_rotation_rotates_when_size_threshold_exceeded -- --nocapture`
  - Failed: `expected first rotated backup to exist`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-core spec_c0 -- --nocapture`
  - Failed: `spec_c01...` and `spec_c02...` backup assertions

GREEN:
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-core spec_c0 -- --nocapture`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-runtime spec_c04_tool_audit_logger_rotates_and_keeps_writing_after_threshold -- --nocapture`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-runtime spec_c04_runtime_heartbeat_cycle_report_rotates_and_keeps_latest_record -- --nocapture`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-gateway spec_c04_gateway_cycle_report_rotates_and_keeps_latest_record -- --nocapture`

REGRESSION / integration verification:
- `CARGO_TARGET_DIR=target-fast-2268 cargo check -p tau-core -p tau-runtime -p tau-gateway -p tau-dashboard -p tau-deployment -p tau-orchestrator -p tau-custom-command -p tau-voice -p tau-multi-channel`
- `CARGO_TARGET_DIR=target-fast-2268 cargo clippy -p tau-core -p tau-runtime -p tau-gateway -p tau-dashboard -p tau-deployment -p tau-orchestrator -p tau-custom-command -p tau-voice -p tau-multi-channel -- -D warnings`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-runtime`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-gateway`
- `CARGO_TARGET_DIR=target-fast-2268 cargo test -p tau-dashboard -p tau-deployment -p tau-orchestrator -p tau-custom-command -p tau-voice -p tau-multi-channel`
- `cargo fmt --check`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`, `spec_c02`, `spec_c03` in `tau-core` | |
| Property | N/A | | No randomized invariant surface introduced in this slice |
| Contract/DbC | N/A | | No `contracts` DbC macros/invariants introduced in touched APIs |
| Snapshot | N/A | | No snapshot-style golden outputs introduced |
| Functional | ✅ | Existing runtime functional suites plus `cargo test -p tau-runtime` | |
| Conformance | ✅ | `spec_c01`..`spec_c04` tests mapped in AC table | |
| Integration | ✅ | `cargo test -p tau-runtime`; `cargo test -p tau-gateway`; multi-crate runtime test sweep | |
| Fuzz | N/A | | Change is deterministic file rotation logic; no new untrusted parser boundary added |
| Mutation | N/A | | `cargo-mutants` unavailable in environment (`cargo-mutants-not-installed`) |
| Regression | ✅ | Existing regression suites across touched runtime crates remained green | |
| Performance | N/A | | No benchmark harness in this slice; no hot-path algorithmic expansion beyond bounded file ops |

## Mutation
- `cargo mutants --in-diff`: N/A in this environment (`cargo-mutants-not-installed`).

## Risks / Rollback
- Risk: very low thresholds may cause frequent rollovers.
- Rollback: revert this PR; rotation helper usage is localized to append callsites.

## Docs / ADR
- Updated: `docs/guides/transports.md`
- ADR: not required (no protocol/schema/dependency change).
