### PR TITLE
docs(spec): mark #2953 spec status as Implemented

### DIFF
--- a/specs/2953/spec.md
+++ b/specs/2953/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2953 - Wire `/cortex/chat` to LLM with observer context and fallback
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 `/cortex/chat` currently returns deterministic mock output (`render_cortex_output_text`) and does not invoke the configured provider client. This leaves G3 partially closed and blocks real cross-session analytical responses in Cortex admin chat.


### PR DESCRIPTION
Summary:
This follow-up updates `specs/2953/spec.md` status from `Reviewed` to `Implemented` after PR #2954 merged and issue #2953 closed.

Links:
- Parent implementation PR: #2954
- Issue: #2953
- Spec: `specs/2953/spec.md`

Risk/Rollback:
- None (documentation/status-only).