### PR TITLE
docs: mark #2647 spec implemented and m106 completed

### DIFF
--- a/specs/2647/spec.md
+++ b/specs/2647/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2647 - External coding-agent subprocess worker support in bridge runtime (G21 phase 3)
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Tau's G21 bridge currently provides session lifecycle, follow-up queueing, and SSE-ready event replay, but does not execute a real external coding-agent subprocess per worker session. This leaves the final G21 parity item incomplete (`Add external coding agent subprocess support to worker system`) and prevents live worker process supervision through the existing bridge/session APIs.

--- a/specs/milestones/m106/index.md
+++ b/specs/milestones/m106/index.md
@@ -1,6 +1,6 @@
 # M106 - Spacebot G21 External Worker Subprocess Integration
 
-Status: In Progress
+Status: Completed
 Related roadmap items: `tasks/spacebot-comparison.md` (G21 remaining subprocess worker item)
 
 ## Objective


### PR DESCRIPTION
## Summary
Marks the implementation spec for #2647 as `Implemented` and marks milestone index `m106` as `Completed` after merge of PR #2648.

## Links
- Milestone: M106 - Spacebot G21 External Worker Subprocess Integration
- Follow-up to: #2647
- Implements closeout for: https://github.com/njfio/Tau/pull/2648
- Spec: `specs/2647/spec.md`
- Milestone index: `specs/milestones/m106/index.md`

## Verification
- Docs/spec status update only; no runtime behavior change.
