### PR TITLE
Recover stuck background jobs without operator polling

### DIFF
--- a/crates/tau-runtime/src/background_jobs_runtime.rs
+++ b/crates/tau-runtime/src/background_jobs_runtime.rs
@@ -43,6 +43,7 @@ const BACKGROUND_JOB_REASON_TRACE_WRITE_FAILED: &str = "job_trace_write_failed";
 const BACKGROUND_JOB_RECENT_REASON_CODE_CAP: usize = 16;
 const BACKGROUND_JOB_RECENT_DIAGNOSTICS_CAP: usize = 24;
 const BACKGROUND_JOB_WORKER_POLL_MS: u64 = 100;
+const BACKGROUND_JOB_STUCK_RECOVERY_POLL_MS: u64 = 1_000;
 const BACKGROUND_JOB_ID_PREFIX: &str = "job";
 
 static BACKGROUND_JOB_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -263,6 +264,7 @@ pub struct BackgroundJobRuntimeConfig {
     pub default_timeout_ms: u64,
     pub max_timeout_ms: u64,
     pub worker_poll_ms: u64,
+    pub stuck_recovery_poll_ms: u64,
 }
 
 impl Default for BackgroundJobRuntimeConfig {
@@ -272,6 +274,7 @@ impl Default for BackgroundJobRuntimeConfig {
             default_timeout_ms: 30_000,
             max_timeout_ms: 900_000,
             worker_poll_ms: BACKGROUND_JOB_WORKER_POLL_MS,
+            stuck_recovery_poll_ms: BACKGROUND_JOB_STUCK_RECOVERY_POLL_MS,
         }
     }
 }
@@ -293,6 +296,7 @@ struct BackgroundJobRuntimeInner {
     cancellation_requests: Mutex<BTreeSet<String>>,
     health: Mutex<BackgroundJobHealthSnapshot>,
     worker_running: AtomicBool,
+    recovery_watchdog_running: AtomicBool,
 }
 
 /// Persistent queue/runtime abstraction for background job execution.
@@ -314,6 +318,7 @@ impl BackgroundJobRuntime {
                 cancellation_requests: Mutex::new(BTreeSet::new()),
                 health: Mutex::new(health),
                 worker_running: AtomicBool::new(false),
+                recovery_watchdog_running: AtomicBool::new(false),
             }),
         };
         runtime.recover_queue_from_disk()?;
@@ -415,6 +420,7 @@ impl BackgroundJobRuntime {
         );
 
         self.schedule_worker();
+        self.schedule_recovery_watchdog();
         Ok(record)
     }
 
@@ -454,6 +460,7 @@ impl BackgroundJobRuntime {
         let report = self.recover_stuck_jobs_at(current_unix_timestamp_ms())?;
         if report.recovered > 0 {
             self.schedule_worker();
+            self.schedule_recovery_watchdog();
         }
         Ok(report)
     }
@@ -602,6 +609,7 @@ impl BackgroundJobRuntime {
                 persist_background_job_health_snapshot(self.state_dir(), &health)?;
             }
             self.schedule_worker();
+            self.schedule_recovery_watchdog();
         } else {
             let mut health = lock_unpoisoned(&self.inner.health);
             health.queue_depth = 0;
@@ -715,6 +723,77 @@ impl BackgroundJobRuntime {
         persist_background_job_health_snapshot(self.state_dir(), &health)?;
 
         Ok(report)
+    }
+
+    fn schedule_recovery_watchdog(&self) {
+        let poll_ms = self.inner.config.stuck_recovery_poll_ms;
+        if poll_ms == 0 {
+            return;
+        }
+        if self
+            .inner
+            .recovery_watchdog_running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let runtime = self.clone();
+        spawn_background_future(async move {
+            runtime.recovery_watchdog_loop().await;
+        });
+    }
+
+    async fn recovery_watchdog_loop(self) {
+        let poll_interval = Duration::from_millis(self.inner.config.stuck_recovery_poll_ms.max(10));
+        loop {
+            tokio::time::sleep(poll_interval).await;
+            if let Err(error) = self.recovery_watchdog_tick().await {
+                let _ = self.record_recovery_watchdog_error(error).await;
+            }
+
+            match self.has_nonterminal_jobs() {
+                Ok(true) => continue,
+                Ok(false) => break,
+                Err(error) => {
+                    let _ = self.record_recovery_watchdog_error(error).await;
+                    break;
+                }
+            }
+        }
+
+        self.inner
+            .recovery_watchdog_running
+            .store(false, Ordering::SeqCst);
+        if self.has_nonterminal_jobs().unwrap_or(false) {
+            self.schedule_recovery_watchdog();
+        }
+    }
+
+    async fn recovery_watchdog_tick(&self) -> Result<Option<BackgroundJobRecoveryReport>> {
+        if self.inner.worker_running.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        self.recover_stuck_jobs().await.map(Some)
+    }
+
+    async fn record_recovery_watchdog_error(&self, error: anyhow::Error) -> Result<()> {
+        self.update_health_mutation(
+            None,
+            BACKGROUND_JOB_REASON_RUNTIME_ERROR,
+            Some(format!("background_job_recovery_watchdog_error: {error}")),
+            |snapshot| {
+                snapshot.failed_total = snapshot.failed_total.saturating_add(1);
+            },
+        )
+        .await
+    }
+
+    fn has_nonterminal_jobs(&self) -> Result<bool> {
+        Ok(load_background_job_records(self.state_dir())?
+            .into_iter()
+            .any(|record| !record.status.is_terminal()))
     }
 
     fn schedule_worker(&self) {
@@ -1453,6 +1532,7 @@ mod tests {
         BackgroundJobStatusFilter, BackgroundJobTraceContext,
     };
     use std::collections::BTreeMap;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -1520,6 +1600,7 @@ mod tests {
             default_timeout_ms: 5_000,
             max_timeout_ms: 10_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         })
         .expect("runtime");
 
@@ -1558,6 +1639,7 @@ mod tests {
             default_timeout_ms: 5_000,
             max_timeout_ms: 10_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         })
         .expect("runtime");
 
