### PR TITLE
docs: mark m252 milestone index completed

### DIFF
--- a/specs/3306/plan.md
+++ b/specs/3306/plan.md
@@ -1,0 +1,22 @@
+# Plan: Issue #3306
+
+## Approach
+1. Add #3306 lifecycle artifacts under `specs/3306/`.
+2. Update `specs/milestones/m252/index.md` status and add closeout note.
+3. Verify conformance with deterministic file/content checks.
+
+## Affected Modules
+- `specs/milestones/m252/index.md`
+- `specs/3306/spec.md`
+- `specs/3306/plan.md`
+- `specs/3306/tasks.md`
+
+## Risks and Mitigations
+- Risk: closeout reference mismatch.
+  Mitigation: reference merged PR/issue IDs only (#3305, #3304).
+
+## Interfaces / Contracts
+- Docs/process metadata only; no executable code path changes.
+
+## ADR
+Not required.

--- a/specs/3306/spec.md
+++ b/specs/3306/spec.md
@@ -1,0 +1,37 @@
+# Spec: Issue #3306 - Mark m252 milestone index completed
+
+Status: Implemented
+
+## Problem Statement
+After merging #3305, milestone `M252` achieved its documented objective, but `specs/milestones/m252/index.md` still reports `Status: In Progress`, leaving lifecycle metadata inconsistent.
+
+## Scope
+In scope:
+- Update `specs/milestones/m252/index.md` to completed status.
+- Add a closeout note referencing merged completion work (#3305, #3304).
+- Create per-issue lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`) for #3306.
+
+Out of scope:
+- Any runtime, API, or behavior changes.
+
+## Acceptance Criteria
+### AC-1 M252 index is completed
+Given milestone objective work is merged,
+when `specs/milestones/m252/index.md` is read,
+then status is completed and closeout note references #3305 and #3304.
+
+### AC-2 Issue lifecycle artifacts are complete
+Given issue #3306,
+when repository specs are inspected,
+then `specs/3306/spec.md`, `specs/3306/plan.md`, and `specs/3306/tasks.md` exist and are implemented.
+
+## Conformance Cases
+| Case | AC | Tier | Given | When | Then |
+|---|---|---|---|---|---|
+| C-01 | AC-1 | Conformance/Docs | m252 milestone index file | validate status + closeout references | status is completed and closeout references #3305/#3304 |
+| C-02 | AC-2 | Conformance/Process | lifecycle artifact paths | validate files/status | spec/plan/tasks exist and are completed |
+
+## Success Metrics / Observable Signals
+- `rg -n "^Status: Completed" specs/milestones/m252/index.md`
+- `rg -n "Closeout|#3305|#3304" specs/milestones/m252/index.md`
+- `test -f specs/3306/spec.md && test -f specs/3306/plan.md && test -f specs/3306/tasks.md`

--- a/specs/3306/tasks.md
+++ b/specs/3306/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: Issue #3306 - m252 closeout status sync
+
+- [x] T1 (RED): verify drift (`specs/milestones/m252/index.md` still in-progress after #3305 merge).
+- [x] T2 (GREEN): update `specs/milestones/m252/index.md` to completed status with closeout note.
+- [x] T3 (VERIFY): run deterministic conformance checks for status/closeout references and artifact presence.

--- a/specs/milestones/m252/index.md
+++ b/specs/milestones/m252/index.md
@@ -1,6 +1,6 @@
 # M252 - Review #37 / M251 closeout consistency
 
-Status: In Progress
+Status: Completed
 
 ## Context
 Milestone `M251` was closed after completing APO live runtime integration and Review #37 Phase-4 follow-up work, but repository milestone-index status remained stale.
@@ -12,6 +12,10 @@ Milestone `M251` was closed after completing APO live runtime integration and Re
 
 ## Linked Issues
 - Task: #3304
+
+## Closeout
+- Milestone objective completed and merged via `#3305`.
+- Completion task `#3304` is closed with `status:done`.
 
 ## Success Signals
 - `specs/milestones/m251/index.md` reports completed status and closeout note.


### PR DESCRIPTION
## Summary
This PR finalizes `M252` milestone metadata by marking `specs/milestones/m252/index.md` as completed and adding a closeout note.
It also adds lifecycle artifacts for issue `#3306`.

## Links
- Milestone: M252
- Closes #3306
- Spec: `specs/3306/spec.md`
- Plan: `specs/3306/plan.md`

## Spec Verification (AC -> checks)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: M252 index completed with closeout refs | ✅ | `rg -n "^Status: Completed" specs/milestones/m252/index.md`; `rg -n "Closeout|#3305|#3304" specs/milestones/m252/index.md` |
| AC-2: #3306 lifecycle artifacts complete | ✅ | `test -f specs/3306/spec.md && test -f specs/3306/plan.md && test -f specs/3306/tasks.md` |

## TDD Evidence
### RED
- File showed drift before change: `specs/milestones/m252/index.md` had `Status: In Progress`.

### GREEN
- `rg -n "^Status: Completed" specs/milestones/m252/index.md`
- `rg -n "Closeout|#3305|#3304" specs/milestones/m252/index.md`
- `test -f specs/3306/spec.md && test -f specs/3306/plan.md && test -f specs/3306/tasks.md`

### REGRESSION summary
- N/A (docs-only metadata sync).

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | | Docs-only change |
| Property | N/A | | Docs-only change |
| Contract/DbC | N/A | | No executable API contract changes |
| Snapshot | N/A | | No snapshot surface |
| Functional | N/A | | No runtime behavior change |
| Conformance | ✅ | content/file checks listed above | |
| Integration | N/A | | No cross-module runtime behavior change |
| Fuzz | N/A | | No parser/untrusted-input change |
| Mutation | N/A | | No executable logic changed |
| Regression | ✅ | status drift check (`In Progress` -> `Completed`) | |
| Performance | N/A | | No performance-sensitive change |

## Mutation
- N/A (docs-only update).

## Risks / Rollback
- Risks: none (documentation metadata only).
- Rollback: revert this PR.

## Docs / ADR
- Updated: `specs/milestones/m252/index.md`, `specs/3306/spec.md`, `specs/3306/plan.md`, `specs/3306/tasks.md`.
- ADR: not required.
