### PR TITLE
fix(runtime): recycle stale tau-unified runtimes before reuse

### DIFF
--- a/scripts/run/tau-unified.sh
+++ b/scripts/run/tau-unified.sh
@@ -9,6 +9,7 @@ RUNTIME_DIR="${TAU_UNIFIED_RUNTIME_DIR:-${RUNTIME_DIR_DEFAULT}}"
 PID_FILE="${RUNTIME_DIR}/tau-unified.pid"
 LOG_FILE="${RUNTIME_DIR}/tau-unified.log"
 CMD_FILE="${RUNTIME_DIR}/tau-unified.last-cmd"
+FINGERPRINT_FILE="${RUNTIME_DIR}/tau-unified.runtime-fingerprint"
 
 MODEL_DEFAULT="${TAU_UNIFIED_MODEL:-gpt-5.3-codex}"
 BIND_DEFAULT="${TAU_UNIFIED_BIND:-127.0.0.1:8791}"
@@ -129,7 +130,50 @@ cleanup_stale_pid() {
   pid="$(cat "${PID_FILE}")"
   if [[ -z "${pid}" ]] || ! pid_is_alive "${pid}"; then
     rm -f "${PID_FILE}"
+    rm -f "${FINGERPRINT_FILE}"
   fi
+}
+
+compute_runtime_fingerprint_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 -r | awk '{print $1}'
+  else
+    die "tau-unified: requires sha256sum, shasum, or openssl to compute runtime fingerprint"
+  fi
+}
+
+build_runtime_fingerprint() {
+  local command="$1"
+  local git_head="nogit"
+  local tracked_changes="clean"
+
+  if git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_head="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo "unknown")"
+    tracked_changes="$(
+      git -C "${REPO_ROOT}" status --porcelain --untracked-files=no 2>/dev/null || true
+    )"
+  fi
+
+  printf 'head=%s\ncommand=%s\ntracked_changes=%s\n' \
+    "${git_head}" \
+    "${command}" \
+    "${tracked_changes}" \
+    | compute_runtime_fingerprint_checksum
+}
+
+runtime_fingerprint_matches() {
+  local expected="$1"
+  if [[ ! -f "${FINGERPRINT_FILE}" ]]; then
+    return 1
+  fi
+
+  local recorded
+  recorded="$(tr -d '\n' < "${FINGERPRINT_FILE}")"
+  [[ -n "${recorded}" && "${recorded}" == "${expected}" ]]
 }
 
 run_runner_mode() {
@@ -263,18 +307,27 @@ cmd_up() {
   ensure_runtime_dir
   cleanup_stale_pid
 
+  local command
+  command="$(build_up_command "${model}" "${bind}" "${auth_mode}" "${auth_token}" "${auth_password}" "${gateway_state_dir}" "${dashboard_state_dir}" "${request_timeout_ms}" "${agent_request_max_retries}" "${provider_max_retries}")"
+  local runtime_fingerprint
+  runtime_fingerprint="$(build_runtime_fingerprint "${command}")"
+
   if [[ -f "${PID_FILE}" ]]; then
     local existing_pid
     existing_pid="$(cat "${PID_FILE}")"
     if pid_is_alive "${existing_pid}"; then
-      log "tau-unified: already running (pid=${existing_pid})"
-      return 0
+      if runtime_fingerprint_matches "${runtime_fingerprint}"; then
+        log "tau-unified: already running (pid=${existing_pid})"
+        return 0
+      fi
+      log "tau-unified: recycling stale runtime (pid=${existing_pid}) because repo/runtime fingerprint changed"
+      cmd_down || true
+    else
+      rm -f "${PID_FILE}"
+      rm -f "${FINGERPRINT_FILE}"
     fi
-    rm -f "${PID_FILE}"
   fi
 
-  local command
-  command="$(build_up_command "${model}" "${bind}" "${auth_mode}" "${auth_token}" "${auth_password}" "${gateway_state_dir}" "${dashboard_state_dir}" "${request_timeout_ms}" "${agent_request_max_retries}" "${provider_max_retries}")"
   printf '%s\n' "${command}" > "${CMD_FILE}"
   : > "${LOG_FILE}"
 
@@ -298,6 +351,8 @@ cmd_up() {
     rm -f "${PID_FILE}"
     die "tau-unified: failed to start runtime process"
   fi
+
+  printf '%s\n' "${runtime_fingerprint}" > "${FINGERPRINT_FILE}"
 
   log "tau-unified: started (pid=${pid}) profile=${profile}"
   log "tau-unified: webchat=http://${bind}/webchat"
@@ -329,6 +384,7 @@ cmd_status() {
   log "tau-unified: pid_file=${PID_FILE}"
   log "tau-unified: log_file=${LOG_FILE}"
   log "tau-unified: command_file=${CMD_FILE}"
+  log "tau-unified: fingerprint_file=${FINGERPRINT_FILE}"
 }
 
 cmd_down() {
@@ -357,6 +413,7 @@ cmd_down() {
   fi
 
   rm -f "${PID_FILE}"
+  rm -f "${FINGERPRINT_FILE}"
   log "tau-unified: stopped"
 }
 
@@ -388,17 +445,6 @@ bootstrap_runtime_for_tui() {
   local dashboard_state_dir="$8"
   local request_timeout_ms="$9"
   local agent_request_max_retries="${10}"
-
-  cleanup_stale_pid
-  if [[ -f "${PID_FILE}" ]]; then
-    local existing_pid
-    existing_pid="$(cat "${PID_FILE}")"
-    if pid_is_alive "${existing_pid}"; then
-      log "tau-unified: runtime already running (pid=${existing_pid})"
-      return 0
-    fi
-    rm -f "${PID_FILE}"
-  fi
 
   log "tau-unified: bootstrapping runtime for tui"
   cmd_up \

--- a/scripts/run/test-tau-unified.sh
+++ b/scripts/run/test-tau-unified.sh
@@ -38,6 +38,12 @@ assert_not_contains() {
   fi
 }
 
+count_runner_mode() {
+  local mode="$1"
+  local log_path="$2"
+  grep -c "^runner_mode=${mode}\$" "${log_path}" 2>/dev/null || true
+}
+
 if [[ ! -x "${LAUNCHER_SCRIPT}" ]]; then
   echo "error: launcher script missing or not executable: ${LAUNCHER_SCRIPT}" >&2
   exit 1
@@ -112,6 +118,7 @@ assert_contains "${up_output}" "http://127.0.0.1:8899/webchat" "up webchat endpo
 pid_file="${runtime_dir}/tau-unified.pid"
 log_file="${runtime_dir}/tau-unified.log"
 cmd_file="${runtime_dir}/tau-unified.last-cmd"
+fingerprint_file="${runtime_dir}/tau-unified.runtime-fingerprint"
 
 if [[ ! -f "${pid_file}" ]]; then
   echo "expected pid file to exist after up: ${pid_file}" >&2
@@ -125,10 +132,58 @@ if [[ ! -f "${cmd_file}" ]]; then
   echo "expected command file to exist after up: ${cmd_file}" >&2
   exit 1
 fi
+if [[ ! -f "${fingerprint_file}" ]]; then
+  echo "expected fingerprint file to exist after up: ${fingerprint_file}" >&2
+  exit 1
+fi
 assert_contains "$(cat "${cmd_file}")" "--model gpt-5.3-codex" "up default model flag"
 assert_contains "$(cat "${cmd_file}")" "--request-timeout-ms 180000" "up default timeout flag"
 assert_contains "$(cat "${cmd_file}")" "--agent-request-max-retries 0" "up default agent retries flag"
 assert_contains "$(cat "${cmd_file}")" "--provider-max-retries 0" "up default provider retries flag"
+if [[ -z "$(cat "${fingerprint_file}")" ]]; then
+  echo "expected fingerprint file to contain a non-empty fingerprint" >&2
+  exit 1
+fi
+
+same_up_count_before="$(count_runner_mode up "${runner_log}")"
+same_down_count_before="$(count_runner_mode down "${runner_log}")"
+same_up_output="$(
+  TAU_UNIFIED_RUNNER="${runner}" \
+  TAU_UNIFIED_RUNNER_LOG="${runner_log}" \
+  TAU_UNIFIED_RUNNER_PID="${runner_pid}" \
+  TAU_UNIFIED_RUNTIME_DIR="${runtime_dir}" \
+  "${LAUNCHER_SCRIPT}" up --profile test-profile --bind 127.0.0.1:8899 --auth-mode localhost-dev 2>&1
+)"
+assert_contains "${same_up_output}" "tau-unified: already running" "same fingerprint reuse marker"
+same_up_count_after="$(count_runner_mode up "${runner_log}")"
+same_down_count_after="$(count_runner_mode down "${runner_log}")"
+assert_equals "${same_up_count_before}" "${same_up_count_after}" "same fingerprint up reuse"
+assert_equals "${same_down_count_before}" "${same_down_count_after}" "same fingerprint down reuse"
+
+printf 'stale-fingerprint\n' > "${fingerprint_file}"
+stale_up_count_before="$(count_runner_mode up "${runner_log}")"
+stale_down_count_before="$(count_runner_mode down "${runner_log}")"
+stale_up_output="$(
+  TAU_UNIFIED_RUNNER="${runner}" \
+  TAU_UNIFIED_RUNNER_LOG="${runner_log}" \
+  TAU_UNIFIED_RUNNER_PID="${runner_pid}" \
+  TAU_UNIFIED_RUNTIME_DIR="${runtime_dir}" \
+  "${LAUNCHER_SCRIPT}" up --profile test-profile --bind 127.0.0.1:8899 --auth-mode localhost-dev 2>&1
+)"
+assert_contains "${stale_up_output}" "tau-unified: recycling stale runtime" "stale up recycle marker"
+assert_contains "${stale_up_output}" "tau-unified: started" "stale up restart marker"
+stale_up_count_after="$(count_runner_mode up "${runner_log}")"
+stale_down_count_after="$(count_runner_mode down "${runner_log}")"
+if [[ "${stale_up_count_after}" -le "${stale_up_count_before}" ]]; then
+  echo "assertion failed (stale up restarts runtime): expected runner up count to increase" >&2
+  cat "${runner_log}" >&2
+  exit 1
+fi
+if [[ "${stale_down_count_after}" -le "${stale_down_count_before}" ]]; then
+  echo "assertion failed (stale up recycles runtime): expected runner down count to increase" >&2
+  cat "${runner_log}" >&2
+  exit 1
+fi
 
 status_output="$(
   TAU_UNIFIED_RUNNER="${runner}" \
@@ -153,6 +208,10 @@ if [[ -f "${pid_file}" ]]; then
   echo "expected pid file to be removed after down: ${pid_file}" >&2
   exit 1
 fi
+if [[ -f "${fingerprint_file}" ]]; then
+  echo "expected fingerprint file to be removed after down: ${fingerprint_file}" >&2
+  exit 1
+fi
 
 set +e
 down_again_output="$(
@@ -167,7 +226,7 @@ set -e
 assert_equals "1" "${down_again_rc}" "down when stopped exit"
 assert_contains "${down_again_output}" "tau-unified: not running" "down when stopped output"
 
-up_count_before_tui="$(grep -c '^runner_mode=up$' "${runner_log}" || true)"
+up_count_before_tui="$(count_runner_mode up "${runner_log}")"
 
 tui_output="$(
   TAU_UNIFIED_RUNNER="${runner}" \
@@ -177,12 +236,12 @@ tui_output="$(
   "${LAUNCHER_SCRIPT}" tui --no-color 2>&1 || true
 )"
 assert_contains "${tui_output}" "tau-unified: launching tui (interactive)" "tui interactive marker"
-up_count_after_tui="$(grep -c '^runner_mode=up$' "${runner_log}" || true)"
+up_count_after_tui="$(count_runner_mode up "${runner_log}")"
 assert_equals "${up_count_before_tui}" "${up_count_after_tui}" "tui default does not bootstrap runtime in runner mode"
 assert_contains "$(cat "${runner_log}")" "--request-timeout-ms 180000" "tui default timeout flag"
 assert_contains "$(cat "${runner_log}")" "--agent-request-max-retries 0" "tui default retries flag"
 
-up_count_before_bootstrap="$(grep -c '^runner_mode=up$' "${runner_log}" || true)"
+up_count_before_bootstrap="$(count_runner_mode up "${runner_log}")"
 tui_bootstrap_output="$(
   TAU_UNIFIED_RUNNER="${runner}" \
   TAU_UNIFIED_RUNNER_LOG="${runner_log}" \
@@ -192,11 +251,50 @@ tui_bootstrap_output="$(
 )"
 assert_contains "${tui_bootstrap_output}" "tau-unified: bootstrapping runtime for tui" "tui bootstrap marker"
 assert_contains "${tui_bootstrap_output}" "tau-unified: started" "tui bootstrap started"
-up_count_after_bootstrap="$(grep -c '^runner_mode=up$' "${runner_log}" || true)"
+up_count_after_bootstrap="$(count_runner_mode up "${runner_log}")"
 if [[ "${up_count_after_bootstrap}" -le "${up_count_before_bootstrap}" ]]; then
   echo "assertion failed (runner up logged for bootstrap path): expected up count to increase" >&2
   echo "before=${up_count_before_bootstrap} after=${up_count_after_bootstrap}" >&2
   echo "runner log:" >&2
+  cat "${runner_log}" >&2
+  exit 1
+fi
+
+tui_same_up_count_before="$(count_runner_mode up "${runner_log}")"
+tui_same_down_count_before="$(count_runner_mode down "${runner_log}")"
+tui_same_bootstrap_output="$(
+  TAU_UNIFIED_RUNNER="${runner}" \
+  TAU_UNIFIED_RUNNER_LOG="${runner_log}" \
+  TAU_UNIFIED_RUNNER_PID="${runner_pid}" \
+  TAU_UNIFIED_RUNTIME_DIR="${runtime_dir}" \
+  "${LAUNCHER_SCRIPT}" tui --bootstrap-runtime --no-color 2>&1 || true
+)"
+assert_not_contains "${tui_same_bootstrap_output}" "tau-unified: recycling stale runtime" "tui bootstrap same fingerprint reuse"
+tui_same_up_count_after="$(count_runner_mode up "${runner_log}")"
+tui_same_down_count_after="$(count_runner_mode down "${runner_log}")"
+assert_equals "${tui_same_up_count_before}" "${tui_same_up_count_after}" "tui bootstrap same fingerprint up reuse"
+assert_equals "${tui_same_down_count_before}" "${tui_same_down_count_after}" "tui bootstrap same fingerprint down reuse"
+
+printf 'stale-fingerprint\n' > "${fingerprint_file}"
+tui_stale_up_count_before="$(count_runner_mode up "${runner_log}")"
+tui_stale_down_count_before="$(count_runner_mode down "${runner_log}")"
+tui_stale_bootstrap_output="$(
+  TAU_UNIFIED_RUNNER="${runner}" \
+  TAU_UNIFIED_RUNNER_LOG="${runner_log}" \
+  TAU_UNIFIED_RUNNER_PID="${runner_pid}" \
+  TAU_UNIFIED_RUNTIME_DIR="${runtime_dir}" \
+  "${LAUNCHER_SCRIPT}" tui --bootstrap-runtime --no-color 2>&1 || true
+)"
+assert_contains "${tui_stale_bootstrap_output}" "tau-unified: recycling stale runtime" "tui bootstrap stale recycle marker"
+tui_stale_up_count_after="$(count_runner_mode up "${runner_log}")"
+tui_stale_down_count_after="$(count_runner_mode down "${runner_log}")"
+if [[ "${tui_stale_up_count_after}" -le "${tui_stale_up_count_before}" ]]; then
+  echo "assertion failed (tui bootstrap stale runtime restarts): expected runner up count to increase" >&2
+  cat "${runner_log}" >&2
+  exit 1
+fi
+if [[ "${tui_stale_down_count_after}" -le "${tui_stale_down_count_before}" ]]; then
+  echo "assertion failed (tui bootstrap stale runtime recycles): expected runner down count to increase" >&2
   cat "${runner_log}" >&2
   exit 1
 fi

