### PR TITLE
docs(spec): mark #2958 spec status as Implemented

### DIFF
--- a/specs/2958/spec.md
+++ b/specs/2958/spec.md
@@ -1,6 +1,6 @@
 # Spec: Issue #2958 - Create operator deployment guide and validate commands end-to-end
 
-Status: Reviewed
+Status: Implemented
 
 ## Problem Statement
 Tau has multiple operations runbooks, but there is no single operator deployment guide that covers


### PR DESCRIPTION
Summary:
Follow-up docs-only update to set `specs/2958/spec.md` status to `Implemented` after PR #2959 merged and issue #2958 closed.

Links:
- Parent implementation PR: #2959
- Issue: #2958
- Spec: `specs/2958/spec.md`

Risk/Rollback:
- None (status metadata only).