### PR TITLE
feat(tau-gateway): add PRD tools inventory/stats endpoints (#2691)

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses.rs
+++ b/crates/tau-gateway/src/gateway_openresponses.rs
@@ -66,6 +66,7 @@ mod safety_runtime;
 mod session_runtime;
 #[cfg(test)]
 mod tests;
+mod tools_runtime;
 mod training_runtime;
 mod types;
 mod webchat_page;
@@ -96,6 +97,7 @@ use session_runtime::{
     collect_assistant_reply, gateway_session_path, initialize_gateway_session_runtime,
     persist_messages, persist_session_usage_delta,
 };
+use tools_runtime::{handle_gateway_tools_inventory, handle_gateway_tools_stats};
 use training_runtime::{handle_gateway_training_config_patch, handle_gateway_training_rollouts};
 use types::{
     GatewayAuthSessionRequest, GatewayAuthSessionResponse, GatewayChannelLifecycleRequest,
@@ -139,6 +141,8 @@ const GATEWAY_AUDIT_LOG_ENDPOINT: &str = "/gateway/audit/log";
 const GATEWAY_TRAINING_STATUS_ENDPOINT: &str = "/gateway/training/status";
 const GATEWAY_TRAINING_ROLLOUTS_ENDPOINT: &str = "/gateway/training/rollouts";
 const GATEWAY_TRAINING_CONFIG_ENDPOINT: &str = "/gateway/training/config";
+const GATEWAY_TOOLS_ENDPOINT: &str = "/gateway/tools";
+const GATEWAY_TOOLS_STATS_ENDPOINT: &str = "/gateway/tools/stats";
 const GATEWAY_UI_TELEMETRY_ENDPOINT: &str = "/gateway/ui/telemetry";
 const DASHBOARD_HEALTH_ENDPOINT: &str = "/dashboard/health";
 const DASHBOARD_WIDGETS_ENDPOINT: &str = "/dashboard/widgets";
@@ -820,6 +824,11 @@ fn build_gateway_openresponses_router(state: Arc<GatewayOpenResponsesServerState
             GATEWAY_TRAINING_CONFIG_ENDPOINT,
             patch(handle_gateway_training_config_patch),
         )
+        .route(GATEWAY_TOOLS_ENDPOINT, get(handle_gateway_tools_inventory))
+        .route(
+            GATEWAY_TOOLS_STATS_ENDPOINT,
+            get(handle_gateway_tools_stats),
+        )
         .route(
             GATEWAY_UI_TELEMETRY_ENDPOINT,
             post(handle_gateway_ui_telemetry),
@@ -937,6 +946,8 @@ async fn handle_gateway_status(
                     "training_status_endpoint": GATEWAY_TRAINING_STATUS_ENDPOINT,
                     "training_rollouts_endpoint": GATEWAY_TRAINING_ROLLOUTS_ENDPOINT,
                     "training_config_endpoint": GATEWAY_TRAINING_CONFIG_ENDPOINT,
+                    "tools_endpoint": GATEWAY_TOOLS_ENDPOINT,
+                    "tool_stats_endpoint": GATEWAY_TOOLS_STATS_ENDPOINT,
                     "ui_telemetry_endpoint": GATEWAY_UI_TELEMETRY_ENDPOINT,
                     "policy_gates": {
                         "session_write": SESSION_WRITE_POLICY_GATE,

--- a/crates/tau-gateway/src/gateway_openresponses/tools_runtime.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/tools_runtime.rs
@@ -1,0 +1,254 @@
+//! Gateway tools inventory/stats endpoint handlers.
+//!
+//! This module exposes dashboard-oriented contracts for tool inventory and
+//! usage diagnostics aggregated from gateway UI telemetry.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tau_agent_core::{Agent, AgentConfig};
+use tau_core::current_unix_timestamp_ms;
+
+use super::{
+    authorize_dashboard_request, gateway_ui_telemetry_path, GatewayOpenResponsesServerState,
+    OpenResponsesApiError,
+};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct GatewayToolInventoryItem {
+    name: String,
+    enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct GatewayToolStatsItem {
+    tool_name: String,
+    registered: bool,
+    event_count: u64,
+    action_counts: BTreeMap<String, u64>,
+    reason_code_counts: BTreeMap<String, u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_event_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GatewayUiTelemetryRecord {
+    #[serde(default)]
+    timestamp_unix_ms: u64,
+    #[serde(default)]
+    view: String,
+    #[serde(default)]
+    action: String,
+    #[serde(default)]
+    reason_code: String,
+    #[serde(default)]
+    metadata: Value,
+}
+
+#[derive(Debug, Default)]
+struct GatewayToolStatsLoad {
+    total_events: u64,
+    invalid_records: u64,
+    stats: BTreeMap<String, GatewayToolStatsItem>,
+    diagnostics: Vec<String>,
+}
+
+pub(super) async fn handle_gateway_tools_inventory(
+    State(state): State<Arc<GatewayOpenResponsesServerState>>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(error) = authorize_dashboard_request(&state, &headers) {
+        return error.into_response();
+    }
+    let tools = collect_tool_inventory_items(&state);
+    (
+        StatusCode::OK,
+        Json(json!({
+            "schema_version": 1,
+            "generated_unix_ms": current_unix_timestamp_ms(),
+            "total_tools": tools.len(),
+            "tools": tools,
+        })),
+    )
+        .into_response()
+}
+
+pub(super) async fn handle_gateway_tools_stats(
+    State(state): State<Arc<GatewayOpenResponsesServerState>>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(error) = authorize_dashboard_request(&state, &headers) {
+        return error.into_response();
+    }
+
+    let inventory = collect_tool_inventory_items(&state);
+    let load = match load_tool_stats(&state.config.state_dir, &inventory) {
+        Ok(load) => load,
+        Err(error) => return error.into_response(),
+    };
+    let stats = load.stats.into_values().collect::<Vec<_>>();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "schema_version": 1,
+            "generated_unix_ms": current_unix_timestamp_ms(),
+            "total_tools": inventory.len(),
+            "total_events": load.total_events,
+            "invalid_records": load.invalid_records,
+            "stats": stats,
+            "diagnostics": load.diagnostics,
+        })),
+    )
+        .into_response()
+}
+
+fn collect_tool_inventory_items(
+    state: &GatewayOpenResponsesServerState,
+) -> Vec<GatewayToolInventoryItem> {
+    let mut agent = Agent::new(
+        state.config.client.clone(),
+        AgentConfig {
+            model: state.config.model.clone(),
+            system_prompt: state.config.system_prompt.clone(),
+            max_turns: state.config.max_turns,
+            temperature: Some(0.0),
+            max_tokens: None,
+            ..AgentConfig::default()
+        },
+    );
+    state.config.tool_registrar.register(&mut agent);
+    agent
+        .registered_tool_names()
+        .into_iter()
+        .map(|name| GatewayToolInventoryItem {
+            name,
+            enabled: true,
+        })
+        .collect()
+}
+
+fn load_tool_stats(
+    state_dir: &Path,
+    inventory: &[GatewayToolInventoryItem],
+) -> Result<GatewayToolStatsLoad, OpenResponsesApiError> {
+    let mut stats_by_tool = BTreeMap::<String, GatewayToolStatsItem>::new();
+    for tool in inventory {
+        stats_by_tool.insert(
+            tool.name.clone(),
+            GatewayToolStatsItem {
+                tool_name: tool.name.clone(),
+                registered: true,
+                event_count: 0,
+                action_counts: BTreeMap::new(),
+                reason_code_counts: BTreeMap::new(),
+                last_event_unix_ms: None,
+            },
+        );
+    }
+
+    let path = gateway_ui_telemetry_path(state_dir);
+    if !path.exists() {
+        return Ok(GatewayToolStatsLoad {
+            total_events: 0,
+            invalid_records: 0,
+            stats: stats_by_tool,
+            diagnostics: vec![format!("tools_telemetry_missing:{}", path.display())],
+        });
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        OpenResponsesApiError::internal(format!(
+            "failed to read tools telemetry '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    let registered_names = inventory
+        .iter()
+        .map(|item| item.name.clone())
+        .collect::<BTreeSet<_>>();
+    let mut load = GatewayToolStatsLoad {
+        stats: stats_by_tool,
+        ..GatewayToolStatsLoad::default()
+    };
+    for (line_number, line) in raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parsed = match serde_json::from_str::<GatewayUiTelemetryRecord>(trimmed) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                load.invalid_records = load.invalid_records.saturating_add(1);
+                load.diagnostics.push(format!(
+                    "tools_telemetry_malformed_line:{}",
+                    line_number.saturating_add(1)
+                ));
+                continue;
+            }
+        };
+        if !parsed.view.eq_ignore_ascii_case("tools") {
+            continue;
+        }
+        let Some(tool_name) = parsed
+            .metadata
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let entry = load
+            .stats
+            .entry(tool_name.clone())
+            .or_insert_with(|| GatewayToolStatsItem {
+                tool_name: tool_name.clone(),
+                registered: registered_names.contains(&tool_name),
+                event_count: 0,
+                action_counts: BTreeMap::new(),
+                reason_code_counts: BTreeMap::new(),
+                last_event_unix_ms: None,
+            });
+        entry.event_count = entry.event_count.saturating_add(1);
+        load.total_events = load.total_events.saturating_add(1);
+        increment_u64_counter(
+            &mut entry.action_counts,
+            normalize_non_empty(parsed.action.as_str(), "unknown"),
+        );
+        increment_u64_counter(
+            &mut entry.reason_code_counts,
+            normalize_non_empty(parsed.reason_code.as_str(), "unknown"),
+        );
+        entry.last_event_unix_ms = Some(
+            entry
+                .last_event_unix_ms
+                .unwrap_or(0)
+                .max(parsed.timestamp_unix_ms),
+        );
+    }
+
+    Ok(load)
+}
+
+fn normalize_non_empty(raw: &str, fallback: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn increment_u64_counter(counters: &mut BTreeMap<String, u64>, key: String) {
+    *counters.entry(key).or_insert(0) += 1;
+}

--- a/specs/2691/plan.md
+++ b/specs/2691/plan.md
@@ -1,0 +1,32 @@
+# Plan: Issue #2691 - PRD gateway tools inventory and stats endpoints
+
+## Approach
+1. Extend `gateway_openresponses` route constants/router wiring with tools inventory/stats endpoints.
+2. Add `tools_runtime` helper module for:
+   - Tool inventory collection from configured `GatewayToolRegistrar`.
+   - Telemetry JSONL aggregation into per-tool stats with malformed-line accounting.
+3. Add handlers with existing auth/error conventions.
+4. Extend `/gateway/status` discovery metadata under `gateway.web_ui`.
+5. Add tests first (RED), implement handlers (GREEN), then run scoped gates.
+
+## Affected Modules
+- `crates/tau-gateway/src/gateway_openresponses.rs`
+- `crates/tau-gateway/src/gateway_openresponses/tests.rs`
+- `crates/tau-gateway/src/gateway_openresponses/tools_runtime.rs` (new)
+
+## Risks / Mitigations
+- Risk: test inventory may be empty under no-op registrar.
+  - Mitigation: use fixture tool registrar in tests to assert non-empty deterministic inventory.
+- Risk: telemetry payload drift.
+  - Mitigation: tolerant parser with defaults + malformed-line counters and diagnostics.
+- Risk: accidental behavior drift on existing endpoints.
+  - Mitigation: scoped plus full crate test gate before PR.
+
+## Interfaces / Contracts
+- `GET /gateway/tools`
+  - `200`: `{ schema_version, generated_unix_ms, total_tools, tools: [{name, enabled}] }`
+- `GET /gateway/tools/stats`
+  - `200`: `{ schema_version, generated_unix_ms, total_tools, total_events, invalid_records, stats: [...], diagnostics: [...] }`
+
+## ADR
+- Not required. No dependency/protocol/architecture decision change.

--- a/specs/2691/spec.md
+++ b/specs/2691/spec.md
@@ -1,0 +1,71 @@
+# Spec: Issue #2691 - PRD gateway tools inventory and stats endpoints
+
+Status: Implemented
+
+## Problem Statement
+`specs/tau-ops-dashboard-prd.md` API contract requires tool observability surfaces:
+- `GET /gateway/tools`
+- `GET /gateway/tools/stats`
+
+`tau-gateway` currently lacks these endpoints, limiting dashboard-side tool inventory and usage diagnostics.
+
+## Acceptance Criteria
+
+### AC-1 Authenticated operators can fetch tool inventory
+Given a valid authenticated request,
+When `GET /gateway/tools` is called,
+Then the gateway returns deterministic inventory derived from the configured tool registrar.
+
+### AC-2 Authenticated operators can fetch tool usage stats
+Given a valid authenticated request,
+When `GET /gateway/tools/stats` is called,
+Then the gateway returns deterministic per-tool aggregate usage stats payload.
+
+### AC-3 Tool stats endpoint fails open with deterministic fallback diagnostics
+Given missing or malformed telemetry artifacts,
+When `GET /gateway/tools/stats` is called,
+Then the endpoint returns `200` with deterministic diagnostics and stable aggregate shape.
+
+### AC-4 Unauthorized tool inventory/stats requests are rejected
+Given missing or invalid auth,
+When `GET /gateway/tools` or `GET /gateway/tools/stats` are called,
+Then the gateway returns fail-closed `401`.
+
+### AC-5 Gateway status discovery advertises tools endpoints
+Given an authenticated status request,
+When `GET /gateway/status` is called,
+Then `gateway.web_ui` includes `tools_endpoint` and `tool_stats_endpoint`.
+
+### AC-6 Scoped verification gates pass
+Given this implementation slice,
+When scoped checks run,
+Then `cargo fmt --check`, `cargo clippy -p tau-gateway -- -D warnings`, and targeted gateway tests pass.
+
+## Scope
+
+### In Scope
+- Add gateway routes:
+  - `GET /gateway/tools`
+  - `GET /gateway/tools/stats`
+- Aggregate tool usage stats from existing UI telemetry artifacts.
+- Add status discovery fields for tools inventory/stats endpoints.
+- Add conformance/regression tests for success, fallback, and auth behavior.
+
+### Out of Scope
+- Dashboard UI implementation.
+- Tool execution runtime redesign.
+- New telemetry ingestion producers.
+
+## Conformance Cases
+- C-01 (integration): `GET /gateway/tools` returns deterministic authenticated inventory.
+- C-02 (integration): `GET /gateway/tools/stats` returns deterministic authenticated aggregate stats.
+- C-03 (regression): missing telemetry artifact yields deterministic fallback diagnostics.
+- C-04 (regression): malformed telemetry lines are tolerated and counted deterministically.
+- C-05 (regression): unauthorized inventory/stats requests return `401`.
+- C-06 (regression): `/gateway/status` includes `tools_endpoint` and `tool_stats_endpoint`.
+- C-07 (verify): scoped fmt/clippy/targeted tests pass.
+
+## Success Metrics / Observable Signals
+- Dashboard can discover and query tool inventory/stats endpoints through `/gateway/status`.
+- Tool stats endpoint remains stable under missing/malformed telemetry artifacts.
+- Endpoint auth and response contracts are deterministic and test-covered.

--- a/specs/2691/tasks.md
+++ b/specs/2691/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Issue #2691 - PRD gateway tools inventory and stats endpoints
+
+## Ordered Tasks
+1. [x] T1 (RED): add failing integration/regression tests for C-01..C-06.
+2. [x] T2 (GREEN): add tools routes and status discovery metadata.
+3. [x] T3 (GREEN): implement tool inventory and telemetry stats aggregation handlers.
+4. [x] T4 (REGRESSION): verify missing/malformed telemetry fallback and unauthorized fail-closed behavior.
+5. [x] T5 (VERIFY): run scoped fmt/clippy/targeted tests and capture C-07 evidence.
+
+## Tier Mapping
+- Unit: endpoint helper behavior coverage.
+- Property: N/A (no randomized invariant algorithm introduced).
+- Contract/DbC: N/A (contracts macros not introduced in touched modules).
+- Snapshot: N/A (explicit field assertions used).
+- Functional: C-01, C-02.
+- Conformance: C-01..C-07.
+- Integration: C-01, C-02, C-06.
+- Fuzz: N/A (no new parser/codec boundary requiring fuzz harness in this bounded slice).
+- Mutation: N/A (bounded additive endpoint slice).
+- Regression: C-03, C-04, C-05, C-06.
+- Performance: N/A (no hotspot/perf budget contract changed).

--- a/specs/milestones/m110/index.md
+++ b/specs/milestones/m110/index.md
@@ -25,6 +25,8 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
 - Completed Task: #2685
 - Completed Story: #2687
 - Completed Task: #2688
+- Completed Story: #2690
+- Completed Task: #2691
 
 ## Deliverables
 - Completed (`#2667`):
@@ -72,9 +74,16 @@ Execute production implementation slices from the Tau Ops Dashboard PRD by addin
     - `PATCH /gateway/training/config`
   - Rollout pagination/fallback contracts and training config override persistence semantics.
   - Status discovery metadata for training rollouts/config endpoints.
+- Completed (`#2691`):
+  - Gateway tools inventory endpoint:
+    - `GET /gateway/tools`
+  - Gateway tools stats endpoint:
+    - `GET /gateway/tools/stats`
+  - Tool inventory discovery and telemetry-based per-tool stats aggregation contracts.
+  - Status discovery metadata for tools inventory/stats endpoints.
 
 ## Exit Criteria
 - Epic #2665 is closed with all scoped PRD phase-1 tasks completed.
-- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, `specs/2682/spec.md`, `specs/2685/spec.md`, and `specs/2688/spec.md` status are `Implemented`.
+- `specs/2667/spec.md`, `specs/2670/spec.md`, `specs/2673/spec.md`, `specs/2676/spec.md`, `specs/2679/spec.md`, `specs/2682/spec.md`, `specs/2685/spec.md`, `specs/2688/spec.md`, and `specs/2691/spec.md` status are `Implemented`.
 - Scoped verification gates pass with evidence (`fmt`, `clippy -p tau-gateway`, targeted tests).
 - PRD checklist progress is updated for completed phase-1 endpoint slices.


### PR DESCRIPTION
## Summary
Adds PRD-aligned tools observability API surfaces in `tau-gateway`: `GET /gateway/tools` and `GET /gateway/tools/stats`. Implements deterministic inventory collection from the configured tool registrar and telemetry-based per-tool usage aggregation with malformed-line tolerance. Extends `/gateway/status` discovery metadata for tools inventory/stats endpoint wiring.

## Links
- Milestone: `specs/milestones/m110/index.md`
- Parent Story: #2690
- Closes #2691
- Spec: `specs/2691/spec.md`
- Plan: `specs/2691/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: authenticated tool inventory endpoint | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads` |
| AC-2: authenticated tool stats endpoint | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads` |
| AC-3: deterministic fallback diagnostics for missing/malformed telemetry | ✅ | `regression_spec_2691_c03_c04_tools_stats_endpoint_returns_fallback_for_missing_or_malformed_artifacts` |
| AC-4: unauthorized requests rejected (`401`) | ✅ | `regression_spec_2691_c05_tools_endpoints_reject_unauthorized_requests` |
| AC-5: `/gateway/status` discovery fields include tools endpoints | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads` |
| AC-6: scoped verification gates pass | ✅ | `cargo fmt --check`; `cargo clippy -p tau-gateway -- -D warnings`; `cargo test -p tau-gateway`; `cargo test -p tau-gateway spec_2691` |

## TDD Evidence
- RED cmd: `cargo test -p tau-gateway spec_2691`
- RED output excerpt (pre-impl):
  - `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads ... FAILED` (`404` vs expected `200`)
  - `regression_spec_2691_c03_c04_tools_stats_endpoint_returns_fallback_for_missing_or_malformed_artifacts ... FAILED` (`404` vs expected `200`)
  - `regression_spec_2691_c05_tools_endpoints_reject_unauthorized_requests ... FAILED` (`404` vs expected `401`)
- GREEN cmd: `cargo test -p tau-gateway spec_2691`
- GREEN output excerpt:
  - `running 3 tests`
  - all `spec_2691` tests `... ok`
  - `test result: ok. 3 passed; 0 failed`
- REGRESSION summary:
  - `cargo fmt --check` ✅
  - `cargo clippy -p tau-gateway -- -D warnings` ✅
  - `cargo test -p tau-gateway` ✅ (`117 passed`)

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | Existing gateway unit suite + endpoint helper behavior coverage | |
| Property | N/A | | No randomized invariant algorithm introduced |
| Contract/DbC | N/A | | No contracts macro boundary introduced |
| Snapshot | N/A | | Explicit response field assertions used |
| Functional | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads` | |
| Conformance | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads`; `regression_spec_2691_c03_c04_tools_stats_endpoint_returns_fallback_for_missing_or_malformed_artifacts`; `regression_spec_2691_c05_tools_endpoints_reject_unauthorized_requests` | |
| Integration | ✅ | `integration_spec_2691_c01_c02_c06_tools_inventory_and_stats_endpoints_return_deterministic_payloads` | |
| Fuzz | N/A | | No new parser/codec boundary requiring fuzz harness in this bounded slice |
| Mutation | N/A | | Bounded additive endpoint slice; no critical-path algorithmic branch change |
| Regression | ✅ | `regression_spec_2691_c03_c04_tools_stats_endpoint_returns_fallback_for_missing_or_malformed_artifacts`; `regression_spec_2691_c05_tools_endpoints_reject_unauthorized_requests` | |
| Performance | N/A | | No hotspot/perf budget contract modified |

## Mutation
- N/A for this bounded endpoint-additive slice (no critical-path algorithmic mutation target changed).

## Risks / Rollback
- Risk: Low. Additive authenticated endpoints and status metadata.
- Rollback: Revert this PR to remove `/gateway/tools`, `/gateway/tools/stats`, and corresponding status discovery fields.

## Docs / ADR
- Updated:
  - `specs/2691/spec.md`
  - `specs/2691/plan.md`
  - `specs/2691/tasks.md`
  - `specs/milestones/m110/index.md`
- ADR: Not required (no dependency/protocol/architecture decision change).