@@ -1606,6 +1688,7 @@ mod tests {
             default_timeout_ms: 15_000,
             max_timeout_ms: 15_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         })
         .expect("runtime");
 
@@ -1662,6 +1745,7 @@ mod tests {
             default_timeout_ms: 5_000,
             max_timeout_ms: 10_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         };
         let bootstrap = BackgroundJobRuntime::new(config.clone()).expect("bootstrap runtime");
         drop(bootstrap);
@@ -1730,6 +1814,7 @@ mod tests {
             default_timeout_ms: 50,
             max_timeout_ms: 1_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         })
         .expect("runtime");
 
@@ -1785,6 +1870,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regression_background_job_runtime_watchdog_requeues_stuck_running_manifest() {
+        let temp = tempdir().expect("tempdir");
+        let state_dir = temp.path().join("jobs");
+        let runtime = BackgroundJobRuntime::new(BackgroundJobRuntimeConfig {
+            state_dir: state_dir.clone(),
+            default_timeout_ms: 50,
+            max_timeout_ms: 1_000,
+            worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 20,
+        })
+        .expect("runtime");
+
+        let job_id = "job-watchdog-stuck-running-1".to_string();
+        let (command, args) = shell_command("echo watchdog-recovered-stuck-job");
+        let record = BackgroundJobRecord {
+            schema_version: 1,
+            job_id: job_id.clone(),
+            command,
+            args,
+            env: BTreeMap::new(),
+            cwd: None,
+            requested_timeout_ms: 50,
+            effective_timeout_ms: 50,
+            status: BackgroundJobStatus::Running,
+            reason_code: "job_started".to_string(),
+            created_unix_ms: 1_700_000_000_000,
+            updated_unix_ms: 1_700_000_000_000,
+            started_unix_ms: Some(1_700_000_000_000),
+            finished_unix_ms: None,
+            exit_code: None,
+            error: None,
+            cancellation_requested: false,
+            stdout_path: state_dir.join("jobs").join(format!("{job_id}.stdout.log")),
+            stderr_path: state_dir.join("jobs").join(format!("{job_id}.stderr.log")),
+            trace: BackgroundJobTraceContext::default(),
+        };
+        let payload = serde_json::to_string_pretty(&record).expect("serialize stuck manifest");
+        std::fs::write(background_job_manifest_path(&state_dir, &job_id), payload)
+            .expect("write stuck manifest");
+
+        runtime.schedule_recovery_watchdog();
+
+        let status = wait_for_terminal_status(&runtime, &job_id, Duration::from_secs(5)).await;
+        assert_eq!(status, BackgroundJobStatus::Succeeded);
+
+        let health = runtime.inspect_health().await;
+        assert_eq!(health.recovered_stuck_total, 1);
+        assert!(health
+            .reason_codes
+            .iter()
+            .any(|code| code == "job_recovered_after_stuck_timeout"));
+    }
+
+    #[tokio::test]
+    async fn regression_background_job_runtime_watchdog_skips_active_worker_manifest() {
+        let temp = tempdir().expect("tempdir");
+        let state_dir = temp.path().join("jobs");
+        let runtime = BackgroundJobRuntime::new(BackgroundJobRuntimeConfig {
+            state_dir: state_dir.clone(),
+            default_timeout_ms: 50,
+            max_timeout_ms: 1_000,
+            worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 20,
+        })
+        .expect("runtime");
+
+        let job_id = "job-watchdog-active-worker-1".to_string();
+        let (command, args) = shell_command("echo should-not-duplicate-active-worker");
+        let record = BackgroundJobRecord {
+            schema_version: 1,
+            job_id: job_id.clone(),
+            command,
+            args,
+            env: BTreeMap::new(),
+            cwd: None,
+            requested_timeout_ms: 50,
+            effective_timeout_ms: 50,
+            status: BackgroundJobStatus::Running,
+            reason_code: "job_started".to_string(),
+            created_unix_ms: 1_700_000_000_000,
+            updated_unix_ms: 1_700_000_000_000,
+            started_unix_ms: Some(1_700_000_000_000),
+            finished_unix_ms: None,
+            exit_code: None,
+            error: None,
+            cancellation_requested: false,
+            stdout_path: state_dir.join("jobs").join(format!("{job_id}.stdout.log")),
+            stderr_path: state_dir.join("jobs").join(format!("{job_id}.stderr.log")),
+            trace: BackgroundJobTraceContext::default(),
+        };
+        let payload = serde_json::to_string_pretty(&record).expect("serialize active manifest");
+        std::fs::write(background_job_manifest_path(&state_dir, &job_id), payload)
+            .expect("write active manifest");
+
+        runtime.inner.worker_running.store(true, Ordering::SeqCst);
+        let report = runtime
+            .recovery_watchdog_tick()
+            .await
+            .expect("watchdog tick");
+        runtime.inner.worker_running.store(false, Ordering::SeqCst);
+
+        assert!(report.is_none(), "active worker should suppress recovery");
+        let refreshed = runtime
+            .get_job(&job_id)
+            .await
+            .expect("get active job")
+            .expect("active job exists");
+        assert_eq!(refreshed.status, BackgroundJobStatus::Running);
+        assert_eq!(runtime.inspect_health().await.recovered_stuck_total, 0);
+    }
+
+    #[tokio::test]
     async fn regression_background_job_runtime_does_not_requeue_fresh_running_manifest() {
         let temp = tempdir().expect("tempdir");
         let state_dir = temp.path().join("jobs");
@@ -1793,6 +1990,7 @@ mod tests {
             default_timeout_ms: 60_000,
             max_timeout_ms: 60_000,
             worker_poll_ms: 20,
+            stuck_recovery_poll_ms: 0,
         })
         .expect("runtime");
 

