### PR TITLE
docs(governance): finalize M291 milestone closure metadata (#3406)

### DIFF
--- a/specs/3406/plan.md
+++ b/specs/3406/plan.md
@@ -1,0 +1,20 @@
+# Plan: Issue #3406 - M291 milestone state closure
+
+## Approach
+1. Verify milestone 291 currently has `open_issues=0`.
+2. Close milestone 291 using GitHub API.
+3. Update `specs/milestones/m291/index.md` closeout with explicit closure metadata.
+4. Verify milestone API state and docs consistency.
+
+## Affected Modules
+- `specs/milestones/m291/index.md`
+
+## Risks / Mitigations
+- Risk: accidental closure of wrong milestone.
+  - Mitigation: use explicit milestone number (`291`) and verify title in response.
+
+## Interfaces / Contracts
+- Governance metadata only; no runtime/API behavior changes.
+
+## ADR
+- Not required.

--- a/specs/3406/spec.md
+++ b/specs/3406/spec.md
@@ -1,0 +1,36 @@
+# Spec: Issue #3406 - Close GitHub milestone M291 after conformance completion
+
+Status: Implemented
+
+## Problem Statement
+All M291 issues are closed and milestone docs report completed conformance, but the GitHub milestone `M291 - Tau E2E PRD Execution` remains in `open` state.
+
+## Scope
+In scope:
+- Set GitHub milestone `291` state to `closed`.
+- Record closure metadata in `specs/milestones/m291/index.md`.
+
+Out of scope:
+- Any runtime/test behavior changes.
+- Any scenario remapping changes.
+
+## Acceptance Criteria
+### AC-1 GitHub milestone is formally closed
+Given no open issues remain in milestone 291,
+when milestone metadata is queried,
+then milestone state is `closed`.
+
+### AC-2 Repository milestone index records closure metadata
+Given milestone close action is completed,
+when milestone index is reviewed,
+then closeout section includes closure record with issue/PR trace.
+
+## Conformance Cases
+| Case | AC | Tier | Given | When | Then |
+|---|---|---|---|---|---|
+| C-01 | AC-1 | Process/Conformance | milestone 291 has open_issues=0 | GitHub milestone state updated | API returns `state=closed` |
+| C-02 | AC-2 | Docs/Conformance | m291 index exists | closure note added | index includes milestone closure metadata |
+
+## Success Metrics / Observable Signals
+- `gh api repos/njfio/Tau/milestones/291` reports `state: closed`.
+- `specs/milestones/m291/index.md` includes a closure note with reference to issue `#3406`.

--- a/specs/3406/tasks.md
+++ b/specs/3406/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: Issue #3406 - Close milestone M291
+
+- [x] T1 (RED): verify milestone 291 is still open despite full issue closure.
+- [x] T2 (GREEN): close milestone 291 and record closure metadata in milestone index.
+- [x] T3 (VERIFY): confirm API state is `closed` and docs align.

--- a/specs/milestones/m291/index.md
+++ b/specs/milestones/m291/index.md
@@ -31,6 +31,8 @@ Status: Completed
 - Task: #3398
 - Task: #3400
 - Task: #3402
+- Task: #3404
+- Task: #3406
 
 ## Closeout
 - Phase 1 delivered via issue `#3386` and PR `#3387`.
@@ -42,6 +44,8 @@ Status: Completed
 - Phase 7 delivered via issue `#3398`, closing tool-builder/WASM scenario coverage (`E14-01`, `E14-02`, `E14-03`).
 - Phase 8 delivered via issue `#3400`, closing provider fallback/circuit-breaker scenario coverage (`F10-01`, `F10-02`, `F10-03`, `F10-04`, `F10-05`, `F10-08`).
 - Phase 9 delivered via issue `#3402`, closing remaining C5/K13/R8 scenario coverage.
+- Phase 10 delivered via issue `#3404`, finalizing milestone index closeout status and coverage summary.
+- Phase 11 delivered via issue `#3406`, formally closing GitHub milestone `M291` on 2026-02-23.
 
 ## Success Signals
 - `specs/3386/spec.md`, `specs/3386/plan.md`, and `specs/3386/tasks.md` exist and are implemented.


### PR DESCRIPTION
## Summary
This final governance closeout closes GitHub milestone `M291` and aligns milestone index lineage with the final delivery sequence. It records phase 10/11 closeout references and preserves the final conformance summary state.

## Links
- Milestone: M291 - Tau E2E PRD Execution
- Closes #3406
- Spec: `specs/3406/spec.md`
- Plan: `specs/3406/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 GitHub milestone is formally closed | ✅ | `gh api repos/njfio/Tau/milestones/291` -> `state=closed` |
| AC-2 Milestone index records closure metadata | ✅ | `specs/milestones/m291/index.md` includes task `#3406` and Phase 11 closure line |

## TDD Evidence
RED evidence:
- Before action: `gh api repos/njfio/Tau/milestones/291` returned `state=open`.

GREEN evidence:
- After action: `gh api repos/njfio/Tau/milestones/291` returns `state=closed` and `closed_at=2026-02-23T06:05:11Z`.
- `rg -n "Task: #3406|Phase 11" specs/milestones/m291/index.md` returns expected closure references.

REGRESSION summary:
- `specs/3386/conformance-matrix.md` summary remains `Covered=112`, `N/A=0`.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | n/a | Governance/docs-only change. |
| Property | N/A | n/a | Governance/docs-only change. |
| Contract/DbC | N/A | n/a | Governance/docs-only change. |
| Snapshot | N/A | n/a | Governance/docs-only change. |
| Functional | ✅ | deterministic API + docs assertions (`gh api`, `rg`) | |
| Conformance | ✅ | `specs/3406/spec.md` + updated milestone index | |
| Integration | N/A | n/a | Governance/docs-only change. |
| Fuzz | N/A | n/a | Governance/docs-only change. |
| Mutation | N/A | n/a | Governance/docs-only change; no runtime code diff. |
| Regression | ✅ | matrix summary check remains `Covered=112`, `N/A=0` | |
| Performance | N/A | n/a | Governance/docs-only change. |

## Mutation
- N/A (docs/governance-only change).

## Risks / Rollback
- Risk: low (metadata only).
- Rollback: revert commit `57ef793b` and reopen milestone if needed.

## Docs / ADR
- Updated:
  - `specs/milestones/m291/index.md`
  - `specs/3406/spec.md`
  - `specs/3406/plan.md`
  - `specs/3406/tasks.md`
- ADR: not required.
