### PR TITLE
docs(spec): mark m88 specs implemented (#2514)

### DIFF
--- a/specs/2512/spec.md
+++ b/specs/2512/spec.md
@@ -1,6 +1,6 @@
 # Spec #2512 - Epic: G12 skip-tool closure + validation
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G12 is still marked incomplete in `tasks/spacebot-comparison.md` even though skip behavior exists across multiple crates. We need formal closure with spec-driven evidence.

--- a/specs/2513/spec.md
+++ b/specs/2513/spec.md
@@ -1,6 +1,6 @@
 # Spec #2513 - Story: validate skip response behavior in channel/runtime flows
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 Skip behavior spans tool contract, agent turn lifecycle, and channel runtime logging. The story must prove those behaviors together.

--- a/specs/2514/spec.md
+++ b/specs/2514/spec.md
@@ -1,6 +1,6 @@
 # Spec #2514 - Task: implement/validate G12 skip-tool conformance
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G12 requires explicit proof that skip behavior suppresses user-facing replies, records skip reasons, and is available in multi-user tool sets.

--- a/specs/2515/spec.md
+++ b/specs/2515/spec.md
@@ -1,6 +1,6 @@
 # Spec #2515 - Subtask: RED/GREEN + live validation evidence for G12
 
-Status: Accepted
+Status: Implemented
 
 ## Problem Statement
 G12 closure requires explicit RED/GREEN and validation artifacts attached to the issue/PR chain.


### PR DESCRIPTION
## Summary
Marks M88 specs (`2512`-`2515`) as `Status: Implemented` after merge of `#2516`, completing the repository spec lifecycle contract.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/88
- Epic: #2512
- Story: #2513
- Task: #2514
- Subtask: #2515

## Changes
- `specs/2512/spec.md`: `Status: Implemented`
- `specs/2513/spec.md`: `Status: Implemented`
- `specs/2514/spec.md`: `Status: Implemented`
- `specs/2515/spec.md`: `Status: Implemented`

## Verification
- Docs-only update; no runtime behavior change.
