### PR TITLE
Agent Canvas proof loop stores comparison evidence

### DIFF
--- a/scripts/dev/ops-chat-canvas-proof.sh
+++ b/scripts/dev/ops-chat-canvas-proof.sh
@@ -57,6 +57,108 @@ json_escape() {
   printf '%s' "${value}"
 }
 
+json_bool() {
+  if [[ "$1" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+contains_bool() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+count_marker() {
+  local haystack="$1"
+  local needle="$2"
+  awk -v needle="${needle}" '
+    {
+      pos = 1
+      while ((idx = index(substr($0, pos), needle)) > 0) {
+        count++
+        pos += idx + length(needle) - 1
+      }
+    }
+    END { print count + 0 }
+  ' <<<"${haystack}"
+}
+
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  else
+    echo "error: requires sha256sum or shasum to compute artifact hash" >&2
+    exit 1
+  fi
+}
+
+file_size_bytes() {
+  wc -c <"$1" | tr -d '[:space:]'
+}
+
+validate_agent_canvas_contract() {
+  local html="$1"
+  require_contains "${html}" 'id="tau-ops-chat-agent-canvas"' "agent canvas section"
+  require_contains "${html}" 'data-preview-status="loaded"' "loaded preview status"
+  require_contains "${html}" 'id="tau-ops-chat-agent-preview-frame"' "preview frame"
+  require_contains "${html}" 'sandbox="allow-scripts"' "sandboxed preview frame"
+  require_contains "${html}" 'data-agent-canvas-runtime="postmessage-v2"' "canvas runtime bridge"
+  require_contains "${html}" 'data-agent-canvas-artifact-history="true"' "artifact history"
+  require_contains "${html}" 'data-agent-canvas-controls="postmessage"' "controlled interaction surface"
+  require_contains "${html}" 'data-agent-canvas-diagnostics="true"' "diagnostics surface"
+  require_contains "${html}" 'data-preview-runtime-status="pending"' "runtime status marker"
+  require_contains "${html}" 'data-dom-node-count="0"' "DOM snapshot counter marker"
+  require_contains "${html}" 'data-dom-snapshot-count="0"' "DOM snapshot list counter marker"
+  require_contains "${html}" 'data-canvas-count="0"' "canvas counter marker"
+  require_contains "${html}" 'data-console-error-count="0"' "console error counter marker"
+  require_contains "${html}" 'data-pixel-sample-count="0"' "pixel sample counter marker"
+  require_contains "${html}" 'data-screenshot-sample-count="0"' "screenshot sample counter marker"
+  require_contains "${html}" 'data-interaction-mode="postmessage"' "interaction mode marker"
+  require_contains "${html}" 'data-agent-canvas-tool="snapshot"' "snapshot tool control"
+  require_contains "${html}" 'data-agent-canvas-tool="click"' "click tool control"
+  require_contains "${html}" 'data-agent-canvas-tool="type"' "type tool control"
+  require_contains "${html}" 'data-agent-canvas-dom-snapshot="true"' "DOM snapshot diagnostics list"
+  require_contains "${html}" 'data-agent-canvas-console-events="true"' "console diagnostics list"
+  require_contains "${html}" 'data-agent-canvas-pixel-samples="true"' "pixel diagnostics list"
+  require_contains "${html}" 'data-agent-canvas-screenshot-samples="true"' "screenshot diagnostics list"
+}
+
+apply_agent_canvas_proof_loop_fix() {
+  local artifact_path="$1"
+  mkdir -p "$(dirname "${artifact_path}")"
+  cat >"${artifact_path}" <<'HTML'
+<!doctype html>
+<html lang="en" data-agent-canvas-proof-loop="fixed">
+<head>
+  <meta charset="utf-8">
+  <title>Agent Canvas proof-loop fixed artifact</title>
+</head>
+<body>
+  <canvas id="game" width="96" height="48" data-agent-canvas-proof-loop-canvas="fixed"></canvas>
+  <input id="agent-canvas-proof-loop-input" aria-label="Agent Canvas proof-loop input">
+  <script>
+    const canvas = document.getElementById("game");
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#18a957";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#062a19";
+    ctx.fillRect(8, 8, 24, 16);
+    console.log("agent-canvas-proof-loop:fixed");
+  </script>
+</body>
+</html>
+HTML
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --base-url)
@@ -202,29 +304,75 @@ curl -sS --fail-with-body --max-time "${TIMEOUT_SECONDS}" \
   >"${chat_body}"
 
 chat_html="$(cat "${chat_body}")"
-require_contains "${chat_html}" 'id="tau-ops-chat-agent-canvas"' "agent canvas section"
-require_contains "${chat_html}" 'data-preview-status="loaded"' "loaded preview status"
-require_contains "${chat_html}" 'id="tau-ops-chat-agent-preview-frame"' "preview frame"
-require_contains "${chat_html}" 'sandbox="allow-scripts"' "sandboxed preview frame"
-require_contains "${chat_html}" 'data-agent-canvas-runtime="postmessage-v2"' "canvas runtime bridge"
-require_contains "${chat_html}" 'data-agent-canvas-artifact-history="true"' "artifact history"
-require_contains "${chat_html}" 'data-agent-canvas-controls="postmessage"' "controlled interaction surface"
-require_contains "${chat_html}" 'data-agent-canvas-diagnostics="true"' "diagnostics surface"
-require_contains "${chat_html}" 'data-preview-runtime-status="pending"' "runtime status marker"
-require_contains "${chat_html}" 'data-dom-node-count="0"' "DOM snapshot counter marker"
-require_contains "${chat_html}" 'data-dom-snapshot-count="0"' "DOM snapshot list counter marker"
-require_contains "${chat_html}" 'data-canvas-count="0"' "canvas counter marker"
-require_contains "${chat_html}" 'data-console-error-count="0"' "console error counter marker"
-require_contains "${chat_html}" 'data-pixel-sample-count="0"' "pixel sample counter marker"
-require_contains "${chat_html}" 'data-screenshot-sample-count="0"' "screenshot sample counter marker"
-require_contains "${chat_html}" 'data-interaction-mode="postmessage"' "interaction mode marker"
-require_contains "${chat_html}" 'data-agent-canvas-tool="snapshot"' "snapshot tool control"
-require_contains "${chat_html}" 'data-agent-canvas-tool="click"' "click tool control"
-require_contains "${chat_html}" 'data-agent-canvas-tool="type"' "type tool control"
-require_contains "${chat_html}" 'data-agent-canvas-dom-snapshot="true"' "DOM snapshot diagnostics list"
-require_contains "${chat_html}" 'data-agent-canvas-console-events="true"' "console diagnostics list"
-require_contains "${chat_html}" 'data-agent-canvas-pixel-samples="true"' "pixel diagnostics list"
-require_contains "${chat_html}" 'data-agent-canvas-screenshot-samples="true"' "screenshot diagnostics list"
+validate_agent_canvas_contract "${chat_html}"
+
+proof_loop_result="skipped"
+before_artifact_sha256=""
+after_artifact_sha256=""
+before_artifact_bytes=0
+after_artifact_bytes=0
+before_dom_marker_count=0
+after_dom_marker_count=0
+before_dom_snapshot_contract="false"
+after_dom_snapshot_contract="false"
+before_console_error_contract="false"
+after_console_error_contract="false"
+before_pixel_sample_contract="false"
+after_pixel_sample_contract="false"
+before_screenshot_sample_contract="false"
+after_screenshot_sample_contract="false"
+before_controlled_interaction_contract="false"
+after_controlled_interaction_contract="false"
+before_artifact_history_contract="false"
+after_artifact_history_contract="false"
+artifact_changed="false"
+targeted_fix_visible="false"
+route_contract_stable="false"
+
+if [[ "${file_check}" == "passed" ]]; then
+  before_artifact_sha256="$(file_sha256 "${ARTIFACT_PATH}")"
+  before_artifact_bytes="$(file_size_bytes "${ARTIFACT_PATH}")"
+  before_dom_marker_count="$(count_marker "${chat_html}" "data-agent-canvas")"
+  before_dom_snapshot_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-dom-snapshot="true"')"
+  before_console_error_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-console-events="true"')"
+  before_pixel_sample_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-pixel-samples="true"')"
+  before_screenshot_sample_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-screenshot-samples="true"')"
+  before_controlled_interaction_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-controls="postmessage"')"
+  before_artifact_history_contract="$(contains_bool "${chat_html}" 'data-agent-canvas-artifact-history="true"')"
+
+  apply_agent_canvas_proof_loop_fix "${ARTIFACT_PATH}"
+
+  after_body="${tmp_dir}/chat-after-fix.html"
+  curl -sS --fail-with-body --max-time "${TIMEOUT_SECONDS}" \
+    "${auth_args[@]}" \
+    "${BASE_URL%/}/ops/chat?theme=dark&sidebar=expanded&session=${SESSION_KEY}" \
+    >"${after_body}"
+  after_chat_html="$(cat "${after_body}")"
+  validate_agent_canvas_contract "${after_chat_html}"
+
+  after_artifact_sha256="$(file_sha256 "${ARTIFACT_PATH}")"
+  after_artifact_bytes="$(file_size_bytes "${ARTIFACT_PATH}")"
+  after_dom_marker_count="$(count_marker "${after_chat_html}" "data-agent-canvas")"
+  after_dom_snapshot_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-dom-snapshot="true"')"
+  after_console_error_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-console-events="true"')"
+  after_pixel_sample_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-pixel-samples="true"')"
+  after_screenshot_sample_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-screenshot-samples="true"')"
+  after_controlled_interaction_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-controls="postmessage"')"
+  after_artifact_history_contract="$(contains_bool "${after_chat_html}" 'data-agent-canvas-artifact-history="true"')"
+
+  if [[ "${before_artifact_sha256}" != "${after_artifact_sha256}" ]]; then
+    artifact_changed="true"
+  fi
+  if grep -Fq 'data-agent-canvas-proof-loop="fixed"' "${ARTIFACT_PATH}"; then
+    targeted_fix_visible="true"
+  fi
+  route_contract_stable="true"
+  if [[ "${artifact_changed}" != "true" || "${targeted_fix_visible}" != "true" ]]; then
+    echo "error: proof loop comparison did not observe the targeted fix" >&2
+    exit 1
+  fi
+  proof_loop_result="passed"
+fi
 
 mkdir -p "$(dirname "${OUTPUT_JSON}")"
 cat >"${OUTPUT_JSON}" <<JSON
@@ -247,6 +395,48 @@ cat >"${OUTPUT_JSON}" <<JSON
     "controlled_click": true,
     "controlled_type": true,
     "artifact_history": true
+  },
+  "proof_loop": {
+    "result": "$(json_escape "${proof_loop_result}")",
+    "targeted_fix": {
+      "action": "rewrite_artifact_with_deterministic_fixed_canvas_contract",
+      "applied": $(json_bool "${targeted_fix_visible}"),
+      "marker": "data-agent-canvas-proof-loop=\"fixed\""
+    },
+    "iterations": [
+      {
+        "label": "before",
+        "artifact_sha256": "$(json_escape "${before_artifact_sha256}")",
+        "artifact_bytes": ${before_artifact_bytes},
+        "route_contract_check": "passed",
+        "dom_marker_count": ${before_dom_marker_count},
+        "dom_snapshot_contract": $(json_bool "${before_dom_snapshot_contract}"),
+        "console_error_contract": $(json_bool "${before_console_error_contract}"),
+        "pixel_sample_contract": $(json_bool "${before_pixel_sample_contract}"),
+        "screenshot_sample_contract": $(json_bool "${before_screenshot_sample_contract}"),
+        "controlled_interaction_contract": $(json_bool "${before_controlled_interaction_contract}"),
+        "artifact_history_contract": $(json_bool "${before_artifact_history_contract}")
+      },
+      {
+        "label": "after",
+        "artifact_sha256": "$(json_escape "${after_artifact_sha256}")",
+        "artifact_bytes": ${after_artifact_bytes},
+        "route_contract_check": "passed",
+        "dom_marker_count": ${after_dom_marker_count},
+        "dom_snapshot_contract": $(json_bool "${after_dom_snapshot_contract}"),
+        "console_error_contract": $(json_bool "${after_console_error_contract}"),
+        "pixel_sample_contract": $(json_bool "${after_pixel_sample_contract}"),
+        "screenshot_sample_contract": $(json_bool "${after_screenshot_sample_contract}"),
+        "controlled_interaction_contract": $(json_bool "${after_controlled_interaction_contract}"),
+        "artifact_history_contract": $(json_bool "${after_artifact_history_contract}")
+      }
+    ],
+    "comparison": {
+      "artifact_changed": $(json_bool "${artifact_changed}"),
+      "targeted_fix_visible": $(json_bool "${targeted_fix_visible}"),
+      "route_contract_stable": $(json_bool "${route_contract_stable}"),
+      "rerun_contract_check": "passed"
+    }
   },
   "result": "passed"
 }