--- a/specs/3661/plan.md
+++ b/specs/3661/plan.md
@@ -1,0 +1,77 @@
+# Plan: Issue #3661 - Recycle stale tau-unified runtime after repo/runtime fingerprint changes
+
+## Approach
+1. Introduce a lightweight launcher fingerprint file in `.tau/unified` that is
+   derived from the current repo/runtime launch inputs.
+2. Reuse that fingerprint in both `up` and `tui` bootstrap so stale runtime
+   detection happens before the launcher decides to short-circuit on an existing
+   pid.
+3. Keep the contract additive and shell-local: no gateway changes, no new
+   long-lived daemons, and no behavioral change for same-fingerprint reuse.
+
+## Proposed Design
+### Fingerprint source
+- Create `tau-unified.runtime-fingerprint` beside the existing pid/log/command
+  files.
+- Build the fingerprint from the current launch command plus current Git HEAD
+  when available.
+- Treat missing fingerprint files as stale so old runtime generations are
+  recycled automatically after the launcher upgrade lands.
+
+### Stale runtime handling
+- Add a helper that evaluates:
+  - pid file exists
+  - process is alive
+  - persisted fingerprint matches current fingerprint
+- For mismatches:
+  - emit a clear `tau-unified: recycling stale runtime ...` message
+  - call `cmd_down`
+  - continue into the normal `up` path
+
+### TUI bootstrap path
+- Reuse the same stale-runtime detection inside `bootstrap_runtime_for_tui`
+  instead of returning early on any alive pid.
+- Preserve the existing no-bootstrap runner-mode default and same-fingerprint
+  fast path.
+
+## Compatibility Assessment
+```yaml
+implementation_strategy:
+  task: "3661"
+  change_surface:
+    - symbol: "tau-unified runtime bookkeeping"
+      location: "scripts/run/tau-unified.sh"
+      change_type: "addition"
+      current: "pid/log/command files only"
+      proposed: "pid/log/command files plus launcher fingerprint"
+      compatibility: "safe"
+      reason: "launcher-local metadata only"
+    - symbol: "tau-unified runtime reuse behavior"
+      location: "scripts/run/tau-unified.sh"
+      change_type: "modification"
+      current: "any alive pid is reused"
+      proposed: "alive pid is reused only when fingerprint matches"
+      compatibility: "safe"
+      reason: "prevents stale runtime reuse and preserves same-fingerprint reuse"
+  overall_compatibility: "safe"
+  approach:
+    strategy: "Add runtime freshness detection before launcher reuse"
+    steps:
+      - "persist fingerprint on successful up"
+      - "recycle mismatched runtime on up"
+      - "recycle mismatched runtime on tui bootstrap"
+    version_impact: "none"
+```
+
+## Risks / Mitigations
+- Risk: false-positive mismatch causes unnecessary restarts.
+  Mitigation: fingerprint only uses stable launcher inputs plus Git HEAD.
+- Risk: old runtimes created before this change lack a fingerprint file.
+  Mitigation: treat missing fingerprint as stale by design.
+- Risk: runner-mode tests become brittle.
+  Mitigation: keep all new behavior observable through runner log assertions.
+
+## Verification
+- `bash scripts/run/test-tau-unified.sh`
+- `bash scripts/dev/test-root-just-launcher.sh`
+- ad hoc launcher smoke: stale fingerprint triggers recycle message

