### PR TITLE
docs(spec): finalize M84 phase-1 spec statuses

### DIFF
--- a/specs/2490/spec.md
+++ b/specs/2490/spec.md
@@ -1,6 +1,6 @@
 # Spec #2490 - G9 memory ingestion phase-1 orchestration
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Tau lacks first-class bulk memory ingestion from workspace files. We need a bounded, testable phase-1 slice that introduces deterministic ingestion foundations without broad runtime architecture changes.

--- a/specs/2491/spec.md
+++ b/specs/2491/spec.md
@@ -1,6 +1,6 @@
 # Spec #2491 - tau-memory ingestion worker foundation
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 `tau-memory` currently has no reusable ingestion worker API for batch files, leaving G9 unimplemented.

--- a/specs/2492/spec.md
+++ b/specs/2492/spec.md
@@ -1,6 +1,6 @@
 # Spec #2492 - implement G9 phase-1 chunked ingestion + resume checkpoints
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Bulk ingestion must process supported files safely and resumably. Today Tau has no ingestion worker path, so imports are manual and non-resilient.

--- a/specs/2493/spec.md
+++ b/specs/2493/spec.md
@@ -1,6 +1,6 @@
 # Spec #2493 - RED/GREEN conformance evidence for G9 phase-1 ingestion
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Task #2492 requires explicit RED/GREEN proof that conformance tests fail before implementation and pass after implementation.


### PR DESCRIPTION
## Summary
Docs-only follow-up to align phase-1 G9 spec artifacts with issue state.
Marks `specs/2490..2493/spec.md` as `Status: Implemented` after closure of the M84 issue chain.

## Links
- Milestone: [M84 - Spacebot G9 Memory Ingestion (Phase 1)](https://github.com/njfio/Tau/milestone/84)
- Prior implementation PR: #2494

## Changes
- `specs/2490/spec.md` -> `Status: Implemented`
- `specs/2491/spec.md` -> `Status: Implemented`
- `specs/2492/spec.md` -> `Status: Implemented`
- `specs/2493/spec.md` -> `Status: Implemented`

## Risk
None (metadata/docs-only).