--- a/scripts/dev/test-ops-chat-canvas-proof.sh
+++ b/scripts/dev/test-ops-chat-canvas-proof.sh
@@ -16,8 +16,23 @@ assert_contains() {
   fi
 }
 
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+}
+
 if [[ ! -x "${PROOF_SCRIPT}" ]]; then
   echo "missing executable proof script: ${PROOF_SCRIPT}" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "missing required command: jq" >&2
   exit 1
 fi
 
@@ -128,6 +143,18 @@ assert_contains "$(cat "${output_json}")" '"file_check": "passed"' "file check r
 assert_contains "$(cat "${output_json}")" '"send_get_recovery": "passed"' "GET recovery result"
 assert_contains "$(cat "${output_json}")" '"send_failure_recovery": "passed"' "failure recovery result"
 assert_contains "$(cat "${output_json}")" '"runtime_contract_check": "passed"' "runtime contract result"
+assert_contains "$(cat "${output_json}")" '"proof_loop": {' "proof loop section"
+assert_contains "$(cat "${output_json}")" '"label": "before"' "before iteration"
+assert_contains "$(cat "${output_json}")" '"label": "after"' "after iteration"
+assert_contains "$(cat "${output_json}")" '"artifact_changed": true' "artifact changed comparison"
+assert_contains "$(cat "${output_json}")" '"targeted_fix_visible": true' "targeted fix visible comparison"
+assert_contains "$(cat "${output_json}")" '"route_contract_stable": true' "stable route contract comparison"
+assert_contains "$(cat "${artifact}")" 'data-agent-canvas-proof-loop="fixed"' "targeted artifact fix marker"
+assert_equals "passed" "$(jq -r '.proof_loop.result' "${output_json}")" "proof loop result"
+assert_equals "2" "$(jq -r '.proof_loop.iterations | length' "${output_json}")" "proof loop iteration count"
+assert_equals "true" "$(jq -r '.proof_loop.comparison.artifact_changed' "${output_json}")" "proof loop artifact changed"
+assert_equals "true" "$(jq -r '.proof_loop.comparison.targeted_fix_visible' "${output_json}")" "proof loop targeted fix visible"
+assert_equals "true" "$(jq -r '.proof_loop.comparison.route_contract_stable' "${output_json}")" "proof loop route contract stable"
 assert_contains "$(cat "${curl_log}")" "/ops/chat/send" "chat send call"
 assert_contains "$(cat "${curl_log}")" "/ops/chat?theme=dark&sidebar=expanded&session=proof-session" "chat render call"
 

