### PR TITLE
Expose coding mission state in operator surfaces (#3654)

### DIFF
--- a/crates/tau-gateway/src/gateway_openresponses/mission_api_runtime.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/mission_api_runtime.rs
@@ -1,11 +1,20 @@
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    sync::Arc,
+};
 
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use serde::Deserialize;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tau_agent_core::{
+    coding_mission_state_path, load_coding_mission_state, CodingMissionPhase,
+    CodingMissionPrPublicationStatus, CodingMissionState, CodingWorkspaceCommandEvidence,
+    CodingWorkspaceCommandStatus,
+};
 
 use super::mission_supervisor_runtime::{
     gateway_mission_state_path, gateway_missions_root, load_gateway_mission_state,
@@ -20,6 +29,28 @@ use super::{
 pub(super) struct GatewayMissionsListQuery {
     #[serde(default)]
     limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct GatewayCodingMissionSummary {
+    mission_id: String,
+    phase: &'static str,
+    repo_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verifier_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verifier_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_failure: Option<String>,
+    changed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resume_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr_state: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr_url: Option<String>,
 }
 
 pub(super) async fn handle_gateway_missions_list(
@@ -60,18 +91,61 @@ pub(super) async fn handle_gateway_missions_list(
     }
 
     missions.sort_by_key(|mission| std::cmp::Reverse(mission.updated_unix_ms));
-    missions.truncate(limit);
     let harness_missions = missions
         .iter()
+        .take(limit)
         .map(GatewayMissionState::to_shared_mission_snapshot)
         .collect::<Vec<_>>();
+    let coding_states = match load_coding_mission_states(&state.config.state_dir) {
+        Ok(states) => states,
+        Err(error) => return error.into_response(),
+    };
+    let coding_states_by_id = coding_states
+        .into_iter()
+        .map(|coding_state| (coding_state.mission_id.clone(), coding_state))
+        .collect::<BTreeMap<_, _>>();
+    let coding_missions = coding_states_by_id
+        .values()
+        .map(coding_mission_summary)
+        .collect::<Vec<_>>();
+    let mut seen_gateway_mission_ids = BTreeSet::new();
+    let mut mission_values = Vec::new();
+    for mission in &missions {
+        seen_gateway_mission_ids.insert(mission.mission_id.clone());
+        match gateway_mission_response_value(
+            mission,
+            coding_states_by_id.get(mission.mission_id.as_str()),
+        ) {
+            Ok(value) => mission_values.push(value),
+            Err(error) => return error.into_response(),
+        }
+    }
+    for coding_state in coding_states_by_id.values() {
+        if seen_gateway_mission_ids.contains(coding_state.mission_id.as_str()) {
+            continue;
+        }
+        match coding_mission_response_value(coding_state) {
+            Ok(value) => mission_values.push(value),
+            Err(error) => return error.into_response(),
+        }
+    }
+    mission_values.sort_by_key(|mission| {
+        std::cmp::Reverse(
+            mission
+                .get("updated_unix_ms")
+                .and_then(Value::as_u64)
+                .unwrap_or_default(),
+        )
+    });
+    mission_values.truncate(limit);
 
     state.record_ui_telemetry_event("missions", "list", "mission_list_requested");
     (
         StatusCode::OK,
         Json(json!({
-            "missions": missions,
+            "missions": mission_values,
             "harness_missions": harness_missions,
+            "coding_missions": coding_missions,
             "limit": limit,
         })),
     )
@@ -89,28 +163,315 @@ pub(super) async fn handle_gateway_mission_detail(
 
     let mission_id = sanitize_session_key(mission_id.as_str());
     let mission_path = gateway_mission_state_path(&state.config.state_dir, &mission_id);
-    if !mission_path.exists() {
+    let coding_state =
+        match load_coding_mission_state_if_present(&state.config.state_dir, &mission_id) {
+            Ok(state) => state,
+            Err(error) => return error.into_response(),
+        };
+    let mission = if mission_path.exists() {
+        match load_gateway_mission_state(&mission_path) {
+            Ok(mission) => mission,
+            Err(error) => return error.into_response(),
+        }
+    } else if let Some(coding_state) = coding_state.as_ref() {
+        state.record_ui_telemetry_event("missions", "detail", "mission_detail_requested");
+        return match coding_mission_response_value(coding_state) {
+            Ok(mission_value) => (
+                StatusCode::OK,
+                Json(json!({
+                    "mission": mission_value,
+                    "harness_mission": Value::Null,
+                    "coding_mission": coding_mission_summary(coding_state),
+                    "path": coding_mission_state_path(&state.config.state_dir, &mission_id)
+                        .display()
+                        .to_string(),
+                })),
+            )
+                .into_response(),
+            Err(error) => error.into_response(),
+        };
+    } else {
         return OpenResponsesApiError::not_found(
             "mission_not_found",
             format!("mission '{mission_id}' does not exist"),
         )
         .into_response();
-    }
-
-    let mission = match load_gateway_mission_state(&mission_path) {
-        Ok(mission) => mission,
-        Err(error) => return error.into_response(),
     };
     let harness_mission = mission.to_shared_mission_snapshot();
+    let mission_value = match gateway_mission_response_value(&mission, coding_state.as_ref()) {
+        Ok(value) => value,
+        Err(error) => return error.into_response(),
+    };
 
     state.record_ui_telemetry_event("missions", "detail", "mission_detail_requested");
     (
         StatusCode::OK,
         Json(json!({
-            "mission": mission,
+            "mission": mission_value,
             "harness_mission": harness_mission,
+            "coding_mission": coding_state.as_ref().map(coding_mission_summary),
             "path": mission_path.display().to_string(),
         })),
     )
         .into_response()
+}
+
+fn load_coding_mission_states(
+    state_dir: &Path,
+) -> Result<Vec<CodingMissionState>, OpenResponsesApiError> {
+    let missions_root = state_dir.join("coding-missions");
+    if !missions_root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let dir_entries = std::fs::read_dir(&missions_root).map_err(|error| {
+        OpenResponsesApiError::internal(format!(
+            "failed to list coding missions directory {}: {error}",
+            missions_root.display()
+        ))
+    })?;
+    let mut states = Vec::new();
+    for dir_entry in dir_entries.flatten() {
+        let path = dir_entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(mission_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        states.push(
+            load_coding_mission_state(state_dir, mission_id).map_err(|error| {
+                OpenResponsesApiError::internal(format!(
+                    "failed to load coding mission state {}: {error}",
+                    path.display()
+                ))
+            })?,
+        );
+    }
+    Ok(states)
+}
+
+fn load_coding_mission_state_if_present(
+    state_dir: &Path,
+    mission_id: &str,
+) -> Result<Option<CodingMissionState>, OpenResponsesApiError> {
+    let path = coding_mission_state_path(state_dir, mission_id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    load_coding_mission_state(state_dir, mission_id)
+        .map(Some)
+        .map_err(|error| {
+            OpenResponsesApiError::internal(format!(
+                "failed to load coding mission state {}: {error}",
+                path.display()
+            ))
+        })
+}
+
+fn gateway_mission_response_value(
+    mission: &GatewayMissionState,
+    coding_state: Option<&CodingMissionState>,
+) -> Result<Value, OpenResponsesApiError> {
+    let mut value = serde_json::to_value(mission).map_err(|error| {
+        OpenResponsesApiError::internal(format!("failed to serialize gateway mission: {error}"))
+    })?;
+    if let Some(coding_state) = coding_state {
+        value["coding_mission"] = serde_json::to_value(coding_mission_summary(coding_state))
+            .map_err(|error| {
+                OpenResponsesApiError::internal(format!(
+                    "failed to serialize coding mission summary: {error}"
+                ))
+            })?;
+    }
+    Ok(value)
+}
+
+fn coding_mission_response_value(
+    state: &CodingMissionState,
+) -> Result<Value, OpenResponsesApiError> {
+    let summary = coding_mission_summary(state);
+    let latest_verifier = coding_latest_verifier_value(state);
+    let latest_output = coding_latest_output_summary(state);
+    let latest_completion = summary.resume_command.as_ref().map(|resume_command| {
+        json!({
+            "status": if state.phase == CodingMissionPhase::Blocked { "blocked" } else { "partial" },
+            "summary": latest_output.clone(),
+            "next_step": resume_command,
+        })
+    });
+    serde_json::to_value(json!({
+        "schema_version": 1,
+        "mission_id": state.mission_id,
+        "session_key": state.session_key,
+        "response_id": format!("coding_{}", state.mission_id),
+        "goal_summary": state.goal,
+        "latest_output_summary": latest_output,
+        "status": coding_phase_gateway_status(state.phase),
+        "created_unix_ms": state.created_unix_ms,
+        "updated_unix_ms": state.updated_unix_ms,
+        "iteration_count": state.command_evidence.len(),
+        "latest_verifier": latest_verifier,
+        "latest_completion": latest_completion,
+        "iterations": [],
+        "coding_mission": summary,
+    }))
+    .map_err(|error| {
+        OpenResponsesApiError::internal(format!("failed to serialize coding mission: {error}"))
+    })
+}
+
+fn coding_mission_summary(state: &CodingMissionState) -> GatewayCodingMissionSummary {
+    let latest_command = state.command_evidence.last();
+    let latest_failed_command = state
+        .command_evidence
+        .iter()
+        .rev()
+        .find(|command| command.status != CodingWorkspaceCommandStatus::Succeeded);
+    GatewayCodingMissionSummary {
+        mission_id: state.mission_id.clone(),
+        phase: coding_phase_label(state.phase),
+        repo_path: state.repo_path.display().to_string(),
+        branch_name: coding_branch_name(state),
+        verifier_status: latest_command.map(coding_command_status_summary),
+        verifier_command: latest_command.map(|command| command.argv.join(" ")),
+        last_failure: latest_failed_command.map(coding_command_status_summary),
+        changed_files: coding_changed_files(state),
+        resume_command: state
+            .resume_checkpoint
+            .as_ref()
+            .map(|checkpoint| checkpoint.operator_resume_command.clone()),
+        pr_state: state
+            .pr_ready_bundle
+            .as_ref()
+            .map(|bundle| coding_pr_publication_label(bundle.status))
+            .or_else(|| (state.phase == CodingMissionPhase::PrReady).then_some("pr_ready")),
+        pr_url: state
+            .pr_ready_bundle
+            .as_ref()
+            .and_then(|bundle| bundle.pr_url.clone()),
+    }
+}
+
+fn coding_latest_verifier_value(state: &CodingMissionState) -> Value {
+    if let Some(command) = state.command_evidence.last() {
+        json!({
+            "kind": "coding_mission_verifier",
+            "status": match command.status {
+                CodingWorkspaceCommandStatus::Succeeded => "passed",
+                CodingWorkspaceCommandStatus::Failed | CodingWorkspaceCommandStatus::Denied => "failed",
+            },
+            "reason_code": command.reason_code,
+            "message": coding_command_status_summary(command),
+        })
+    } else {
+        json!({
+            "kind": "coding_mission_verifier",
+            "status": "continue",
+            "reason_code": "coding_mission_pending_verifier",
+            "message": "coding mission has not recorded verifier evidence yet",
+        })
+    }
+}
+
+fn coding_latest_output_summary(state: &CodingMissionState) -> String {
+    state
+        .resume_checkpoint
+        .as_ref()
+        .map(|checkpoint| checkpoint.latest_learning_summary.clone())
+        .or_else(|| state.events.last().map(|event| event.message.clone()))
+        .unwrap_or_else(|| "coding mission state persisted".to_string())
+}
+
+fn coding_branch_name(state: &CodingMissionState) -> Option<String> {
+    state
+        .resume_checkpoint
+        .as_ref()
+        .and_then(|checkpoint| checkpoint.branch_name.clone())
+        .or_else(|| {
+            state
+                .pr_ready_bundle
+                .as_ref()
+                .map(|bundle| bundle.branch_name.clone())
+        })
+        .or_else(|| {
+            state
+                .git_evidence
+                .iter()
+                .rev()
+                .find(|evidence| !evidence.branch_name.trim().is_empty())
+                .map(|evidence| evidence.branch_name.clone())
+        })
+}
+
+fn coding_changed_files(state: &CodingMissionState) -> Vec<String> {
+    if let Some(bundle) = state
+        .pr_ready_bundle
+        .as_ref()
+        .filter(|bundle| !bundle.changed_files.is_empty())
+    {
+        return bundle.changed_files.clone();
+    }
+    if let Some(evidence) = state
+        .git_evidence
+        .iter()
+        .rev()
+        .find(|evidence| !evidence.changed_files.is_empty())
+    {
+        return evidence.changed_files.clone();
+    }
+    state
+        .resume_checkpoint
+        .as_ref()
+        .and_then(|checkpoint| checkpoint.mutation_fingerprint.as_ref())
+        .map(|fingerprint| fingerprint.changed_files.clone())
+        .unwrap_or_default()
+}
+
+fn coding_command_status_summary(command: &CodingWorkspaceCommandEvidence) -> String {
+    format!(
+        "{}:{}",
+        coding_command_status_label(command.status),
+        command.reason_code
+    )
+}
+
+fn coding_command_status_label(status: CodingWorkspaceCommandStatus) -> &'static str {
+    match status {
+        CodingWorkspaceCommandStatus::Succeeded => "succeeded",
+        CodingWorkspaceCommandStatus::Failed => "failed",
+        CodingWorkspaceCommandStatus::Denied => "denied",
+    }
+}
+
+fn coding_phase_gateway_status(phase: CodingMissionPhase) -> &'static str {
+    match phase {
+        CodingMissionPhase::Intake | CodingMissionPhase::Planned => "checkpointed",
+        CodingMissionPhase::PreparingBranch
+        | CodingMissionPhase::Executing
+        | CodingMissionPhase::Verifying => "running",
+        CodingMissionPhase::PrReady => "checkpointed",
+        CodingMissionPhase::Blocked => "blocked",
+        CodingMissionPhase::Completed => "completed",
+    }
+}
+
+fn coding_phase_label(phase: CodingMissionPhase) -> &'static str {
+    match phase {
+        CodingMissionPhase::Intake => "intake",
+        CodingMissionPhase::Planned => "planned",
+        CodingMissionPhase::PreparingBranch => "preparing_branch",
+        CodingMissionPhase::Executing => "executing",
+        CodingMissionPhase::Verifying => "verifying",
+        CodingMissionPhase::PrReady => "pr_ready",
+        CodingMissionPhase::Blocked => "blocked",
+        CodingMissionPhase::Completed => "completed",
+    }
+}
+
+fn coding_pr_publication_label(status: CodingMissionPrPublicationStatus) -> &'static str {
+    match status {
+        CodingMissionPrPublicationStatus::ManualReady => "manual_ready",
+        CodingMissionPrPublicationStatus::DraftCreated => "draft_created",
+        CodingMissionPrPublicationStatus::DraftFailed => "draft_failed",
+    }
 }

--- a/crates/tau-gateway/src/gateway_openresponses/tests.rs
+++ b/crates/tau-gateway/src/gateway_openresponses/tests.rs
@@ -35,6 +35,13 @@ use reqwest::Client;
 use safety_rules::*;
 use serde_json::Value;
 use state_helpers::*;
+use tau_agent_core::{
+    save_coding_mission_state, CodingGitLifecycleEvidence, CodingGitLifecycleEvidenceKind,
+    CodingMissionConfig, CodingMissionMutationFingerprint, CodingMissionPhase, CodingMissionPrMode,
+    CodingMissionPrPublicationStatus, CodingMissionPrReadyBundle, CodingMissionResumeAction,
+    CodingMissionResumeCheckpoint, CodingMissionState, CodingWorkspaceCommandEvidence,
+    CodingWorkspaceCommandStatus,
+};
 use tau_ai::{ChatResponse, ChatUsage, ContentBlock, Message, MessageRole, ToolChoice};
 use tau_memory::action_history::{
     ActionFilter, ActionHistoryConfig, ActionHistoryStore, ActionRecord, ActionType,
@@ -67,6 +74,120 @@ where
         .expect("spawn high-stack test thread")
         .join()
         .expect("high-stack test thread panicked");
+}
+
+fn save_operator_coding_mission_state(
+    state_root: &std::path::Path,
+    mission_id: &str,
+    session_key: &str,
+    phase: CodingMissionPhase,
+    latest_status: CodingWorkspaceCommandStatus,
+    latest_reason_code: &str,
+) -> CodingMissionState {
+    let repo_path = state_root.join("fixture-repo");
+    std::fs::create_dir_all(&repo_path).expect("create coding fixture repo");
+    let branch_name = "codex/issue-3654-operator".to_string();
+    let mut state = CodingMissionState::create(CodingMissionConfig {
+        state_root: state_root.to_path_buf(),
+        mission_id: mission_id.to_string(),
+        session_key: session_key.to_string(),
+        repo_path: repo_path.clone(),
+        issue_url: Some("https://github.com/example/tau/issues/3654".to_string()),
+        goal: "surface coding mission operator state".to_string(),
+        base_branch: "master".to_string(),
+        branch_prefix: "codex/issue-3654".to_string(),
+        verifier_commands: vec!["cargo test -p tau-agent-core coding_mission".to_string()],
+        pr_mode: CodingMissionPrMode::PrReady,
+        allowed_roots: vec![state_root.to_path_buf()],
+        created_unix_ms: 100,
+    })
+    .expect("create coding mission state");
+    state.phase = phase;
+    state.updated_unix_ms = 260;
+    state.command_evidence.push(CodingWorkspaceCommandEvidence {
+        command_id: "verifier-red".to_string(),
+        cwd: repo_path.clone(),
+        argv: vec![
+            "cargo".to_string(),
+            "test".to_string(),
+            "-p".to_string(),
+            "tau-agent-core".to_string(),
+            "coding_mission".to_string(),
+        ],
+        stdout_path: state_root.join("verifier-red.stdout"),
+        stderr_path: state_root.join("verifier-red.stderr"),
+        exit_status: Some(101),
+        elapsed_ms: 23,
+        reason_code: "red_verifier_failed".to_string(),
+        status: CodingWorkspaceCommandStatus::Failed,
+        denied_reason: None,
+    });
+    state.command_evidence.push(CodingWorkspaceCommandEvidence {
+        command_id: "verifier-latest".to_string(),
+        cwd: repo_path.clone(),
+        argv: vec![
+            "cargo".to_string(),
+            "test".to_string(),
+            "-p".to_string(),
+            "tau-agent-core".to_string(),
+            "coding_mission".to_string(),
+        ],
+        stdout_path: state_root.join("verifier-latest.stdout"),
+        stderr_path: state_root.join("verifier-latest.stderr"),
+        exit_status: if latest_status == CodingWorkspaceCommandStatus::Succeeded {
+            Some(0)
+        } else {
+            Some(101)
+        },
+        elapsed_ms: 42,
+        reason_code: latest_reason_code.to_string(),
+        status: latest_status,
+        denied_reason: None,
+    });
+    state.git_evidence.push(CodingGitLifecycleEvidence {
+        kind: CodingGitLifecycleEvidenceKind::BranchPrepared,
+        branch_name: branch_name.clone(),
+        base_branch: "master".to_string(),
+        created_branch: true,
+        reused_branch: false,
+        commit_hash: Some("abc1234".to_string()),
+        changed_files: vec!["crates/tau-agent-core/src/coding_mission.rs".to_string()],
+        reason_code: "branch_prepared".to_string(),
+        created_unix_ms: 200,
+    });
+    state.resume_checkpoint = Some(CodingMissionResumeCheckpoint {
+        next_action: CodingMissionResumeAction::RunVerifier,
+        branch_name: Some(branch_name.clone()),
+        pending_verifier_command: Some("cargo test -p tau-agent-core coding_mission".to_string()),
+        latest_verifier_command_id: Some("verifier-latest".to_string()),
+        mutation_fingerprint: Some(CodingMissionMutationFingerprint {
+            changed_files: vec!["crates/tau-agent-core/src/coding_mission.rs".to_string()],
+            diff_hash: "diffhash".to_string(),
+        }),
+        latest_learning_summary: "operator checkpoint is resumable".to_string(),
+        operator_resume_command: format!("tau coding resume {mission_id}"),
+        updated_unix_ms: 260,
+    });
+    if phase == CodingMissionPhase::PrReady {
+        state.pr_ready_bundle = Some(CodingMissionPrReadyBundle {
+            status: CodingMissionPrPublicationStatus::ManualReady,
+            branch_name: branch_name.clone(),
+            commit_hash: Some("abc1234".to_string()),
+            title: "Surface coding operator state".to_string(),
+            body: "ready".to_string(),
+            body_path: state_root.join("pr-body.md"),
+            manual_gh_pr_create_command: "gh pr create --draft".to_string(),
+            changed_files: vec!["crates/tau-agent-core/src/coding_mission.rs".to_string()],
+            verifier_evidence_ids: vec!["verifier-latest".to_string()],
+            risk_notes: Vec::new(),
+            rollback_notes: Vec::new(),
+            pr_url: Some("https://github.com/example/tau/pull/3654".to_string()),
+            error_summary: None,
+            created_unix_ms: 270,
+        });
+    }
+    save_coding_mission_state(&state).expect("save coding mission state");
+    state
 }
 
 #[test]
@@ -11889,6 +12010,14 @@ async fn regression_gateway_missions_list_exposes_persisted_checkpointed_and_blo
         },
     )
     .expect("save blocked mission");
+    let coding_state = save_operator_coding_mission_state(
+        &state.config.state_dir,
+        "checkpoint-alpha",
+        "session-alpha",
+        CodingMissionPhase::PrReady,
+        CodingWorkspaceCommandStatus::Succeeded,
+        "verification_passed",
+    );
 
     let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
     let client = Client::new();
@@ -11911,6 +12040,32 @@ async fn regression_gateway_missions_list_exposes_persisted_checkpointed_and_blo
     assert_eq!(
         missions[0]["latest_completion"]["summary"],
         "scaffolded the first gameplay slice"
+    );
+    assert_eq!(missions[0]["coding_mission"]["phase"], "pr_ready");
+    assert_eq!(
+        missions[0]["coding_mission"]["repo_path"],
+        coding_state.repo_path.display().to_string()
+    );
+    assert_eq!(
+        missions[0]["coding_mission"]["branch_name"],
+        "codex/issue-3654-operator"
+    );
+    assert_eq!(
+        missions[0]["coding_mission"]["verifier_status"],
+        "succeeded:verification_passed"
+    );
+    assert_eq!(
+        missions[0]["coding_mission"]["last_failure"],
+        "failed:red_verifier_failed"
+    );
+    assert_eq!(
+        missions[0]["coding_mission"]["resume_command"],
+        "tau coding resume checkpoint-alpha"
+    );
+    assert_eq!(missions[0]["coding_mission"]["pr_state"], "manual_ready");
+    assert_eq!(
+        missions[0]["coding_mission"]["pr_url"],
+        "https://github.com/example/tau/pull/3654"
     );
     assert_eq!(missions[1]["mission_id"], "blocked-beta");
     assert_eq!(missions[1]["status"], "blocked");
@@ -11992,6 +12147,14 @@ async fn regression_gateway_mission_detail_exposes_verifier_and_completion_state
         },
     )
     .expect("save checkpoint mission");
