### PR TITLE
docs(governance): close out G16 phase-1 spec statuses

### DIFF
--- a/specs/2463/spec.md
+++ b/specs/2463/spec.md
@@ -1,6 +1,6 @@
 # Spec #2463 - G16 hot-reload config phase-1 orchestration
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 `tasks/spacebot-comparison.md` identifies `G16` as a gap: Tau runtime configuration changes require process restart. This orchestration issue defines the first bounded delivery slice for runtime hot-reload behavior.

--- a/specs/2464/spec.md
+++ b/specs/2464/spec.md
@@ -1,6 +1,6 @@
 # Spec #2464 - runtime heartbeat policy hot-reload without restart
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Runtime heartbeat scheduler policy is currently fixed at startup. Operators cannot tune heartbeat cadence without restarting the process.

--- a/specs/2465/spec.md
+++ b/specs/2465/spec.md
@@ -1,6 +1,6 @@
 # Spec #2465 - add heartbeat scheduler policy reload path + conformance tests
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 `G16` phase-1 requires runtime hot-reload behavior for heartbeat scheduler policy so operators can tune cadence without process restart.

--- a/specs/2466/spec.md
+++ b/specs/2466/spec.md
@@ -1,6 +1,6 @@
 # Spec #2466 - RED/GREEN conformance for G16 phase-1 hot-reload behavior
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G16 phase-1 requires explicit RED/GREEN proof for heartbeat hot-reload conformance before closure.


### PR DESCRIPTION
## Summary
Marks G16 phase-1 spec artifacts as `Implemented` now that PR #2467 has merged. This is a governance closeout-only change with no runtime behavior changes.

## Links
- Milestone: M79 - Spacebot G16 Hot-Reload Config (Phase 1)
- Closes #2463
- Closes #2464
- Closes #2465
- Closes #2466
- Spec path: `specs/2463/spec.md`
- Plan path: `specs/2463/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Orchestration scope is explicit and bounded | ✅ | Evidence-only: `specs/2463/spec.md` scope unchanged and implemented |
| AC-2: Child work products are complete and traceable | ✅ | Evidence-only: merged implementation PR `#2467` + implemented statuses in `specs/2464/spec.md`, `specs/2465/spec.md`, `specs/2466/spec.md` |

## TDD Evidence
- RED cmd+output: N/A (no behavior change; RED/GREEN evidence captured in PR #2467 for #2465/#2466)
- GREEN cmd+output: N/A (no behavior change)
- REGRESSION summary: N/A (no runtime/code changes)

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | None | Documentation/status-only change |
| Property | N/A | None | Documentation/status-only change |
| Contract/DbC | N/A | None | Documentation/status-only change |
| Snapshot | N/A | None | Documentation/status-only change |
| Functional | N/A | None | Documentation/status-only change |
| Conformance | ✅ | specs + merged PR evidence | C-01/C-02 implemented and evidenced in #2467 |
| Integration | N/A | None | Documentation/status-only change |
| Fuzz | N/A | None | Documentation/status-only change |
| Mutation | N/A | None | Documentation/status-only change |
| Regression | N/A | None | Documentation/status-only change |
| Performance | N/A | None | Documentation/status-only change |

## Mutation
N/A for this closeout-only documentation/status update. Mutation evidence for the implemented behavior is captured in #2467.

## Risks/Rollback
None. Rollback would be reverting status fields if required.

## Docs/ADR
- Updated: `specs/2463/spec.md`
- Updated: `specs/2464/spec.md`
- Updated: `specs/2465/spec.md`
- Updated: `specs/2466/spec.md`