--- a/specs/3764-agent-canvas-proof-loop/plan.md
+++ b/specs/3764-agent-canvas-proof-loop/plan.md
@@ -1,0 +1,48 @@
+# Plan: Issue #3764 - Agent Canvas proof loop stores comparison evidence
+
+## Approach
+
+Keep the implementation in the existing proof automation. The script already
+submits `/ops/chat/send`, checks route recovery behavior, verifies that an HTML
+artifact exists, fetches `/ops/chat`, and validates Agent Canvas v2 markers. Add a
+small loop layer around those checks:
+
+1. Capture the first route inspection and artifact hash as the `before`
+   iteration.
+2. Apply a deterministic proof-only artifact fix that adds a durable marker,
+   a canvas, an input target, and a console success signal.
+3. Fetch `/ops/chat` again and run the same route contract checks.
+4. Persist a comparison section with before/after hashes, marker visibility,
+   stable route-contract status, and rerun status.
+
+The shell test remains the RED/GREEN contract for CI. It uses a fake `curl`
+gateway and a temporary artifact so the proof-loop JSON shape is validated
+without credentials or a browser dependency.
+
+## Affected Modules
+
+- `scripts/dev/ops-chat-canvas-proof.sh`
+- `scripts/dev/test-ops-chat-canvas-proof.sh`
+- `specs/3764-agent-canvas-proof-loop/*`
+- `tasks/reports/ops-chat-canvas-proof-loop.json` if live proof is run and
+  checked in as evidence
+
+## Risks and Mitigations
+
+- Risk: Shell-only proof could overstate browser runtime evidence.
+  Mitigation: Persist diagnostics as contract/capability markers, not as actual
+  browser pixel values, unless a live browser proof is separately recorded.
+- Risk: The targeted fix could mask a missing artifact.
+  Mitigation: Keep the existing file check before applying the fix.
+- Risk: JSON assembled in shell could become invalid.
+  Mitigation: Test with `jq` when available and assert stable fields in the
+  shell regression.
+- Risk: The issue number collides with existing `specs/3764/`.
+  Mitigation: Use the explicit conflict-safe path
+  `specs/3764-agent-canvas-proof-loop/` and call that out in the issue/PR.
+
+## Verification
+
+Run the shell regression first, then focused static checks. If a local gateway
+with the necessary tool path is available, run the proof script against it and
+store the resulting comparison evidence under `tasks/reports/`.

