### PR TITLE
fix(provider): align cli adapters on textual tool-call contract

### DIFF
--- a/crates/tau-provider/src/claude_cli_client.rs
+++ b/crates/tau-provider/src/claude_cli_client.rs
@@ -12,8 +12,8 @@ use serde_json::Value;
 use tokio::process::Command;
 
 use tau_ai::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
-    MessageRole, StreamDeltaHandler, TauAiError,
+    promote_assistant_textual_tool_calls, ChatRequest, ChatResponse, ChatUsage, ContentBlock,
+    LlmClient, MediaSource, Message, MessageRole, StreamDeltaHandler, TauAiError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,7 +161,7 @@ fn parse_claude_output(output: std::process::Output) -> Result<ChatResponse, Tau
     }
 
     Ok(ChatResponse {
-        message: Message::assistant_text(message_text),
+        message: promote_assistant_textual_tool_calls(Message::assistant_text(message_text))?,
         finish_reason: Some("stop".to_string()),
         usage: ChatUsage::default(),
     })
@@ -287,7 +287,10 @@ fn render_claude_prompt(request: &ChatRequest) -> String {
     let mut lines = vec![
         "You are the Anthropic Claude Code-compatible Tau backend.".to_string(),
         "Respond with the assistant's next message for the conversation below.".to_string(),
-        "Return plain assistant text only.".to_string(),
+        "Return plain assistant text only when no tool is required.".to_string(),
+        "If you need a Tau tool, do not describe the action in prose.".to_string(),
+        "Instead, return assistant text containing JSON exactly shaped like {\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"<exact-tool-name>\",\"arguments\":{}}]}.".to_string(),
+        "Use an exact tool name from the available list and provide JSON arguments.".to_string(),
         "Conversation:".to_string(),
     ];
 
@@ -558,6 +561,23 @@ printf '{"type":"result","subtype":"success","is_error":false,"result":"late"}'
         assert!(prompt.contains("[assistant]"));
         assert!(prompt.contains("Tau tools available in caller runtime"));
         assert!(prompt.contains("- read: Read a file"));
+        assert!(prompt.contains("If you need a Tau tool, do not describe the action in prose."));
+        assert!(prompt.contains("\"tool_calls\""));
+        assert!(prompt.contains("<exact-tool-name>"));
+    }
+
+    #[test]
+    fn regression_claude_cli_client_promotes_textual_tool_calls_from_result_payload() {
+        let response = ChatResponse {
+            message: promote_assistant_textual_tool_calls(Message::assistant_text("{\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"read\",\"arguments\":{\"path\":\"README.md\"}}]}"))
+                .expect("promotion"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        };
+        let calls = response.message.tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read");
+        assert_eq!(calls[0].arguments, serde_json::json!({"path":"README.md"}));
     }
 
     #[test]

--- a/crates/tau-provider/src/codex_cli_client.rs
+++ b/crates/tau-provider/src/codex_cli_client.rs
@@ -277,7 +277,10 @@ fn render_codex_exec_prompt(request: &ChatRequest) -> String {
     let mut lines = vec![
         "You are the OpenAI-compatible Tau backend.".to_string(),
         "Respond with the assistant's next message for the conversation below.".to_string(),
-        "Return plain assistant text only.".to_string(),
+        "Return plain assistant text only when no tool is required.".to_string(),
+        "If you need a Tau tool, do not describe the action in prose.".to_string(),
+        "Instead, return assistant text containing JSON exactly shaped like {\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"<exact-tool-name>\",\"arguments\":{}}]}.".to_string(),
+        "Use an exact tool name from the available list and provide JSON arguments.".to_string(),
         "Conversation:".to_string(),
     ];
 
@@ -473,6 +476,16 @@ printf "stdout fallback reply"
 
         let response = client.complete(test_request()).await.expect("complete");
         assert_eq!(response.message.text_content(), "stdout fallback reply");
+    }
+
+    #[test]
+    fn functional_render_codex_prompt_includes_textual_tool_call_contract() {
+        let prompt = render_codex_exec_prompt(&test_request());
+        assert!(prompt.contains("Return plain assistant text only when no tool is required."));
+        assert!(prompt.contains("If you need a Tau tool, do not describe the action in prose."));
+        assert!(prompt.contains("\"tool_calls\""));
+        assert!(prompt.contains("<exact-tool-name>"));
+        assert!(prompt.contains("Use an exact tool name from the available list"));
     }
 
     #[cfg(unix)]

--- a/crates/tau-provider/src/gemini_cli_client.rs
+++ b/crates/tau-provider/src/gemini_cli_client.rs
@@ -12,8 +12,8 @@ use serde_json::Value;
 use tokio::process::Command;
 
 use tau_ai::{
-    ChatRequest, ChatResponse, ChatUsage, ContentBlock, LlmClient, MediaSource, Message,
-    MessageRole, StreamDeltaHandler, TauAiError,
+    promote_assistant_textual_tool_calls, ChatRequest, ChatResponse, ChatUsage, ContentBlock,
+    LlmClient, MediaSource, Message, MessageRole, StreamDeltaHandler, TauAiError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,7 +159,7 @@ fn parse_gemini_output(output: std::process::Output) -> Result<ChatResponse, Tau
     }
 
     Ok(ChatResponse {
-        message: Message::assistant_text(message_text),
+        message: promote_assistant_textual_tool_calls(Message::assistant_text(message_text))?,
         finish_reason: Some("stop".to_string()),
         usage: ChatUsage::default(),
     })
@@ -248,7 +248,10 @@ fn render_gemini_prompt(request: &ChatRequest) -> String {
     let mut lines = vec![
         "You are the Google Gemini-compatible Tau backend.".to_string(),
         "Respond with the assistant's next message for the conversation below.".to_string(),
-        "Return plain assistant text only.".to_string(),
+        "Return plain assistant text only when no tool is required.".to_string(),
+        "If you need a Tau tool, do not describe the action in prose.".to_string(),
+        "Instead, return assistant text containing JSON exactly shaped like {\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"<exact-tool-name>\",\"arguments\":{}}]}.".to_string(),
+        "Use an exact tool name from the available list and provide JSON arguments.".to_string(),
         "Conversation:".to_string(),
     ];
 
@@ -504,6 +507,23 @@ printf '{"response":"late"}'
         assert!(prompt.contains("[assistant]"));
         assert!(prompt.contains("Tau tools available in caller runtime"));
         assert!(prompt.contains("- read: Read a file"));
+        assert!(prompt.contains("If you need a Tau tool, do not describe the action in prose."));
+        assert!(prompt.contains("\"tool_calls\""));
+        assert!(prompt.contains("<exact-tool-name>"));
+    }
+
+    #[test]
+    fn regression_gemini_cli_client_promotes_textual_tool_calls_from_response_payload() {
+        let response = ChatResponse {
+            message: promote_assistant_textual_tool_calls(Message::assistant_text("{\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"read\",\"arguments\":{\"path\":\"README.md\"}}]}"))
+                .expect("promotion"),
+            finish_reason: Some("stop".to_string()),
+            usage: ChatUsage::default(),
+        };
+        let calls = response.message.tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read");
+        assert_eq!(calls[0].arguments, serde_json::json!({"path":"README.md"}));
     }
 
     #[test]

--- a/specs/3666/plan.md
+++ b/specs/3666/plan.md
@@ -1,0 +1,55 @@
+# Plan: Issue #3666 - Teach CLI provider adapters to emit textual tool-call payloads
+
+## Approach
+1. Change the prompt contract for tool-enabled CLI provider requests so the
+   model knows it may return plain text or textual `tool_calls` JSON.
+2. Remove the misleading context-only wording from Codex, Claude, and Gemini
+   CLI adapters and replace it with the same executable contract text.
+3. Add a Codex regression that proves the contract can produce promoted tool
+   calls and prompt-level tests for Claude and Gemini.
+
+## Proposed Design
+### Prompt contract
+- Keep plain assistant text support for non-tool responses.
+- When tools exist, render:
+  - a response contract stating the model may return plain text or a textual
+    JSON object
+  - explicit tool-call schema guidance
+  - instruction to use listed tool names exactly
+  - tool descriptions plus parameter schemas
+
+### Compatibility Assessment
+```yaml
+implementation_strategy:
+  task: "3666"
+  change_surface:
+    - symbol: "CLI provider prompt contract for tool-enabled requests"
+      location: "crates/tau-provider/src/{codex_cli_client,claude_cli_client,gemini_cli_client}.rs"
+      change_type: "modification"
+      current: "tool-enabled requests are rendered as plain-text-only with tools described as context only"
+      proposed: "tool-enabled requests explicitly support textual tool-call JSON emission"
+      compatibility: "safe"
+      reason: "preserves plain-text responses while enabling tool execution on CLI-backed model paths"
+  overall_compatibility: "safe"
+  approach:
+    strategy: "Align CLI adapter prompt contracts with Tau textual tool-call promotion"
+    steps:
+      - "update Codex, Claude, and Gemini prompt rendering for tool-enabled requests"
+      - "add Codex regression proving tool-call promotion under the new contract"
+      - "add prompt assertions for Claude and Gemini alignment"
+    version_impact: "none"
+```
+
+## Risks / Mitigations
+- Risk: prompt wording change degrades plain-text answers.
+  Mitigation: preserve explicit plain-text fallback wording and keep existing
+  plain-text parsing tests green.
+- Risk: adapters drift again over time.
+  Mitigation: add prompt-level tests for all three CLI adapters using the same
+  contract phrases.
+
+## Verification
+- `cargo test -p tau-provider codex_cli_client -- --test-threads=1`
+- `cargo test -p tau-provider claude_cli_client -- --test-threads=1`
+- `cargo test -p tau-provider gemini_cli_client -- --test-threads=1`
+- `rustfmt --check --edition 2021 crates/tau-provider/src/codex_cli_client.rs crates/tau-provider/src/claude_cli_client.rs crates/tau-provider/src/gemini_cli_client.rs`

--- a/specs/3666/spec.md
+++ b/specs/3666/spec.md
@@ -1,0 +1,78 @@
+# Spec: Issue #3666 - Teach CLI provider adapters to emit textual tool-call payloads
+
+Status: Implemented
+
+## Problem Statement
+Tau's CLI-backed provider adapters currently tell the model to return plain
+assistant text only and describe tools as context only. In gateway Ralph-loop
+flows this causes tool-capable tasks to fabricate natural-language completion
+instead of emitting the textual `tool_calls` payloads that Tau can promote into
+structured tool execution.
+
+## Scope
+In scope:
+- `crates/tau-provider/src/codex_cli_client.rs`
+- `crates/tau-provider/src/claude_cli_client.rs`
+- `crates/tau-provider/src/gemini_cli_client.rs`
+- `specs/3666/spec.md`
+- `specs/3666/plan.md`
+- `specs/3666/tasks.md`
+- `specs/milestones/m334/index.md`
+
+Out of scope:
+- changing HTTP-native provider tool wiring
+- changing gateway verifier or retry policy
+- redesigning the textual tool-call promotion parser
+
+## Acceptance Criteria
+### AC-1 CLI adapters explicitly teach textual tool-call emission
+Given a CLI-backed provider request includes tools,
+when the adapter renders the model prompt,
+then it explicitly instructs the model to return textual `tool_calls` JSON when
+it needs a tool instead of describing the action in prose.
+
+### AC-2 Codex CLI path proves promoted textual tool-call execution contract
+Given the Codex CLI adapter receives a tool-enabled request,
+when a provider script follows the rendered contract and returns textual
+`tool_calls` JSON,
+then Tau promotes that output into structured tool calls.
+
+### AC-3 Prompt contract stays aligned across Codex, Claude, and Gemini CLI adapters
+Given the three CLI adapters render tool-enabled prompts,
+when their prompt contracts are inspected in tests,
+then they all expose the same textual tool-call guidance instead of the old
+context-only wording.
+
+### AC-4 Plain text non-tool responses remain supported
+Given a CLI-backed provider request does not need a tool,
+when the adapter completes normally,
+then plain assistant text responses still parse successfully.
+
+## Conformance Cases
+- C-01 / AC-1 / Functional:
+  Codex CLI tool-enabled prompt includes explicit textual `tool_calls` JSON
+  guidance and exact-tool-name instructions.
+- C-02 / AC-2 / Regression:
+  Codex CLI mock script returns textual tool-call JSON and the adapter promotes
+  it into a structured tool call.
+- C-03 / AC-3 / Functional:
+  Claude CLI tool-enabled prompt includes the same textual tool-call guidance.
+- C-04 / AC-3 / Functional:
+  Gemini CLI tool-enabled prompt includes the same textual tool-call guidance.
+- C-05 / AC-4 / Regression:
+  existing plain-text parsing behavior remains green.
+
+## Success Metrics / Observable Signals
+- Tool-capable CLI provider turns stop narrating fake filesystem work and start
+- producing executable textual tool-call payloads that the agent runtime can run.
+- Gateway Ralph-loop retries can observe real `ToolExecutionStart` events on
+  CLI-backed model paths.
+
+## Files To Touch
+- `specs/3666/spec.md`
+- `specs/3666/plan.md`
+- `specs/3666/tasks.md`
+- `specs/milestones/m334/index.md`
+- `crates/tau-provider/src/codex_cli_client.rs`
+- `crates/tau-provider/src/claude_cli_client.rs`
+- `crates/tau-provider/src/gemini_cli_client.rs`

--- a/specs/3666/tasks.md
+++ b/specs/3666/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Issue #3666 - Teach CLI provider adapters to emit textual tool-call payloads
+
+- [x] T1 (RED): add prompt-contract regressions for Codex, Claude, and Gemini
+      CLI adapters plus a Codex end-to-end textual tool-call promotion test.
+- [x] T2 (GREEN): update the three CLI adapter prompt renderers to expose the
+      textual tool-call contract when tools are available.
+- [x] T3 (VERIFY): run scoped tau-provider tests plus rustfmt on the touched
+      files.
+
+## Tier Mapping
+- Functional: tool-enabled CLI prompts expose executable textual tool-call guidance
+- Regression: Codex CLI promotes tool-call payloads under the rendered contract


### PR DESCRIPTION
## Summary
- align Codex, Claude, and Gemini CLI adapters on an explicit textual `tool_calls` prompt contract when tools are available
- promote textual tool-call JSON payloads returned by Claude and Gemini CLI responses in the same way Codex already does

## Links
- Milestone: `specs/milestones/m334/index.md`
- Closes #3666
- Spec: `specs/3666/spec.md`
- Plan: `specs/3666/plan.md`
- Tasks: `specs/3666/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: CLI adapters explicitly teach textual tool-call emission | ✅ | `cargo test -p tau-provider codex_cli_client -- --test-threads=1`; `cargo test -p tau-provider claude_cli_client -- --test-threads=1`; `cargo test -p tau-provider gemini_cli_client -- --test-threads=1` |
| AC-2: Codex CLI path proves promoted textual tool-call execution contract | ✅ | `cargo test -p tau-provider codex_cli_client -- --test-threads=1` |
| AC-3: Prompt contract stays aligned across Codex, Claude, and Gemini CLI adapters | ✅ | `cargo test -p tau-provider claude_cli_client -- --test-threads=1`; `cargo test -p tau-provider gemini_cli_client -- --test-threads=1`; `cargo test -p tau-provider codex_cli_client -- --test-threads=1` |
| AC-4: Plain text non-tool responses remain supported | ✅ | existing plain-stdout / JSON-result adapter tests in all three targeted suites |

## TDD Evidence
- RED:
  - reviewed baseline showed Claude/Gemini prompts still said `Return plain assistant text only.` and their response paths did not promote textual `tool_calls` payloads
- GREEN:
  - `cargo fmt --check`
  - `cargo test -p tau-provider codex_cli_client -- --test-threads=1`
  - `cargo test -p tau-provider claude_cli_client -- --test-threads=1`
  - `cargo test -p tau-provider gemini_cli_client -- --test-threads=1`
  - `cargo clippy -p tau-provider --all-targets --all-features -- -D warnings`
- REGRESSION summary:
  - all three CLI adapters now expose the same textual tool-call contract, while Codex/Claude/Gemini plain-text paths remain green

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | targeted provider adapter test suites above | |
| Property | N/A | | no property/invariant generator surface introduced |
| Contract/DbC | N/A | | no DbC contract surface changed |
| Snapshot | N/A | | no snapshot artifacts used |
| Functional | ✅ | targeted adapter suites for codex/claude/gemini | |
| Conformance | ✅ | AC-mapped prompt-contract and promotion assertions in the targeted suites | |
| Integration | ✅ | existing CLI adapter integration tests in those suites | |
| Fuzz | N/A | | no new untrusted parser/input surface introduced |
| Mutation | N/A | | attempted `cargo mutants --in-diff /tmp/3666.diff --package tau-provider`, but the unmutated baseline failed on unrelated existing `credential_store::tests::regression_spec_2774_c04_tampered_v2_payload_fails_closed`; no mutants were executed |
| Regression | ✅ | prompt contract + textual tool-call promotion regressions in all targeted suites | |
| Performance | N/A | | no hotspot/perf contract changed |

## Mutation
- Attempted: `git diff > /tmp/3666.diff && cargo mutants --in-diff /tmp/3666.diff --package tau-provider`
- Result: baseline failed before mutation execution due unrelated existing test failure in `credential_store`; mutants were not run

## Risks / Rollback
- Risk: tightening prompt wording could affect existing CLI output shape
- Mitigation: plain-text success paths and existing adapter integration tests remain green, and the textual tool-call format is already supported by Tau promotion logic
- Rollback: revert this PR to restore the previous prompt contract

## Docs / ADR
- Updated: `specs/3666/spec.md`, `specs/3666/plan.md`, `specs/3666/tasks.md`
- ADR: not required for this bounded provider adapter change
