### PR TITLE
feat(gateway): add embedded /dashboard shell endpoint

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses.rs
+++ b/crates/tau-gateway/src/gateway_openresponses.rs
@@ -60,6 +60,7 @@ mod audit_runtime;
 mod auth_runtime;
 mod cortex_bulletin_runtime;
 mod cortex_runtime;
+mod dashboard_shell_page;
 mod dashboard_status;
 mod deploy_runtime;
 mod jobs_runtime;
@@ -89,6 +90,7 @@ use cortex_runtime::{
     record_cortex_memory_entry_write_event, record_cortex_memory_write_event,
     record_cortex_session_append_event, record_cortex_session_reset_event,
 };
+use dashboard_shell_page::render_gateway_dashboard_shell_page;
 use dashboard_status::{
     apply_gateway_dashboard_action, collect_gateway_dashboard_snapshot,
     GatewayDashboardActionRequest,
@@ -134,6 +136,7 @@ const OPENRESPONSES_ENDPOINT: &str = "/v1/responses";
 const OPENAI_CHAT_COMPLETIONS_ENDPOINT: &str = "/v1/chat/completions";
 const OPENAI_COMPLETIONS_ENDPOINT: &str = "/v1/completions";
 const OPENAI_MODELS_ENDPOINT: &str = "/v1/models";
+const DASHBOARD_SHELL_ENDPOINT: &str = "/dashboard";
 const WEBCHAT_ENDPOINT: &str = "/webchat";
 const GATEWAY_STATUS_ENDPOINT: &str = "/gateway/status";
 const GATEWAY_WS_ENDPOINT: &str = "/gateway/ws";
@@ -917,6 +920,7 @@ fn build_gateway_openresponses_router(state: Arc<GatewayOpenResponsesServerState
             EXTERNAL_CODING_AGENT_REAP_ENDPOINT,
             post(handle_external_coding_agent_reap),
         )
+        .route(DASHBOARD_SHELL_ENDPOINT, get(handle_dashboard_shell_page))
         .route(WEBCHAT_ENDPOINT, get(handle_webchat_page))
         .route(GATEWAY_STATUS_ENDPOINT, get(handle_gateway_status))
         .route(DASHBOARD_HEALTH_ENDPOINT, get(handle_dashboard_health))
@@ -934,6 +938,10 @@ fn build_gateway_openresponses_router(state: Arc<GatewayOpenResponsesServerState
 
 async fn handle_webchat_page() -> Html<String> {
     Html(render_gateway_webchat_page())
+}
+
+async fn handle_dashboard_shell_page() -> Html<String> {
+    Html(render_gateway_dashboard_shell_page())
 }
 
 async fn handle_gateway_status(
@@ -1014,6 +1022,7 @@ async fn handle_gateway_status(
                     },
                     "telemetry_runtime": state.collect_ui_telemetry_status_report(),
                 },
+                "dashboard_shell_endpoint": DASHBOARD_SHELL_ENDPOINT,
                 "webchat_endpoint": WEBCHAT_ENDPOINT,
                 "auth_session_endpoint": GATEWAY_AUTH_SESSION_ENDPOINT,
                 "status_endpoint": GATEWAY_STATUS_ENDPOINT,

--- a/crates/tau-gateway/src/gateway_openresponses/dashboard_shell.html
+++ b/crates/tau-gateway/src/gateway_openresponses/dashboard_shell.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tau Ops Dashboard</title>
+    <style>
+      :root {
+        --bg: #0f172a;
+        --panel: #111827;
+        --muted: #94a3b8;
+        --ink: #e2e8f0;
+        --accent: #38bdf8;
+        --line: #1f2937;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #1e293b, var(--bg));
+        color: var(--ink);
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      }
+      .layout {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 1rem;
+      }
+      .panel {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: color-mix(in srgb, var(--panel) 92%, black);
+        padding: 1rem;
+      }
+      h1 {
+        margin: 0;
+        font-size: 1.25rem;
+      }
+      .muted {
+        color: var(--muted);
+      }
+      .tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 1rem 0;
+      }
+      .tab {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #0b1220;
+        color: var(--ink);
+        padding: 0.45rem 0.65rem;
+        cursor: pointer;
+      }
+      .tab.active {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .view {
+        display: none;
+      }
+      .view.active {
+        display: block;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main id="dashboard-shell-root" class="layout">
+      <section class="panel">
+        <h1>Tau Ops Dashboard</h1>
+        <p class="muted">
+          Embedded gateway shell for dashboard SPA hosting evolution.
+          <a href="/webchat">Open webchat</a>.
+        </p>
+        <div class="tabs" role="tablist" aria-label="Dashboard shell views">
+          <button class="tab active" data-view="overview" role="tab" aria-selected="true">Overview</button>
+          <button class="tab" data-view="sessions" role="tab" aria-selected="false">Sessions</button>
+          <button class="tab" data-view="memory" role="tab" aria-selected="false">Memory</button>
+          <button class="tab" data-view="configuration" role="tab" aria-selected="false">Configuration</button>
+        </div>
+        <section id="dashboard-shell-view-overview" class="view active" role="tabpanel" aria-hidden="false">
+          <h2>Overview</h2>
+          <p class="muted">Overview widgets and rollout posture surface is reserved here.</p>
+        </section>
+        <section id="dashboard-shell-view-sessions" class="view" role="tabpanel" aria-hidden="true">
+          <h2>Sessions</h2>
+          <p class="muted">Session inspector shell placeholder.</p>
+        </section>
+        <section id="dashboard-shell-view-memory" class="view" role="tabpanel" aria-hidden="true">
+          <h2>Memory</h2>
+          <p class="muted">Memory browser shell placeholder.</p>
+        </section>
+        <section id="dashboard-shell-view-configuration" class="view" role="tabpanel" aria-hidden="true">
+          <h2>Configuration</h2>
+          <p class="muted">Configuration editor shell placeholder.</p>
+        </section>
+      </section>
+    </main>
+    <script>
+      const tabs = Array.from(document.querySelectorAll(".tab"));
+      const views = Array.from(document.querySelectorAll(".view"));
+
+      function activateView(viewName) {
+        tabs.forEach((tab) => {
+          const active = tab.dataset.view === viewName;
+          tab.classList.toggle("active", active);
+          tab.setAttribute("aria-selected", active ? "true" : "false");
+        });
+        views.forEach((view) => {
+          const active = view.id === "dashboard-shell-view-" + viewName;
+          view.classList.toggle("active", active);
+          view.setAttribute("aria-hidden", active ? "false" : "true");
+        });
+      }
+
+      tabs.forEach((tab) => {
+        tab.addEventListener("click", () => {
+          activateView(tab.dataset.view || "overview");
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/crates/tau-gateway/src/gateway_openresponses/dashboard_shell_page.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/dashboard_shell_page.rs
@@ -1,0 +1,5 @@
+const DASHBOARD_SHELL_HTML: &str = include_str!("dashboard_shell.html");
+
+pub(super) fn render_gateway_dashboard_shell_page() -> String {
+    DASHBOARD_SHELL_HTML.to_string()
+}

--- a/specs/2738/plan.md
+++ b/specs/2738/plan.md
@@ -1,0 +1,28 @@
+# Plan: Issue #2738 - G18 embedded dashboard shell route
+
+## Approach
+1. Add RED tests for new shell markers and `/dashboard` endpoint contract.
+2. Add embedded shell renderer module and deterministic HTML shell content.
+3. Wire new `/dashboard` route in gateway router and status report payload.
+4. Run regression suite for existing webchat/dashboard behavior.
+5. Run scoped verification + live localhost route smoke and update checklist evidence.
+
+## Affected Modules
+- `crates/tau-gateway/src/gateway_openresponses.rs`
+- `crates/tau-gateway/src/gateway_openresponses/tests.rs`
+- `crates/tau-gateway/src/gateway_openresponses/dashboard_shell_page.rs` (new)
+- `tasks/spacebot-comparison.md`
+
+## Risks / Mitigations
+- Risk: new route or status field may drift existing status contract assertions.
+  - Mitigation: update/add deterministic integration assertions.
+- Risk: shell route introduces accidental auth coupling.
+  - Mitigation: mirror `/webchat` public-shell behavior and verify with functional endpoint test.
+
+## Interfaces / Contracts
+- New endpoint: `GET /dashboard` (HTML shell).
+- Existing endpoint extension: `GET /gateway/status` adds `gateway.dashboard_shell_endpoint`.
+- No breaking changes to existing endpoints.
+
+## ADR
+- Not required: no dependency/protocol change.

--- a/specs/2738/spec.md
+++ b/specs/2738/spec.md
@@ -1,0 +1,59 @@
+# Spec: Issue #2738 - G18 embedded dashboard shell route
+
+Status: Accepted
+
+## Problem Statement
+Gateway exposes operational dashboard APIs and a webchat shell, but there is no dedicated embedded dashboard shell endpoint for SPA hosting evolution. This blocks completion of G18's `Serve embedded SPA from gateway` parity pathway.
+
+## Acceptance Criteria
+
+### AC-1 Gateway exposes embedded dashboard shell endpoint
+Given gateway runtime is active,
+When a client requests `/dashboard`,
+Then gateway returns deterministic HTML shell content.
+
+### AC-2 Embedded shell includes baseline navigation placeholders
+Given `/dashboard` shell renders,
+When operator inspects sections,
+Then shell includes Overview, Sessions, Memory, and Configuration placeholder views with deterministic markers.
+
+### AC-3 Gateway status advertises shell endpoint
+Given authenticated status request,
+When `/gateway/status` is requested,
+Then payload includes `gateway.dashboard_shell_endpoint` with `/dashboard`.
+
+### AC-4 Existing webchat/dashboard behavior remains compatible
+Given prior `/webchat` and dashboard API flows,
+When shell route is introduced,
+Then existing functional/integration regressions remain green.
+
+### AC-5 Scoped verification and live validation pass
+Given this slice,
+When validation runs,
+Then `cargo fmt --check`, `cargo clippy -p tau-gateway -- -D warnings`, and `cargo test -p tau-gateway` pass, and live localhost route smoke confirms `/dashboard` shell availability.
+
+## Scope
+
+### In Scope
+- New embedded dashboard shell renderer for gateway.
+- New `/dashboard` route wiring in gateway router.
+- Status payload endpoint advertisement for shell route.
+- Unit/functional/integration regression coverage updates.
+- G18 checklist evidence update in `tasks/spacebot-comparison.md`.
+
+### Out of Scope
+- Full React/Leptos dashboard implementation.
+- New backend API schema changes.
+- New dependency additions.
+
+## Conformance Cases
+- C-01 (unit): dashboard shell renderer contains deterministic route and section markers.
+- C-02 (functional): `/dashboard` endpoint returns HTML shell response.
+- C-03 (integration): `/gateway/status` advertises `dashboard_shell_endpoint`.
+- C-04 (regression): existing `/webchat` and dashboard endpoint tests stay green.
+- C-05 (verify/live): scoped gates and localhost route smoke pass.
+
+## Success Metrics / Observable Signals
+- Operators can load gateway-hosted dashboard shell at `/dashboard`.
+- G18 `Serve embedded SPA from gateway` pathway item is closed with linked evidence.
+- No regressions in current webchat/dashboard contract tests.

--- a/specs/2738/tasks.md
+++ b/specs/2738/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Issue #2738 - G18 embedded dashboard shell route
+
+## Ordered Tasks
+1. [x] T1 (RED): add failing tests for dashboard shell renderer + `/dashboard` endpoint + status advertisement.
+2. [x] T2 (GREEN): add embedded dashboard shell renderer and deterministic markers.
+3. [x] T3 (GREEN): wire `/dashboard` route and status payload endpoint field.
+4. [x] T4 (REGRESSION): verify existing webchat/dashboard endpoint regressions remain green.
+5. [x] T5 (VERIFY): run scoped fmt/clippy/tau-gateway tests and live localhost smoke for `/dashboard`.
+6. [x] T6 (DOC): update G18 checklist evidence in `tasks/spacebot-comparison.md`.
+
+## Tier Mapping
+- Unit: C-01
+- Property: N/A (no randomized invariants introduced)
+- Contract/DbC: N/A (no contracts macro changes)
+- Snapshot: N/A (marker assertions are explicit)
+- Functional: C-02
+- Conformance: C-01..C-05
+- Integration: C-03, C-04
+- Fuzz: N/A (no new untrusted parser boundary)
+- Mutation: N/A (UI shell wiring, non-critical mutation lane)
+- Regression: C-04
+- Performance: N/A (no benchmark/hotspot change)

--- a/specs/milestones/m118/index.md
+++ b/specs/milestones/m118/index.md
@@ -1,0 +1,20 @@
+# M118 - Spacebot G18 Embedded SPA Shell from Gateway
+
+## Context
+`tasks/spacebot-comparison.md` still leaves the `Serve embedded SPA from gateway` G18 pathway item unresolved. Tau currently serves `/webchat` as an inline HTML shell, but there is no dedicated embedded dashboard shell route for future SPA expansion.
+
+## Linked Work
+- Epic: #2736
+- Story: #2737
+- Task: #2738
+- Source parity checklist: `tasks/spacebot-comparison.md` (G18 Serve embedded SPA from gateway)
+
+## Scope
+- Add a gateway-served embedded dashboard shell route.
+- Provide baseline shell navigation placeholders for overview/sessions/memory/configuration.
+- Preserve existing `/webchat` and dashboard API behavior.
+
+## Exit Criteria
+- `/dashboard` returns deterministic embedded shell HTML.
+- Shell includes baseline sections for overview/sessions/memory/configuration.
+- Existing gateway webchat/dashboard tests remain green.

--- a/tasks/spacebot-comparison.md
+++ b/tasks/spacebot-comparison.md
@@ -440,8 +440,8 @@ Spacebot is a Rust-based AI agent for teams, communities, and multi-user environ
 - [x] Stretch page: Memory graph visualization
 - [x] Stretch page: Cortex admin chat
 - [x] Stretch page: Cron management
-- [ ] Serve embedded SPA from gateway (rust-embed or include_bytes)
-- Progress evidence: #2614 (gateway dashboard operator tab baseline), #2667 (PRD memory explorer API foundation: entry CRUD + filtered search), #2727 (memory graph force-layout + `/api/memories/graph` parity), #2730 (cortex admin webchat panel), #2734 (webchat routines/cron management panel + live gateway status/jobs/cancel validation)
+- [x] Serve embedded SPA from gateway (rust-embed or include_bytes)
+- Progress evidence: #2614 (gateway dashboard operator tab baseline), #2667 (PRD memory explorer API foundation: entry CRUD + filtered search), #2727 (memory graph force-layout + `/api/memories/graph` parity), #2730 (cortex admin webchat panel), #2734 (webchat routines/cron management panel + live gateway status/jobs/cancel validation), #2738 (embedded `/dashboard` SPA shell served by gateway + status discovery wiring)
 - **Files**: `tau-dashboard/` or new `interface/` directory
 - **Effort**: Large
 


### PR DESCRIPTION
## Summary
Adds a gateway-served embedded dashboard shell at `/dashboard` using embedded static HTML assets (`include_str!`), with baseline Overview/Sessions/Memory/Configuration placeholders and tab navigation. The change also advertises the shell route in `/gateway/status` via `gateway.dashboard_shell_endpoint` and preserves existing `/webchat` + dashboard API behavior.

## Links
- Milestone: M118 - Spacebot G18 Embedded SPA Shell from Gateway
- Closes #2738
- Spec: `specs/2738/spec.md`
- Plan: `specs/2738/plan.md`
- Tasks: `specs/2738/tasks.md`
- Milestone index: `specs/milestones/m118/index.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Gateway exposes embedded dashboard shell endpoint | ✅ | `cargo test -p tau-gateway functional_dashboard_shell_endpoint_returns_html_shell -- --nocapture` |
| AC-2: Shell includes overview/sessions/memory/configuration placeholders | ✅ | `cargo test -p tau-gateway unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers -- --nocapture`; `cargo test -p tau-gateway functional_dashboard_shell_endpoint_returns_html_shell -- --nocapture` |
| AC-3: Status advertises `gateway.dashboard_shell_endpoint` | ✅ | `cargo test -p tau-gateway integration_gateway_status_endpoint_returns_service_snapshot -- --nocapture` |
| AC-4: Existing webchat/dashboard behavior remains compatible | ✅ | `cargo test -p tau-gateway functional_webchat_endpoint_returns_html_shell -- --nocapture`; `cargo test -p tau-gateway integration_dashboard_endpoints_return_state_health_widgets_timeline_and_alerts -- --nocapture`; `cargo test -p tau-gateway` |
| AC-5: Scoped verify + live validation pass | ✅ | `cargo fmt --check`; `cargo clippy -p tau-gateway -- -D warnings`; `cargo test -p tau-gateway`; localhost live `/dashboard` smoke command below |

## TDD Evidence
- RED command:
  - `cargo test -p tau-gateway unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers -- --nocapture`
- RED output excerpt:
  - `cannot find function render_gateway_dashboard_shell_page in this scope`
  - `cannot find value DASHBOARD_SHELL_ENDPOINT in this scope`
- GREEN command:
  - `cargo test -p tau-gateway unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers -- --nocapture`
- GREEN output excerpt:
  - `test ... unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers ... ok`
- REGRESSION summary:
  - `cargo test -p tau-gateway` -> `144 passed; 0 failed`

## Live Validation Evidence
- Command (localhost-dev gateway runtime):
  - `cargo run -p tau-coding-agent -- --gateway-openresponses-server --gateway-openresponses-auth-mode localhost-dev --gateway-openresponses-bind 127.0.0.1:8792 ...`
  - Verified with `curl` against `/dashboard` and `/gateway/status`.
- Result:
  - `live-validation: /dashboard shell markers and status discovery endpoint verified on localhost-dev gateway`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers`; `unit_render_gateway_webchat_page_includes_expected_endpoints` | |
| Property | N/A | | No new randomized invariant/parsing boundary introduced |
| Contract/DbC | N/A | | No contracts macro changes on public API |
| Snapshot | N/A | | Deterministic explicit marker assertions used |
| Functional | ✅ | `functional_dashboard_shell_endpoint_returns_html_shell`; `functional_webchat_endpoint_returns_html_shell`; live localhost `/dashboard` smoke | |
| Conformance | ✅ | `unit_spec_2738_c01_dashboard_shell_page_contains_navigation_markers`; `functional_dashboard_shell_endpoint_returns_html_shell`; `integration_gateway_status_endpoint_returns_service_snapshot`; full `cargo test -p tau-gateway` | |
| Integration | ✅ | `integration_gateway_status_endpoint_returns_service_snapshot`; dashboard integration tests in `cargo test -p tau-gateway` | |
| Fuzz | N/A | | No new untrusted parser boundary |
| Mutation | N/A | | UI shell wiring slice outside critical mutation lane |
| Regression | ✅ | Full `cargo test -p tau-gateway` including existing webchat/dashboard regressions | |
| Performance | N/A | | No hotspot/benchmark contract changed |

## Mutation
- N/A for issue scope (UI shell route + status wiring).

## Risks/Rollback
- Risk: low. Changes are isolated to gateway route wiring, static shell asset rendering, and status payload extension.
- Rollback: revert this PR commit to remove `/dashboard` shell endpoint and status field.

## Docs/ADR
- Updated: `tasks/spacebot-comparison.md` (G18 `Serve embedded SPA from gateway` marked complete with evidence)
- Added: `specs/milestones/m118/index.md`, `specs/2738/spec.md`, `specs/2738/plan.md`, `specs/2738/tasks.md`
- ADR: not required (no dependency/protocol/architecture decision change)
