### PR TITLE
docs(specs): mark issue specs implemented after merge

### DIFF
--- a/specs/2610/spec.md
+++ b/specs/2610/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2610 - Branch hygiene wave for stale merged remote branches
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Merged remote branches accumulate over time and increase operational noise for active lane triage. The repository needs a deterministic, auditable procedure that identifies stale merged branches and supports safe pruning with explicit destructive confirmation plus rollback guidance.

--- a/specs/2612/spec.md
+++ b/specs/2612/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2612 - Runtime log sanitization audit and leak-prevention checks
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Runtime observability logs must never emit credential/token material. Existing logger coverage validates structure and counters but does not explicitly enforce redaction guarantees for secret-like values flowing through tool-event metadata. This creates false-negative risk where high-entropy secrets could leak into persisted logs.


### PR DESCRIPTION
## Summary
Marks `specs/2612/spec.md` and `specs/2610/spec.md` status fields as `Implemented` after merged delivery PRs. This aligns repository spec artifacts with actual merge state for closure tracking.

## Links
- Closes #2612
- Refs #2610

## Verification
- Docs-only update; no runtime behavior change.