+    save_operator_coding_mission_state(
+        &state.config.state_dir,
+        "checkpoint-alpha",
+        "session-alpha",
+        CodingMissionPhase::PrReady,
+        CodingWorkspaceCommandStatus::Succeeded,
+        "verification_passed",
+    );
 
     let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
     let client = Client::new();
@@ -12019,6 +12182,15 @@ async fn regression_gateway_mission_detail_exposes_verifier_and_completion_state
         payload["mission"]["latest_completion"]["next_step"],
         "run validation"
     );
+    assert_eq!(payload["mission"]["coding_mission"]["phase"], "pr_ready");
+    assert_eq!(
+        payload["mission"]["coding_mission"]["changed_files"][0],
+        "crates/tau-agent-core/src/coding_mission.rs"
+    );
+    assert_eq!(
+        payload["mission"]["coding_mission"]["resume_command"],
+        "tau coding resume checkpoint-alpha"
+    );
     assert_eq!(payload["mission"]["iterations"][0]["attempt"], 1);
     assert_eq!(
         payload["mission"]["iterations"][0]["tool_execution_count"],
@@ -12040,6 +12212,50 @@ async fn regression_gateway_mission_detail_exposes_verifier_and_completion_state
     assert_eq!(
         payload["harness_mission"]["checkpoints"][0]["pending_plan_node_ids"][0],
         "run validation"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn regression_gateway_mission_detail_falls_back_to_coding_mission_state() {
+    let temp = tempdir().expect("tempdir");
+    let state = test_state(temp.path(), 10_000, "secret");
+    save_operator_coding_mission_state(
+        &state.config.state_dir,
+        "coding-only-alpha",
+        "coding-session-alpha",
+        CodingMissionPhase::Blocked,
+        CodingWorkspaceCommandStatus::Failed,
+        "verification_failed",
+    );
+
+    let (addr, handle) = spawn_test_server(state).await.expect("spawn server");
+    let client = Client::new();
+    let endpoint = expand_mission_template(GATEWAY_MISSION_DETAIL_ENDPOINT, "coding-only-alpha");
+    let response = client
+        .get(format!("http://{addr}{endpoint}"))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("coding mission detail");
+    let status = response.status();
+    let payload = response
+        .json::<Value>()
+        .await
+        .expect("parse coding mission detail payload");
+    assert_eq!(status, StatusCode::OK, "unexpected payload: {payload}");
+    assert_eq!(payload["mission"]["mission_id"], "coding-only-alpha");
+    assert_eq!(payload["mission"]["session_key"], "coding-session-alpha");
+    assert_eq!(payload["mission"]["status"], "blocked");
+    assert_eq!(payload["mission"]["coding_mission"]["phase"], "blocked");
+    assert_eq!(
+        payload["mission"]["coding_mission"]["verifier_status"],
+        "failed:verification_failed"
+    );
+    assert_eq!(
+        payload["mission"]["latest_completion"]["next_step"],
+        "tau coding resume coding-only-alpha"
     );
 
     handle.abort();

--- a/crates/tau-tui/src/interactive/app.rs
+++ b/crates/tau-tui/src/interactive/app.rs
@@ -160,6 +160,12 @@ impl App {
                         content.push_str(&format!("\nnext step: {next_step}"));
                     }
                 }
+                let mut coding_lines = Vec::new();
+                append_coding_mission_detail(&mut coding_lines, &mission);
+                if !coding_lines.is_empty() {
+                    content.push('\n');
+                    content.push_str(coding_lines.join("\n").as_str());
+                }
                 self.push_timestamped_message(MessageRole::System, content);
             }
             Err(error) => {
@@ -493,13 +499,27 @@ fn render_mission_list(missions: &[GatewayMissionSnapshot]) -> String {
 
     let mut lines = vec!["Recent missions:".to_string()];
     for mission in missions {
+        let coding = mission
+            .coding_mission
+            .as_ref()
+            .map(|coding| {
+                format!(
+                    " coding_phase={} branch={} verifier={} pr={}",
+                    coding.phase,
+                    coding.branch_name.as_deref().unwrap_or("none"),
+                    coding.verifier_status.as_deref().unwrap_or("none"),
+                    coding.pr_state.as_deref().unwrap_or("none")
+                )
+            })
+            .unwrap_or_default();
         lines.push(format!(
-            "- {} [{}] session={} attempts={} verifier={} goal={}",
+            "- {} [{}] session={} attempts={} verifier={}{} goal={}",
             mission.mission_id,
             mission.status,
             mission.session_key,
             mission.iteration_count,
             mission.latest_verifier.reason_code,
+            coding,
             mission.goal_summary
         ));
     }
@@ -530,5 +550,43 @@ fn render_mission_detail(mission: &GatewayMissionSnapshot) -> String {
             lines.push(format!("next step: {next_step}"));
         }
     }
+    append_coding_mission_detail(&mut lines, mission);
     lines.join("\n")
+}
+
+fn append_coding_mission_detail(lines: &mut Vec<String>, mission: &GatewayMissionSnapshot) {
+    if let Some(coding) = mission.coding_mission.as_ref() {
+        lines.push(format!("coding phase: {}", coding.phase));
+        lines.push(format!("coding repo: {}", coding.repo_path));
+        lines.push(format!(
+            "coding branch: {}",
+            coding.branch_name.as_deref().unwrap_or("none")
+        ));
+        lines.push(format!(
+            "coding verifier: {}",
+            coding.verifier_status.as_deref().unwrap_or("none")
+        ));
+        if let Some(command) = coding.verifier_command.as_deref() {
+            lines.push(format!("coding verifier command: {command}"));
+        }
+        lines.push(format!(
+            "coding last failure: {}",
+            coding.last_failure.as_deref().unwrap_or("none")
+        ));
+        if !coding.changed_files.is_empty() {
+            lines.push(format!(
+                "coding changed files: {}",
+                coding.changed_files.join(", ")
+            ));
+        }
+        if let Some(resume_command) = coding.resume_command.as_deref() {
+            lines.push(format!("coding resume: {resume_command}"));
+        }
+        let pr_status = coding
+            .pr_url
+            .as_deref()
+            .or(coding.pr_state.as_deref())
+            .unwrap_or("none");
+        lines.push(format!("coding pr: {pr_status}"));
+    }
 }

--- a/crates/tau-tui/src/interactive/app_gateway_tests.rs
+++ b/crates/tau-tui/src/interactive/app_gateway_tests.rs
@@ -955,7 +955,7 @@ fn red_spec_3618_non_matching_prompt_omits_active_skill_label() {
 fn red_spec_3659_command_missions_lists_persisted_mission_summaries() {
     let (bind, _) = spawn_scripted_gateway_server(vec![(
         "200 OK",
-        r#"{"missions":[{"mission_id":"checkpoint-alpha","session_key":"session-alpha","status":"checkpointed","goal_summary":"build the game scaffold","latest_output_summary":"scaffolded the first gameplay slice","iteration_count":1,"updated_unix_ms":220,"latest_verifier":{"status":"passed","reason_code":"mutation_evidence_observed","message":"observed workspace mutation"},"latest_completion":{"status":"partial","summary":"scaffolded the first gameplay slice","next_step":"run validation"}}],"limit":20}"#,
+        r#"{"missions":[{"mission_id":"checkpoint-alpha","session_key":"session-alpha","status":"checkpointed","goal_summary":"build the game scaffold","latest_output_summary":"scaffolded the first gameplay slice","iteration_count":1,"updated_unix_ms":220,"latest_verifier":{"status":"passed","reason_code":"mutation_evidence_observed","message":"observed workspace mutation"},"latest_completion":{"status":"partial","summary":"scaffolded the first gameplay slice","next_step":"run validation"},"coding_mission":{"mission_id":"checkpoint-alpha","phase":"pr_ready","repo_path":"/tmp/tau-fixture-repo","branch_name":"codex/issue-3654-operator","verifier_status":"succeeded:verification_passed","verifier_command":"cargo test -p tau-agent-core coding_mission","last_failure":"none","changed_files":["crates/tau-agent-core/src/coding_mission.rs"],"resume_command":"tau coding resume checkpoint-alpha","pr_state":"manual_ready","pr_url":"https://github.com/example/tau/pull/3654"}}],"limit":20}"#,
     )]);
     let mut app = build_app(bind);
     set_input(&mut app, "/missions");
@@ -966,13 +966,16 @@ fn red_spec_3659_command_missions_lists_persisted_mission_summaries() {
     assert!(system.contains("Recent missions:"));
     assert!(system.contains("checkpoint-alpha [checkpointed]"));
     assert!(system.contains("session=session-alpha"));
+    assert!(system.contains("coding_phase=pr_ready"));
+    assert!(system.contains("branch=codex/issue-3654-operator"));
+    assert!(system.contains("pr=manual_ready"));
 }
 
 #[test]
 fn red_spec_3659_resume_command_binds_active_mission_and_surfaces_status() {
     let (bind, _) = spawn_scripted_gateway_server(vec![(
         "200 OK",
-        r#"{"mission":{"mission_id":"checkpoint-alpha","session_key":"session-alpha","status":"checkpointed","goal_summary":"build the game scaffold","latest_output_summary":"scaffolded the first gameplay slice","iteration_count":1,"updated_unix_ms":220,"latest_verifier":{"status":"passed","reason_code":"mutation_evidence_observed","message":"observed workspace mutation"},"latest_completion":{"status":"partial","summary":"scaffolded the first gameplay slice","next_step":"run validation"}}}"#,
+        r#"{"mission":{"mission_id":"checkpoint-alpha","session_key":"session-alpha","status":"checkpointed","goal_summary":"build the game scaffold","latest_output_summary":"scaffolded the first gameplay slice","iteration_count":1,"updated_unix_ms":220,"latest_verifier":{"status":"passed","reason_code":"mutation_evidence_observed","message":"observed workspace mutation"},"latest_completion":{"status":"partial","summary":"scaffolded the first gameplay slice","next_step":"run validation"},"coding_mission":{"mission_id":"checkpoint-alpha","phase":"pr_ready","repo_path":"/tmp/tau-fixture-repo","branch_name":"codex/issue-3654-operator","verifier_status":"succeeded:verification_passed","verifier_command":"cargo test -p tau-agent-core coding_mission","last_failure":"none","changed_files":["crates/tau-agent-core/src/coding_mission.rs"],"resume_command":"tau coding resume checkpoint-alpha","pr_state":"manual_ready","pr_url":"https://github.com/example/tau/pull/3654"}}}"#,
     )]);
     let mut app = build_app(bind);
     set_input(&mut app, "/resume checkpoint-alpha");
@@ -991,6 +994,13 @@ fn red_spec_3659_resume_command_binds_active_mission_and_surfaces_status() {
     let system = last_message(&app, MessageRole::System).unwrap_or_default();
     assert!(system.contains("Resumed mission checkpoint-alpha"));
     assert!(system.contains("next step: run validation"));
+    assert!(system.contains("coding phase: pr_ready"));
+    assert!(system.contains("coding repo: /tmp/tau-fixture-repo"));
+    assert!(system.contains("coding branch: codex/issue-3654-operator"));
+    assert!(system.contains("coding verifier: succeeded:verification_passed"));
+    assert!(system.contains("coding changed files: crates/tau-agent-core/src/coding_mission.rs"));
+    assert!(system.contains("coding resume: tau coding resume checkpoint-alpha"));
+    assert!(system.contains("coding pr: https://github.com/example/tau/pull/3654"));
 
     let backend = ratatui::backend::TestBackend::new(120, 24);
     let mut terminal = ratatui::Terminal::new(backend).expect("terminal");

--- a/crates/tau-tui/src/interactive/gateway_client.rs
+++ b/crates/tau-tui/src/interactive/gateway_client.rs
@@ -84,6 +84,29 @@ pub struct GatewayMissionCompletionSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayCodingMissionSummary {
+    pub mission_id: String,
+    pub phase: String,
+    pub repo_path: String,
+    #[serde(default)]
+    pub branch_name: Option<String>,
+    #[serde(default)]
+    pub verifier_status: Option<String>,
+    #[serde(default)]
+    pub verifier_command: Option<String>,
+    #[serde(default)]
+    pub last_failure: Option<String>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(default)]
+    pub resume_command: Option<String>,
+    #[serde(default)]
+    pub pr_state: Option<String>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct GatewayMissionSnapshot {
     pub mission_id: String,
     pub session_key: String,
@@ -95,6 +118,8 @@ pub struct GatewayMissionSnapshot {
     pub latest_verifier: GatewayMissionVerifierSummary,
     #[serde(default)]
     pub latest_completion: Option<GatewayMissionCompletionSummary>,
+    #[serde(default)]
+    pub coding_mission: Option<GatewayCodingMissionSummary>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/scripts/run/tau-unified.sh
+++ b/scripts/run/tau-unified.sh
@@ -174,6 +174,8 @@ write_control_plane_snapshot() {
     printf 'background_jobs_restart_recovery=running_manifests_requeued_after_restart\n'
     printf 'background_jobs_ops_guide=docs/guides/background-jobs-ops.md\n'
     printf 'routines_state=visible_via_webchat_routines_panel\n'
+    printf 'coding_missions_endpoint=http://%s/gateway/missions\n' "${bind}"
+    write_coding_mission_snapshot_fields "${gateway_state_dir}"
     printf 'autonomy_boundary=durable_jobs_replay_crash_resume_not_claimed\n'
   } >"${CONTROL_SNAPSHOT_FILE}"
 }
@@ -192,6 +194,119 @@ control_plane_snapshot_value() {
   printf '%s' "${default_value}"
 }
 
+write_default_coding_mission_snapshot_fields() {
+  local gateway_state_dir="$1"
+  printf 'coding_mission_state_dir=%s/coding-missions\n' "${gateway_state_dir}"
+  printf 'coding_mission_id=none\n'
+  printf 'coding_mission_phase=none\n'
+  printf 'coding_mission_repo=unknown\n'
+  printf 'coding_mission_branch=none\n'
+  printf 'coding_mission_verifier=none\n'
+  printf 'coding_mission_last_failure=none\n'
+  printf 'coding_mission_changed_files=none\n'
+  printf 'coding_mission_resume_command=none\n'
+  printf 'coding_mission_pr_state=none\n'
+  printf 'coding_mission_pr_url=none\n'
+}
+
+write_coding_mission_snapshot_fields() {
+  local gateway_state_dir="$1"
+  local missions_dir="${gateway_state_dir}/coding-missions"
+  if [[ ! -d "${missions_dir}" ]] || ! command -v python3 >/dev/null 2>&1; then
+    write_default_coding_mission_snapshot_fields "${gateway_state_dir}"
+    return 0
+  fi
+
+  local snapshot
+  snapshot="$(python3 - "${missions_dir}" <<'PY' 2>/dev/null || true
+import glob
+import json
+import os
+import sys
+
+missions_dir = sys.argv[1]
+
+def clean(value, default="none"):
+    if value is None:
+        value = default
+    value = str(value).replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
+    return value if value else default
+
+states = []
+for path in glob.glob(os.path.join(missions_dir, "*.json")):
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        continue
+    if payload.get("mission_id"):
+        payload["_path"] = path
+        states.append(payload)
+
+if not states:
+    sys.exit(0)
+
+state = max(states, key=lambda item: int(item.get("updated_unix_ms") or 0))
+commands = list(state.get("command_evidence") or [])
+git_evidence = list(state.get("git_evidence") or [])
+checkpoint = state.get("resume_checkpoint") or {}
+pr_bundle = state.get("pr_ready_bundle") or {}
+
+latest_command = commands[-1] if commands else {}
+failed_command = next(
+    (
+        command
+        for command in reversed(commands)
+        if clean(command.get("status"), "unknown") != "succeeded"
+    ),
+    {},
+)
+latest_git = git_evidence[-1] if git_evidence else {}
+
+def command_summary(command):
+    if not command:
+        return "none"
+    return f"{clean(command.get('status'), 'unknown')}:{clean(command.get('reason_code'), 'unknown')}"
+
+changed_files = (
+    pr_bundle.get("changed_files")
+    or latest_git.get("changed_files")
+    or (checkpoint.get("mutation_fingerprint") or {}).get("changed_files")
+    or []
+)
+branch = (
+    checkpoint.get("branch_name")
+    or pr_bundle.get("branch_name")
+    or latest_git.get("branch_name")
+)
+pr_state = pr_bundle.get("status") or ("pr_ready" if state.get("phase") == "pr_ready" else "none")
+
+fields = {
+    "coding_mission_state_dir": missions_dir,
+    "coding_mission_id": state.get("mission_id"),
+    "coding_mission_phase": state.get("phase"),
+    "coding_mission_repo": state.get("repo_path"),
+    "coding_mission_branch": branch,
+    "coding_mission_verifier": command_summary(latest_command),
+    "coding_mission_last_failure": command_summary(failed_command),
+    "coding_mission_changed_files": ",".join(map(clean, changed_files)) if changed_files else "none",
+    "coding_mission_resume_command": checkpoint.get("operator_resume_command"),
+    "coding_mission_pr_state": pr_state,
+    "coding_mission_pr_url": pr_bundle.get("pr_url"),
+}
+
+for key, value in fields.items():
+    print(f"{key}={clean(value)}")
+PY
+)"
+
+  if [[ -z "${snapshot}" ]]; then
+    write_default_coding_mission_snapshot_fields "${gateway_state_dir}"
+    return 0
+  fi
+  printf '%s\n' "${snapshot}"
+}
+
 log_control_plane_snapshot() {
   log "tau-unified: control_plane.health=running"
   log "tau-unified: control_plane.runtime_state_dir=${RUNTIME_DIR}"
@@ -202,6 +317,16 @@ log_control_plane_snapshot() {
 
   if [[ ! -f "${CONTROL_SNAPSHOT_FILE}" ]]; then
     log "tau-unified: control_plane.snapshot=missing"
+    log "tau-unified: control_plane.coding_mission.id=none"
+    log "tau-unified: control_plane.coding_mission.phase=none"
+    log "tau-unified: control_plane.coding_mission.repo=unknown"
+    log "tau-unified: control_plane.coding_mission.branch=none"
+    log "tau-unified: control_plane.coding_mission.verifier=none"
+    log "tau-unified: control_plane.coding_mission.last_failure=none"
+    log "tau-unified: control_plane.coding_mission.changed_files=none"
+    log "tau-unified: control_plane.coding_mission.resume_command=none"
+    log "tau-unified: control_plane.coding_mission.pr_state=none"
+    log "tau-unified: control_plane.coding_mission.pr_url=none"
     log "tau-unified: control_plane.autonomy_boundary=durable_jobs_replay_crash_resume_not_claimed"
     return 0
   fi
@@ -231,6 +356,18 @@ log_control_plane_snapshot() {
   log "tau-unified: control_plane.dashboard_state_dir=$(control_plane_snapshot_value dashboard_state_dir unknown)"
   log "tau-unified: control_plane.jobs_state_dir=$(control_plane_snapshot_value jobs_state_dir unknown)"
   log "tau-unified: control_plane.deploy_state_file=$(control_plane_snapshot_value deploy_state_file unknown)"
+  log "tau-unified: control_plane.coding_missions_endpoint=$(control_plane_snapshot_value coding_missions_endpoint unknown)"
+  log "tau-unified: control_plane.coding_mission.state_dir=$(control_plane_snapshot_value coding_mission_state_dir unknown)"
+  log "tau-unified: control_plane.coding_mission.id=$(control_plane_snapshot_value coding_mission_id none)"
+  log "tau-unified: control_plane.coding_mission.phase=$(control_plane_snapshot_value coding_mission_phase none)"
+  log "tau-unified: control_plane.coding_mission.repo=$(control_plane_snapshot_value coding_mission_repo unknown)"
+  log "tau-unified: control_plane.coding_mission.branch=$(control_plane_snapshot_value coding_mission_branch none)"
+  log "tau-unified: control_plane.coding_mission.verifier=$(control_plane_snapshot_value coding_mission_verifier none)"
+  log "tau-unified: control_plane.coding_mission.last_failure=$(control_plane_snapshot_value coding_mission_last_failure none)"
+  log "tau-unified: control_plane.coding_mission.changed_files=$(control_plane_snapshot_value coding_mission_changed_files none)"
+  log "tau-unified: control_plane.coding_mission.resume_command=$(control_plane_snapshot_value coding_mission_resume_command none)"
+  log "tau-unified: control_plane.coding_mission.pr_state=$(control_plane_snapshot_value coding_mission_pr_state none)"
+  log "tau-unified: control_plane.coding_mission.pr_url=$(control_plane_snapshot_value coding_mission_pr_url none)"
   log "tau-unified: control_plane.autonomy_boundary=$(control_plane_snapshot_value autonomy_boundary durable_jobs_replay_crash_resume_not_claimed)"
 }
 

--- a/scripts/run/test-tau-unified.sh
+++ b/scripts/run/test-tau-unified.sh
@@ -194,6 +194,105 @@ test_status_control_plane_snapshot() {
   local test_dashboard_state_dir="${tmp_dir}/status-dashboard"
   local test_jobs_state_dir="${tmp_dir}/status-jobs"
   local status_bind="127.0.0.1:8911"
+  mkdir -p "${test_gateway_state_dir}/coding-missions"
+  cat >"${test_gateway_state_dir}/coding-missions/status-coding-alpha.json" <<JSON
+{
+  "schema_version": 1,
+  "state_root": "${test_gateway_state_dir}",
+  "mission_id": "status-coding-alpha",
+  "session_key": "session-status-alpha",
+  "repo_path": "${tmp_dir}/fixture-repo",
+  "goal": "surface coding mission status",
+  "base_branch": "master",
+  "branch_prefix": "codex/issue-3654",
+  "verifier_commands": ["cargo test -p tau-agent-core coding_mission"],
+  "pr_mode": "pr_ready",
+  "allowed_roots": ["${tmp_dir}"],
+  "phase": "pr_ready",
+  "created_unix_ms": 10,
+  "updated_unix_ms": 99,
+  "mission": {
+    "schema_version": 1,
+    "mission_id": "status-coding-alpha",
+    "title": "surface coding mission status",
+    "status": "checkpointed",
+    "created_unix_ms": 10,
+    "updated_unix_ms": 99,
+    "tool_budget": {"max_tool_calls": 0, "consumed_tool_calls": 0},
+    "checkpoints": [],
+    "artifacts": [],
+    "learning_records": [],
+    "verification_gates": [],
+    "recovery_state": null
+  },
+  "events": [],
+  "command_evidence": [
+    {
+      "command_id": "verifier-0",
+      "cwd": "${tmp_dir}/fixture-repo",
+      "argv": ["cargo", "test", "-p", "tau-agent-core", "coding_mission"],
+      "stdout_path": "${tmp_dir}/stdout-old.txt",
+      "stderr_path": "${tmp_dir}/stderr-old.txt",
+      "exit_status": 101,
+      "elapsed_ms": 24,
+      "reason_code": "red_verifier_failed",
+      "status": "failed"
+    },
+    {
+      "command_id": "verifier-1",
+      "cwd": "${tmp_dir}/fixture-repo",
+      "argv": ["cargo", "test", "-p", "tau-agent-core", "coding_mission"],
+      "stdout_path": "${tmp_dir}/stdout.txt",
+      "stderr_path": "${tmp_dir}/stderr.txt",
+      "exit_status": 0,
+      "elapsed_ms": 42,
+      "reason_code": "verification_passed",
+      "status": "succeeded"
+    }
+  ],
+  "git_evidence": [
+    {
+      "kind": "branch_prepared",
+      "branch_name": "codex/issue-3654-operator",
+      "base_branch": "master",
+      "created_branch": true,
+      "reused_branch": false,
+      "commit_hash": "abc1234",
+      "changed_files": ["crates/tau-agent-core/src/coding_mission.rs"],
+      "reason_code": "branch_prepared",
+      "created_unix_ms": 40
+    }
+  ],
+  "resume_checkpoint": {
+    "next_action": "run_verifier",
+    "branch_name": "codex/issue-3654-operator",
+    "pending_verifier_command": "cargo test -p tau-agent-core coding_mission",
+    "latest_verifier_command_id": "verifier-1",
+    "mutation_fingerprint": {
+      "changed_files": ["crates/tau-agent-core/src/coding_mission.rs"],
+      "diff_hash": "diffhash"
+    },
+    "latest_learning_summary": "operator status checkpoint",
+    "operator_resume_command": "tau coding resume status-coding-alpha",
+    "updated_unix_ms": 99
+  },
+  "pr_ready_bundle": {
+    "status": "manual_ready",
+    "branch_name": "codex/issue-3654-operator",
+    "commit_hash": "abc1234",
+    "title": "Surface coding operator state",
+    "body": "ready",
+    "body_path": "${tmp_dir}/pr-body.md",
+    "manual_gh_pr_create_command": "gh pr create --draft",
+    "changed_files": ["crates/tau-agent-core/src/coding_mission.rs"],
+    "verifier_evidence_ids": ["verifier-1"],
+    "risk_notes": [],
+    "rollback_notes": [],
+    "pr_url": "https://github.com/example/tau/pull/3654",
+    "created_unix_ms": 100
+  }
+}
+JSON
 
   local up_status_output
   up_status_output="$(
@@ -245,6 +344,16 @@ test_status_control_plane_snapshot() {
   assert_contains "${status_output}" "tau-unified: control_plane.gateway_state_dir=${test_gateway_state_dir}" "status gateway state dir"
   assert_contains "${status_output}" "tau-unified: control_plane.dashboard_state_dir=${test_dashboard_state_dir}" "status dashboard state dir"
   assert_contains "${status_output}" "tau-unified: control_plane.deploy_state_file=${test_gateway_state_dir}/deploy-agent-state.json" "status deploy state file"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.id=status-coding-alpha" "status coding mission id"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.phase=pr_ready" "status coding mission phase"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.repo=${tmp_dir}/fixture-repo" "status coding mission repo"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.branch=codex/issue-3654-operator" "status coding mission branch"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.verifier=succeeded:verification_passed" "status coding mission verifier"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.last_failure=failed:red_verifier_failed" "status coding mission last failure"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.changed_files=crates/tau-agent-core/src/coding_mission.rs" "status coding mission changed files"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.resume_command=tau coding resume status-coding-alpha" "status coding mission resume command"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.pr_state=manual_ready" "status coding mission pr state"
+  assert_contains "${status_output}" "tau-unified: control_plane.coding_mission.pr_url=https://github.com/example/tau/pull/3654" "status coding mission pr url"
   assert_contains "${status_output}" "tau-unified: control_plane.autonomy_boundary=durable_jobs_replay_crash_resume_not_claimed" "status autonomy boundary"
 
   TAU_UNIFIED_RUNNER="${runner}" \

--- a/specs/3654/tasks.md
+++ b/specs/3654/tasks.md
@@ -307,17 +307,42 @@ Evidence:
 
 ### Slice G: Operator command center integration
 
-- [ ] T46 RED: extend `tau-unified status` tests to require active coding
+- [x] T46 RED: extend `tau-unified status` tests to require active coding
       mission id, phase, repo, branch, verifier, last failure, and PR-ready or
       PR URL state.
-- [ ] T47 GREEN: surface coding mission state through the existing
+- [x] T47 GREEN: surface coding mission state through the existing
       control-plane snapshot and gateway mission endpoints.
-- [ ] T48 RED: extend TUI mission commands to show coding mission phase,
+- [x] T48 RED: extend TUI mission commands to show coding mission phase,
       verifier result, changed files, and resume command.
-- [ ] T49 GREEN: wire `/missions`, `/mission <id>`, and `/resume <id>` to the
+- [x] T49 GREEN: wire `/missions`, `/mission <id>`, and `/resume <id>` to the
       real coding mission runner state.
-- [ ] T50 VERIFY: run `scripts/run/test-tau-unified.sh status_contract` plus
+- [x] T50 VERIFY: run `scripts/run/test-tau-unified.sh status_contract` plus
       focused TUI mission tests.
+
+- RED: `scripts/run/test-tau-unified.sh status_contract` failed before
+  implementation because `tau-unified status` did not emit
+  `control_plane.coding_mission.*` fields from saved coding mission state.
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p
+  tau-gateway regression_gateway_mission_detail_falls_back_to_coding_mission_state
+  -- --test-threads=1` failed before implementation with
+  `mission_not_found` for a coding-only durable mission.
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p
+  tau-tui red_spec_3659 -- --test-threads=1` failed before the resume renderer
+  shared the coding detail block because `/resume` did not include
+  `coding phase: pr_ready`.
+- GREEN: `scripts/run/test-tau-unified.sh status_contract` passed with a saved
+  coding mission exposing id, phase, repo, branch, verifier, last failure,
+  changed files, resume command, PR state, and PR URL.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p
+  tau-gateway regression_gateway_mission -- --test-threads=1` passed 3 gateway
+  mission list/detail tests, including coding-only fallback.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p
+  tau-tui red_spec_3659 -- --test-threads=1` passed 3 TUI mission/resume tests.
+- VERIFY: `cargo fmt --check` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p
+  tau-tui app_gateway_tests -- --test-threads=1` passed 18 TUI gateway tests.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo clippy -p
+  tau-tui -p tau-gateway -- -D warnings` passed.
 
 Done when:
 - Operators can see what Tau is doing without opening raw state files.


### PR DESCRIPTION
## Summary
Connects the live coding mission durable state to the operator surfaces that already exist: `tau-unified status`, `/gateway/missions`, `/gateway/missions/{id}`, and TUI `/missions`/`/mission`/`/resume`.

This completes Slice G of `specs/3654/tasks.md`: operators can now see phase, repo, branch, verifier state, last failure, changed files, resume command, and PR-ready/PR URL state without opening raw JSON.

## Links
- Closes #3654
- Spec: `specs/3654/spec.md`
- Plan: `specs/3654/plan.md`
- Tasks: `specs/3654/tasks.md`

## Spec Verification
| AC | Status | Test(s) |
|---|---:|---|
| Operator status exposes active coding mission state | ✅ | `scripts/run/test-tau-unified.sh status_contract` |
| Gateway mission endpoints surface coding runner state without a parallel lifecycle source | ✅ | `cargo test -p tau-gateway regression_gateway_mission -- --test-threads=1` |
| TUI mission commands show coding phase/verifier/changed files/resume/PR state | ✅ | `cargo test -p tau-tui red_spec_3659 -- --test-threads=1`; `cargo test -p tau-tui app_gateway_tests -- --test-threads=1` |
| Slice G tasks are recorded with RED/GREEN/VERIFY evidence | ✅ | `specs/3654/tasks.md` updated |

## TDD Evidence
RED:
- `scripts/run/test-tau-unified.sh status_contract` failed before implementation because `control_plane.coding_mission.*` fields were missing.
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p tau-gateway regression_gateway_mission_detail_falls_back_to_coding_mission_state -- --test-threads=1` failed with `mission_not_found` for a coding-only durable mission.
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p tau-tui red_spec_3659 -- --test-threads=1` failed before the resume renderer shared the coding detail block because `/resume` did not include `coding phase: pr_ready`.

GREEN/VERIFY:
- `scripts/run/test-tau-unified.sh status_contract`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p tau-gateway regression_gateway_mission -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p tau-tui red_spec_3659 -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo test -p tau-tui app_gateway_tests -- --test-threads=1`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3654-operator-target cargo clippy -p tau-tui -p tau-gateway -- -D warnings`
- `git diff --check`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`

## Test Tiers
| Tier | Status | Tests | N/A Why |
|---|---:|---|---|
| Unit | ✅ | Gateway/TUI focused unit tests listed above | |
| Property | N/A | | No parser/invariant algorithm introduced |
| Contract/DbC | N/A | | No contract macro surface changed |
| Snapshot | N/A | | No insta snapshots changed |
| Functional | ✅ | `status_contract`, TUI mission command tests | |
| Conformance | ✅ | Slice G RED/GREEN tests mapped in `specs/3654/tasks.md` | |
| Integration | ✅ | Gateway mission API list/detail tests with saved coding state | |
| Fuzz | N/A | | No untrusted parser/fuzz target changed |
| Mutation | N/A | | Operator surface adapter slice; no critical algorithmic path in this PR |
| Regression | ✅ | Existing mission list/detail and TUI gateway tests still pass | |
| Performance | N/A | | No hot-path performance claim |

## Mutation
N/A for this operator integration slice; no escaped mutants claimed.

## Risks/Rollback
Risk: `tau-unified.sh` uses `python3` opportunistically to summarize saved coding mission JSON; if unavailable, it reports honest `none` defaults. Gateway/TUI surfaces remain backward-compatible because `coding_mission` is optional.

Rollback: revert this PR to return to raw-state-only visibility; no storage migration is introduced.

## Docs/ADR
- Updated `specs/3654/tasks.md` Slice G evidence.
- No ADR required; this reuses existing `CodingMissionState` and gateway mission endpoints.

## Remaining Boundary
Slice H remains: the live end-to-end autonomous coding loop benchmark is not claimed here.