--- a/specs/3764-agent-canvas-proof-loop/spec.md
+++ b/specs/3764-agent-canvas-proof-loop/spec.md
@@ -1,0 +1,71 @@
+# Spec: Issue #3764 - Agent Canvas proof loop stores comparison evidence
+
+Status: Implemented
+Priority: P1
+Milestone: M334 - Tau Ralph loop supervisor architecture
+Parent: #3654
+
+## Problem Statement
+
+Agent Canvas v2 can render generated HTML artifacts and expose diagnostics
+markers, but the repeatable proof stops at validating the surface. To make the
+canvas a flagship agent loop, the proof must show a closed iteration: generate an
+artifact, inspect route/runtime evidence, apply one targeted deterministic fix,
+rerun the proof, and persist before/after comparison evidence.
+
+## Scope
+
+In scope:
+
+- Extend `scripts/dev/ops-chat-canvas-proof.sh` with deterministic proof-loop
+  evidence.
+- Preserve the existing `/ops/chat/send` recovery, artifact generation, and
+  Agent Canvas v2 runtime contract checks.
+- Persist before/after artifact hashes, route contract markers, diagnostics
+  capability checks, targeted fix metadata, and rerun comparison status in JSON.
+- Add shell regression coverage for the proof-loop JSON contract.
+- Record this issue's artifact path explicitly because `specs/3764/` already
+  contains an older implemented local spec.
+
+Out of scope:
+
+- Adding browser dependencies to CI.
+- Changing the Agent Canvas product UI layout.
+- Reworking the gateway agent runtime or provider/tool selection.
+- Claiming true pixel values from a headed browser when the proof is running in
+  shell-only CI mode.
+
+## Acceptance Criteria
+
+AC-1: Given the ops-chat canvas proof script completes, when the proof JSON is
+written, then it contains a `proof_loop.result = "passed"` section with before
+and after iterations.
+
+AC-2: Given the generated HTML artifact exists, when the proof loop runs, then it
+records the before artifact hash, applies one deterministic targeted fix, records
+the after artifact hash, and reports that the artifact changed.
+
+AC-3: Given the `/ops/chat` route is fetched before and after the targeted fix,
+when the route HTML is inspected, then both iterations preserve Agent Canvas DOM,
+console, pixel, screenshot, controlled interaction, and artifact-history
+contract markers.
+
+AC-4: Given the proof loop reruns after the fix, when comparison evidence is
+written, then it reports the rerun contract as stable and the targeted fix marker
+as visible in the artifact.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | fake live gateway shell test | run proof script | JSON includes `proof_loop.result = "passed"` and two iterations |
+| C-02 | AC-2 | Functional | generated artifact file | proof loop applies fix | before/after SHA-256 values differ and `artifact_changed = true` |
+| C-03 | AC-3 | Conformance | fake `/ops/chat` route response | route fetched before and after | both iterations record Agent Canvas diagnostics contracts as true |
+| C-04 | AC-4 | Regression | fixed artifact | rerun proof evidence emitted | comparison reports stable route contract and visible targeted fix |
+
+## Success Metrics / Observable Signals
+
+- `scripts/dev/test-ops-chat-canvas-proof.sh`
+- `scripts/dev/ops-chat-canvas-proof.sh --base-url <local gateway> --session <key> --artifact-path <workspace html> --output-json tasks/reports/ops-chat-canvas-proof-loop.json`
+- `git diff --check`
+- Proof JSON contains machine-readable before/after hashes and comparison status.