--- a/crates/tau-tools/src/tools/runtime_helpers.rs
+++ b/crates/tau-tools/src/tools/runtime_helpers.rs
@@ -394,6 +394,7 @@ pub(super) fn resolve_background_job_runtime(
             .jobs_max_timeout_ms
             .max(policy.jobs_default_timeout_ms.max(1)),
         worker_poll_ms: 100,
+        stuck_recovery_poll_ms: 1_000,
     })
     .map_err(|error| format!("failed to initialize background job runtime: {error}"))?;
     let runtime = Arc::new(runtime);

--- a/docs/guides/background-jobs-ops.md
+++ b/docs/guides/background-jobs-ops.md
@@ -85,4 +85,5 @@ This allows operators to correlate asynchronous execution with transport/session
 - Cancelling a queued job transitions it directly to `cancelled`.
 - Cancelling a running job sets a cancellation signal and the worker terminates the process.
 - Running jobs recovered after process restart are re-queued with `job_recovered_after_restart`.
-- `jobs_list` runs a stuck-job recovery sweep before returning jobs and health. A persisted `running` manifest whose last activity exceeds its effective timeout is re-queued with `job_recovered_after_stuck_timeout`, increments `recovered_stuck_total`, and is scheduled for worker execution.
+- Active jobs runtimes run a watchdog while non-terminal jobs exist. The watchdog skips recovery while the worker loop is active, then reuses the stuck-job recovery sweep when the worker is idle.
+- `jobs_list` also runs a stuck-job recovery sweep before returning jobs and health. A persisted `running` manifest whose last activity exceeds its effective timeout is re-queued with `job_recovered_after_stuck_timeout`, increments `recovered_stuck_total`, and is scheduled for worker execution.

