### PR TITLE
spec(g21): mark #2638 spec implemented

### DIFF
--- a/specs/2638/spec.md
+++ b/specs/2638/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2638 - Gateway external coding-agent APIs and SSE stream (G21 phase 2)
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Tau has runtime bridge contracts for external coding-agent sessions (#2619), but no gateway-facing API layer for opening/reusing sessions, routing follow-ups, replaying progress via SSE, and exposing bridge runtime state in operator status views. Without this integration, the bridge remains inaccessible to live operators and tooling.


### PR DESCRIPTION
## Summary
Marks `specs/2638/spec.md` as `Status: Implemented` after merged delivery in #2639.

## Links
- Milestone: `M105 - Spacebot Remaining Gap Integration Wave 1`
- Ref: #2638
- Delivered by: #2639
- Spec: `specs/2638/spec.md`

## Verification
- `python3 .github/scripts/docs_link_check.py`
