### PR TITLE
docs(governance): mark m81 phase-2 specs implemented (#2474)

### DIFF
--- a/specs/2474/spec.md
+++ b/specs/2474/spec.md
@@ -1,6 +1,6 @@
 # Spec #2474 - G17 prompt templates phase-2 orchestration
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G17 phase 1 delivered workspace template rendering, but Tau still lacks explicit built-in template defaults and traceable template-source diagnostics.

--- a/specs/2475/spec.md
+++ b/specs/2475/spec.md
@@ -1,6 +1,6 @@
 # Spec #2475 - startup prompt template source fallback and diagnostics
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Operators need deterministic startup prompt template behavior even when workspace template files are absent or invalid, and startup needs diagnostics that indicate which template source was used.

--- a/specs/2476/spec.md
+++ b/specs/2476/spec.md
@@ -1,6 +1,6 @@
 # Spec #2476 - implement startup template builtin fallback and source diagnostics
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Startup prompt composition currently reports no template source metadata and only supports workspace template selection with silent default fallback.

--- a/specs/2477/spec.md
+++ b/specs/2477/spec.md
@@ -1,6 +1,6 @@
 # Spec #2477 - RED/GREEN conformance evidence for G17 phase-2 template source fallback
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Phase-2 delivery requires explicit RED/GREEN evidence proving template-source fallback and diagnostics behavior.


### PR DESCRIPTION
## Summary
Mark phase-2 G17 specs as `Implemented` after merge of #2478 so issue closure state matches repository contract artifacts. No runtime behavior changes.

## Links
- Milestone: M81 - Spacebot G17 Prompt Templates (Phase 2)
- Closes #2474
- Closes #2475
- Closes #2477
- Spec: `specs/2474/spec.md`
- Plan: `specs/2474/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: phase-2 scope bounded in milestone/spec artifacts | ✅ | Artifact verification in `specs/milestones/m81/index.md` and child specs |
| AC-2: child artifacts close with traceable conformance | ✅ | RED/GREEN + conformance evidence recorded in #2478 and `specs/2476/spec.md` |

## TDD Evidence
- RED: Already captured in merged implementation PR #2478 (`cargo test -p tau-onboarding -- spec_2476 --nocapture` failing pre-impl).
- GREEN: Already captured in merged implementation PR #2478 (same scoped suite passing post-impl).
- REGRESSION: Already captured in #2478 via added regression tests and full crate run.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | N/A | Docs/spec status-only update; no code path change |
| Property | N/A | N/A | No invariant/parsing change |
| Contract/DbC | N/A | N/A | No API contract change |
| Snapshot | N/A | N/A | No snapshot output change |
| Functional | N/A | N/A | No behavior change |
| Conformance | ✅ | Existing conformance in #2478 | This PR updates completion metadata only |
| Integration | N/A | N/A | No integration path change |
| Fuzz | N/A | N/A | No untrusted input code touched |
| Mutation | ✅ | Existing mutation evidence in #2478 | This PR updates completion metadata only |
| Regression | ✅ | Existing regression evidence in #2478 | This PR updates completion metadata only |
| Performance | N/A | N/A | No runtime path change |

## Mutation
- Refer to #2478: 14 caught, 6 unviable, 0 missed (in diff scope).

## Risks/Rollback
- None. Rollback is reverting this commit.

## Docs/ADR
- Updated:
  - `specs/2474/spec.md`
  - `specs/2475/spec.md`
  - `specs/2476/spec.md`
  - `specs/2477/spec.md`
- ADR: not required.
