### PR TITLE
docs(spec): mark issue-2872 spec as implemented

### DIFF
--- a/specs/2872/spec.md
+++ b/specs/2872/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2872 - chat new-session creation contracts
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Tau Ops chat currently supports selecting existing sessions and sending messages, but does not expose a deterministic contract for explicit “new session” creation flow. This leaves the PRD checklist item “New session creation works” unverifiable.


### PR DESCRIPTION
## Summary
Marks `specs/2872/spec.md` lifecycle state as `Implemented` after merge of #2876.

## Links
- Follow-up to #2876
- Issue: #2872
- Spec: `specs/2872/spec.md`

## Change
- `Status: Reviewed` -> `Status: Implemented`

## Validation
- Docs metadata-only change; no runtime behavior changes.
