### PR TITLE
docs: mark spec 2642 implemented

### DIFF
--- a/specs/2642/spec.md
+++ b/specs/2642/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2642 - G22 skill prompt-mode routing and SKILL.md compatibility hardening
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Tau already supports markdown skills and `SKILL.md` directories, including frontmatter parsing and `{baseDir}` substitution. However, startup prompt composition still injects full skill bodies into channel-level prompts, and delegated/worker orchestration paths do not receive an explicit full-skill context channel. This misses the G22 parity target: channel prompts should carry concise skill summaries while worker/delegated execution paths receive full skill content.


### PR DESCRIPTION
## Summary
Sets `specs/2642/spec.md` status from `Reviewed` to `Implemented` after merge of #2643.

## Links
- Follow-up to #2643
- Milestone: M105 - Spacebot Remaining Gap Integration Wave 1
- Spec: `specs/2642/spec.md`

## Notes
Contract closeout-only change; no code or behavior changes.