--- a/specs/3661/spec.md
+++ b/specs/3661/spec.md
@@ -1,0 +1,81 @@
+# Spec: Issue #3661 - Recycle stale tau-unified runtime after repo/runtime fingerprint changes
+
+Status: Implemented
+
+## Problem Statement
+`just tui` and `tau-unified.sh tui` can silently reuse a long-running
+`tau-coding-agent` process that was started from an older checkout state. When
+the repo has moved forward, the operator can end up talking to a stale gateway
+binary that does not include the currently merged Ralph-loop behavior. The
+launcher needs an explicit runtime freshness contract so local testing reflects
+the code on the current checkout.
+
+## Scope
+In scope:
+- `scripts/run/tau-unified.sh`
+- `scripts/run/test-tau-unified.sh`
+- `specs/3661/spec.md`
+- `specs/3661/plan.md`
+- `specs/3661/tasks.md`
+- `specs/milestones/m334/index.md`
+
+Out of scope:
+- changing gateway loop semantics or verifier behavior
+- TUI command behavior outside launcher/runtime bootstrap
+- dashboard/runtime state migration beyond launcher metadata
+
+## Acceptance Criteria
+### AC-1 Launcher records a reusable runtime fingerprint
+Given `tau-unified.sh up` starts a runtime,
+when the launcher persists its runtime bookkeeping,
+then it stores a fingerprint describing the current repo/runtime state together
+with the existing pid/command files.
+
+### AC-2 Launcher recycles stale runtime for `up`
+Given a live runtime process exists and the persisted runtime fingerprint differs
+from the current repo/runtime fingerprint,
+when the operator runs `tau-unified.sh up`,
+then the launcher stops the stale process, replaces it with a fresh runtime, and
+prints a clear recycle message instead of silently returning `already running`.
+
+### AC-3 Launcher recycles stale runtime for `tui` bootstrap
+Given `tau-unified.sh tui` is bootstrapping a runtime and the existing runtime
+fingerprint is stale,
+when bootstrap runs,
+then the launcher recycles the runtime before launching the TUI so the operator
+does not connect to an older gateway build.
+
+### AC-4 Same-fingerprint reuse still stays cheap
+Given a live runtime process exists and the persisted runtime fingerprint matches
+the current repo/runtime fingerprint,
+when the operator runs `tau-unified.sh up` or bootstrapped `tui`,
+then the launcher keeps the current process and does not issue an unnecessary
+restart.
+
+## Conformance Cases
+- C-01 / AC-1 / Regression:
+  start the launcher in runner mode and verify a runtime fingerprint file is
+  written alongside pid/log/command metadata.
+- C-02 / AC-2 / Regression:
+  seed a live pid plus mismatched fingerprint, run `up`, and verify the launcher
+  logs a recycle event and issues `down` followed by `up`.
+- C-03 / AC-3 / Regression:
+  seed a live pid plus mismatched fingerprint, run bootstrapped `tui`, and
+  verify the launcher recycles the runtime before launching the TUI.
+- C-04 / AC-4 / Functional:
+  seed a live pid plus matching fingerprint, run `up` and bootstrapped `tui`,
+  and verify the launcher reuses the runtime without issuing `down`.
+
+## Success Metrics / Observable Signals
+- Local `just tui` sessions no longer reuse a runtime started from an older repo
+  state after merged gateway/loop changes
+- Launcher output explicitly says when it is reusing versus recycling a runtime
+- Runner-mode tests cover both stale and current runtime decisions
+
+## Files To Touch
+- `specs/3661/spec.md`
+- `specs/3661/plan.md`
+- `specs/3661/tasks.md`
+- `specs/milestones/m334/index.md`
+- `scripts/run/tau-unified.sh`
+- `scripts/run/test-tau-unified.sh`

