### PR TITLE
feat(skiptool): land G12 phase-2 SkipTool wiring on master (#2425)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ High-level crates:
 
 Full workspace membership is defined in [`Cargo.toml`](Cargo.toml).
 
+## Examples and Starter Assets
+
+Repository-tracked examples used by integration tests and starter workflows:
+
+- `./examples/starter/package.json`
+- `./examples/extensions`
+- `./examples/extensions/issue-assistant/extension.json`
+- `./examples/extensions/issue-assistant/payload.json`
+- `./examples/events`
+- `./examples/events-state.json`
+
 ## Quickstart
 
 Run all commands from repository root.

--- a/crates/tau-coding-agent/src/events.rs
+++ b/crates/tau-coding-agent/src/events.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use tau_agent_core::{Agent, AgentConfig, AgentEvent};
+use tau_agent_core::{extract_skip_response_reason, Agent, AgentConfig, AgentEvent};
 use tau_ai::{LlmClient, Message, MessageRole};
 use tau_events::{
     run_event_scheduler as run_core_event_scheduler, EventRunner,
@@ -212,6 +212,9 @@ fn initialize_channel_session_runtime(
 }
 
 fn collect_assistant_reply(messages: &[Message]) -> String {
+    if extract_skip_response_reason(messages).is_some() {
+        return String::new();
+    }
     let content = messages
         .iter()
         .filter(|message| message.role == MessageRole::Assistant)

--- a/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
+++ b/crates/tau-coding-agent/src/tests/auth_provider/commands_and_packages.rs
@@ -1674,8 +1674,10 @@ fn unit_render_skills_list_handles_empty_catalog() {
 fn unit_render_skills_show_includes_metadata_and_content() {
     let skill = crate::skills::Skill {
         name: "checklist".to_string(),
+        description: "Checklist skill".to_string(),
         content: "line one\nline two".to_string(),
         path: PathBuf::from("checklist.md"),
+        base_dir: PathBuf::from(".tau/skills"),
     };
     let rendered = render_skills_show(Path::new(".tau/skills"), &skill);
     assert!(rendered.contains("skills show: path=.tau/skills"));
@@ -1787,18 +1789,24 @@ fn unit_derive_skills_prune_candidates_filters_tracked_and_sorts() {
     let catalog = vec![
         crate::skills::Skill {
             name: "zeta".to_string(),
+            description: "zeta skill".to_string(),
             content: "zeta".to_string(),
             path: PathBuf::from(".tau/skills/zeta.md"),
+            base_dir: PathBuf::from(".tau/skills"),
         },
         crate::skills::Skill {
             name: "alpha".to_string(),
+            description: "alpha skill".to_string(),
             content: "alpha".to_string(),
             path: PathBuf::from(".tau/skills/alpha.md"),
+            base_dir: PathBuf::from(".tau/skills"),
         },
         crate::skills::Skill {
             name: "beta".to_string(),
+            description: "beta skill".to_string(),
             content: "beta".to_string(),
             path: PathBuf::from(".tau/skills/beta.md"),
+            base_dir: PathBuf::from(".tau/skills"),
         },
     ];
     let tracked = HashSet::from([String::from("alpha.md")]);

--- a/crates/tau-runtime/src/runtime_output_runtime.rs
+++ b/crates/tau-runtime/src/runtime_output_runtime.rs
@@ -7,7 +7,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use tau_agent_core::AgentEvent;
+use tau_agent_core::{extract_skip_response_reason, AgentEvent};
 use tau_ai::{Message, MessageRole};
 use tau_session::SessionRuntime;
 
@@ -51,6 +51,9 @@ pub fn print_assistant_messages(
     _stream_delay_ms: u64,
     suppress_first_streamed_text: bool,
 ) {
+    if extract_skip_response_reason(messages).is_some() {
+        return;
+    }
     let mut suppressed_once = false;
     for message in messages {
         if message.role != MessageRole::Assistant {

--- a/crates/tau-tools/src/tools/registry_core.rs
+++ b/crates/tau-tools/src/tools/registry_core.rs
@@ -585,6 +585,7 @@ pub fn register_builtin_tools(agent: &mut Agent, policy: ToolPolicy) {
     agent.register_tool(JobsCancelTool::new(policy.clone()));
     agent.register_tool(UndoTool::new(policy.clone()));
     agent.register_tool(RedoTool::new(policy.clone()));
+    agent.register_tool(SkipTool::new(policy.clone()));
     agent.register_tool(HttpTool::new(policy.clone()));
     if policy.tool_builder_enabled {
         agent.register_tool(ToolBuilderTool::new(policy.clone()));

--- a/specs/2425/plan.md
+++ b/specs/2425/plan.md
@@ -1,0 +1,40 @@
+# Plan: Issue #2425 - G12 phase-2 SkipTool implementation and validation
+
+## Approach
+1. Add RED conformance tests in `tau-tools`, `tau-agent-core`, `tau-runtime`, and `tau-gateway`
+   for skip tool registration, payload shape, loop termination, and output suppression.
+2. Implement `SkipTool` in `tau-tools` and register it in built-in registry/name catalog.
+3. Extend `tau-agent-core` run loop to detect successful skip directives and terminate without a
+   follow-up model completion turn.
+4. Add shared skip-directive extraction helper in `tau-agent-core`, then consume it in
+   `tau-runtime` output rendering and gateway/session reply collection.
+5. Run scoped verify gates and targeted regression for `/tau skip` command behavior.
+
+## Affected Modules
+- `crates/tau-tools/src/tools.rs`
+- `crates/tau-tools/src/tools/registry_core.rs`
+- `crates/tau-tools/src/tools/tests.rs`
+- `crates/tau-agent-core/src/lib.rs`
+- `crates/tau-runtime/src/runtime_output_runtime.rs`
+- `crates/tau-gateway/src/gateway_openresponses/session_runtime.rs`
+- `crates/tau-multi-channel/src/multi_channel_runtime/tests.rs` (regression verification run)
+
+## Risks / Mitigations
+- Risk: false-positive suppression from unrelated tool outputs.
+  - Mitigation: require `tool_name == "skip"` and explicit suppression marker in parsed payload.
+- Risk: run-loop control regression in tool-heavy flows.
+  - Mitigation: preserve existing tool execution path and add dedicated integration test proving one
+    model completion turn when skip is used.
+- Risk: hidden fallback text leaks into user output.
+  - Mitigation: update collectors to check skip directive before fallback rendering.
+
+## Interfaces / Contracts
+- New built-in tool contract:
+  - name: `skip`
+  - args: `{ "reason"?: string }`
+  - success payload: `{ "skip_response": true, "reason": string, "reason_code": "skip_suppressed" }`
+- New helper in `tau-agent-core`:
+  - `extract_skip_response_reason(messages: &[Message]) -> Option<String>`
+
+## ADR
+- Not required: no new dependencies, wire protocol, or architecture-level replacement.

--- a/specs/2425/spec.md
+++ b/specs/2425/spec.md
@@ -1,0 +1,64 @@
+# Spec: Issue #2425 - G12 phase-2 SkipTool implementation and validation
+
+Status: Implemented
+
+## Problem Statement
+Tau supports `/tau skip` command suppression in `tau-multi-channel`, but does not expose a
+first-class built-in `skip` tool that the model can invoke through normal tool-calling flows.
+This leaves G12 phase-2 incomplete: the agent cannot explicitly end a turn and suppress outbound
+text through tool orchestration.
+
+## Acceptance Criteria
+
+### AC-1 Built-in tool registry includes `skip`
+Given Tau registers built-in tools via `register_builtin_tools`,
+When the tool catalog is inspected,
+Then `skip` is present in `builtin_agent_tool_names()` and can be resolved as a registered tool.
+
+### AC-2 `skip` tool returns a structured suppression payload
+Given the model invokes `skip` with optional `reason`,
+When the tool executes,
+Then it returns a success payload that explicitly marks response suppression and includes the
+normalized reason for audit/debug use.
+
+### AC-3 Agent run loop terminates after successful `skip` tool directive
+Given an assistant message that requests `skip`,
+When the tool call executes successfully with suppression marker,
+Then the agent loop ends the run without requesting another model turn.
+
+### AC-4 User-facing output collectors suppress textual fallback on skip directive
+Given new messages include a successful `skip` tool result marker,
+When user-facing reply collectors/renderers run,
+Then they suppress textual output rather than emitting fallback strings.
+
+### AC-5 Existing `/tau skip` command path remains functional
+Given current command-mode skip behavior in `tau-multi-channel`,
+When regression tests execute,
+Then `/tau skip` suppression behavior remains unchanged.
+
+## Scope
+
+### In Scope
+- Add `skip` built-in tool implementation in `tau-tools`.
+- Add skip directive detection in `tau-agent-core` run loop.
+- Add shared skip directive extraction helpers for output suppression.
+- Update gateway/runtime output collectors to suppress text for skip directives.
+- Add conformance/regression tests across touched crates.
+
+### Out of Scope
+- Replacing `/tau skip` command behavior with tool-only behavior.
+- New provider integrations or routing policy changes.
+- G13/G14 reaction/file tool orchestration.
+
+## Conformance Cases
+- C-01 (AC-1, unit): `spec_c01_builtin_agent_tool_name_registry_includes_skip_tool`
+- C-02 (AC-2, functional): `spec_c02_skip_tool_returns_structured_suppression_payload`
+- C-03 (AC-3, integration): `integration_spec_c03_prompt_skip_tool_call_terminates_run_without_follow_up_model_turn`
+- C-04 (AC-4, unit): `spec_c04_extract_skip_response_reason_detects_valid_skip_tool_payload`
+- C-05 (AC-4, integration): `integration_spec_c05_collect_assistant_reply_suppresses_output_when_skip_tool_result_present`
+- C-06 (AC-5, regression): `functional_runner_executes_tau_skip_command_without_outbound_delivery`
+
+## Success Metrics / Observable Signals
+- Conformance tests C-01..C-06 pass.
+- `cargo fmt --check`, scoped `clippy`, and scoped crate tests pass.
+- No regression in existing `/tau skip` command behavior.

--- a/specs/2425/tasks.md
+++ b/specs/2425/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Issue #2425 - G12 phase-2 SkipTool implementation and validation
+
+## Ordered Tasks
+1. T1 (RED): add C-01/C-02 tests in `tau-tools` for built-in registry and skip payload contract.
+2. T2 (RED): add C-03 integration test in `tau-agent-core` proving run-loop termination after skip.
+3. T3 (RED): add C-04/C-05 tests for skip extraction and output suppression in runtime/gateway.
+4. T4 (GREEN): implement `SkipTool` and register built-in name + registration wiring.
+5. T5 (GREEN): implement agent-core skip detection and loop short-circuit termination.
+6. T6 (GREEN): wire collectors/renderers to suppress fallback output when skip marker is present.
+7. T7 (REGRESSION): run existing `/tau skip` regression test C-06 unchanged.
+8. T8 (VERIFY): run `cargo fmt --check`, scoped `clippy`, and targeted test commands.
+9. T9 (CLOSE): update issue/PR AC mapping, RED/GREEN evidence, tier matrix, and milestone links.
+
+## Tier Mapping
+- Unit: C-01, C-04
+- Functional: C-02
+- Conformance: C-01..C-06
+- Integration: C-03, C-05
+- Regression: C-06
+- Property: N/A (no parser/invariant randomness added in this slice)
+- Contract/DbC: N/A (no new DbC annotations in this slice)
+- Snapshot: N/A (no stable snapshot output added)
+- Fuzz: N/A (no new untrusted parser surface beyond existing command parser coverage)
+- Mutation: N/A for iterative dev loop (pre-PR gate can run scoped mutants if requested)
+- Performance: N/A (no hot-path algorithm changes)

--- a/specs/milestones/m71/index.md
+++ b/specs/milestones/m71/index.md
@@ -1,0 +1,22 @@
+# M71 - Spacebot G12 Skip Tool (LLM Tool Wiring)
+
+Milestone objective: deliver the phase-2 G12 scope that adds a first-class `skip` tool in
+the agent tool registry and runtime orchestration so a model can intentionally suppress one
+outbound response while preserving auditable reason metadata.
+
+## Scope
+- Add `skip` as a built-in tool in `tau-tools`.
+- Define structured skip tool input (`reason`) and result payload contract.
+- Wire agent run-loop/runtime handling so a `skip` tool call suppresses outbound response.
+- Propagate skip metadata into session/message logs for observability.
+- Add conformance and regression tests for tool registration, parsing, and runtime behavior.
+
+## Out of Scope
+- Replacing existing `/tau skip` command path in `tau-multi-channel`.
+- Provider/model routing changes.
+- Reaction/file tooling from G13/G14.
+
+## Exit Criteria
+- Task issue `#2425` has accepted spec, implemented code, and passing verification.
+- Tool registry and runtime behavior are covered by conformance tests.
+- `fmt`, scoped `clippy`, and scoped tests pass for touched crates.


### PR DESCRIPTION
## Summary
Land the previously unmerged G12 phase-2 SkipTool slice on top of current `master` by replaying commit `97836f2e` as `d4be50a4` with one safe conflict resolution in `bash_tool` (kept current master behavior). This restores built-in `skip` tool wiring, run-loop short-circuiting, and user-facing output suppression behavior with conformance coverage.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/71
- Closes #2425
- Spec: `specs/2425/spec.md`
- Plan: `specs/2425/plan.md`
- Tasks: `specs/2425/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Built-in tool registry includes `skip` | ✅ | `cargo test -p tau-tools spec_c01_builtin_agent_tool_name_registry_includes_skip_tool -- --nocapture` |
| AC-2: `skip` tool returns structured suppression payload | ✅ | `cargo test -p tau-tools spec_c02_skip_tool_returns_structured_suppression_payload -- --nocapture` |
| AC-3: Agent loop terminates after successful `skip` tool directive | ✅ | `cargo test -p tau-agent-core integration_spec_c03_prompt_skip_tool_call_terminates_run_without_follow_up_model_turn -- --nocapture` |
| AC-4: Collectors suppress textual fallback on skip marker | ✅ | `cargo test -p tau-agent-core spec_c04_extract_skip_response_reason_detects_valid_skip_tool_payload -- --nocapture`; `cargo test -p tau-gateway integration_spec_c05_collect_assistant_reply_suppresses_output_when_skip_tool_result_present -- --nocapture` |
| AC-5: Existing `/tau skip` command path remains functional | ✅ | `cargo test -p tau-multi-channel functional_runner_executes_tau_skip_command_without_outbound_delivery -- --nocapture` |

## TDD Evidence
- RED (baseline absence on `origin/master`):
  - `git show origin/master:crates/tau-tools/src/tools/tests.rs | rg -n "spec_c01_builtin_agent_tool_name_registry_includes_skip_tool"`
  - Output: `RED baseline: spec_c01 skip-tool conformance test absent on origin/master (rg exit 1)`
  - `git show origin/master:crates/tau-tools/src/tools/registry_core.rs | rg -n '"skip"'`
  - Output: `RED baseline: skip built-in registry entry absent on origin/master (rg exit 1)`
- GREEN:
  - `cargo fmt --check`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-tools spec_c01_builtin_agent_tool_name_registry_includes_skip_tool -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-tools spec_c02_skip_tool_returns_structured_suppression_payload -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-agent-core integration_spec_c03_prompt_skip_tool_call_terminates_run_without_follow_up_model_turn -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-agent-core spec_c04_extract_skip_response_reason_detects_valid_skip_tool_payload -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-gateway integration_spec_c05_collect_assistant_reply_suppresses_output_when_skip_tool_result_present -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo test -p tau-multi-channel functional_runner_executes_tau_skip_command_without_outbound_delivery -- --nocapture`
  - `CARGO_TARGET_DIR=target-fast-2425 CARGO_INCREMENTAL=0 cargo clippy -p tau-tools -p tau-agent-core -p tau-gateway -p tau-runtime --no-deps -- -D warnings`
- REGRESSION summary:
  - Existing `/tau skip` runtime command regression test remains green (`functional_runner_executes_tau_skip_command_without_outbound_delivery`).

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01_builtin_agent_tool_name_registry_includes_skip_tool`; `spec_c04_extract_skip_response_reason_detects_valid_skip_tool_payload` | |
| Property | N/A | | No new randomized/parser invariant surface in this slice |
| Contract/DbC | N/A | | No new contract-annotated API introduced |
| Snapshot | N/A | | No stable snapshot artifacts introduced |
| Functional | ✅ | `spec_c02_skip_tool_returns_structured_suppression_payload` | |
| Conformance | ✅ | C-01..C-06 mapped to targeted tests listed above | |
| Integration | ✅ | `integration_spec_c03_*`; `integration_spec_c05_*` | |
| Fuzz | N/A | | No new untrusted parser/input boundary added |
| Mutation | N/A | | Slice is runtime/tool wiring; no critical path mutation gate requested for this replay PR |
| Regression | ✅ | `functional_runner_executes_tau_skip_command_without_outbound_delivery` | |
| Performance | N/A | | No hotspot/perf-sensitive algorithm changes |

## Mutation
- N/A for this replay PR scope; no new critical algorithmic path introduced.

## Risks / Rollback
- Risk: behavior divergence in bash policy logic during replay conflict.
- Mitigation: resolved conflict in `crates/tau-tools/src/tools/bash_tool.rs` by keeping current `master` implementation (`--ours`) and validated scoped clippy/tests.
- Rollback: revert commit `d4be50a4`.

## Docs / ADR
- Added spec artifacts:
  - `specs/milestones/m71/index.md`
  - `specs/2425/spec.md`
  - `specs/2425/plan.md`
  - `specs/2425/tasks.md`
- No ADR required (no architecture/protocol/dependency decision change in this replay).
