### PR TITLE
docs(spec): finalize M86 spec statuses as implemented

### DIFF
--- a/specs/2500/spec.md
+++ b/specs/2500/spec.md
@@ -1,6 +1,6 @@
 # Spec #2500 - G9 phase-3 watcher polling + LLM chunk memory extraction
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G9 still lacks two required capabilities: continuous ingest directory watching and chunk processing through an LLM memory-save tool pathway.

--- a/specs/2501/spec.md
+++ b/specs/2501/spec.md
@@ -1,6 +1,6 @@
 # Spec #2501 - phase-3 watcher polling and LLM chunk memory_save orchestration
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 `tau-memory` ingestion has deterministic one-shot execution, but it cannot watch an ingest directory over polling cycles or route chunk ingestion through an LLM tool-call extraction flow.

--- a/specs/2502/spec.md
+++ b/specs/2502/spec.md
@@ -1,6 +1,6 @@
 # Spec #2502 - RED/GREEN validation for G9 phase-3 watcher + LLM ingestion slice
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Task #2503 requires explicit RED/GREEN proof that phase-3 conformance tests fail before implementation and pass after implementation.

--- a/specs/2503/spec.md
+++ b/specs/2503/spec.md
@@ -1,6 +1,6 @@
 # Spec #2503 - Implement G9 phase-3 watch polling and LLM chunk memory_save ingestion
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 The final unchecked G9 items require `tau-memory` to (1) watch the ingest directory via polling and (2) process each chunk through an LLM memory-save tool-call path.


### PR DESCRIPTION
## Summary
Follow-up docs-only closure update after merged PR #2504.
Marks M86 issue specs as `Status: Implemented` to align repository artifacts with issue closure state per `AGENTS.md`.

## Links
- Milestone: [M86 - Spacebot G9 Memory Ingestion (Phase 3)](https://github.com/njfio/Tau/milestone/86)
- Prior implementation PR: #2504

## Changes
- `specs/2500/spec.md` -> `Status: Implemented`
- `specs/2501/spec.md` -> `Status: Implemented`
- `specs/2502/spec.md` -> `Status: Implemented`
- `specs/2503/spec.md` -> `Status: Implemented`

## Risk
None (metadata/docs-only).
