### PR TITLE
feat(#3620): enable action history by default + JSONL persistence

### DIFF
--- a/crates/tau-agent-core/src/lib.rs
+++ b/crates/tau-agent-core/src/lib.rs
@@ -183,6 +183,7 @@ pub struct AgentConfig {
     // Phase 7: Learning — action history
     pub action_history_enabled: bool,
     pub action_history_max_records: usize,
+    pub action_history_retention_days: u32,
 
     // Phase 8: Self-repair — failure detection
     pub failure_detection_enabled: bool,
@@ -261,8 +262,9 @@ impl Default for AgentConfig {
             context_summary_max_chars: 4000,
 
             // Phase 7: Learning
-            action_history_enabled: false,
-            action_history_max_records: 500,
+            action_history_enabled: true,
+            action_history_max_records: 1000,
+            action_history_retention_days: 30,
 
             // Phase 8: Self-repair
             failure_detection_enabled: true,

--- a/crates/tau-memory/src/action_history.rs
+++ b/crates/tau-memory/src/action_history.rs
@@ -111,6 +111,76 @@ impl ActionHistoryStore {
         }
     }
 
+    /// Load an action history store from a JSONL file.
+    ///
+    /// Reads each line as a JSON-serialized `ActionRecord`, filtering out
+    /// records older than `retention_days`. If the file does not exist,
+    /// returns an empty store.
+    pub fn load(path: &Path, retention_days: u32, config: ActionHistoryConfig) -> std::io::Result<Self> {
+        if !path.exists() {
+            return Ok(Self {
+                config,
+                records: Vec::new(),
+            });
+        }
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let cutoff_ms = now_ms.saturating_sub(retention_days as u64 * 86_400 * 1_000);
+
+        let file = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut records = Vec::new();
+
+        for line in reader.lines() {
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<ActionRecord>(trimmed) {
+                Ok(record) => {
+                    if record.timestamp_ms >= cutoff_ms {
+                        records.push(record);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Skipping malformed action history line: {}", e);
+                }
+            }
+        }
+
+        Ok(Self { config, records })
+    }
+
+    /// Save all records to a JSONL file using atomic rename.
+    ///
+    /// Writes to a `.tmp` file first, then renames to the final path.
+    /// Creates parent directories if they don't exist.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = path.with_extension("jsonl.tmp");
+        {
+            let file = std::fs::File::create(&tmp_path)?;
+            let mut writer = BufWriter::new(file);
+            for record in &self.records {
+                let line = serde_json::to_string(record).map_err(|e| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+                })?;
+                writeln!(writer, "{}", line)?;
+            }
+            writer.flush()?;
+        }
+
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+
     /// Append an action record.
     pub fn record(&mut self, action: ActionRecord) {
         self.records.push(action);
@@ -223,6 +293,13 @@ impl ActionHistoryStore {
 mod tests {
     use super::*;
 
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
+
     fn make_record(tool: &str, success: bool) -> ActionRecord {
         ActionRecord {
             session_id: "s1".to_string(),
@@ -237,7 +314,7 @@ mod tests {
             },
             success,
             latency_ms: 100,
-            timestamp_ms: 1000,
+            timestamp_ms: now_ms(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Enable action history by default in `AgentConfig` (was disabled)
- Increase max records from 500 to 1000
- Add `action_history_retention_days` field (default: 30 days)
- Implement JSONL file persistence for `ActionHistoryStore` with `load()` and `save()` methods

## Changes
- `crates/tau-agent-core/src/lib.rs`: Updated `AgentConfig` struct and `Default` impl
  - `action_history_enabled: false` -> `true`
  - `action_history_max_records: 500` -> `1000`
  - Added `action_history_retention_days: u32` with default `30`
- `crates/tau-memory/src/action_history.rs`: Added JSONL persistence
  - `ActionHistoryStore::load(path, retention_days, config)` — reads JSONL, prunes records older than retention_days
  - `ActionHistoryStore::save(path)` — writes JSONL with atomic rename (.tmp -> final)
  - Handles missing files gracefully (load returns empty store)
  - Creates parent directories on save
  - Skips malformed lines with `tracing::warn`

## Test Evidence
- [x] 5 new tests written (TDD red-green cycle)
  - `jsonl_round_trip` — save/load verifies records match
  - `retention_pruning_on_load` — old records pruned by retention_days
  - `load_missing_file_returns_empty_store` — graceful handling
  - `save_creates_parent_dirs` — auto-creates directory tree
  - `save_uses_atomic_rename` — no .tmp file left after save
- [x] All 97 tau-memory tests passing
- [x] All 9 tau-agent-core doc-tests passing
- [x] Full workspace compiles cleanly (`cargo check --workspace`)

## Issue Link
Closes #3620

## Checklist
- [x] Tests written first (TDD red-green-refactor)
- [x] No unrelated changes included
- [x] Commit messages follow convention
- [x] Self-review completed