--- a/specs/3777-background-job-recovery-watchdog/plan.md
+++ b/specs/3777-background-job-recovery-watchdog/plan.md
@@ -1,0 +1,28 @@
+# Plan
+
+Status: Implemented
+
+1. Add failing `tau-runtime` regressions for watchdog recovery and active-worker
+   skip behavior.
+2. Extend `BackgroundJobRuntimeConfig` with a recovery watchdog poll interval.
+3. Add a bounded watchdog loop that wakes while non-terminal jobs exist, skips
+   recovery when the worker is active, and reuses `recover_stuck_jobs`.
+4. Enable the watchdog from the jobs tool runtime construction path.
+5. Update ops docs/spec evidence and run focused runtime/tool validation.
+
+## Affected Modules
+
+- `crates/tau-runtime/src/background_jobs_runtime.rs`
+- `crates/tau-tools/src/tools/runtime_helpers.rs`
+- `docs/guides/background-jobs-ops.md`
+- `specs/3777-background-job-recovery-watchdog/*`
+
+## Risks
+
+- Risk: watchdog duplicates work while a worker is still executing a long job.
+  Mitigation: watchdog skips recovery whenever the runtime worker loop is active.
+- Risk: watchdog tasks keep one-shot processes alive.
+  Mitigation: watchdog exits once no non-terminal manifests remain.
+- Risk: this is overstated as full crash replay.
+  Mitigation: scope and docs keep the claim limited to background-job manifest
+  recovery.

--- a/specs/3777-background-job-recovery-watchdog/spec.md
+++ b/specs/3777-background-job-recovery-watchdog/spec.md
@@ -1,0 +1,60 @@
+# Issue #3777: Background Job Recovery Watchdog
+
+Status: Implemented
+
+## Problem
+
+Issue #3775 made stuck background-job recovery real, but still reactive: the
+operator or agent has to inspect jobs before stale `running` manifests are
+requeued. A usable autonomous runtime needs the active jobs runtime to keep
+checking for stuck manifests while non-terminal work exists.
+
+## Scope
+
+In:
+- Add a configurable recovery watchdog to `BackgroundJobRuntime`.
+- Start the watchdog from existing job runtime paths while non-terminal jobs
+  exist.
+- Reuse the existing `job_recovered_after_stuck_timeout` reason code,
+  `recovered_stuck_total` counter, event log, and worker scheduling behavior.
+- Avoid requeueing manifests that are still fresh or currently owned by an
+  active worker loop.
+
+Out:
+- No new scheduler crate or dependency.
+- No claim of full mission replay/crash-resume.
+- No dashboard redesign.
+
+## Acceptance Criteria
+
+### AC-1: Watchdog Recovers Stale Running Jobs
+
+Given a jobs runtime has watchdog recovery enabled and a persisted job manifest
+is `running` beyond its effective timeout while no worker is active, when the
+watchdog tick runs, then the job is requeued, scheduled, and can execute to
+completion.
+
+### AC-2: Watchdog Does Not Duplicate Active Worker Jobs
+
+Given the runtime worker is active, when the watchdog tick runs, then it does
+not requeue a worker-owned `running` manifest even if the manifest appears old.
+
+### AC-3: Recovery Remains Operator Visible
+
+Given the watchdog recovers a stuck job, when health is inspected, then
+`recovered_stuck_total` and `job_recovered_after_stuck_timeout` show the
+recovery through the existing health surface.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Regression | stale `running` manifest and idle worker | watchdog tick runs | manifest is requeued and job succeeds |
+| C-02 | AC-2 | Regression | active worker loop | watchdog tick runs | recovery is skipped and no duplicate queue entry is created |
+| C-03 | AC-3 | Functional | watchdog-recovered job | health is inspected | stuck recovery counter and reason code are visible |
+
+## Success Metrics
+
+- Active background-job runtimes do not require a `jobs_list` call to recover
+  stale `running` manifests.
+- Existing explicit recovery behavior from #3775 remains compatible.