--- a/specs/3661/tasks.md
+++ b/specs/3661/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Issue #3661 - Recycle stale tau-unified runtime after repo/runtime fingerprint changes
+
+- [x] T1 (RED): extend launcher tests to cover fingerprint persistence, stale
+      runtime recycle on `up`, and stale runtime recycle on bootstrapped `tui`.
+- [x] T2 (GREEN): add runtime fingerprint bookkeeping and mismatch detection to
+      `scripts/run/tau-unified.sh`.
+- [x] T3 (GREEN): integrate stale runtime recycle behavior into `up` and
+      `bootstrap_runtime_for_tui`.
+- [x] T4 (VERIFY): run scoped launcher verification and capture the stale
+      runtime reproduction evidence for `#3661`.
+
+## Tier Mapping
+- Regression: stale runtime recycle for `up` and bootstrapped `tui`
+- Functional: same-fingerprint reuse remains a no-op
+- Integration: launcher bookkeeping stays compatible with existing runner mode


### PR DESCRIPTION
## Summary
Recycle stale `tau-unified` runtimes whenever the current repo/runtime fingerprint changes so `up` and bootstrapped `tui` stop reusing outdated gateway builds.

## Links
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Closes #3661
- Spec: `specs/3661/spec.md`
- Plan: `specs/3661/plan.md`

