### PR TITLE
feat: close G13 React Tool with conformance and live validation

### DIFF
--- a/crates/tau-tools/src/tools/registry_core.rs
+++ b/crates/tau-tools/src/tools/registry_core.rs
@@ -587,6 +587,7 @@ pub fn register_builtin_tools(agent: &mut Agent, policy: ToolPolicy) {
     agent.register_tool(JobsCancelTool::new(policy.clone()));
     agent.register_tool(UndoTool::new(policy.clone()));
     agent.register_tool(RedoTool::new(policy.clone()));
+    agent.register_tool(ReactTool::new(policy.clone()));
     agent.register_tool(SkipTool::new(policy.clone()));
     agent.register_tool(HttpTool::new(policy.clone()));
     if policy.tool_builder_enabled {

--- a/specs/2518/plan.md
+++ b/specs/2518/plan.md
@@ -1,0 +1,20 @@
+# Plan #2518
+
+Approach:
+- Reuse existing reaction delivery path in `tau-multi-channel`; add the missing agent-facing tool contract and deterministic suppression semantics.
+- Keep implementation narrow to avoid protocol churn.
+
+Affected modules:
+- `crates/tau-tools/src/tools.rs`
+- `crates/tau-tools/src/tools/registry_core.rs`
+- `crates/tau-tools/src/tools/tests.rs`
+- `crates/tau-agent-core/src/lib.rs`
+- `crates/tau-agent-core/src/tests/config_and_direct_message.rs`
+- `crates/tau-coding-agent/src/events.rs`
+
+Risks:
+- Medium: false-positive suppression if react detection is too broad.
+
+Mitigations:
+- Restrict extraction to successful `tool_name == "react"` payloads with explicit directive fields.
+- Add regression tests for non-react turns.

--- a/specs/2518/spec.md
+++ b/specs/2518/spec.md
@@ -1,0 +1,42 @@
+# Spec #2518 - Epic: G13 react-tool closure + validation
+
+Status: Implemented
+
+## Problem Statement
+Tau already supports reaction delivery at channel adapter/runtime layers, but lacks a first-class agent tool contract for reaction intent. This prevents deterministic LLM-initiated reaction-only acknowledgements.
+
+## Acceptance Criteria
+### AC-1 Tool contract exists
+Given built-in tool registration, when tools are enumerated, then `react` is present with a stable JSON schema.
+
+### AC-2 Reaction intent suppresses textual reply
+Given a successful `react` tool execution during a turn, when the run completes, then no follow-up assistant text reply is emitted for that turn.
+
+### AC-3 Diagnostics preserve reaction intent
+Given a successful `react` directive, when outbound event diagnostics are written, then the payload records reaction metadata for audit/tuning.
+
+### AC-4 Adapter compatibility remains valid
+Given existing channel adapter reaction dispatch contracts, when conformance tests run, then platform-specific emoji/message-id translation remains green.
+
+## Scope
+In scope:
+- `tau-tools` react tool contract + registration.
+- `tau-agent-core` turn suppression wiring for react directives.
+- `tau-coding-agent` outbound event diagnostics for reaction directives.
+- Conformance checks against existing `tau-multi-channel` reaction dispatch tests.
+
+Out of scope:
+- New transport implementations.
+- Broad command protocol redesign.
+
+## Conformance Cases
+- C-01 (AC-1, functional): `spec_2520_c01_builtin_agent_tool_name_registry_includes_react_tool`
+- C-02 (AC-1, functional): `spec_2520_c02_react_tool_returns_structured_reaction_payload`
+- C-03 (AC-2, integration): `integration_spec_2520_c03_prompt_react_tool_call_terminates_run_without_follow_up_model_turn`
+- C-04 (AC-2, unit): `spec_2520_c04_extract_reaction_request_detects_valid_react_tool_payload`
+- C-05 (AC-3, integration): `integration_spec_2520_c05_runner_persists_reaction_payload_and_suppresses_text_reply`
+- C-06 (AC-4, functional): `functional_runner_executes_tau_react_command_and_records_reaction_delivery`
+
+## Success Metrics
+- C-01..C-06 pass.
+- `tasks/spacebot-comparison.md` G13 pathway is fully checked.

--- a/specs/2518/tasks.md
+++ b/specs/2518/tasks.md
@@ -1,0 +1,7 @@
+# Tasks #2518
+
+1. T1 (tests, RED): Add conformance tests for react tool registry/payload and turn suppression extraction.
+2. T2 (impl, GREEN): Implement `ReactTool` + registration and agent-core extraction/suppression wiring.
+3. T3 (integration): Add coding-agent outbound diagnostics tests for reaction directives.
+4. T4 (verify): Run scoped tests, mutation in diff, and live validation.
+5. T5 (docs): Update G13 checklist in `tasks/spacebot-comparison.md`.

--- a/specs/2519/plan.md
+++ b/specs/2519/plan.md
@@ -1,0 +1,10 @@
+# Plan #2519
+
+Approach:
+- Implement story scope via task #2520 as a single focused slice across tool, agent core, and events diagnostics.
+
+Risks:
+- Medium: ambiguous payload shape could break downstream usage.
+
+Mitigations:
+- Use explicit fields (`react_response`, `emoji`, `message_id`, `reason_code`) and conformance tests.

--- a/specs/2519/spec.md
+++ b/specs/2519/spec.md
@@ -1,0 +1,29 @@
+# Spec #2519 - Story: expose reaction intent via tool contract for channel runs
+
+Status: Implemented
+
+## Problem Statement
+Channel behavior supports reactions operationally, but story-level delivery requires a first-class tool contract so agents can request reactions intentionally and suppress redundant text output.
+
+## Acceptance Criteria
+### AC-1
+Given a `react` tool call with emoji + optional message id, when executed, then the result payload includes structured reaction intent fields and stable reason code.
+
+### AC-2
+Given a successful react tool result in a prompt run, when the turn finalizes, then the run ends without generating a follow-up assistant text reply.
+
+### AC-3
+Given a react-only run, when runtime diagnostics are emitted, then reaction metadata is present in outbound payload.
+
+## Scope
+In scope:
+- Tool contract and suppression semantics.
+- Diagnostics for observability.
+
+Out of scope:
+- New command families beyond react.
+
+## Conformance Cases
+- C-01: `spec_2520_c02_react_tool_returns_structured_reaction_payload`
+- C-02: `integration_spec_2520_c03_prompt_react_tool_call_terminates_run_without_follow_up_model_turn`
+- C-03: `integration_spec_2520_c05_runner_persists_reaction_payload_and_suppresses_text_reply`

--- a/specs/2519/tasks.md
+++ b/specs/2519/tasks.md
@@ -1,0 +1,5 @@
+# Tasks #2519
+
+1. T1: Land task #2520 implementation + tests.
+2. T2: Verify conformance and live validation evidence.
+3. T3: Update checklist and close story.

--- a/specs/2520/plan.md
+++ b/specs/2520/plan.md
@@ -1,0 +1,21 @@
+# Plan #2520
+
+Approach:
+- Introduce `ReactTool` in `tau-tools` with strict arg parsing.
+- Add `extract_react_response` helper in `tau-agent-core` and set suppression flag on successful react tool results.
+- Extend `tau-coding-agent` event payload builder to optionally attach reaction metadata and reason code.
+
+Affected modules:
+- `crates/tau-tools/src/tools.rs`
+- `crates/tau-tools/src/tools/registry_core.rs`
+- `crates/tau-tools/src/tools/tests.rs`
+- `crates/tau-agent-core/src/lib.rs`
+- `crates/tau-agent-core/src/tests/config_and_direct_message.rs`
+- `crates/tau-coding-agent/src/events.rs`
+
+Risks:
+- Medium: suppression could trigger on malformed/non-react payloads.
+
+Mitigations:
+- Parse only valid successful react payloads.
+- Add regression tests asserting no suppression for normal responses.

--- a/specs/2520/spec.md
+++ b/specs/2520/spec.md
@@ -1,0 +1,41 @@
+# Spec #2520 - Task: implement and validate G13 ReactTool pathway
+
+Status: Implemented
+
+## Problem Statement
+G13 remains open because no built-in `react` tool exists even though transport adapters already support reaction delivery semantics.
+
+## Acceptance Criteria
+### AC-1 React tool registry and schema
+Given built-in tools are registered, when names are enumerated, then `react` is present; when executed with valid args, then response includes normalized `emoji`, optional `message_id`, and a stable reason code.
+
+### AC-2 Turn suppression behavior
+Given a successful `react` tool result, when the prompt run completes, then the run terminates without a follow-up assistant text response.
+
+### AC-3 Outbound diagnostics
+Given a successful react directive in event execution, when outbound payload is recorded, then payload includes reaction metadata and an explicit reason code.
+
+### AC-4 Adapter compatibility
+Given multi-channel reaction dispatch tests, when executed, then existing adapter translation/dispatch remains green.
+
+## Scope
+In scope:
+- Add `ReactTool` to `tau-tools` and register as built-in.
+- Add extraction + suppression handling in `tau-agent-core`.
+- Add reaction metadata to `tau-coding-agent` outbound event payload.
+- Verify against existing `tau-multi-channel` reaction coverage.
+
+Out of scope:
+- New outbound transport support.
+
+## Conformance Cases
+- C-01 (AC-1, functional): `spec_2520_c01_builtin_agent_tool_name_registry_includes_react_tool`
+- C-02 (AC-1, functional): `spec_2520_c02_react_tool_returns_structured_reaction_payload`
+- C-03 (AC-2, integration): `integration_spec_2520_c03_prompt_react_tool_call_terminates_run_without_follow_up_model_turn`
+- C-04 (AC-2, unit): `spec_2520_c04_extract_reaction_request_detects_valid_react_tool_payload`
+- C-05 (AC-3, integration): `integration_spec_2520_c05_runner_persists_reaction_payload_and_suppresses_text_reply`
+- C-06 (AC-4, functional): `functional_runner_executes_tau_react_command_and_records_reaction_delivery`
+
+## Success Metrics
+- All C-01..C-06 pass.
+- No regressions in skip-tool behavior tests.

--- a/specs/2520/tasks.md
+++ b/specs/2520/tasks.md
@@ -1,0 +1,8 @@
+# Tasks #2520
+
+1. T1 (tests, RED): Add C-01..C-05 conformance tests and confirm C-06 baseline.
+2. T2 (impl, GREEN): Implement `ReactTool` + registration and core extraction/suppression.
+3. T3 (impl, GREEN): Add coding-agent outbound reaction diagnostics.
+4. T4 (regression): Re-run skip-tool and reaction-delivery regressions.
+5. T5 (verify): Run fmt, clippy, targeted tests, mutation in diff, and live validation script.
+6. T6 (docs): Mark G13 checklist complete in `tasks/spacebot-comparison.md`.

--- a/specs/2521/plan.md
+++ b/specs/2521/plan.md
@@ -1,0 +1,12 @@
+# Plan #2521
+
+Approach:
+- Record explicit RED first.
+- Complete implementation and capture GREEN.
+- Run scoped mutation and live validation as final gates.
+
+Risks:
+- Low: verification-only scope.
+
+Mitigations:
+- Keep command outputs captured in PR template evidence.

--- a/specs/2521/spec.md
+++ b/specs/2521/spec.md
@@ -1,0 +1,22 @@
+# Spec #2521 - Subtask: RED/GREEN + live validation evidence for G13 ReactTool
+
+Status: Implemented
+
+## Problem Statement
+Task #2520 requires explicit RED/GREEN proof, targeted verification, and live validation artifacts to satisfy AGENTS merge gates.
+
+## Acceptance Criteria
+### AC-1
+Given new conformance tests, when run before implementation, then at least one spec-derived test fails (RED).
+
+### AC-2
+Given implementation is complete, when rerun, then all scoped conformance tests pass (GREEN).
+
+### AC-3
+Given final diff, when mutation + live validation execute, then no escaped mutants in touched critical paths and live validation passes.
+
+## Conformance Cases
+- C-01: RED evidence command/output for a spec_2520 test.
+- C-02: GREEN evidence for all spec_2520 conformance tests.
+- C-03: `cargo mutants --in-diff` (scoped) shows zero escapes.
+- C-04: `./scripts/demo/local.sh ...` passes.

--- a/specs/2521/tasks.md
+++ b/specs/2521/tasks.md
@@ -1,0 +1,7 @@
+# Tasks #2521
+
+1. T1: Execute and capture RED for a spec_2520 conformance test.
+2. T2: Execute and capture GREEN for spec_2520 suite.
+3. T3: Run mutation in diff for touched crates/paths.
+4. T4: Run live validation script and record results.
+5. T5: Populate PR TDD evidence and testing matrix.

--- a/specs/milestones/m89/index.md
+++ b/specs/milestones/m89/index.md
@@ -1,0 +1,14 @@
+# M89 - Spacebot G13 React Tool Closure
+
+Milestone issue: https://github.com/njfio/Tau/milestone/89
+
+Scope:
+- Close G13 by adding a first-class `react` tool contract in `tau-tools`.
+- Ensure successful react directives suppress textual replies in agent turn execution.
+- Preserve/validate existing platform adapter reaction dispatch behavior.
+
+Issues:
+- Epic: #2518
+- Story: #2519
+- Task: #2520
+- Subtask: #2521

--- a/tasks/spacebot-comparison.md
+++ b/tasks/spacebot-comparison.md
@@ -370,9 +370,9 @@ Spacebot is a Rust-based AI agent for teams, communities, and multi-user environ
 **What**: The agent can add emoji reactions to messages instead of replying.
 **Why it matters**: Lightweight acknowledgment without cluttering the conversation. "Got it" as a thumbs-up.
 **Pathway**:
-- [ ] Add `ReactTool` to `tau-tools` — takes `message_id` and `emoji` parameters
-- [ ] Wire to platform adapters (Slack, Discord, Telegram all support reactions)
-- [ ] Channel adapter translates emoji to platform-specific format
+- [x] Add `ReactTool` to `tau-tools` — takes `message_id` and `emoji` parameters
+- [x] Wire to platform adapters (Slack, Discord, Telegram all support reactions)
+- [x] Channel adapter translates emoji to platform-specific format
 - **Files**: `tau-tools/src/tools/`, messaging runtime modules
 - **Effort**: Small
 


### PR DESCRIPTION
## Summary
Implements G13 React Tool end-to-end: adds a first-class `react` built-in tool, wires reaction-only turn suppression in `tau-agent-core`, and records reaction diagnostics in `tau-coding-agent` event payloads. Includes spec/plan/tasks artifacts for milestone M89 and scoped conformance, mutation, and live-validation evidence.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/89
- Closes #2520
- Related: #2518, #2519, #2521
- Spec: `specs/2520/spec.md`
- Plan: `specs/2520/plan.md`
- Tasks: `specs/2520/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: React tool registry and schema | ✅ | `spec_2520_c01_builtin_agent_tool_name_registry_includes_react_tool`, `spec_2520_c01_register_builtin_tools_registers_react_tool`, `spec_2520_c02_react_tool_returns_structured_reaction_payload` |
| AC-2: React success suppresses follow-up text | ✅ | `integration_spec_2520_c03_prompt_react_tool_call_terminates_run_without_follow_up_model_turn`, `spec_2520_c04_extract_reaction_request_detects_valid_react_tool_payload`, `spec_2520_c04_extract_reaction_request_accepts_action_only_payload` |
| AC-3: Outbound diagnostics preserve reaction metadata | ✅ | `integration_spec_2520_c05_runner_persists_reaction_payload_and_suppresses_text_reply` |
| AC-4: Adapter compatibility remains green | ✅ | `functional_runner_executes_tau_react_command_and_records_reaction_delivery` |

## TDD Evidence
- RED:
  - Command: `CARGO_TARGET_DIR=target-fast-2520-red cargo test -p tau-tools -- spec_2520_c02_react_tool_returns_structured_reaction_payload`
  - Excerpt: `error[E0432]: unresolved import super::ReactTool`
- GREEN:
  - `CARGO_TARGET_DIR=target-fast-2520-verify cargo test -p tau-tools -- spec_2520_`
  - `CARGO_TARGET_DIR=target-fast-2520-verify cargo test -p tau-agent-core -- 2520`
  - `CARGO_TARGET_DIR=target-fast-2520-verify cargo test -p tau-coding-agent -- 2520`
  - `CARGO_TARGET_DIR=target-fast-2520-verify cargo test -p tau-multi-channel -- functional_runner_executes_tau_react_command_and_records_reaction_delivery`
- REGRESSION:
  - `regression_2520_extract_reaction_request_ignores_error_tool_messages`
  - `regression_2520_extract_reaction_request_defaults_empty_reason_code`
  - `regression_2520_prompt_react_tool_error_does_not_suppress_follow_up_model_turn`
  - `regression_2520_prompt_react_tool_without_directive_payload_does_not_suppress_follow_up_model_turn`
  - `regression_2520_collect_assistant_reply_ignores_error_react_tool_results`
  - `regression_2520_collect_assistant_reply_rejects_invalid_react_action_marker`
  - `regression_2520_parse_react_payload_defaults_empty_reason_code`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_2520_c04_*`, `regression_2520_*` parser/suppression tests | |
| Property | N/A | | No new invariant-heavy algorithm/parsing surface requiring randomized generators |
| Contract/DbC | N/A | | No new `contracts` annotations or non-trivial public API DbC surface added |
| Snapshot | N/A | | Behavior is asserted directly via structured-field assertions |
| Functional | ✅ | `spec_2520_c01_*`, `spec_2520_c02_*`, adapter functional coverage | |
| Conformance | ✅ | C-01..C-06 mapped in spec | |
| Integration | ✅ | `integration_spec_2520_c03_*`, `integration_spec_2520_c05_*`, multi-channel functional integration | |
| Fuzz | N/A | | No new untrusted parser/protocol entrypoint introduced in this change |
| Mutation | ✅ | See Mutation section | |
| Regression | ✅ | `regression_2520_*` suite in `tau-agent-core` and `tau-coding-agent` | |
| Performance | N/A | | No hotspot path or throughput-sensitive algorithm change |

## Mutation
- `tau-tools` diff scope: `4 total = 2 caught, 2 unviable, 0 missed`
- `tau-agent-core` diff scope: `21 total = 19 caught, 2 unviable, 0 missed`
- `tau-coding-agent` events diff scope: `21 total = 19 caught, 2 unviable, 0 missed`

## Command Gate Summary
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test -p tau-tools` ✅
- `cargo test -p tau-agent-core` ✅
- `cargo test -p tau-coding-agent` ⚠️ fails on pre-existing mock-route 404s in unrelated skill/package e2e tests (no new G13 failures)
- Live validation: `./scripts/demo/local.sh --skip-build --binary target-fast-2520-verify/debug/tau-coding-agent --timeout-seconds 120` ✅ (3/3)

## Risks/Rollback
- Risk: minimal; change is additive (`react` tool) with suppression gated on successful react directive payloads.
- Rollback: remove `ReactTool` registration and react directive extraction/suppression hooks in `tau-agent-core`/`tau-coding-agent`.

## Docs/ADR
- Updated: `tasks/spacebot-comparison.md` (G13 checklist -> complete)
- Added/updated specs: `specs/milestones/m89/index.md`, `specs/2518/*`, `specs/2519/*`, `specs/2520/*`, `specs/2521/*`
- ADR: N/A (no new dependency/protocol/architecture decision requiring ADR)
