### PR TITLE
Add runtime reality gate for agentic-runtime claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Some surfaces are intentionally diagnostics-first or staged:
   - scenario-expansion depth (demo mode behavior + parser/shell-live edge paths + workflow-depth chaining) is aggregated in `scripts/verify/m317-tui-scenario-expansion-depth.sh`,
   - remains complementary to (not a replacement for) web dashboard workflows.
 
+Executable claim boundary:
+
+```bash
+./scripts/dev/runtime-reality-gate.sh \
+  --output-json /tmp/tau-runtime-reality.json \
+  --output-md /tmp/tau-runtime-reality.md
+```
+
+The runtime reality gate is the fast default check for Tau product claims. It
+runs deterministic proof surfaces, records heavyweight/live validation as
+explicit opt-in evidence, and keeps unsupported claims such as autonomous-forever
+operation or shell-only browser-pixel proof from being represented as complete.
+
 ## Maturity Matrix
 
 | Capability Area | Status | Meaning | Primary Reference |

--- a/scripts/dev/runtime-reality-gate.sh
+++ b/scripts/dev/runtime-reality-gate.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUTPUT_JSON="${TAU_RUNTIME_REALITY_OUTPUT_JSON:-tasks/reports/runtime-reality-gate.json}"
+OUTPUT_MD="${TAU_RUNTIME_REALITY_OUTPUT_MD:-tasks/reports/runtime-reality-gate.md}"
+RUN_FAST_CHECKS="true"
+RUN_HEAVY_CHECKS="${TAU_RUNTIME_REALITY_RUN_HEAVY_CHECKS:-false}"
+RUN_LIVE_CHECKS="${TAU_RUNTIME_REALITY_RUN_LIVE_CHECKS:-false}"
+
+PRODUCT_PROOF="${TAU_RUNTIME_REALITY_PRODUCT_PROOF:-${REPO_ROOT}/scripts/dev/prove-tau-product.sh}"
+TAU_UNIFIED_TEST="${TAU_RUNTIME_REALITY_TAU_UNIFIED_TEST:-${REPO_ROOT}/scripts/run/test-tau-unified.sh}"
+AGENT_CANVAS_TEST="${TAU_RUNTIME_REALITY_AGENT_CANVAS_TEST:-${REPO_ROOT}/scripts/dev/test-ops-chat-canvas-proof.sh}"
+ROADMAP_SYNC="${TAU_RUNTIME_REALITY_ROADMAP_SYNC:-${REPO_ROOT}/scripts/dev/roadmap-status-sync.sh}"
+
+DASHBOARD_UI_LIB_PATH="${TAU_RUNTIME_REALITY_DASHBOARD_UI_LIB_PATH:-${REPO_ROOT}/crates/tau-dashboard-ui/src/lib.rs}"
+OPS_DASHBOARD_SHELL_PATH="${TAU_RUNTIME_REALITY_OPS_DASHBOARD_SHELL_PATH:-${REPO_ROOT}/crates/tau-gateway/src/gateway_openresponses/ops_dashboard_shell.rs}"
+GATEWAY_OPENRESPONSES_TESTS_PATH="${TAU_RUNTIME_REALITY_GATEWAY_OPENRESPONSES_TESTS_PATH:-${REPO_ROOT}/crates/tau-gateway/src/gateway_openresponses/tests.rs}"
+
+DASHBOARD_UI_LIB_BUDGET="${TAU_RUNTIME_REALITY_DASHBOARD_UI_LIB_BUDGET:-5000}"
+OPS_DASHBOARD_SHELL_BUDGET="${TAU_RUNTIME_REALITY_OPS_DASHBOARD_SHELL_BUDGET:-4000}"
+GATEWAY_OPENRESPONSES_TESTS_BUDGET="${TAU_RUNTIME_REALITY_GATEWAY_OPENRESPONSES_TESTS_BUDGET:-10000}"
+
+RL_HARNESS_COMMAND="${TAU_RUNTIME_REALITY_RL_HARNESS_COMMAND:-cargo run -p tau-trainer --bin rl_e2e_harness -- --run-id runtime-reality --output-dir /tmp/tau-runtime-reality-rl --print-json}"
+FULL_VALIDATE_COMMAND="${TAU_RUNTIME_REALITY_FULL_VALIDATE_COMMAND:-env RUST_MIN_STACK=16777216 scripts/dev/fast-validate.sh --full}"
+LIVE_PROVIDER_COMMAND="${TAU_RUNTIME_REALITY_LIVE_PROVIDER_COMMAND:-scripts/dev/provider-live-smoke.sh}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/runtime-reality-gate.sh [options]
+
+Emit machine-readable and markdown evidence for Tau runtime/product claims.
+Default mode runs fast deterministic proof checks and records heavyweight/live
+proof as explicit opt-in boundaries.
+
+Options:
+  --output-json <path>       JSON evidence output path
+  --output-md <path>         Markdown evidence output path
+  --skip-fast-checks         Do not run fast proof checks
+  --run-heavy                Run heavyweight local checks
+  --run-live                 Run live-env checks
+  --help                     Show this help
+USAGE
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '%s' "${value}"
+}
+
+json_bool() {
+  if [[ "$1" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+append_json_item() {
+  local __array_name="$1"
+  local item="$2"
+  eval "${__array_name}+=(\"\${item}\")"
+}
+
+json_array() {
+  local first="true"
+  printf '['
+  for item in "$@"; do
+    if [[ "${first}" == "true" ]]; then
+      first="false"
+    else
+      printf ','
+    fi
+    printf '%s' "${item}"
+  done
+  printf ']'
+}
+
+require_executable() {
+  local path="$1"
+  local label="$2"
+  if [[ ! -x "${path}" ]]; then
+    echo "error: ${label} is missing or not executable: ${path}" >&2
+    return 1
+  fi
+}
+
+line_count() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    printf '0'
+    return
+  fi
+  wc -l <"${path}" | tr -d '[:space:]'
+}
+
+hotspot_status() {
+  local lines="$1"
+  local budget="$2"
+  if [[ "${lines}" -gt "${budget}" ]]; then
+    printf 'over_budget'
+  else
+    printf 'within_budget'
+  fi
+}
+
+command_display() {
+  local display=""
+  for arg in "$@"; do
+    if [[ -z "${display}" ]]; then
+      display="$arg"
+    else
+      display="${display} ${arg}"
+    fi
+  done
+  printf '%s' "${display}"
+}
+
+run_check() {
+  local id="$1"
+  local label="$2"
+  shift 2
+  local log_path="${tmp_dir}/${id}.log"
+  local rc=0
+  set +e
+  "$@" >"${log_path}" 2>&1
+  rc=$?
+  set -e
+
+  local status="passed"
+  if [[ "${rc}" -ne 0 ]]; then
+    status="failed"
+    gate_failed="true"
+  fi
+
+  append_json_item fast_check_items "$(
+    printf '{"id":"%s","label":"%s","status":"%s","exit_code":%s,"command":"%s"}' \
+      "$(json_escape "${id}")" \
+      "$(json_escape "${label}")" \
+      "$(json_escape "${status}")" \
+      "${rc}" \
+      "$(json_escape "$(command_display "$@")")"
+  )"
+}
+
+skip_check() {
+  local id="$1"
+  local label="$2"
+  local command="$3"
+  append_json_item fast_check_items "$(
+    printf '{"id":"%s","label":"%s","status":"skipped","exit_code":null,"command":"%s"}' \
+      "$(json_escape "${id}")" \
+      "$(json_escape "${label}")" \
+      "$(json_escape "${command}")"
+  )"
+}
+
+run_string_opt_in_check() {
+  local id="$1"
+  local label="$2"
+  local command="$3"
+  local enabled="$4"
+  local log_path="${tmp_dir}/${id}.log"
+
+  if [[ "${enabled}" != "true" ]]; then
+    append_json_item opt_in_check_items "$(
+      printf '{"id":"%s","label":"%s","status":"skipped","opt_in":true,"command":"%s"}' \
+        "$(json_escape "${id}")" \
+        "$(json_escape "${label}")" \
+        "$(json_escape "${command}")"
+    )"
+    return
+  fi
+
+  local rc=0
+  set +e
+  (cd "${REPO_ROOT}" && bash -lc "${command}") >"${log_path}" 2>&1
+  rc=$?
+  set -e
+
+  local status="passed"
+  if [[ "${rc}" -ne 0 ]]; then
+    status="failed"
+    gate_failed="true"
+  fi
+  append_json_item opt_in_check_items "$(
+    printf '{"id":"%s","label":"%s","status":"%s","opt_in":true,"exit_code":%s,"command":"%s"}' \
+      "$(json_escape "${id}")" \
+      "$(json_escape "${label}")" \
+      "$(json_escape "${status}")" \
+      "${rc}" \
+      "$(json_escape "${command}")"
+  )"
+}
+
+surface_json() {
+  local id="$1"
+  local title="$2"
+  local classification="$3"
+  local boundary="$4"
+  local required_evidence="$5"
+  printf '{"id":"%s","title":"%s","classification":"%s","boundary":"%s","required_evidence":"%s"}' \
+    "$(json_escape "${id}")" \
+    "$(json_escape "${title}")" \
+    "$(json_escape "${classification}")" \
+    "$(json_escape "${boundary}")" \
+    "$(json_escape "${required_evidence}")"
+}
+
+classification_for_surface() {
+  case "$1" in
+    tau_core_runtime|tau_unified_launcher|agent_canvas_shell_proof|auth_transports_deterministic|release_validation_isolated|true_rl_deterministic_harness)
+      printf 'deterministic_integrated'
+      ;;
+    dashboard_operator_ux|unified_runtime_control_plane|maintainability_hotspots)
+      printf 'partial'
+      ;;
+    true_rl_productionization|full_release_validation|headed_browser_canvas_pixel_live)
+      printf 'opt_in_heavy'
+      ;;
+    auth_transports_live_validation)
+      printf 'live_env_required'
+      ;;
+    autonomy_forever|live_browser_pixel_proof|release_validation_shared_target|maintainability_solved)
+      printf 'not_claimable'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+claim_can_be_complete() {
+  local classification="$1"
+  case "${classification}" in
+    deterministic_integrated)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-md)
+      OUTPUT_MD="$2"
+      shift 2
+      ;;
+    --skip-fast-checks)
+      RUN_FAST_CHECKS="false"
+      shift
+      ;;
+    --run-heavy)
+      RUN_HEAVY_CHECKS="true"
+      shift
+      ;;
+    --run-live)
+      RUN_LIVE_CHECKS="true"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+gate_failed="false"
+fast_check_items=()
+opt_in_check_items=()
+surface_items=()
+hotspot_items=()
+overstatement_items=()
+
+if [[ "${RUN_FAST_CHECKS}" == "true" ]]; then
+  if require_executable "${PRODUCT_PROOF}" "Tau product proof script"; then
+    run_check "tau_product_proof_check" "Tau product proof check" "${PRODUCT_PROOF}" --check --report "${tmp_dir}/tau-product-proof.json"
+  else
+    gate_failed="true"
+  fi
+  if require_executable "${TAU_UNIFIED_TEST}" "tau-unified launcher test"; then
+    run_check "tau_unified_launcher_test" "tau-unified launcher regression" "${TAU_UNIFIED_TEST}"
+  else
+    gate_failed="true"
+  fi
+  if require_executable "${AGENT_CANVAS_TEST}" "Agent Canvas proof-loop test"; then
+    run_check "agent_canvas_proof_loop_test" "Agent Canvas proof-loop regression" "${AGENT_CANVAS_TEST}"
+  else
+    gate_failed="true"
+  fi
+  if require_executable "${ROADMAP_SYNC}" "roadmap status sync"; then
+    run_check "roadmap_status_sync_check" "Roadmap status sync check" "${ROADMAP_SYNC}" --check --quiet
+  else
+    gate_failed="true"
+  fi
+else
+  skip_check "tau_product_proof_check" "Tau product proof check" "${PRODUCT_PROOF} --check"
+  skip_check "tau_unified_launcher_test" "tau-unified launcher regression" "${TAU_UNIFIED_TEST}"
+  skip_check "agent_canvas_proof_loop_test" "Agent Canvas proof-loop regression" "${AGENT_CANVAS_TEST}"
+  skip_check "roadmap_status_sync_check" "Roadmap status sync check" "${ROADMAP_SYNC} --check --quiet"
+fi
+
+run_string_opt_in_check "rl_e2e_harness" "RL deterministic harness and gates" "${RL_HARNESS_COMMAND}" "${RUN_HEAVY_CHECKS}"
+run_string_opt_in_check "isolated_full_fast_validate" "Isolated full release validation" "${FULL_VALIDATE_COMMAND}" "${RUN_HEAVY_CHECKS}"
+run_string_opt_in_check "live_provider_validation" "Live third-party provider validation" "${LIVE_PROVIDER_COMMAND}" "${RUN_LIVE_CHECKS}"
+
+append_json_item surface_items "$(surface_json "tau_core_runtime" "Core Tau runtime path" "deterministic_integrated" "CLI/session/tool/safety/gateway path has runnable deterministic proof." "scripts/dev/prove-tau-product.sh --check")"
+append_json_item surface_items "$(surface_json "tau_unified_launcher" "tau-unified launcher" "deterministic_integrated" "up/status/down/tui launcher contract is covered by shell regression." "scripts/run/test-tau-unified.sh")"
+append_json_item surface_items "$(surface_json "dashboard_operator_ux" "Dashboard/operator UX" "partial" "Routes and diagnostics exist, but polished command-center workflow remains expanding." "scripts/verify/m318-dashboard-command-center-depth.sh plus product UX review")"
+append_json_item surface_items "$(surface_json "unified_runtime_control_plane" "One obvious runtime experience" "partial" "tau-unified is real, but health/logs/jobs/sessions/memory/deploy are not yet one complete operator pane." "Dedicated control-plane UX and end-to-end operator workflow proof")"
+append_json_item surface_items "$(surface_json "agent_canvas_shell_proof" "Agent Canvas shell proof-loop" "deterministic_integrated" "Shell proof records route contract, artifact hashes, and targeted fix comparison." "scripts/dev/test-ops-chat-canvas-proof.sh")"
+append_json_item surface_items "$(surface_json "live_browser_pixel_proof" "Live browser pixel proof" "not_claimable" "Shell Agent Canvas proof does not claim headed-browser pixel truth." "Headed browser proof with screenshot/canvas pixel capture")"
+append_json_item surface_items "$(surface_json "headed_browser_canvas_pixel_live" "Headed browser canvas-pixel validation" "opt_in_heavy" "Possible future proof path, not part of default shell evidence." "Browser automation run that stores screenshot and canvas-pixel artifacts")"
+append_json_item surface_items "$(surface_json "true_rl_deterministic_harness" "True RL deterministic harness" "deterministic_integrated" "GAE/PPO/promotion/rollback evidence exists as deterministic harness output." "cargo run -p tau-trainer --bin rl_e2e_harness -- --print-json")"
+append_json_item surface_items "$(surface_json "true_rl_productionization" "Production RL policy operations" "opt_in_heavy" "Long-horizon policy operations, scale, and drills remain expansion work." "Long-horizon evals, promotion controls, rollback drills, and statistically useful evidence")"
+append_json_item surface_items "$(surface_json "auth_transports_deterministic" "Auth/transports deterministic coverage" "deterministic_integrated" "Deterministic auth, transport, and multi-channel suites exist." "scripts/verify/m303-auth-workflow-depth.sh and scripts/verify/m307-multi-channel-orchestration-depth.sh")"
+append_json_item surface_items "$(surface_json "auth_transports_live_validation" "Auth/transports live validation" "live_env_required" "Third-party credential/provider behavior remains environment-specific." "Live provider credentials and network validation")"
+append_json_item surface_items "$(surface_json "release_validation_isolated" "Release validation isolated target" "deterministic_integrated" "Isolated fast-validate path is the credible release evidence." "RUST_MIN_STACK=16777216 scripts/dev/fast-validate.sh --full")"
+append_json_item surface_items "$(surface_json "release_validation_shared_target" "Shared target release evidence" "not_claimable" "Shared target path has documented stale/contended compiler-state risk." "Use isolated CARGO_TARGET_DIR or fast-validate isolation")"
+append_json_item surface_items "$(surface_json "autonomy_forever" "Autonomous forever runtime" "not_claimable" "Durable always-on autonomy, stuck-job recovery, replay, and crash-resume are not complete as one product loop." "Durable jobs/routines/recovery proof with operator controls")"
+append_json_item surface_items "$(surface_json "maintainability_hotspots" "Maintainability hotspot status" "partial" "Large files remain a real tax until split further." "Hotspot line counts below agreed budgets")"
+append_json_item surface_items "$(surface_json "maintainability_solved" "Maintainability solved" "not_claimable" "Current hotspot counts still exceed desired bounds." "Hotspot line counts below agreed budgets")"
+
+dashboard_lines="$(line_count "${DASHBOARD_UI_LIB_PATH}")"
+ops_shell_lines="$(line_count "${OPS_DASHBOARD_SHELL_PATH}")"
+gateway_tests_lines="$(line_count "${GATEWAY_OPENRESPONSES_TESTS_PATH}")"
+
+append_json_item hotspot_items "$(
+  printf '{"id":"dashboard_ui_lib","path":"%s","line_count":%s,"budget":%s,"status":"%s"}' \
+    "$(json_escape "${DASHBOARD_UI_LIB_PATH}")" \
+    "${dashboard_lines}" \
+    "${DASHBOARD_UI_LIB_BUDGET}" \
+    "$(hotspot_status "${dashboard_lines}" "${DASHBOARD_UI_LIB_BUDGET}")"
+)"
+append_json_item hotspot_items "$(
+  printf '{"id":"ops_dashboard_shell","path":"%s","line_count":%s,"budget":%s,"status":"%s"}' \
+    "$(json_escape "${OPS_DASHBOARD_SHELL_PATH}")" \
+    "${ops_shell_lines}" \
+    "${OPS_DASHBOARD_SHELL_BUDGET}" \
+    "$(hotspot_status "${ops_shell_lines}" "${OPS_DASHBOARD_SHELL_BUDGET}")"
+)"
+append_json_item hotspot_items "$(
+  printf '{"id":"gateway_openresponses_tests","path":"%s","line_count":%s,"budget":%s,"status":"%s"}' \
+    "$(json_escape "${GATEWAY_OPENRESPONSES_TESTS_PATH}")" \
+    "${gateway_tests_lines}" \
+    "${GATEWAY_OPENRESPONSES_TESTS_BUDGET}" \
+    "$(hotspot_status "${gateway_tests_lines}" "${GATEWAY_OPENRESPONSES_TESTS_BUDGET}")"
+)"
+
+IFS=',' read -r -a forced_complete_claims <<<"${TAU_RUNTIME_REALITY_FORCE_COMPLETE_CLAIMS:-}"
+for raw_claim in "${forced_complete_claims[@]}"; do
+  claim="$(printf '%s' "${raw_claim}" | xargs)"
+  if [[ -z "${claim}" ]]; then
+    continue
+  fi
+  classification="$(classification_for_surface "${claim}")"
+  if ! claim_can_be_complete "${classification}"; then
+    gate_failed="true"
+    append_json_item overstatement_items "$(
+      printf '{"id":"%s","classification":"%s","reason":"claim cannot be represented as complete with current evidence"}' \
+        "$(json_escape "${claim}")" \
+        "$(json_escape "${classification}")"
+    )"
+  fi
+done
+
+result="passed"
+if [[ "${gate_failed}" == "true" ]]; then
+  result="failed"
+fi
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")" "$(dirname "${OUTPUT_MD}")"
+
+cat >"${OUTPUT_JSON}" <<JSON
+{
+  "schema_version": 1,
+  "gate": "tau_runtime_reality_gate",
+  "result": "$(json_escape "${result}")",
+  "modes": {
+    "fast_checks": $(json_bool "${RUN_FAST_CHECKS}"),
+    "heavy_checks": $(json_bool "${RUN_HEAVY_CHECKS}"),
+    "live_checks": $(json_bool "${RUN_LIVE_CHECKS}")
+  },
+  "fast_checks": $(json_array "${fast_check_items[@]}"),
+  "opt_in_checks": $(json_array "${opt_in_check_items[@]}"),
+  "surfaces": $(json_array "${surface_items[@]}"),
+  "hotspots": $(json_array "${hotspot_items[@]}"),
+  "claim_guard": {
+    "forced_complete_claims": "$(json_escape "${TAU_RUNTIME_REALITY_FORCE_COMPLETE_CLAIMS:-}")",
+    "unsupported_overstatements": $(json_array "${overstatement_items[@]}")
+  }
+}
+JSON
+
+{
+  printf '# Tau Runtime Reality Gate\n\n'
+  printf 'Result: `%s`\n\n' "${result}"
+  printf '## Fast Checks\n\n'
+  for item in "${fast_check_items[@]}"; do
+    id="$(printf '%s' "${item}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+    status="$(printf '%s' "${item}" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')"
+    printf -- '- `%s`: `%s`\n' "${id}" "${status}"
+  done
+  printf '\n## Works With Caveats\n\n'
+  printf -- '- Dashboard/operator UX is `partial`: routes and diagnostics exist; polished command-center workflow remains expanding.\n'
+  printf -- '- Production RL policy operations are `opt_in_heavy`: deterministic RL exists, but production-scale operations need long-horizon proof.\n'
+  printf -- '- Auth/transports live validation is `live_env_required`: deterministic suites exist; third-party credentials are environment-bound.\n'
+  printf -- '- Release validation is credible through isolated validation, not shared-target compiler state.\n'
+  printf '\n## Not Claimable\n\n'
+  printf -- '- Autonomous forever runtime is not claimable as complete.\n'
+  printf -- '- Shell Agent Canvas proof is not headed-browser pixel proof.\n'
+  printf -- '- Shared target release validation is not credible release evidence.\n'
+  printf -- '- Maintainability solved is not claimable while hotspot files exceed budgets.\n'
+  printf '\n## Maintainability Hotspots\n\n'
+  printf -- '- `%s`: %s lines, budget %s, `%s`\n' "${DASHBOARD_UI_LIB_PATH}" "${dashboard_lines}" "${DASHBOARD_UI_LIB_BUDGET}" "$(hotspot_status "${dashboard_lines}" "${DASHBOARD_UI_LIB_BUDGET}")"
+  printf -- '- `%s`: %s lines, budget %s, `%s`\n' "${OPS_DASHBOARD_SHELL_PATH}" "${ops_shell_lines}" "${OPS_DASHBOARD_SHELL_BUDGET}" "$(hotspot_status "${ops_shell_lines}" "${OPS_DASHBOARD_SHELL_BUDGET}")"
+  printf -- '- `%s`: %s lines, budget %s, `%s`\n' "${GATEWAY_OPENRESPONSES_TESTS_PATH}" "${gateway_tests_lines}" "${GATEWAY_OPENRESPONSES_TESTS_BUDGET}" "$(hotspot_status "${gateway_tests_lines}" "${GATEWAY_OPENRESPONSES_TESTS_BUDGET}")"
+  printf '\n## Opt-In Evidence\n\n'
+  printf -- '- RL harness: `%s`\n' "${RL_HARNESS_COMMAND}"
+  printf -- '- Full isolated validation: `%s`\n' "${FULL_VALIDATE_COMMAND}"
+  printf -- '- Live provider validation: `%s`\n' "${LIVE_PROVIDER_COMMAND}"
+  if [[ "${#overstatement_items[@]}" -gt 0 ]]; then
+    printf '\n## Unsupported Overstatements\n\n'
+    for item in "${overstatement_items[@]}"; do
+      id="$(printf '%s' "${item}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+      classification="$(printf '%s' "${item}" | sed -n 's/.*"classification":"\([^"]*\)".*/\1/p')"
+      printf -- '- `%s` cannot be claimed complete; current classification is `%s`.\n' "${id}" "${classification}"
+    done
+  fi
+} >"${OUTPUT_MD}"
+
+if [[ "${result}" != "passed" ]]; then
+  echo "runtime reality gate failed; see ${OUTPUT_JSON}" >&2
+  exit 1
+fi
+
+echo "runtime reality gate passed: ${OUTPUT_JSON}"

--- a/scripts/dev/test-runtime-reality-gate.sh
+++ b/scripts/dev/test-runtime-reality-gate.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+GATE_SCRIPT="${REPO_ROOT}/scripts/dev/runtime-reality-gate.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "assertion failed (${label}): expected '${expected}' got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "assertion failed (${label}): expected '${needle}'" >&2
+    echo "actual output:" >&2
+    echo "${haystack}" >&2
+    exit 1
+  fi
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd jq
+
+if [[ ! -x "${GATE_SCRIPT}" ]]; then
+  echo "missing executable runtime reality gate: ${GATE_SCRIPT}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+make_fake_check() {
+  local path="$1"
+  local label="$2"
+  local exit_code="${3:-0}"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' '${label}' >> "\${TAU_RUNTIME_REALITY_TEST_LOG:?}"
+exit ${exit_code}
+EOF
+  chmod +x "${path}"
+}
+
+make_lines() {
+  local path="$1"
+  local count="$2"
+  : >"${path}"
+  for i in $(seq 1 "${count}"); do
+    printf 'line %s\n' "${i}" >>"${path}"
+  done
+}
+
+product_check="${tmp_dir}/product-check.sh"
+unified_check="${tmp_dir}/unified-check.sh"
+canvas_check="${tmp_dir}/canvas-check.sh"
+roadmap_check="${tmp_dir}/roadmap-check.sh"
+make_fake_check "${product_check}" "product"
+make_fake_check "${unified_check}" "unified"
+make_fake_check "${canvas_check}" "canvas"
+make_fake_check "${roadmap_check}" "roadmap"
+
+dashboard_hotspot="${tmp_dir}/dashboard-ui-lib.rs"
+ops_shell_hotspot="${tmp_dir}/ops-dashboard-shell.rs"
+gateway_tests_hotspot="${tmp_dir}/gateway-openresponses-tests.rs"
+make_lines "${dashboard_hotspot}" 5
+make_lines "${ops_shell_hotspot}" 4
+make_lines "${gateway_tests_hotspot}" 3
+
+pass_json="${tmp_dir}/reality-pass.json"
+pass_md="${tmp_dir}/reality-pass.md"
+pass_log="${tmp_dir}/checks.log"
+
+TAU_RUNTIME_REALITY_TEST_LOG="${pass_log}" \
+TAU_RUNTIME_REALITY_PRODUCT_PROOF="${product_check}" \
+TAU_RUNTIME_REALITY_TAU_UNIFIED_TEST="${unified_check}" \
+TAU_RUNTIME_REALITY_AGENT_CANVAS_TEST="${canvas_check}" \
+TAU_RUNTIME_REALITY_ROADMAP_SYNC="${roadmap_check}" \
+TAU_RUNTIME_REALITY_DASHBOARD_UI_LIB_PATH="${dashboard_hotspot}" \
+TAU_RUNTIME_REALITY_OPS_DASHBOARD_SHELL_PATH="${ops_shell_hotspot}" \
+TAU_RUNTIME_REALITY_GATEWAY_OPENRESPONSES_TESTS_PATH="${gateway_tests_hotspot}" \
+TAU_RUNTIME_REALITY_DASHBOARD_UI_LIB_BUDGET=2 \
+TAU_RUNTIME_REALITY_OPS_DASHBOARD_SHELL_BUDGET=2 \
+TAU_RUNTIME_REALITY_GATEWAY_OPENRESPONSES_TESTS_BUDGET=2 \
+"${GATE_SCRIPT}" --output-json "${pass_json}" --output-md "${pass_md}"
+
+assert_equals "passed" "$(jq -r '.result' "${pass_json}")" "pass result"
+assert_equals "4" "$(jq -r '.fast_checks | length' "${pass_json}")" "fast check count"
+assert_equals "true" "$(jq -r '[.fast_checks[].status] | all(. == "passed")' "${pass_json}")" "fast checks passed"
+assert_equals "partial" "$(jq -r '.surfaces[] | select(.id == "dashboard_operator_ux") | .classification' "${pass_json}")" "dashboard partial"
+assert_equals "opt_in_heavy" "$(jq -r '.surfaces[] | select(.id == "true_rl_productionization") | .classification' "${pass_json}")" "rl opt-in"
+assert_equals "live_env_required" "$(jq -r '.surfaces[] | select(.id == "auth_transports_live_validation") | .classification' "${pass_json}")" "auth live env"
+assert_equals "not_claimable" "$(jq -r '.surfaces[] | select(.id == "autonomy_forever") | .classification' "${pass_json}")" "autonomy not claimable"
+assert_equals "not_claimable" "$(jq -r '.surfaces[] | select(.id == "live_browser_pixel_proof") | .classification' "${pass_json}")" "pixel not claimable"
+assert_equals "3" "$(jq -r '.hotspots | length' "${pass_json}")" "hotspot count"
+assert_equals "true" "$(jq -r '[.hotspots[].status] | all(. == "over_budget")' "${pass_json}")" "hotspot status"
+assert_equals "0" "$(jq -r '.claim_guard.unsupported_overstatements | length' "${pass_json}")" "no overstatements"
+assert_contains "$(cat "${pass_md}")" "Works With Caveats" "markdown caveat section"
+assert_contains "$(cat "${pass_md}")" "Not Claimable" "markdown not-claimable section"
+assert_contains "$(cat "${pass_log}")" "product" "product check invoked"
+assert_contains "$(cat "${pass_log}")" "unified" "unified check invoked"
+assert_contains "$(cat "${pass_log}")" "canvas" "canvas check invoked"
+assert_contains "$(cat "${pass_log}")" "roadmap" "roadmap check invoked"
+
+failed_product_check="${tmp_dir}/product-fail.sh"
+make_fake_check "${failed_product_check}" "product-fail" 17
+fail_json="${tmp_dir}/reality-fast-fail.json"
+fail_md="${tmp_dir}/reality-fast-fail.md"
+
+set +e
+TAU_RUNTIME_REALITY_TEST_LOG="${tmp_dir}/fail-checks.log" \
+TAU_RUNTIME_REALITY_PRODUCT_PROOF="${failed_product_check}" \
+TAU_RUNTIME_REALITY_TAU_UNIFIED_TEST="${unified_check}" \
+TAU_RUNTIME_REALITY_AGENT_CANVAS_TEST="${canvas_check}" \
+TAU_RUNTIME_REALITY_ROADMAP_SYNC="${roadmap_check}" \
+TAU_RUNTIME_REALITY_DASHBOARD_UI_LIB_PATH="${dashboard_hotspot}" \
+TAU_RUNTIME_REALITY_OPS_DASHBOARD_SHELL_PATH="${ops_shell_hotspot}" \
+TAU_RUNTIME_REALITY_GATEWAY_OPENRESPONSES_TESTS_PATH="${gateway_tests_hotspot}" \
+"${GATE_SCRIPT}" --output-json "${fail_json}" --output-md "${fail_md}" >/dev/null 2>&1
+fail_rc=$?
+set -e
+
+assert_equals "1" "${fail_rc}" "failed fast-check exit"
+assert_equals "failed" "$(jq -r '.result' "${fail_json}")" "failed fast-check result"
+assert_equals "failed" "$(jq -r '.fast_checks[] | select(.id == "tau_product_proof_check") | .status' "${fail_json}")" "product check failed status"
+
+overclaim_json="${tmp_dir}/reality-overclaim.json"
+overclaim_md="${tmp_dir}/reality-overclaim.md"
+set +e
+TAU_RUNTIME_REALITY_TEST_LOG="${tmp_dir}/overclaim-checks.log" \
+TAU_RUNTIME_REALITY_PRODUCT_PROOF="${product_check}" \
+TAU_RUNTIME_REALITY_TAU_UNIFIED_TEST="${unified_check}" \
+TAU_RUNTIME_REALITY_AGENT_CANVAS_TEST="${canvas_check}" \
+TAU_RUNTIME_REALITY_ROADMAP_SYNC="${roadmap_check}" \
+TAU_RUNTIME_REALITY_FORCE_COMPLETE_CLAIMS="autonomy_forever,live_browser_pixel_proof" \
+"${GATE_SCRIPT}" --skip-fast-checks --output-json "${overclaim_json}" --output-md "${overclaim_md}" >/dev/null 2>&1
+overclaim_rc=$?
+set -e
+
+assert_equals "1" "${overclaim_rc}" "overclaim exit"
+assert_equals "failed" "$(jq -r '.result' "${overclaim_json}")" "overclaim result"
+assert_equals "2" "$(jq -r '.claim_guard.unsupported_overstatements | length' "${overclaim_json}")" "overclaim count"
+assert_contains "$(cat "${overclaim_md}")" "Unsupported Overstatements" "markdown overclaim section"
+
+echo "runtime-reality-gate tests passed"

--- a/specs/3768-runtime-reality-gate/plan.md
+++ b/specs/3768-runtime-reality-gate/plan.md
@@ -1,0 +1,47 @@
+# Plan: Issue #3768 - Runtime reality gate for agentic-runtime claims
+
+## Approach
+
+Add a fast shell gate under `scripts/dev/` that turns the current reality check
+into a repeatable artifact. The gate should be useful for humans and CI:
+
+1. Run fast deterministic proof checks by default.
+2. Emit structured JSON and markdown.
+3. Keep heavyweight/live checks opt-in and visible.
+4. Fail closed when a surface that is intentionally not claimable is marked as
+   complete.
+5. Keep hotspot line counts visible without making this slice a refactor.
+
+The implementation is intentionally a claim-boundary gate, not a replacement for
+production RL, live-provider, or headed-browser validation.
+
+## Affected Modules
+
+- `scripts/dev/runtime-reality-gate.sh`
+- `scripts/dev/test-runtime-reality-gate.sh`
+- `README.md`
+- `specs/3768-runtime-reality-gate/*`
+
+## Risks and Mitigations
+
+- Risk: The gate becomes another aspirational report.
+  Mitigation: run fast proof commands by default and fail if any fail.
+- Risk: Heavy checks make default validation unusably slow.
+  Mitigation: record heavyweight/live commands as opt-in by default.
+- Risk: Hotspot over-threshold status causes false failure.
+  Mitigation: classify hotspots as partial evidence, not a failing condition,
+  until a separate refactor slice changes budgets.
+- Risk: Shell JSON becomes invalid.
+  Mitigation: validate outputs with `jq` in the regression test.
+
+## Verification
+
+- RED/GREEN: `scripts/dev/test-runtime-reality-gate.sh`
+- Default gate: `scripts/dev/runtime-reality-gate.sh --output-json /tmp/tau-runtime-reality.json --output-md /tmp/tau-runtime-reality.md`
+- Existing fast proofs:
+  - `scripts/dev/prove-tau-product.sh --check`
+  - `scripts/run/test-tau-unified.sh`
+  - `scripts/dev/test-ops-chat-canvas-proof.sh`
+  - `scripts/dev/roadmap-status-sync.sh --check --quiet`
+- Static: `bash -n scripts/dev/runtime-reality-gate.sh scripts/dev/test-runtime-reality-gate.sh`
+- Static: `git diff --check`

--- a/specs/3768-runtime-reality-gate/spec.md
+++ b/specs/3768-runtime-reality-gate/spec.md
@@ -1,0 +1,80 @@
+# Spec: Issue #3768 - Runtime reality gate for agentic-runtime claims
+
+Status: Implemented
+Priority: P1
+Milestone: M334 - Tau Ralph loop supervisor architecture
+Parent: #3654
+
+## Problem Statement
+
+Tau has real runtime, gateway, Agent Canvas, RL harness, auth, transport, and
+validation proof surfaces. The remaining risk is claim drift: deterministic
+proof, live proof, production-readiness, and aspiration can be described as if
+they are the same thing. Operators need one executable gate that says what works,
+what is partial, what is opt-in/live-env only, and what must not be claimed yet.
+
+## Scope
+
+In scope:
+
+- Add a deterministic runtime reality gate script that emits JSON and markdown
+  evidence.
+- Run the fast proof surfaces by default: Tau product proof check, tau-unified
+  launcher regression, Agent Canvas proof-loop regression, and roadmap status
+  sync.
+- Record opt-in evidence requirements for heavyweight/live gates without running
+  them by default.
+- Record maintainability hotspot line counts and classify them honestly.
+- Fail closed if an unsupported claim is represented as fully complete.
+- Update README guidance so product claims point to the executable gate.
+
+Out of scope:
+
+- Completing production-scale RL policy operations.
+- Building a full dashboard command center UX.
+- Running live third-party provider credentials by default.
+- Claiming headed-browser pixel evidence from shell-only Agent Canvas proof.
+- Refactoring large hotspot files in this slice.
+
+## Acceptance Criteria
+
+AC-1: Given the runtime reality gate runs, when evidence is written, then JSON
+and markdown outputs separate integrated, partial, deterministic-only,
+live-env-required, opt-in-heavy, and not-claimable surfaces.
+
+AC-2: Given a not-claimable surface such as autonomous-forever or shell-only
+browser-pixel proof, when the gate evaluates claims, then it fails if that
+surface is represented as complete.
+
+AC-3: Given current `master`, when the gate runs in default mode, then it
+executes and records the fast proof surfaces: Tau product proof check,
+tau-unified launcher test, Agent Canvas proof-loop test, and roadmap status sync.
+
+AC-4: Given heavyweight or live-env proof is not requested, when the gate runs,
+then RL productionization, full release validation, live provider validation, and
+headed-browser pixel proof are recorded as opt-in or not-claimable rather than
+silently passing.
+
+AC-5: Given README capability language is inspected, when future readers look
+for proof boundaries, then it links to the runtime reality gate and preserves the
+deterministic/live/production distinction.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | fake fast proof commands | run gate | JSON and markdown contain all reality categories |
+| C-02 | AC-2 | Regression | unsupported surfaces in default manifest | run gate | unsupported surfaces remain `not_claimable` and gate passes only because they are not overstated |
+| C-03 | AC-3 | Conformance | current repo checkout | run default gate | four fast proof checks are recorded as passed |
+| C-04 | AC-4 | Functional | heavy/live flags omitted | run gate | heavy/live checks are skipped/opt-in with explicit commands |
+| C-05 | AC-5 | Regression | README claim section | inspect docs | runtime reality gate is linked as claim evidence |
+
+## Success Metrics / Observable Signals
+
+- `scripts/dev/test-runtime-reality-gate.sh`
+- `scripts/dev/runtime-reality-gate.sh --output-json /tmp/tau-runtime-reality.json --output-md /tmp/tau-runtime-reality.md`
+- `scripts/dev/prove-tau-product.sh --check`
+- `scripts/run/test-tau-unified.sh`
+- `scripts/dev/test-ops-chat-canvas-proof.sh`
+- `scripts/dev/roadmap-status-sync.sh --check --quiet`
+- `git diff --check`

--- a/specs/3768-runtime-reality-gate/tasks.md
+++ b/specs/3768-runtime-reality-gate/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Issue #3768 - Runtime reality gate for agentic-runtime claims
+
+Status: Implemented
+
+- [x] T1 (SPEC): create conflict-safe spec/plan/tasks for the runtime reality gate.
+- [x] T2 (RED): add shell regression requiring JSON/markdown claim-boundary evidence.
+- [x] T3 (GREEN): implement `runtime-reality-gate.sh` with fast checks, opt-in markers, unsupported-claim enforcement, and hotspot counts.
+- [x] T4 (DOCS): update README proof guidance to point to the reality gate.
+- [x] T5 (VERIFY): run new/existing fast proof gates and static checks.
+
+## Tier Mapping
+
+| Tier | Status | Tests | N/A Why |
+| --- | --- | --- | --- |
+| Unit | N/A | | shell gate; no Rust unit boundary changed |
+| Property | N/A | | no randomized invariant introduced |
+| Contract/DbC | N/A | | no public API contract macro changed |
+| Snapshot | N/A | | JSON/markdown assertions cover generated evidence |
+| Functional | ✅ | `scripts/dev/test-runtime-reality-gate.sh` | |
+| Conformance | ✅ | default runtime reality gate plus fast proof checks | |
+| Integration | N/A | | live provider/browser/full-release checks are opt-in in this slice |
+| Fuzz | N/A | | no parser/codec fuzz boundary changed |
+| Mutation | N/A | | shell/product-claim gate |
+| Regression | ✅ | unsupported claim and failing fast-check paths in shell regression | |
+| Performance | N/A | | no runtime performance path changed |
+
+## Verification Evidence
+
+- RED: `bash scripts/dev/test-runtime-reality-gate.sh` failed with
+  `missing executable runtime reality gate`, proving the gate was absent.
+- GREEN: `scripts/dev/test-runtime-reality-gate.sh` passed with fake fast
+  checks, failing-fast-check coverage, and unsupported-overclaim coverage.
+- CONFORMANCE: `scripts/dev/runtime-reality-gate.sh --output-json
+  /tmp/tau-runtime-reality-current.json --output-md
+  /tmp/tau-runtime-reality-current.md` passed on current `master`.
+- CONFORMANCE: `/tmp/tau-runtime-reality-current.json` recorded all four fast
+  checks as passed and unsupported overstatements as an empty list.
+- STATIC: `bash -n scripts/dev/runtime-reality-gate.sh
+  scripts/dev/test-runtime-reality-gate.sh` passed.
+- STATIC: `scripts/dev/roadmap-status-sync.sh --check --quiet` passed.
+- STATIC: `git diff --check` passed.


### PR DESCRIPTION
## Summary

Adds an executable runtime reality gate for Tau product/runtime claims. The gate runs fast deterministic proof surfaces by default, emits JSON and markdown evidence, records heavyweight/live validation as explicit opt-in work, and fails if unsupported surfaces are represented as complete.

This intentionally completes the validation boundary for the listed caveats rather than pretending production RL, live provider validation, headed-browser pixel proof, and all maintainability work are finished in one patch.

## Links

- Closes #3768
- Parent story: #3654
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Spec: `specs/3768-runtime-reality-gate/spec.md`
- Plan: `specs/3768-runtime-reality-gate/plan.md`
- Tasks: `specs/3768-runtime-reality-gate/tasks.md`
- Note: `specs/3768/` already exists, so this issue uses the conflict-safe path above.

## Spec Verification

| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: JSON/markdown separates integrated, partial, deterministic-only, live-env-required, opt-in-heavy, and not-claimable surfaces | ✅ | `scripts/dev/test-runtime-reality-gate.sh`, default gate output |
| AC-2: not-claimable surfaces fail if represented as complete | ✅ | `TAU_RUNTIME_REALITY_FORCE_COMPLETE_CLAIMS` regression in `scripts/dev/test-runtime-reality-gate.sh` |
| AC-3: default gate runs fast proof surfaces | ✅ | `scripts/dev/runtime-reality-gate.sh --output-json /tmp/tau-runtime-reality-current-final.json --output-md /tmp/tau-runtime-reality-current-final.md` |
| AC-4: heavy/live gates are recorded as opt-in by default | ✅ | `opt_in_checks` JSON assertions and markdown Opt-In Evidence section |
| AC-5: README links product claims to executable gate | ✅ | README Capability Boundaries section |

## TDD Evidence

- RED: `bash scripts/dev/test-runtime-reality-gate.sh` failed with `missing executable runtime reality gate`, proving the gate was absent.
- GREEN: `scripts/dev/test-runtime-reality-gate.sh` passed with fake fast checks, failing-fast-check coverage, and unsupported-overclaim coverage.
- CONFORMANCE: default `scripts/dev/runtime-reality-gate.sh` passed on current master and recorded all four fast checks as passed.

## Test Tiers

| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | N/A | | shell gate; no Rust unit boundary changed |
| Property | N/A | | no randomized invariant introduced |
| Contract/DbC | N/A | | no public API contract macro changed |
| Snapshot | N/A | | JSON/markdown assertions cover generated evidence |
| Functional | ✅ | `scripts/dev/test-runtime-reality-gate.sh` | |
| Conformance | ✅ | default runtime reality gate plus fast proof checks | |
| Integration | N/A | | live provider/browser/full-release checks are opt-in in this slice |
| Fuzz | N/A | | no parser/codec fuzz boundary changed |
| Mutation | N/A | | shell/product-claim gate |
| Regression | ✅ | unsupported claim and failing fast-check paths in shell regression | |
| Performance | N/A | | no runtime performance path changed |

## Additional Verification

- `bash -n scripts/dev/runtime-reality-gate.sh scripts/dev/test-runtime-reality-gate.sh`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
- `git diff --check`

## Risks / Rollback

- Risk: this could be misread as completing every caveat. Mitigation: the gate classifies production RL, live provider validation, headed-browser pixel proof, autonomous-forever operation, and maintainability solved as opt-in, live-env-required, partial, or not-claimable.
- Rollback: revert `6b16690f` to remove the new gate and README link.

## Docs / ADR

- README Capability Boundaries now includes the runtime reality gate command.
- No ADR required; no architecture, dependency, protocol, or error-strategy change.