### PR TITLE
docs(spec): mark M91 epic/story specs implemented

### DIFF
--- a/specs/2528/spec.md
+++ b/specs/2528/spec.md
@@ -1,6 +1,6 @@
 # Spec #2528 - Epic: G14 adapter file delivery closure
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 G14 remains partially open because `send_file` contract support was added, but adapter-level delivery behavior is incomplete across channel transports.
@@ -22,7 +22,7 @@ Out of scope:
 ## Conformance Cases
 - C-01 (AC-1): `spec_2530_c01_functional_dry_run_shapes_discord_send_file_payload`
 - C-02 (AC-1): `spec_2530_c02_integration_provider_mode_posts_discord_send_file_request`
-- C-03 (AC-1): `spec_2530_c03_slack_send_file_directive_dispatches_file_upload`
+- C-03 (AC-1): `spec_2530_c04_slack_send_file_directive_dispatches_file_upload`
 - C-04 (AC-2): PR tier matrix + RED/GREEN + live validation package complete
 
 ## Success Metrics

--- a/specs/2529/spec.md
+++ b/specs/2529/spec.md
@@ -1,6 +1,6 @@
 # Spec #2529 - Story: adapter-level send-file dispatch paths
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Current send-file behavior is transport-incomplete: Telegram path exists, while Discord and Slack adapter dispatch paths are missing or not wired.
@@ -28,7 +28,7 @@ Out of scope:
 ## Conformance Cases
 - C-01 (AC-1, functional): `spec_2530_c01_functional_dry_run_shapes_discord_send_file_payload`
 - C-02 (AC-1, integration): `spec_2530_c02_integration_provider_mode_posts_discord_send_file_request`
-- C-03 (AC-2, integration): `spec_2530_c03_slack_send_file_directive_dispatches_file_upload`
+- C-03 (AC-2, integration): `spec_2530_c04_slack_send_file_directive_dispatches_file_upload`
 - C-04 (AC-3, regression): `regression_2530_send_file_still_rejects_unsupported_transport`
 
 ## Success Metrics


### PR DESCRIPTION
## Summary
Marks the M91 epic/story specs as implemented after PR #2532 merged and corrects the Slack conformance test reference from `spec_2530_c03` to `spec_2530_c04`.

## Links
- Closes #2528
- Closes #2529
- Spec: `specs/2528/spec.md`
- Spec: `specs/2529/spec.md`

## Notes
- Docs-only/spec-status update.
- No runtime code changes.
