### PR TITLE
docs(spec): mark #2566 and #2567 specs as Implemented

### DIFF
--- a/specs/2566/spec.md
+++ b/specs/2566/spec.md
@@ -1,6 +1,6 @@
 # Spec #2566 - Task: implement warn-tier background compaction scheduling and apply flow
 
-Status: Reviewed
+Status: Implemented
 Priority: P0
 Milestone: M97
 Parent: #2565

--- a/specs/2567/spec.md
+++ b/specs/2567/spec.md
@@ -1,6 +1,6 @@
 # Spec #2567 - Subtask: conformance/mutation/live-validation evidence for G2 phase-3 background compaction
 
-Status: Reviewed
+Status: Implemented
 Priority: P0
 Milestone: M97
 Parent: #2566


### PR DESCRIPTION
## Summary
Set final spec statuses to `Implemented` after merge/closure of phase-3 work.

## Links
- Follow-up to merged implementation PR: #2568
- Spec: `specs/2566/spec.md`
- Spec: `specs/2567/spec.md`

## Changes
- `specs/2566/spec.md`: `Status: Reviewed` -> `Status: Implemented`
- `specs/2567/spec.md`: `Status: Reviewed` -> `Status: Implemented`

## Verification
- Docs-only status update; no runtime behavior changes.