--- a/specs/3764-agent-canvas-proof-loop/tasks.md
+++ b/specs/3764-agent-canvas-proof-loop/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Issue #3764 - Agent Canvas proof loop stores comparison evidence
+
+Status: Implemented
+
+- [x] T1 (SPEC): create conflict-safe spec/plan/tasks for the Agent Canvas proof-loop follow-up.
+- [x] T2 (RED): extend the proof-script shell test to require proof-loop comparison JSON.
+- [x] T3 (GREEN): add before/fix/after/rerun comparison evidence to `ops-chat-canvas-proof.sh`.
+- [x] T4 (VERIFY): run shell regression, static checks, and focused proof commands.
+
+## Tier Mapping
+
+| Tier | Status | Tests | N/A Why |
+| --- | --- | --- | --- |
+| Unit | N/A | | shell proof automation; no Rust unit boundary changed |
+| Property | N/A | | no randomized invariant introduced |
+| Contract/DbC | N/A | | no `contracts` macro boundary changed |
+| Snapshot | N/A | | explicit JSON assertions cover the proof payload |
+| Functional | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` | |
+| Conformance | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` proof-loop JSON assertions | |
+| Integration | N/A | | no local credentialed gateway/tool provider was launched for this shell-only automation slice |
+| Fuzz | N/A | | no parser/codec fuzz boundary changed |
+| Mutation | N/A | | shell proof automation slice |
+| Regression | ✅ | proof script fake-gateway regression | |
+| Performance | N/A | | no runtime performance path changed |
+
+## Verification Evidence
+
+- RED: `scripts/dev/test-ops-chat-canvas-proof.sh` failed with
+  `assertion failed (proof loop section): expected '"proof_loop": {'`, proving
+  the previous JSON did not store loop comparison evidence.
+- GREEN: `scripts/dev/test-ops-chat-canvas-proof.sh` passed after the script
+  captured before/after artifact hashes, applied the deterministic fixed-canvas
+  marker, reran the route contract check, and emitted comparison evidence.
+- REGRESSION: the same shell test parses the output with `jq` and asserts
+  `proof_loop.result = "passed"`, two iterations, `artifact_changed = true`,
+  `targeted_fix_visible = true`, and `route_contract_stable = true`.
+- STATIC: `bash -n scripts/dev/ops-chat-canvas-proof.sh
+  scripts/dev/test-ops-chat-canvas-proof.sh` passed.
+- STATIC: `git diff --check` passed.
+- PROCESS: `scripts/dev/roadmap-status-sync.sh --check --quiet` passed after
+  creating GitHub issue `#3764`.


