### PR TITLE
feat(tau-gateway): add PRD training rollouts/config endpoints (#2688)

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses/training_runtime.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/training_runtime.rs
@@ -1,0 +1,422 @@
+//! Gateway training rollouts/config endpoint handlers.
+//!
+//! This module provides dashboard-facing training runtime contracts for
+//! paginated rollout history and persisted config override updates.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tau_core::current_unix_timestamp_ms;
+
+use super::{
+    authorize_dashboard_request, parse_gateway_json_body, read_gateway_config_pending_overrides,
+    GatewayOpenResponsesServerState, OpenResponsesApiError,
+};
+
+const TRAINING_ROLLOUTS_FILE: &str = "rollouts.jsonl";
+const TRAINING_ROLLOUTS_DEFAULT_PER_PAGE: usize = 50;
+const TRAINING_ROLLOUTS_MAX_PER_PAGE: usize = 200;
+const TRAINING_CONFIG_OVERRIDES_FILE: &str = "training-config-overrides.json";
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct GatewayTrainingRolloutsQuery {
+    #[serde(default)]
+    page: Option<String>,
+    #[serde(default)]
+    per_page: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GatewayTrainingConfigPatchRequest {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    update_interval_rollouts: Option<u64>,
+    #[serde(default)]
+    max_rollouts_per_update: Option<u64>,
+    #[serde(default)]
+    max_failure_streak: Option<u64>,
+    #[serde(default)]
+    store_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GatewayTrainingRolloutLine {
+    #[serde(default)]
+    rollout_id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    steps: u64,
+    #[serde(default)]
+    reward: f64,
+    #[serde(default)]
+    duration_ms: u64,
+    #[serde(default)]
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GatewayTrainingRolloutView {
+    rollout_id: String,
+    status: String,
+    mode: String,
+    steps: u64,
+    reward: f64,
+    duration_ms: u64,
+    updated_unix_ms: u64,
+}
+
+#[derive(Debug, Default)]
+struct GatewayTrainingRolloutLoad {
+    records: Vec<GatewayTrainingRolloutView>,
+    invalid_records: u64,
+    diagnostics: Vec<String>,
+}
+
+#[derive(Debug)]
+struct GatewayTrainingRolloutRequest {
+    page: usize,
+    per_page: usize,
+}
+
+pub(super) async fn handle_gateway_training_rollouts(
+    State(state): State<Arc<GatewayOpenResponsesServerState>>,
+    headers: HeaderMap,
+    Query(query): Query<GatewayTrainingRolloutsQuery>,
+) -> Response {
+    if let Err(error) = authorize_dashboard_request(&state, &headers) {
+        return error.into_response();
+    }
+
+    let request = match parse_rollout_request(&query) {
+        Ok(request) => request,
+        Err(error) => return error.into_response(),
+    };
+
+    let load = match load_training_rollouts(&state.config.state_dir) {
+        Ok(load) => load,
+        Err(error) => return error.into_response(),
+    };
+
+    let total_records = load.records.len();
+    let total_pages = if total_records == 0 {
+        0
+    } else {
+        (total_records
+            .saturating_add(request.per_page)
+            .saturating_sub(1))
+            / request.per_page
+    };
+    let start = request
+        .page
+        .saturating_sub(1)
+        .saturating_mul(request.per_page);
+    let records: Vec<GatewayTrainingRolloutView> = if start >= load.records.len() {
+        Vec::new()
+    } else {
+        load.records
+            .iter()
+            .skip(start)
+            .take(request.per_page)
+            .cloned()
+            .collect()
+    };
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "schema_version": 1,
+            "generated_unix_ms": current_unix_timestamp_ms(),
+            "page": request.page,
+            "per_page": request.per_page,
+            "total_records": total_records,
+            "total_pages": total_pages,
+            "invalid_records": load.invalid_records,
+            "records": records,
+            "diagnostics": load.diagnostics,
+        })),
+    )
+        .into_response()
+}
+
+pub(super) async fn handle_gateway_training_config_patch(
+    State(state): State<Arc<GatewayOpenResponsesServerState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(error) = authorize_dashboard_request(&state, &headers) {
+        return error.into_response();
+    }
+    let request = match parse_gateway_json_body::<GatewayTrainingConfigPatchRequest>(&body) {
+        Ok(request) => request,
+        Err(error) => return error.into_response(),
+    };
+
+    let overrides_path = gateway_training_config_overrides_path(&state.config.state_dir);
+    let mut pending_overrides = match read_gateway_config_pending_overrides(&overrides_path) {
+        Ok(overrides) => overrides,
+        Err(error) => return error.into_response(),
+    };
+    let mut accepted = serde_json::Map::<String, Value>::new();
+    let mut applied = serde_json::Map::<String, Value>::new();
+
+    if let Some(enabled) = request.enabled {
+        accepted.insert("enabled".to_string(), json!(enabled));
+        pending_overrides.insert("enabled".to_string(), json!(enabled));
+        applied.insert(
+            "enabled".to_string(),
+            json!({"mode": "persisted_pending", "value": enabled}),
+        );
+    }
+
+    if let Some(update_interval_rollouts) = request.update_interval_rollouts {
+        if update_interval_rollouts == 0 {
+            return OpenResponsesApiError::bad_request(
+                "invalid_training_update_interval_rollouts",
+                "update_interval_rollouts must be greater than zero",
+            )
+            .into_response();
+        }
+        accepted.insert(
+            "update_interval_rollouts".to_string(),
+            json!(update_interval_rollouts),
+        );
+        pending_overrides.insert(
+            "update_interval_rollouts".to_string(),
+            json!(update_interval_rollouts),
+        );
+        applied.insert(
+            "update_interval_rollouts".to_string(),
+            json!({"mode": "persisted_pending", "value": update_interval_rollouts}),
+        );
+    }
+
+    if let Some(max_rollouts_per_update) = request.max_rollouts_per_update {
+        if max_rollouts_per_update == 0 {
+            return OpenResponsesApiError::bad_request(
+                "invalid_training_max_rollouts_per_update",
+                "max_rollouts_per_update must be greater than zero",
+            )
+            .into_response();
+        }
+        accepted.insert(
+            "max_rollouts_per_update".to_string(),
+            json!(max_rollouts_per_update),
+        );
+        pending_overrides.insert(
+            "max_rollouts_per_update".to_string(),
+            json!(max_rollouts_per_update),
+        );
+        applied.insert(
+            "max_rollouts_per_update".to_string(),
+            json!({"mode": "persisted_pending", "value": max_rollouts_per_update}),
+        );
+    }
+
+    if let Some(max_failure_streak) = request.max_failure_streak {
+        if max_failure_streak == 0 {
+            return OpenResponsesApiError::bad_request(
+                "invalid_training_max_failure_streak",
+                "max_failure_streak must be greater than zero",
+            )
+            .into_response();
+        }
+        accepted.insert("max_failure_streak".to_string(), json!(max_failure_streak));
+        pending_overrides.insert("max_failure_streak".to_string(), json!(max_failure_streak));
+        applied.insert(
+            "max_failure_streak".to_string(),
+            json!({"mode": "persisted_pending", "value": max_failure_streak}),
+        );
+    }
+
+    if let Some(store_path) = request.store_path {
+        let trimmed = store_path.trim().to_string();
+        if trimmed.is_empty() {
+            return OpenResponsesApiError::bad_request(
+                "invalid_training_store_path",
+                "store_path must be non-empty",
+            )
+            .into_response();
+        }
+        accepted.insert("store_path".to_string(), json!(trimmed.clone()));
+        pending_overrides.insert("store_path".to_string(), json!(trimmed.clone()));
+        applied.insert(
+            "store_path".to_string(),
+            json!({"mode": "persisted_pending", "value": trimmed}),
+        );
+    }
+
+    if accepted.is_empty() {
+        return OpenResponsesApiError::bad_request(
+            "no_training_config_changes",
+            "patch payload did not include any supported training config fields",
+        )
+        .into_response();
+    }
+
+    let updated_unix_ms = current_unix_timestamp_ms();
+    let payload = json!({
+        "schema_version": 1,
+        "updated_unix_ms": updated_unix_ms,
+        "pending_overrides": pending_overrides,
+    });
+    if let Some(parent) = overrides_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                return OpenResponsesApiError::internal(format!(
+                    "failed to create training config override directory '{}': {error}",
+                    parent.display()
+                ))
+                .into_response();
+            }
+        }
+    }
+    if let Err(error) = std::fs::write(&overrides_path, format!("{payload}\n").as_bytes()) {
+        return OpenResponsesApiError::internal(format!(
+            "failed to write training config overrides '{}': {error}",
+            overrides_path.display()
+        ))
+        .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "accepted": accepted,
+            "applied": applied,
+            "pending_overrides": payload["pending_overrides"],
+            "overrides_path": overrides_path.display().to_string(),
+            "updated_unix_ms": updated_unix_ms,
+        })),
+    )
+        .into_response()
+}
+
+fn parse_rollout_request(
+    query: &GatewayTrainingRolloutsQuery,
+) -> Result<GatewayTrainingRolloutRequest, OpenResponsesApiError> {
+    let page =
+        parse_optional_usize(query.page.as_deref(), "invalid_training_rollouts_page")?.unwrap_or(1);
+    if page == 0 {
+        return Err(OpenResponsesApiError::bad_request(
+            "invalid_training_rollouts_page",
+            "page must be >= 1",
+        ));
+    }
+
+    let per_page = parse_optional_usize(
+        query.per_page.as_deref(),
+        "invalid_training_rollouts_per_page",
+    )?
+    .unwrap_or(TRAINING_ROLLOUTS_DEFAULT_PER_PAGE);
+    if per_page == 0 || per_page > TRAINING_ROLLOUTS_MAX_PER_PAGE {
+        return Err(OpenResponsesApiError::bad_request(
+            "invalid_training_rollouts_per_page",
+            format!(
+                "per_page must be between 1 and {}",
+                TRAINING_ROLLOUTS_MAX_PER_PAGE
+            ),
+        ));
+    }
+
+    Ok(GatewayTrainingRolloutRequest { page, per_page })
+}
+
+fn parse_optional_usize(
+    raw: Option<&str>,
+    code: &'static str,
+) -> Result<Option<usize>, OpenResponsesApiError> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    raw.parse::<usize>().map(Some).map_err(|_| {
+        OpenResponsesApiError::bad_request(code, format!("invalid integer value '{}'", raw))
+    })
+}
+
+fn load_training_rollouts(
+    gateway_state_dir: &Path,
+) -> Result<GatewayTrainingRolloutLoad, OpenResponsesApiError> {
+    let path = gateway_training_rollouts_path(gateway_state_dir);
+    if !path.exists() {
+        return Ok(GatewayTrainingRolloutLoad {
+            diagnostics: vec![format!("training_rollouts_missing:{}", path.display())],
+            ..GatewayTrainingRolloutLoad::default()
+        });
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        OpenResponsesApiError::internal(format!(
+            "failed to read training rollouts '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    let mut load = GatewayTrainingRolloutLoad::default();
+    for (line_number, line) in raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<GatewayTrainingRolloutLine>(trimmed) {
+            Ok(parsed) => load.records.push(GatewayTrainingRolloutView {
+                rollout_id: normalize_non_empty(parsed.rollout_id.as_str(), "unknown"),
+                status: normalize_non_empty(parsed.status.as_str(), "unknown"),
+                mode: normalize_non_empty(parsed.mode.as_str(), "unknown"),
+                steps: parsed.steps,
+                reward: parsed.reward,
+                duration_ms: parsed.duration_ms,
+                updated_unix_ms: parsed.updated_unix_ms,
+            }),
+            Err(_) => {
+                load.invalid_records = load.invalid_records.saturating_add(1);
+                load.diagnostics.push(format!(
+                    "training_rollouts_malformed_line:{}",
+                    line_number.saturating_add(1)
+                ));
+            }
+        }
+    }
+
+    load.records.sort_by(|left, right| {
+        right
+            .updated_unix_ms
+            .cmp(&left.updated_unix_ms)
+            .then_with(|| right.rollout_id.cmp(&left.rollout_id))
+    });
+
+    Ok(load)
+}
+
+fn normalize_non_empty(raw: &str, fallback: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn gateway_training_rollouts_path(state_dir: &Path) -> PathBuf {
+    let tau_root = state_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| state_dir.to_path_buf());
+    tau_root.join("training").join(TRAINING_ROLLOUTS_FILE)
+}
+
+fn gateway_training_config_overrides_path(state_dir: &Path) -> PathBuf {
+    state_dir
+        .join("openresponses")
+        .join(TRAINING_CONFIG_OVERRIDES_FILE)
+}

--- a/specs/2688/plan.md
+++ b/specs/2688/plan.md
@@ -1,0 +1,34 @@
+# Plan: Issue #2688 - PRD gateway training rollouts and config endpoints
+
+## Approach
+1. Extend `gateway_openresponses` route constants/router wiring with training rollouts/config endpoints.
+2. Add small training runtime helpers in a dedicated module for:
+   - Rollout JSONL loading with malformed-line accounting and pagination.
+   - Training config override read/write persistence under `.tau/training/config-overrides.json`.
+3. Add handler implementations with existing auth/error patterns (`authorize_dashboard_request` + deterministic `OpenResponsesApiError`).
+4. Extend `/gateway/status` `gateway.web_ui` discovery metadata.
+5. Add conformance/regression tests first (RED), then implement (GREEN), then run scoped validation gates.
+
+## Affected Modules
+- `crates/tau-gateway/src/gateway_openresponses.rs`
+- `crates/tau-gateway/src/gateway_openresponses/tests.rs`
+- `crates/tau-gateway/src/gateway_openresponses/training_runtime.rs` (new)
+
+## Risks / Mitigations
+- Risk: rollout artifact schema drift.
+  - Mitigation: tolerant parser with field defaults + malformed-line counters.
+- Risk: config patch mutation of unsupported fields.
+  - Mitigation: strict whitelist + deterministic `400` when no supported fields accepted.
+- Risk: pagination abuse.
+  - Mitigation: bounded `page`/`per_page` validation and hard caps.
+
+## Interfaces / Contracts
+- `GET /gateway/training/rollouts?page=<u64>&per_page=<u64>`
+  - `200`: `{ schema_version, generated_unix_ms, page, per_page, total_records, total_pages, invalid_records, records, diagnostics }`
+- `PATCH /gateway/training/config`
+  - request: optional subset of `{ enabled, update_interval_rollouts, max_rollouts_per_update, max_failure_streak, store_path }`
+  - `200`: `{ accepted, applied, pending_overrides, overrides_path, updated_unix_ms }`
+  - `400`: deterministic validation error on invalid/unsupported payload.
+
+## ADR
+- Not required. No dependency, protocol, or architecture decision change.

--- a/specs/2688/spec.md
+++ b/specs/2688/spec.md
@@ -1,0 +1,83 @@
+# Spec: Issue #2688 - PRD gateway training rollouts and config endpoints
+
+Status: Implemented
+
+## Problem Statement
+`specs/tau-ops-dashboard-prd.md` API contract requires training control/history endpoints beyond status:
+- `GET /gateway/training/rollouts`
+- `PATCH /gateway/training/config`
+
+`tau-gateway` currently exposes only `GET /gateway/training/status`, which blocks Training & RL dashboard server-function parity.
+
+## Acceptance Criteria
+
+### AC-1 Authenticated operators can fetch paginated training rollouts
+Given a valid authenticated request,
+When `GET /gateway/training/rollouts` is called,
+Then the gateway returns deterministic rollout history payload with pagination metadata.
+
+### AC-2 Rollouts endpoint fails open with deterministic fallback when artifacts are missing/malformed
+Given missing or partially malformed rollout artifacts,
+When `GET /gateway/training/rollouts` is called,
+Then the endpoint returns `200` with deterministic diagnostics and valid pagination payload.
+
+### AC-3 Rollouts endpoint validates pagination query input
+Given invalid query parameters (`page` / `per_page` bounds),
+When `GET /gateway/training/rollouts` is called,
+Then the gateway returns deterministic fail-closed `400` with actionable error code.
+
+### AC-4 Authenticated operators can patch training config overrides
+Given a valid authenticated patch payload,
+When `PATCH /gateway/training/config` is called,
+Then the gateway persists deterministic training config overrides and returns accepted/applied metadata.
+
+### AC-5 Training config endpoint validates payload and rejects unsupported/invalid updates
+Given missing supported fields or invalid values,
+When `PATCH /gateway/training/config` is called,
+Then the gateway returns deterministic `400` response without mutating persisted overrides.
+
+### AC-6 Unauthorized training endpoint requests are rejected
+Given missing or invalid auth,
+When `GET /gateway/training/rollouts` or `PATCH /gateway/training/config` are called,
+Then the gateway returns fail-closed `401`.
+
+### AC-7 Gateway status discovery advertises training rollouts/config endpoints
+Given an authenticated status request,
+When `GET /gateway/status` is called,
+Then `gateway.web_ui` includes `training_rollouts_endpoint` and `training_config_endpoint`.
+
+### AC-8 Scoped verification gates pass
+Given this implementation slice,
+When scoped checks run,
+Then `cargo fmt --check`, `cargo clippy -p tau-gateway -- -D warnings`, and targeted gateway tests pass.
+
+## Scope
+
+### In Scope
+- Add gateway routes:
+  - `GET /gateway/training/rollouts`
+  - `PATCH /gateway/training/config`
+- Add deterministic training rollouts artifact parsing with bounded pagination.
+- Add deterministic training config override persistence contract.
+- Add status discovery fields under `gateway.web_ui`.
+- Add conformance/regression tests for success, fallback, validation, and auth.
+
+### Out of Scope
+- Dashboard UI implementation.
+- Runtime hot-application of patched training config values.
+- RL algorithm/store schema redesign.
+
+## Conformance Cases
+- C-01 (integration): `GET /gateway/training/rollouts` returns paginated rollout records and status discovery fields.
+- C-02 (regression): missing rollout artifact returns deterministic empty payload with diagnostics.
+- C-03 (regression): malformed rollout artifact lines are tolerated and counted in diagnostics.
+- C-04 (regression): invalid pagination query returns deterministic `400`.
+- C-05 (integration): `PATCH /gateway/training/config` persists supported overrides and returns accepted/applied contract.
+- C-06 (regression): invalid or unsupported training config patch payload returns deterministic `400` without mutation.
+- C-07 (regression): unauthorized training rollout/config requests return `401`.
+- C-08 (verify): scoped fmt/clippy/targeted tests pass.
+
+## Success Metrics / Observable Signals
+- Training dashboard integrations can fetch rollout history and submit training config updates via dedicated endpoints.
+- Missing/malformed training artifacts no longer crash or break endpoint contracts.
+- Endpoint discovery remains API-driven via `/gateway/status`.

--- a/specs/2688/tasks.md
+++ b/specs/2688/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Issue #2688 - PRD gateway training rollouts and config endpoints
+
+## Ordered Tasks
+1. [x] T1 (RED): add failing integration/regression tests for C-01..C-07.
+2. [x] T2 (GREEN): add training rollouts/config routes and status discovery metadata.
+3. [x] T3 (GREEN): implement rollout artifact pagination parser and training config override patch persistence.
+4. [x] T4 (REGRESSION): verify missing/malformed artifact fallback plus invalid-query/payload fail-closed behavior.
+5. [x] T5 (VERIFY): run scoped fmt/clippy/targeted tests and capture C-08 evidence.
+
+## Tier Mapping
+- Unit: endpoint helper behavior coverage.
+- Property: N/A (no randomized invariant algorithm introduced).
+- Contract/DbC: N/A (contracts macros not introduced in touched modules).
+- Snapshot: N/A (explicit field assertions used).
+- Functional: C-01, C-05.
+- Conformance: C-01..C-08.
+- Integration: C-01, C-05, C-07.
+- Fuzz: N/A (no new parser boundary requiring fuzz harness in this slice).
+- Mutation: N/A (bounded additive endpoint slice).
+- Regression: C-02, C-03, C-04, C-06, C-07.
+- Performance: N/A (no hotspot/perf budget contract changed).

--- a/specs/milestones/m110/index.md
+++ b/specs/milestones/m110/index.md
@@ -23,6 +23,8 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
 - Completed Task: #2682
 - Completed Story: #2684
 - Completed Task: #2685
+- Completed Story: #2687
+- Completed Task: #2688
 
 ## Deliverables
 - Completed (`#2667`):
@@ -63,9 +65,16 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
     - `GET /gateway/training/status`
   - Deterministic missing-artifact fallback payload via existing training snapshot contract.
   - Status discovery metadata for training status endpoint.
+- Completed (`#2688`):
+  - Gateway training rollouts endpoint:
+    - `GET /gateway/training/rollouts`
+  - Gateway training config endpoint:
+    - `PATCH /gateway/training/config`
+  - Rollout pagination/fallback contracts and training config override persistence semantics.
+  - Status discovery metadata for training rollouts/config endpoints.
 
 ## Exit Criteria
 - Epic #2665 is closed with all scoped PRD phase-1 tasks completed.
-- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, `specs/2682/spec.md`, and `specs/2685/spec.md` status are `Implemented`.
+- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, `specs/2682/spec.md`, `specs/2685/spec.md`, and `specs/2688/spec.md` status are `Implemented`.
 - Scoped verification gates pass with evidence (`fmt`, `clippy -p tau-gateway`, targeted tests).
 - PRD checklist progress is updated for completed phase-1 endpoint slices.


### PR DESCRIPTION
## Summary
Adds two PRD-aligned training endpoints to `tau-gateway`: `GET /gateway/training/rollouts` and `PATCH /gateway/training/config`. Implements deterministic rollout pagination/fallback behavior and persisted training config override patch semantics. Extends `/gateway/status` discovery metadata for training rollouts/config endpoint wiring.

## Links
- Milestone: `specs/milestones/m110/index.md`
- Parent Story: #2687
- Closes #2688
- Spec: `specs/2688/spec.md`
- Plan: `specs/2688/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: authenticated rollouts endpoint returns paginated history | ✅ | `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination` |
| AC-2: deterministic fallback for missing/malformed rollout artifacts | ✅ | `regression_spec_2688_c02_c03_training_rollouts_endpoint_returns_fallback_when_artifacts_are_missing_or_malformed` |
| AC-3: rollouts pagination query validation | ✅ | `regression_spec_2688_c04_training_rollouts_endpoint_rejects_invalid_pagination_queries` |
| AC-4: authenticated training config patch persists overrides | ✅ | `integration_spec_2688_c05_training_config_patch_persists_supported_overrides` |
| AC-5: invalid/unsupported training config payloads fail closed | ✅ | `regression_spec_2688_c06_c07_training_endpoints_reject_invalid_or_unauthorized_requests` |
| AC-6: unauthorized requests rejected | ✅ | `regression_spec_2688_c06_c07_training_endpoints_reject_invalid_or_unauthorized_requests` |
| AC-7: status discovery advertises training rollouts/config endpoints | ✅ | `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination` |
| AC-8: scoped verification gates pass | ✅ | `cargo fmt --check`; `cargo clippy -p tau-gateway -- -D warnings`; `cargo test -p tau-gateway`; `cargo test -p tau-gateway spec_2688` |

## TDD Evidence
- RED cmd: `cargo test -p tau-gateway spec_2688`
- RED output excerpt (pre-impl):
  - `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination ... FAILED` (`404` vs expected `200`)
  - `integration_spec_2688_c05_training_config_patch_persists_supported_overrides ... FAILED` (`404` vs expected `200`)
  - `regression_spec_2688_c04_training_rollouts_endpoint_rejects_invalid_pagination_queries ... FAILED` (`404` vs expected `400`)
  - `regression_spec_2688_c06_c07_training_endpoints_reject_invalid_or_unauthorized_requests ... FAILED` (`404` vs expected `401`)
- GREEN cmd: `cargo test -p tau-gateway spec_2688`
- GREEN output excerpt:
  - `running 5 tests`
  - all `spec_2688` tests `... ok`
  - `test result: ok. 5 passed; 0 failed`
- REGRESSION summary:
  - `cargo fmt --check` ✅
  - `cargo clippy -p tau-gateway -- -D warnings` ✅
  - `cargo test -p tau-gateway` ✅ (`114 passed`)

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | Existing gateway unit coverage plus endpoint helper behavior in `gateway_openresponses::tests` | |
| Property | N/A | | No randomized invariant algorithm added in this slice |
| Contract/DbC | N/A | | No contracts macro boundary introduced |
| Snapshot | N/A | | Explicit response field assertions used |
| Functional | ✅ | `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination`; `integration_spec_2688_c05_training_config_patch_persists_supported_overrides` | |
| Conformance | ✅ | `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination`; `regression_spec_2688_c02_c03_training_rollouts_endpoint_returns_fallback_when_artifacts_are_missing_or_malformed`; `regression_spec_2688_c04_training_rollouts_endpoint_rejects_invalid_pagination_queries`; `integration_spec_2688_c05_training_config_patch_persists_supported_overrides`; `regression_spec_2688_c06_c07_training_endpoints_reject_invalid_or_unauthorized_requests` | |
| Integration | ✅ | `integration_spec_2688_c01_c07_training_rollouts_and_status_discovery_support_pagination`; `integration_spec_2688_c05_training_config_patch_persists_supported_overrides` | |
| Fuzz | N/A | | No new parser/codec boundary requiring fuzz harness in this bounded slice |
| Mutation | N/A | | Bounded additive endpoint slice; no critical-path algorithm change |
| Regression | ✅ | `regression_spec_2688_c02_c03_training_rollouts_endpoint_returns_fallback_when_artifacts_are_missing_or_malformed`; `regression_spec_2688_c04_training_rollouts_endpoint_rejects_invalid_pagination_queries`; `regression_spec_2688_c06_c07_training_endpoints_reject_invalid_or_unauthorized_requests` | |
| Performance | N/A | | No performance hotspot contract modified |

## Mutation
- N/A for this bounded endpoint-additive slice (no critical-path algorithmic branch mutation target changed).

## Risks / Rollback
- Risk: Low. Additive authenticated endpoints and status metadata only.
- Rollback: Revert this PR to remove `/gateway/training/rollouts`, `/gateway/training/config`, and corresponding status discovery fields.

## Docs / ADR
- Updated:
  - `specs/2688/spec.md`
  - `specs/2688/plan.md`
  - `specs/2688/tasks.md`
  - `specs/milestones/m110/index.md`
- ADR: Not required (no new dependency/protocol/architecture decision).
