### PR TITLE
feat(tau-gateway): add PRD training status endpoint (#2685)

### DIFF
--- a/specs/2685/plan.md
+++ b/specs/2685/plan.md
@@ -1,0 +1,28 @@
+# Plan: Issue #2685 - PRD gateway training status endpoint
+
+## Approach
+1. Add gateway constant/route for `/gateway/training/status`.
+2. Implement handler that enforces auth/rate limits and returns training status from the existing dashboard snapshot loader.
+3. Add `/gateway/status` web UI discovery metadata for the new endpoint.
+4. Add RED-first integration/regression tests for success path, unavailable fallback, unauthorized behavior, and status discovery.
+
+## Affected Modules
+- `crates/tau-gateway/src/gateway_openresponses.rs`
+- `crates/tau-gateway/src/gateway_openresponses/tests.rs`
+- `specs/milestones/m110/index.md`
+
+## Risks / Mitigations
+- Risk: duplicate training-report logic diverges across endpoints.
+  - Mitigation: reuse existing dashboard snapshot training report in the new handler.
+- Risk: endpoint ambiguity when training status is missing.
+  - Mitigation: preserve deterministic `status_present=false` payload and diagnostics.
+
+## Interfaces / Contracts
+- `GET /gateway/training/status`
+  - Response: deterministic training report payload (`status_present`, `run_state`, counts, diagnostics, source path metadata).
+- `/gateway/status` additions under `gateway.web_ui`:
+  - `training_status_endpoint`
+
+## ADR
+- Not required (bounded additive API slice, no dependency/protocol changes).
+- Human review requested in PR because this is a P1 scope.

--- a/specs/2685/spec.md
+++ b/specs/2685/spec.md
@@ -1,0 +1,59 @@
+# Spec: Issue #2685 - PRD gateway training status endpoint
+
+Status: Implemented
+
+## Problem Statement
+`specs/tau-ops-dashboard-prd.md` API contract includes `GET /gateway/training/status` so operators can query live training state through an authenticated dashboard API. `tau-gateway` currently exposes training status inside broader dashboard/status payloads but lacks a dedicated training status endpoint for dashboard server-function wiring.
+
+## Acceptance Criteria
+
+### AC-1 Authenticated operators can fetch training status through a dedicated endpoint
+Given a valid authenticated request,
+When `GET /gateway/training/status` is called,
+Then the gateway returns a deterministic training status payload derived from persisted training runtime artifacts.
+
+### AC-2 Training status endpoint fails open with deterministic unavailable payload
+Given missing or unreadable training runtime status artifacts,
+When `GET /gateway/training/status` is called,
+Then the endpoint returns `200` with `status_present=false` and deterministic diagnostic metadata.
+
+### AC-3 Unauthorized training status requests are rejected
+Given missing or invalid auth,
+When `GET /gateway/training/status` is called,
+Then the gateway returns fail-closed `401`.
+
+### AC-4 Gateway status discovery advertises training status endpoint
+Given an authenticated status request,
+When `GET /gateway/status` is called,
+Then `gateway.web_ui` includes `training_status_endpoint`.
+
+### AC-5 Scoped verification gates pass
+Given this implementation slice,
+When scoped checks run,
+Then `cargo fmt --check`, `cargo clippy -p tau-gateway -- -D warnings`, and targeted gateway tests pass.
+
+## Scope
+
+### In Scope
+- Add new gateway route template:
+  - `GET /gateway/training/status`
+- Reuse persisted training report loading behavior from existing dashboard status runtime artifacts.
+- Add status discovery field for training status endpoint.
+- Add integration/regression tests for success, unavailable fallback, auth, and discovery.
+
+### Out of Scope
+- `GET /gateway/training/rollouts`
+- `PATCH /gateway/training/config`
+- Training runtime state persistence format changes.
+
+## Conformance Cases
+- C-01 (functional): `GET /gateway/training/status` returns parsed training status when artifact exists.
+- C-02 (regression): `GET /gateway/training/status` returns deterministic unavailable payload when artifact is missing.
+- C-03 (regression): unauthorized training status requests return `401`.
+- C-04 (regression): `GET /gateway/status` includes `training_status_endpoint`.
+- C-05 (verify): scoped fmt/clippy/targeted tests pass.
+
+## Success Metrics / Observable Signals
+- Dashboard operators can query training status through a dedicated authenticated endpoint.
+- Missing training artifacts no longer require callers to infer status from unrelated payloads.
+- Endpoint discovery remains API-driven via `/gateway/status`.

--- a/specs/2685/tasks.md
+++ b/specs/2685/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Issue #2685 - PRD gateway training status endpoint
+
+## Ordered Tasks
+1. [x] T1 (RED): add failing integration/regression tests for C-01..C-04.
+2. [x] T2 (GREEN): add `/gateway/training/status` route wiring and status discovery metadata.
+3. [x] T3 (GREEN): implement training status handler using existing snapshot training report.
+4. [x] T4 (REGRESSION): verify missing-artifact fallback and unauthorized fail-closed behavior.
+5. [x] T5 (VERIFY): run scoped fmt/clippy/targeted tests and capture C-05 evidence.
+
+## Tier Mapping
+- Unit: endpoint helper behavior covered through gateway unit/integration suite.
+- Property: N/A (no randomized invariants introduced in this slice).
+- Contract/DbC: N/A (contracts macros not used in touched modules).
+- Snapshot: N/A (explicit field assertions used).
+- Functional: C-01.
+- Conformance: C-01..C-05.
+- Integration: C-01, C-04.
+- Fuzz: N/A (no new parser/codec boundary introduced).
+- Mutation: N/A (bounded additive endpoint slice).
+- Regression: C-02, C-03, C-04.
+- Performance: N/A (no hotspot/perf budget target changed).

--- a/specs/milestones/m110/index.md
+++ b/specs/milestones/m110/index.md
@@ -21,6 +21,8 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
 - Completed Task: #2679
 - Completed Story: #2681
 - Completed Task: #2682
+- Completed Story: #2684
+- Completed Task: #2685
 
 ## Deliverables
 - Completed (`#2667`):
@@ -56,9 +58,14 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
     - `GET /gateway/audit/log`
   - Audit summary/log query contracts for dashboard diagnostics workflows.
   - Status discovery metadata for audit endpoints.
+- Completed (`#2685`):
+  - Gateway training status endpoint:
+    - `GET /gateway/training/status`
+  - Deterministic missing-artifact fallback payload via existing training snapshot contract.
+  - Status discovery metadata for training status endpoint.
 
 ## Exit Criteria
 - Epic #2665 is closed with all scoped PRD phase-1 tasks completed.
-- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, and `specs/2682/spec.md` status are `Implemented`.
+- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, `specs/2682/spec.md`, and `specs/2685/spec.md` status are `Implemented`.
 - Scoped verification gates pass with evidence (`fmt`, `clippy -p tau-gateway`, targeted tests).
 - PRD checklist progress is updated for completed phase-1 endpoint slices.


### PR DESCRIPTION
## Summary
Adds a dedicated authenticated gateway training status endpoint at `GET /gateway/training/status` backed by existing dashboard snapshot training data. Adds gateway status discovery metadata so dashboard clients can discover the endpoint contractually. Includes conformance/regression tests and milestone/spec artifacts for issue `#2685`.

## Links
- Milestone: `specs/milestones/m110/index.md`
- Parent Story: #2684
- Closes #2685
- Spec: `specs/2685/spec.md`
- Plan: `specs/2685/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Authenticated operators can fetch training status endpoint | ✅ | `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery` |
| AC-2: Missing artifact returns deterministic unavailable payload | ✅ | `regression_spec_2685_c02_training_status_endpoint_returns_unavailable_payload_when_missing` |
| AC-3: Unauthorized requests are rejected with `401` | ✅ | `regression_spec_2685_c03_training_status_endpoint_rejects_unauthorized_requests` |
| AC-4: `/gateway/status` advertises `training_status_endpoint` | ✅ | `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery` |
| AC-5: Scoped verification gates pass | ✅ | `cargo fmt --check`; `cargo clippy -p tau-gateway -- -D warnings`; `cargo test -p tau-gateway`; `cargo test -p tau-gateway spec_2685` |

## TDD Evidence
- RED cmd: `cargo test -p tau-gateway spec_2685`
- RED output excerpt (pre-impl):
  - `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery ... FAILED` (`404` vs expected `200`)
  - `regression_spec_2685_c02_training_status_endpoint_returns_unavailable_payload_when_missing ... FAILED` (`404` vs expected `200`)
  - `regression_spec_2685_c03_training_status_endpoint_rejects_unauthorized_requests ... FAILED` (`404` vs expected `401`)
- GREEN cmd: `cargo test -p tau-gateway spec_2685`
- GREEN output excerpt:
  - `running 3 tests`
  - `... c01_c04 ... ok`
  - `... c02 ... ok`
  - `... c03 ... ok`
  - `test result: ok. 3 passed; 0 failed`
- REGRESSION summary:
  - Full scoped suite remains green: `cargo fmt --check`, `cargo clippy -p tau-gateway -- -D warnings`, `cargo test -p tau-gateway` (`109 passed`).

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | Existing gateway unit coverage plus endpoint assertions in `gateway_openresponses::tests` | |
| Property | N/A | | No parser/invariant algorithm changes in this slice |
| Contract/DbC | N/A | | No new `contracts` macro boundary introduced |
| Snapshot | N/A | | Explicit field assertions used instead of snapshots |
| Functional | ✅ | `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery` | |
| Conformance | ✅ | `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery`; `regression_spec_2685_c02_training_status_endpoint_returns_unavailable_payload_when_missing`; `regression_spec_2685_c03_training_status_endpoint_rejects_unauthorized_requests` | |
| Integration | ✅ | `integration_spec_2685_c01_c04_training_status_endpoint_returns_report_and_status_discovery` | |
| Fuzz | N/A | | No untrusted parser/codec path added |
| Mutation | N/A | | Bounded additive endpoint slice; no critical-path branch logic changed |
| Regression | ✅ | `regression_spec_2685_c02_training_status_endpoint_returns_unavailable_payload_when_missing`; `regression_spec_2685_c03_training_status_endpoint_rejects_unauthorized_requests` | |
| Performance | N/A | | No hotspot/perf contract affected |

## Mutation
- N/A for this bounded endpoint-additive slice (no critical-path algorithmic mutation target changed).

## Risks / Rollback
- Risk: Low. Additive authenticated `GET` endpoint and status metadata field.
- Rollback: Revert this PR to remove `/gateway/training/status` route and `training_status_endpoint` status field.

## Docs / ADR
- Updated docs/spec artifacts:
  - `specs/2685/spec.md`
  - `specs/2685/plan.md`
  - `specs/2685/tasks.md`
  - `specs/milestones/m110/index.md`
- ADR: Not required (no dependency/architecture/protocol decision change).