## Spec Verification (AC → tests)

| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: launcher records a reusable runtime fingerprint | ✅ | `scripts/run/test-tau-unified.sh` fingerprint file assertions |
| AC-2: launcher recycles stale runtime for `up` | ✅ | `scripts/run/test-tau-unified.sh` stale fingerprint `up` recycle assertions |
| AC-3: launcher recycles stale runtime for `tui` bootstrap | ✅ | `scripts/run/test-tau-unified.sh` bootstrapped `tui` stale fingerprint assertions |
| AC-4: same-fingerprint reuse stays cheap | ✅ | `scripts/run/test-tau-unified.sh` same-fingerprint `up`/`tui` no-op reuse assertions |

## TDD Evidence
- RED: extended launcher tests first for fingerprint persistence plus stale-runtime recycle on `up` and bootstrapped `tui`.
- GREEN:
  - `bash -n scripts/run/tau-unified.sh`
  - `bash -n scripts/run/test-tau-unified.sh`
  - `scripts/run/test-tau-unified.sh`
  - Output excerpt: `tau-unified launcher tests passed`
- REGRESSION summary: stale runtime generations now recycle automatically, while same-fingerprint reuse remains a no-op.

## Test Tiers

| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A |  | Shell launcher slice; no Rust public API changed |
| Property | N/A |  | No randomized invariant surface |
| Contract/DbC | N/A |  | No Rust contract annotations/API surface changed |
| Snapshot | N/A |  | No snapshot output surface |
| Functional | ✅ | `scripts/run/test-tau-unified.sh` same-fingerprint reuse + launcher status/down flows |  |
| Conformance | ✅ | `scripts/run/test-tau-unified.sh` AC-mapped fingerprint and recycle cases |  |
| Integration | ✅ | runner-mode launcher harness in `scripts/run/test-tau-unified.sh` |  |
| Fuzz | N/A |  | Not an untrusted parser/runtime input surface |
| Mutation | N/A |  | Shell/runtime launcher slice; critical Rust path unchanged |
| Regression | ✅ | stale fingerprint recycle cases in `scripts/run/test-tau-unified.sh` |  |
| Performance | N/A |  | No hotspot/perf-sensitive change |

## Mutation
- N/A for this shell launcher slice; no critical Rust production path changed.

## Risks/Rollback
- Low risk. Roll back by reverting this PR to restore the previous launcher reuse behavior.

## Docs/ADR
- Updated paths:
  - `specs/3661/spec.md`
  - `specs/3661/plan.md`
  - `specs/3661/tasks.md`
  - `scripts/run/tau-unified.sh`
  - `scripts/run/test-tau-unified.sh`