### PR DESCRIPTION
## Summary

Adds a deterministic Agent Canvas proof loop to the ops-chat canvas proof script. The proof now records before/after artifact hashes, applies a targeted fixed-canvas artifact marker, reruns the Agent Canvas route contract, and persists comparison evidence in JSON.

P1 spec note: this spec was authored and marked Implemented by the agent per the repo self-acceptance rule; human review is requested in this PR.

## Links

- Closes #3764
- Parent story: #3654
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Spec: `specs/3764-agent-canvas-proof-loop/spec.md`
- Plan: `specs/3764-agent-canvas-proof-loop/plan.md`
- Tasks: `specs/3764-agent-canvas-proof-loop/tasks.md`
- Note: `specs/3764/` already belongs to an older implemented local spec, so this issue uses the conflict-safe path above.

## Spec Verification

| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: proof JSON contains `proof_loop.result = "passed"` with before/after iterations | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` + `jq` assertions |
| AC-2: generated artifact records before hash, targeted fix, after hash, and changed comparison | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` artifact/hash comparison assertions |
| AC-3: `/ops/chat` route preserves Agent Canvas DOM, console, pixel, screenshot, controlled interaction, and artifact-history markers before/after | ✅ | shared `validate_agent_canvas_contract` rerun in `scripts/dev/ops-chat-canvas-proof.sh` and shell regression |
| AC-4: comparison evidence reports stable rerun contract and visible targeted fix marker | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` JSON assertions |

## TDD Evidence

- RED: `scripts/dev/test-ops-chat-canvas-proof.sh` failed with `assertion failed (proof loop section): expected '"proof_loop": {'`, proving prior JSON lacked loop comparison evidence.
- GREEN: `scripts/dev/test-ops-chat-canvas-proof.sh` passed after the script captured before/after artifact hashes, applied the deterministic fixed-canvas marker, reran the route contract, and emitted comparison evidence.
- REGRESSION: the same shell test parses output with `jq` and asserts `proof_loop.result = "passed"`, two iterations, `artifact_changed = true`, `targeted_fix_visible = true`, and `route_contract_stable = true`.

## Test Tiers

| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | N/A | | shell proof automation; no Rust unit boundary changed |
| Property | N/A | | no randomized invariant introduced |
| Contract/DbC | N/A | | no `contracts` macro boundary changed |
| Snapshot | N/A | | explicit JSON assertions cover the proof payload |
| Functional | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` | |
| Conformance | ✅ | `scripts/dev/test-ops-chat-canvas-proof.sh` proof-loop JSON assertions | |
| Integration | N/A | | no local credentialed gateway/tool provider was launched for this shell-only automation slice |
| Fuzz | N/A | | no parser/codec fuzz boundary changed |
| Mutation | N/A | | shell proof automation slice |
| Regression | ✅ | proof script fake-gateway regression | |
| Performance | N/A | | no runtime performance path changed |

## Mutation

N/A for this shell proof automation slice; no Rust critical-path code changed.

## Additional Verification

- `scripts/dev/test-ops-chat-canvas-proof.sh`
- `bash -n scripts/dev/ops-chat-canvas-proof.sh scripts/dev/test-ops-chat-canvas-proof.sh`
- `git diff --check`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`

## Risks / Rollback

- Risk: shell-only proof could overstate browser runtime evidence. Mitigation: persisted diagnostics are route contract/capability markers, not claimed headed-browser pixel values.
- Rollback: revert `7af64216` to restore the previous static Agent Canvas proof contract.

## Docs / ADR

- Updated spec/plan/tasks under `specs/3764-agent-canvas-proof-loop/`.
- No ADR required; no dependency, protocol, or architecture strategy changed.