--- a/specs/3777-background-job-recovery-watchdog/tasks.md
+++ b/specs/3777-background-job-recovery-watchdog/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+Status: Implemented
+
+- [x] T1 (RED): Add failing watchdog recovery and active-worker skip tests.
+- [x] T2 (GREEN): Implement bounded recovery watchdog scheduling.
+- [x] T3 (GREEN): Enable watchdog in the jobs tool runtime path.
+- [x] T4 (VERIFY): Run focused runtime/tool tests, fmt, diff check, and clippy.
+
+## TDD Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime watchdog -- --test-threads=1` failed before implementation because `BackgroundJobRuntimeConfig` had no `stuck_recovery_poll_ms` field and the watchdog methods did not exist.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime watchdog -- --test-threads=1` passed after implementation.
+- VERIFY:
+  - `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime background_job_runtime -- --test-threads=1`
+  - `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-tools jobs_ -- --test-threads=1`
+  - `cargo fmt --check`
+  - `git diff --check`
+  - `scripts/dev/roadmap-status-sync.sh --check --quiet`
+  - `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo clippy -p tau-runtime -p tau-tools -- -D warnings`
+
+## Test Tiers
+
+| Tier | Status | Tests | Notes |
+| --- | --- | --- | --- |
+| Unit | ✅ | `cargo test -p tau-runtime background_job_runtime` | Runtime regression suite validates public behavior. |
+| Property | N/A | N/A | No new parser/serializer invariant introduced. |
+| Contract/DbC | N/A | N/A | No new contract macro surface introduced. |
+| Snapshot | N/A | N/A | No snapshot output changed. |
+| Functional | ✅ | watchdog recovery tests | Covers AC-1 and AC-3. |
+| Conformance | ✅ | watchdog recovery tests | Covers C-01..C-03. |
+| Integration | ✅ | `cargo test -p tau-tools jobs_` | Verifies tool runtime construction. |
+| Fuzz | N/A | N/A | No untrusted parser or fuzz target changed. |
+| Mutation | N/A | N/A | Narrow runtime watchdog slice; follow-up mutation reserved for larger release gate. |
+| Regression | ✅ | watchdog regression tests | Locks stale-manifest recovery and active-worker skip. |
+| Performance | N/A | N/A | Poll loop is bounded/configurable; no hotspot benchmark changed. |


### PR DESCRIPTION
## Summary

Adds a single-flight background-job recovery watchdog so active jobs runtimes can recover stale `running` manifests without waiting for an operator `jobs_list` call. The watchdog reuses the #3775 stuck recovery path, skips recovery while the worker loop is active, and keeps the claim limited to background-job manifest recovery.

## Links

- Milestone: M334 - Tau Ralph loop supervisor architecture
- Closes #3777
- Parent story: #3654
- Spec: `specs/3777-background-job-recovery-watchdog/spec.md`
- Plan: `specs/3777-background-job-recovery-watchdog/plan.md`
- Tasks: `specs/3777-background-job-recovery-watchdog/tasks.md`

## Spec Verification

| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: Watchdog recovers stale running jobs | ✅ | `regression_background_job_runtime_watchdog_requeues_stuck_running_manifest` |
| AC-2: Watchdog does not duplicate active worker jobs | ✅ | `regression_background_job_runtime_watchdog_skips_active_worker_manifest` |
| AC-3: Recovery remains operator visible | ✅ | `regression_background_job_runtime_watchdog_requeues_stuck_running_manifest` |

## TDD Evidence

RED:
`CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime watchdog -- --test-threads=1`

Failed before implementation because `BackgroundJobRuntimeConfig` had no `stuck_recovery_poll_ms` field and the watchdog methods did not exist.

GREEN:
`CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime watchdog -- --test-threads=1`

Passed after implementation: 2 watchdog tests passed.

REGRESSION:
`CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime background_job_runtime -- --test-threads=1`

Passed: 8 background-job runtime tests.

## Test Tiers

| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | `cargo test -p tau-runtime background_job_runtime` | |
| Property | N/A | | No new parser/serializer invariant introduced. |
| Contract/DbC | N/A | | No new contract macro surface introduced. |
| Snapshot | N/A | | No snapshot output changed. |
| Functional | ✅ | watchdog recovery tests | |
| Conformance | ✅ | watchdog recovery tests | |
| Integration | ✅ | `cargo test -p tau-tools jobs_` | |
| Fuzz | N/A | | No untrusted parser or fuzz target changed. |
| Mutation | N/A | | Narrow runtime watchdog slice; mutation remains a release gate. |
| Regression | ✅ | watchdog regression tests | |
| Performance | N/A | | Poll loop is bounded/configurable; no hotspot benchmark changed. |

## Mutation

N/A for this narrow slice; no mutation run. The PR adds direct regressions for stale-manifest recovery and active-worker duplicate suppression.

## Additional Verification

- `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime watchdog -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-runtime background_job_runtime -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo test -p tau-tools jobs_ -- --test-threads=1`
- `cargo fmt --check`
- `git diff --check`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3777-target cargo clippy -p tau-runtime -p tau-tools -- -D warnings`

## Risks / Rollback

Risk: watchdog recovery could duplicate a worker-owned running manifest. Mitigation: watchdog ticks skip recovery while `worker_running` is true, with a regression test locking that behavior.

Rollback: revert this PR to restore explicit `jobs_list`-triggered stuck recovery only.

## Docs / ADR

- Updated `docs/guides/background-jobs-ops.md`.
- No ADR: this reuses existing runtime/recovery contracts and adds no new dependency or protocol.
