### PR TITLE
docs(readme): refresh onboarding guide and verified feature map (#3416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,91 @@
 # Tau
 
-Tau is a Rust-first agent runtime and operator control plane for running model-driven workflows, persistent sessions, gateway APIs, and multi-channel automations with explicit operational guardrails.
+Tau is a Rust-first agent runtime and operator control plane with a connected core path:
+CLI runtime -> sessions/tools/safety -> gateway APIs -> transport and operator workflows.
+
+Short answer to the integration question: the core runtime path is integrated and runnable today, while some subsystems are still staged or partial.
 
 ## What Tau Is
 
 Tau combines:
 - a primary CLI runtime (`tau-coding-agent`) for interactive and one-shot execution,
-- gateway and dashboard surfaces for operators,
-- tool, memory, and safety policy controls,
-- deterministic demos and validation scripts for local and CI workflows.
+- persistent session and tool-policy/safety controls,
+- gateway and operator surfaces for API and operations workflows,
+- deterministic demos and validation scripts for local and CI loops.
 
-The workspace is intentionally multi-crate and contract-driven. See full membership in [`Cargo.toml`](Cargo.toml).
+The workspace is intentionally multi-crate and contract-driven. Full crate membership is in [`Cargo.toml`](Cargo.toml).
 
 ## Who Tau Is For
 
-- Operators who need repeatable runtime controls, rollout/rollback runbooks, and diagnostics.
+- Operators who need repeatable runtime controls, diagnostics, and rollback-friendly workflows.
 - Integrators who need OpenAI-compatible gateway routes and transport bridges.
 - Contributors working in a spec-driven, TDD-oriented Rust workspace.
+
+## Integrated End-to-End Paths
+
+These are the paths that operate as connected flows today.
+
+| Path | Start Point | Integrated Components | Primary Evidence |
+|---|---|---|---|
+| Local operator loop | `cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive` then prompt mode | CLI runtime, agent core loop, sessions, tools, safety policies | [`docs/guides/quickstart.md`](docs/guides/quickstart.md), [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md) |
+| Gateway auth/session loop | `./scripts/demo/gateway-auth-session.sh` | Gateway auth/session handling, API route contracts, runtime policies | [`docs/guides/gateway-auth-session-smoke.md`](docs/guides/gateway-auth-session-smoke.md), [`docs/guides/gateway-api-reference.md`](docs/guides/gateway-api-reference.md) |
+| Multi-channel ingress loop | `./scripts/demo/multi-channel.sh` | Multi-channel runtime, transport normalization, routing pipeline | [`docs/guides/multi-channel-event-pipeline.md`](docs/guides/multi-channel-event-pipeline.md), [`docs/guides/transports.md`](docs/guides/transports.md) |
+| Prompt optimization loop | [`docs/guides/training-ops.md`](docs/guides/training-ops.md) runbook flow | Training runner/store/tracer/proxy + rollout controls | [`docs/guides/training-ops.md`](docs/guides/training-ops.md), [`docs/guides/training-proxy-ops.md`](docs/guides/training-proxy-ops.md) |
 
 ## What You Can Do Today
 
 - Run interactive and one-shot agent flows from `tau-coding-agent`.
-- Use session persistence and lifecycle operations (branching, resume, export/import/repair).
+- Use session persistence and lifecycle operations (branch, resume, export/import/repair).
 - Route model calls across multiple provider/auth modes.
-- Run gateway API surfaces and dashboard ops routes.
+- Run gateway API surfaces and operator routes.
 - Use built-in tools with policy controls (filesystem/shell/http/path/rate/sandbox).
-- Run channel and bridge runtimes (GitHub Issues, Slack, Discord, Telegram/WhatsApp pipelines).
-- Operate prompt-optimization workflows with SQLite-backed state and optional proxy attribution.
+- Run channel and bridge runtimes (GitHub Issues, Slack, Discord, Telegram/WhatsApp paths).
+- Operate prompt-optimization workflows with SQLite-backed rollout state and optional proxy attribution.
 - Execute deterministic demo suites and validation scripts in local/CI loops.
 
 ## Capability Boundaries
 
-Tau includes some surfaces as diagnostics-first or fixture/live-input flows rather than end-user UX products:
+Some surfaces are intentionally diagnostics-first or staged:
 
-- Voice:
-  - live/contract runners are available,
-  - fixture/file-driven inputs are supported,
-  - built-in microphone capture UX is not bundled in this repository.
-- Browser automation:
-  - live runner exists,
-  - execution depends on an external Playwright-compatible CLI,
-  - no embedded browser engine is shipped in Tau.
-- Dashboard/custom-command/memory contract runners:
-  - older contract-runner flags were removed from active dispatch,
-  - current behavior is routed through runtime/gateway diagnostics and operations guides.
-- Training:
-  - canonical CLI training mode is prompt optimization,
-  - true-RL building blocks (for example PPO/GAE components and proof scripts) exist in-repo, but are staged separately from the canonical prompt-optimization path.
+- True RL:
+  - primitives and proof tooling exist,
+  - not yet delivered as a single production-ready end-to-end operator workflow.
+- Dashboard:
+  - route and diagnostics surfaces exist,
+  - not all desired product UX workflows are fully integrated live-mutation paths.
+- Auth verification:
+  - auth capabilities are implemented,
+  - comprehensive cross-mode verification is still a focused closure track.
+- TUI:
+  - useful as a deterministic demo/smoke surface,
+  - not a full operator dashboard replacement.
+
+## Maturity Matrix
+
+| Capability Area | Status | Meaning | Primary Reference |
+|---|---|---|---|
+| Core CLI runtime + sessions + tools | Integrated | Production-like operating loop available | [`docs/guides/quickstart.md`](docs/guides/quickstart.md) |
+| Gateway auth/session APIs | Integrated | Deterministic auth/session smoke flows and documented API contracts | [`docs/guides/gateway-auth-session-smoke.md`](docs/guides/gateway-auth-session-smoke.md) |
+| Multi-channel and bridge transports | Operational | Runnable with connector-specific maturity differences | [`docs/guides/transports.md`](docs/guides/transports.md) |
+| Dashboard operator UX | Partial | Ops routes and diagnostics available; broader UX still expanding | [`docs/guides/dashboard-ops.md`](docs/guides/dashboard-ops.md) |
+| Prompt optimization training | Integrated | Canonical training path today | [`docs/guides/training-ops.md`](docs/guides/training-ops.md) |
+| True RL | Staged | Building blocks/proof scripts exist; full delivery path in planning | [`docs/planning/true-rl-roadmap-skeleton.md`](docs/planning/true-rl-roadmap-skeleton.md) |
+| TUI | Demo | Smoke/demo terminal surface, not full ops UX | [`crates/tau-tui`](crates/tau-tui) |
+
+## Current Gaps and Execution Plan
+
+| Gap | Current State | Execution Plan Links |
+|---|---|---|
+| True RL end-to-end delivery | primitives present, full operator loop pending | [`docs/planning/integration-gap-closure-plan.md`](docs/planning/integration-gap-closure-plan.md), [`docs/planning/true-rl-roadmap-skeleton.md`](docs/planning/true-rl-roadmap-skeleton.md), [`docs/guides/training-ops.md`](docs/guides/training-ops.md) |
+| Dashboard maturity expansion | ops routes exist, richer workflow UX pending | [`docs/planning/integration-gap-closure-plan.md`](docs/planning/integration-gap-closure-plan.md), [`docs/guides/dashboard-ops.md`](docs/guides/dashboard-ops.md), [`docs/guides/operator-deployment-guide.md`](docs/guides/operator-deployment-guide.md) |
+| Comprehensive auth workflow verification | capability matrix and smokes exist, full verification consolidation pending | [`docs/planning/integration-gap-closure-plan.md`](docs/planning/integration-gap-closure-plan.md), [`docs/provider-auth/provider-auth-capability-matrix.md`](docs/provider-auth/provider-auth-capability-matrix.md), [`docs/guides/gateway-auth-session-smoke.md`](docs/guides/gateway-auth-session-smoke.md) |
+| TUI UX improvements | demo utility available, broader UX improvements pending | [`docs/planning/integration-gap-closure-plan.md`](docs/planning/integration-gap-closure-plan.md), [`crates/tau-tui`](crates/tau-tui), [`docs/guides/demo-index.md`](docs/guides/demo-index.md) |
 
 ## 5-Minute Quickstart
 
-Run commands from repo root.
+Run commands from repository root.
 
-1. Prerequisites
+1. Prerequisite
 
 ```bash
 rustup default stable
@@ -76,7 +109,7 @@ cargo run -p tau-coding-agent -- --onboard --onboard-non-interactive
 cargo run -p tau-coding-agent -- --prompt "Summarize src/lib.rs"
 ```
 
-5. Optional: run the TUI smoke demo
+5. Optional TUI smoke
 
 ```bash
 cargo run -p tau-tui -- --frames 2 --sleep-ms 0 --width 56 --no-color
@@ -104,14 +137,24 @@ Interactive runtime mode:
 cargo run -p tau-coding-agent -- --model openai/gpt-4o-mini
 ```
 
-Deterministic demo index:
+Gateway auth/session smoke:
+
+```bash
+./scripts/demo/gateway-auth-session.sh
+```
+
+Dashboard demo path:
+
+```bash
+./scripts/demo/dashboard.sh
+```
+
+Demo index and selective runs:
 
 ```bash
 ./scripts/demo/index.sh --list
 ./scripts/demo/index.sh --only onboarding,gateway-auth,gateway-remote-access --fail-fast
 ```
-
-Run all demo wrappers:
 
 ```bash
 ./scripts/demo/all.sh --list
@@ -124,59 +167,18 @@ Clean generated local artifacts:
 ./scripts/dev/clean-local-artifacts.sh
 ```
 
-## Workspace Feature Map
-
-Core execution and orchestration:
-- `crates/tau-coding-agent`
-- `crates/tau-agent-core`
-- `crates/tau-runtime`
-- `crates/tau-orchestrator`
-
-Gateway, dashboard, and ops:
-- `crates/tau-gateway`
-- `crates/tau-dashboard`
-- `crates/tau-dashboard-ui`
-- `crates/tau-ops`
-
-Model/provider and tooling:
-- `crates/tau-ai`
-- `crates/tau-provider`
-- `crates/tau-tools`
-- `crates/tau-safety`
-
-Sessions, memory, extensions:
-- `crates/tau-session`
-- `crates/tau-memory`
-- `crates/tau-extensions`
-- `crates/tau-skills`
-
-Transports and channels:
-- `crates/tau-github-issues-runtime`
-- `crates/tau-slack-runtime`
-- `crates/tau-discord-runtime`
-- `crates/tau-multi-channel`
-
-Training and algorithm primitives:
-- `crates/tau-training-types`
-- `crates/tau-training-store`
-- `crates/tau-training-tracer`
-- `crates/tau-training-runner`
-- `crates/tau-training-proxy`
-- `crates/tau-trainer`
-- `crates/tau-algorithm`
-
 ## Docs by Role
 
-Primary doc index: [`docs/README.md`](docs/README.md)
+Primary docs index: [`docs/README.md`](docs/README.md)
 
-Operator guides:
+Operator runbooks:
 - [`docs/guides/operator-deployment-guide.md`](docs/guides/operator-deployment-guide.md)
 - [`docs/guides/operator-control-summary.md`](docs/guides/operator-control-summary.md)
 - [`docs/guides/dashboard-ops.md`](docs/guides/dashboard-ops.md)
 - [`docs/guides/gateway-ops.md`](docs/guides/gateway-ops.md)
 - [`docs/guides/memory-ops.md`](docs/guides/memory-ops.md)
 
-Integrator/API guides:
+Integrator/API references:
 - [`docs/guides/gateway-api-reference.md`](docs/guides/gateway-api-reference.md)
 - [`docs/guides/transports.md`](docs/guides/transports.md)
 - [`docs/provider-auth/provider-auth-capability-matrix.md`](docs/provider-auth/provider-auth-capability-matrix.md)
@@ -189,11 +191,53 @@ Contributor references:
 - [`docs/guides/startup-di-pipeline.md`](docs/guides/startup-di-pipeline.md)
 - [`docs/guides/contract-pattern-lifecycle.md`](docs/guides/contract-pattern-lifecycle.md)
 - [`docs/guides/multi-channel-event-pipeline.md`](docs/guides/multi-channel-event-pipeline.md)
+- [`docs/guides/doc-density-scorecard.md`](docs/guides/doc-density-scorecard.md)
 
-Planning/roadmap references:
+Planning and gap closure:
 - [`docs/planning/true-rl-roadmap-skeleton.md`](docs/planning/true-rl-roadmap-skeleton.md)
 - [`docs/guides/roadmap-execution-index.md`](docs/guides/roadmap-execution-index.md)
-- [`docs/guides/doc-density-scorecard.md`](docs/guides/doc-density-scorecard.md)
+- [`docs/planning/integration-gap-closure-plan.md`](docs/planning/integration-gap-closure-plan.md)
+
+## Workspace Feature Map
+
+Core runtime:
+- `crates/tau-coding-agent`
+- `crates/tau-agent-core`
+- `crates/tau-runtime`
+- `crates/tau-orchestrator`
+
+Gateway and ops:
+- `crates/tau-gateway`
+- `crates/tau-dashboard`
+- `crates/tau-dashboard-ui`
+- `crates/tau-ops`
+
+Model and policy:
+- `crates/tau-ai`
+- `crates/tau-provider`
+- `crates/tau-tools`
+- `crates/tau-safety`
+
+State and extension surfaces:
+- `crates/tau-session`
+- `crates/tau-memory`
+- `crates/tau-extensions`
+- `crates/tau-skills`
+
+Transport/bridge runtimes:
+- `crates/tau-github-issues-runtime`
+- `crates/tau-slack-runtime`
+- `crates/tau-discord-runtime`
+- `crates/tau-multi-channel`
+
+Training and algorithms:
+- `crates/tau-training-types`
+- `crates/tau-training-store`
+- `crates/tau-training-tracer`
+- `crates/tau-training-runner`
+- `crates/tau-training-proxy`
+- `crates/tau-trainer`
+- `crates/tau-algorithm`
 
 ## Packaging and Release Artifacts
 
@@ -203,7 +247,7 @@ Local Docker smoke build:
 ./scripts/dev/docker-image-smoke.sh --tag tau-coding-agent:local-smoke
 ```
 
-Release workflow and artifact details:
+Release workflow and artifacts:
 - [`.github/workflows/release.yml`](.github/workflows/release.yml)
 - [`docs/guides/release-automation-ops.md`](docs/guides/release-automation-ops.md)
 - GitHub Releases: <https://github.com/njfio/Tau/releases>

--- a/docs/planning/integration-gap-closure-plan.md
+++ b/docs/planning/integration-gap-closure-plan.md
@@ -1,0 +1,87 @@
+# Integration Gap Closure Plan
+
+This plan tracks the four capability gaps called out from README review:
+- true RL end-to-end delivery,
+- dashboard maturity expansion,
+- comprehensive auth workflow verification,
+- TUI UX improvements.
+
+## 1) True RL Delivery
+
+Current state:
+- Prompt optimization is the canonical training path today.
+- True-RL primitives and benchmark/safety proof scripts exist.
+
+Closure objective:
+- Promote true RL from staged primitives to an end-to-end, operator-run workflow with acceptance gates.
+
+Execution anchors:
+- [`docs/planning/true-rl-roadmap-skeleton.md`](true-rl-roadmap-skeleton.md)
+- [`docs/guides/training-ops.md`](../guides/training-ops.md)
+- [`scripts/demo/m24-rl-live-benchmark-proof.sh`](../../scripts/demo/m24-rl-live-benchmark-proof.sh)
+
+Initial verification command:
+
+```bash
+./scripts/demo/m24-rl-live-benchmark-proof.sh
+```
+
+## 2) Dashboard Maturity
+
+Current state:
+- Dashboard ops routes and API-backed diagnostics exist.
+- Not all desired product UX surfaces are complete live-mutation experiences.
+
+Closure objective:
+- Expand dashboard from route/ops coverage toward full operator workflows.
+
+Execution anchors:
+- [`docs/guides/dashboard-ops.md`](../guides/dashboard-ops.md)
+- [`docs/guides/operator-deployment-guide.md`](../guides/operator-deployment-guide.md)
+- [`scripts/demo/dashboard.sh`](../../scripts/demo/dashboard.sh)
+
+Initial verification command:
+
+```bash
+./scripts/demo/dashboard.sh
+```
+
+## 3) Auth Workflow Verification
+
+Current state:
+- Provider auth modes and gateway auth/session flows are implemented.
+- Cross-mode verification is not yet represented as a single consolidated acceptance matrix in README-level guidance.
+
+Closure objective:
+- Verify and document all supported auth modes/flows using deterministic smoke steps and provider matrix references.
+
+Execution anchors:
+- [`docs/provider-auth/provider-auth-capability-matrix.md`](../provider-auth/provider-auth-capability-matrix.md)
+- [`docs/guides/gateway-auth-session-smoke.md`](../guides/gateway-auth-session-smoke.md)
+- [`scripts/demo/gateway-auth-session.sh`](../../scripts/demo/gateway-auth-session.sh)
+
+Initial verification command:
+
+```bash
+./scripts/demo/gateway-auth-session.sh
+```
+
+## 4) TUI Improvements
+
+Current state:
+- `tau-tui` is a lightweight demo runner and smoke surface.
+- It is not a full operator dashboard replacement.
+
+Closure objective:
+- Improve usability and operator signal density in terminal UX while preserving deterministic smoke behavior.
+
+Execution anchors:
+- [`crates/tau-tui`](../../crates/tau-tui)
+- [`docs/guides/demo-index.md`](../guides/demo-index.md)
+
+Initial verification command:
+
+```bash
+cargo run -p tau-tui -- --frames 3 --sleep-ms 0 --width 72 --no-color
+```
+

--- a/specs/3416/plan.md
+++ b/specs/3416/plan.md
@@ -11,10 +11,15 @@
    - capability summary with realistic boundaries,
    - 5-minute quickstart,
    - common workflows and doc map.
-4. Run GREEN conformance checks on:
+4. Add integration transparency sections:
+   - integrated end-to-end paths that work now,
+   - a maturity matrix by capability area,
+   - a gap/next-step table linking to concrete runbooks/plans for True RL, dashboard, auth verification, and TUI.
+5. Run GREEN conformance checks on:
    - required headings,
    - referenced links/scripts existence,
    - command entrypoints present in workspace.
+   - docs helper unittest suite used by CI.
 
 ## Affected Modules
 - `README.md`

--- a/specs/3416/spec.md
+++ b/specs/3416/spec.md
@@ -4,6 +4,7 @@ Status: Implemented
 
 ## Problem Statement
 `README.md` is feature-dense but difficult for first-time users to scan quickly. The repository needs a clearer top-level guide that is informative, user-friendly, and aligned with implemented code/doc surfaces.
+The current draft still reads like a component inventory and does not make integrated end-to-end paths, maturity boundaries, and gap-closure plans explicit enough.
 
 ## Scope
 In scope:
@@ -32,6 +33,14 @@ Given referenced file links and command snippets in `README.md`,
 when validated from repo root,  
 then linked docs/scripts exist and primary command paths resolve.
 
+### AC-4 README presents integrated operating paths and maturity/gap transparency
+Given a user evaluating whether Tau is truly integrated,  
+when they read `README.md`,  
+then they can identify:
+- concrete integrated paths that work now end-to-end,
+- a maturity matrix that distinguishes production-ready vs staged/partial areas,
+- explicit gap-closure links for True RL, dashboard maturity, auth verification, and TUI improvements.
+
 ## Conformance Cases
 | Case | AC | Tier | Given | When | Then |
 |---|---|---|---|---|---|
@@ -39,8 +48,12 @@ then linked docs/scripts exist and primary command paths resolve.
 | C-02 | AC-2 | Functional/Conformance | crate/docs inventory | README capability text is cross-checked | feature claims map to real crates/docs |
 | C-03 | AC-3 | Conformance | README links/scripts | path checks are executed | all referenced docs/scripts exist |
 | C-04 | AC-3 | Conformance | README command examples | command target checks are executed | command entrypoints (`cargo run -p ...`, scripts) are present |
+| C-05 | AC-4 | Functional/Conformance | existing README | section headings are inspected | `Integrated End-to-End Paths`, `Maturity Matrix`, and `Current Gaps and Execution Plan` sections exist |
+| C-06 | AC-4 | Conformance | README gap rows | link checks are executed | each gap row includes a valid repository path link for follow-through |
 
 ## Success Metrics / Observable Signals
 - `README.md` is rewritten with user-first flow and concise capability map.
 - Validation checks for linked docs/scripts pass.
 - README contains no references to missing files in this repository.
+- README includes integrated-path-first narrative before crate inventory details.
+- README includes explicit maturity table and gap-closure plan links.

--- a/specs/3416/tasks.md
+++ b/specs/3416/tasks.md
@@ -4,3 +4,6 @@
 - [x] T2 (GREEN, Docs): rewrite `README.md` with user-first structure and verified feature map.
 - [x] T3 (VERIFY, Conformance): validate README links/scripts/entrypoint commands resolve in-repo.
 - [x] T4 (VERIFY, Governance): update spec status to `Implemented` and mark milestone index complete notes.
+- [x] T5 (RED, Functional/Conformance): assert missing integration-transparency sections (`Integrated End-to-End Paths`, `Maturity Matrix`, `Current Gaps and Execution Plan`) in current README revision.
+- [x] T6 (GREEN, Docs): rewrite README narrative to lead with integrated paths and include maturity/gap execution table.
+- [x] T7 (VERIFY, Conformance): re-run README path/link checks and CI docs helper unittest suite.

--- a/specs/milestones/m294/index.md
+++ b/specs/milestones/m294/index.md
@@ -16,6 +16,7 @@ Tau has broad runtime, gateway, tooling, and operations capabilities, but the to
 ## Closeout
 - Issue `#3416` completed with a repository-wide feature/docs inventory pass and a user-first README rewrite.
 - README links/scripts/entrypoint references were validated from repository root.
+- README now includes integrated end-to-end operating paths, a capability maturity matrix, and explicit gap-closure links (`docs/planning/integration-gap-closure-plan.md`).
 
 ## Success Signals
 - `README.md` provides a concise product overview and capability map.


### PR DESCRIPTION
## Summary
This PR rewrites `README.md` to be integration-first instead of component-first. It now shows concrete end-to-end paths, a capability maturity matrix, and explicit execution-plan links for unresolved gaps (True RL delivery, dashboard maturity, auth verification, TUI improvement). It also includes the supporting issue spec artifacts and a gap-closure planning doc.

## Links
- Milestone: https://github.com/njfio/Tau/milestone/294
- Closes #3416
- Spec: `specs/3416/spec.md`
- Plan: `specs/3416/plan.md`
- Tasks: `specs/3416/tasks.md`
- Milestone index: `specs/milestones/m294/index.md`

## Spec Verification (AC -> tests)

| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: README is structured for fast onboarding | ✅ | Heading checks for `Who Tau Is For`, `5-Minute Quickstart`, `Common Workflows`, `Capability Boundaries` |
| AC-2: README reflects implemented capabilities | ✅ | Crate/docs/script inventory cross-check + docs helper unittest suite |
| AC-3: README navigation links and commands are valid | ✅ | Local markdown link + script path + package entrypoint checks |
| AC-4: README shows integrated paths + maturity/gap transparency | ✅ | Heading checks for `Integrated End-to-End Paths`, `Maturity Matrix`, `Current Gaps and Execution Plan` + link existence checks |

## TDD Evidence

RED cmd + output excerpt (onboarding headings):

```bash
for heading in "Who Tau Is For" "5-Minute Quickstart" "Common Workflows" "Capability Boundaries"; do
  rg -q "^## ${heading}$" README.md || echo "MISSING heading: ${heading}"
done
```

```text
MISSING heading: Who Tau Is For
MISSING heading: 5-Minute Quickstart
MISSING heading: Common Workflows
MISSING heading: Capability Boundaries
RED: onboarding structure check failed (4 missing headings)
```

RED cmd + output excerpt (integration transparency headings):

```bash
for heading in "Integrated End-to-End Paths" "Maturity Matrix" "Current Gaps and Execution Plan"; do
  rg -q "^## ${heading}$" README.md || echo "MISSING heading: ${heading}"
done
```

```text
MISSING heading: Integrated End-to-End Paths
MISSING heading: Maturity Matrix
MISSING heading: Current Gaps and Execution Plan
RED: integration-transparency check failed (3 missing headings)
```

GREEN cmd + output excerpt:

```bash
# README conformance suite:
# - onboarding headings
# - integration headings
# - local markdown links
# - script paths
# - workspace package entrypoints
# and CI-equivalent docs tests
python3 -m unittest discover -s .github/scripts -p "test_*docs*_check.py"
```

```text
PASS onboarding headings
PASS integration headings
PASS local markdown links
PASS script paths
PASS cargo package entrypoints
Ran 11 tests ...
OK
GREEN: README + docs quality conformance checks passed
```

REGRESSION summary:
- CI initially failed on required README docs token checks; added required links and revalidated with the same docs unittest suite.

## Test Tiers

| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | None | Docs/spec-only change; no runtime/public function behavior changed. |
| Property | N/A | None | No parser/algorithm changes. |
| Contract/DbC | N/A | None | No API contract code changes. |
| Snapshot | N/A | None | No snapshot output changes. |
| Functional | ✅ | README conformance checks + docs helper unittest suite | |
| Conformance | ✅ | AC-mapped RED/GREEN checks above | |
| Integration | N/A | None | No cross-module runtime behavior changes. |
| Fuzz | N/A | None | No untrusted-input parser changes. |
| Mutation | N/A | None | Docs/spec-only change; no executable critical path deltas. |
| Regression | ✅ | RED -> GREEN loops for onboarding + integration headings and docs-token regression fix | |
| Performance | N/A | None | No runtime hotpath changes. |

## Mutation
- Caught/total: N/A (docs/spec-only change).

## Risks / Rollback
- Risk: Low. Documentation structure/content only.
- Rollback: Revert commits `81c4bcb3`, `4c5287a9`, and `dd79725a`.
- Breaking changes: None.

## Docs / ADR
- Updated:
  - `README.md`
  - `docs/planning/integration-gap-closure-plan.md`
  - `specs/3416/spec.md`
  - `specs/3416/plan.md`
  - `specs/3416/tasks.md`
  - `specs/milestones/m294/index.md`
- ADR: Not required (documentation/process update only).
