### PR TITLE
Enable real-repo multi-file coding missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These are the paths that operate as connected flows today.
 | Unified runtime lifecycle loop | `./scripts/dev/prove-tau-product.sh --check --report /tmp/tau-product-proof-check.json` for static proof evidence, then `./scripts/dev/prove-tau-product.sh --run --webchat-smoke --report /tmp/tau-product-proof-webchat.json` for opt-in live product-surface evidence | One-command runtime bring-up (`up/status/down`) for gateway/dashboard + interactive TUI agent (`tui`) with explicit live-shell fallback, optional webchat readiness smoke, and optional JSON evidence | [`scripts/dev/prove-tau-product.sh`](scripts/dev/prove-tau-product.sh), [`scripts/run/tau-unified.sh`](scripts/run/tau-unified.sh), [`docs/guides/canonical-product-proof.md`](docs/guides/canonical-product-proof.md) |
 | Live coding mission loop | `./scripts/dev/test-full-autonomous-coding-loop.sh` | Disposable-repo M334 `repo_spec_to_pr_feature_delivery` harness through `CodingMissionRunner`: RED verifier, controlled edit, GREEN verifier, commit, PR-ready bundle, crash/resume, and blocked-task fail-closed evidence | [`scripts/dev/test-full-autonomous-coding-loop.sh`](scripts/dev/test-full-autonomous-coding-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs), [`specs/3654/tasks.md`](specs/3654/tasks.md) |
 | Provider-backed coding loop | `TAU_LIVE_PROVIDER_PROOF=1 ./scripts/dev/test-provider-backed-autonomous-coding-loop.sh` | Opt-in disposable-repo proof that calls a configured provider using API-key or subscription auth, parses JSON edit instructions into `CodingMissionRunner`, records RED/GREEN verifier, commit, and PR-ready evidence, and fail-closes malformed provider output | [`scripts/dev/test-provider-backed-autonomous-coding-loop.sh`](scripts/dev/test-provider-backed-autonomous-coding-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs), [`specs/3788-provider-backed-coding-loop-proof/tasks.md`](specs/3788-provider-backed-coding-loop-proof/tasks.md) |
+| Real-repo coding harness | `./scripts/dev/test-real-repo-autonomous-coding-harness.sh` | Temporary worktree of this repository through `CodingMissionRunner`: provider-compatible multi-file edit array, real git branch/commit, RED/GREEN verifier evidence, and manual PR-ready bundle | [`scripts/dev/test-real-repo-autonomous-coding-harness.sh`](scripts/dev/test-real-repo-autonomous-coding-harness.sh), [`crates/tau-agent-core/src/coding_mission.rs`](crates/tau-agent-core/src/coding_mission.rs), [`specs/3792-real-repo-autonomous-coding-harness/spec.md`](specs/3792-real-repo-autonomous-coding-harness/spec.md) |
 | Multi-channel ingress loop | `./scripts/demo/multi-channel.sh` | Multi-channel runtime, transport normalization, routing pipeline | [`docs/guides/multi-channel-event-pipeline.md`](docs/guides/multi-channel-event-pipeline.md), [`docs/guides/transports.md`](docs/guides/transports.md) |
 | Prompt optimization loop | [`docs/guides/training-ops.md`](docs/guides/training-ops.md) runbook flow | Training runner/store/tracer/proxy + rollout controls | [`docs/guides/training-ops.md`](docs/guides/training-ops.md), [`docs/guides/training-proxy-ops.md`](docs/guides/training-proxy-ops.md) |
 | Connected operator GA loop | `./scripts/verify/m296-ga-readiness-gate.sh` | RL maturity wave + auth/readiness checks + rollback trigger validation + closeout signoff criteria | [`docs/guides/m296-ga-readiness-gate.md`](docs/guides/m296-ga-readiness-gate.md), `artifacts/operator-ga-readiness/verification-report.json` |
@@ -50,6 +51,9 @@ These are the paths that operate as connected flows today.
   mission state can branch, retry from RED verifier evidence, apply a controlled
   fix, verify GREEN, commit, package PR-ready output, resume after interruption,
   and stop honestly on a blocked verifier.
+- Run a deterministic real-repo coding harness against a temporary worktree of
+  this repository with provider-compatible multi-file edits, RED/GREEN verifier
+  transcript, commit hash, and PR-ready bundle evidence.
 
 ## Capability Boundaries
 
@@ -94,9 +98,17 @@ Some surfaces are intentionally diagnostics-first or staged:
     adds the provider-backed proof: a configured provider returns JSON edit
     instructions, Tau parses them into `CodingMissionRunner`, and the report
     records sanitized provider/model metadata plus RED/GREEN verifier, commit,
-    and PR-ready evidence. Set `TAU_PROVIDER_PROOF_AUTH_MODE=codex-cli` with a
+    and PR-ready evidence. For OpenRouter-hosted models, include the
+    OpenRouter provider prefix, for example
+    `TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash`. Set
+    `TAU_PROVIDER_PROOF_AUTH_MODE=codex-cli` with a
     Codex CLI-supported model such as `openai/gpt-5.5` to validate the
     local subscription-backed provider path.
+  - `./scripts/dev/test-real-repo-autonomous-coding-harness.sh` runs the same
+    lifecycle against a temporary worktree of this repository and validates a
+    provider-compatible multi-file edit array. This is real git/worktree/commit
+    evidence, but not unattended arbitrary issue selection, durable background
+    recovery UI, or auto-merge.
 
 Executable claim boundary:
 
@@ -129,7 +141,7 @@ validation, or headed-browser pixel proof are complete.
 | Unified runtime control-plane status | Partial | `tau-unified status` exposes health/logs/sessions/memory/jobs/routines/deploy visibility; polished command-center UX and durable proactive recovery remain expanding | [`scripts/run/tau-unified.sh`](scripts/run/tau-unified.sh), [`scripts/dev/runtime-reality-gate.sh`](scripts/dev/runtime-reality-gate.sh) |
 | Prompt optimization training | Integrated | Canonical training path today | [`docs/guides/training-ops.md`](docs/guides/training-ops.md) |
 | True RL | Integrated | Deterministic end-to-end harness emits rollout + GAE/PPO artifact evidence | [`crates/tau-trainer/src/rl_e2e.rs`](crates/tau-trainer/src/rl_e2e.rs), [`crates/tau-trainer/src/bin/rl_e2e_harness.rs`](crates/tau-trainer/src/bin/rl_e2e_harness.rs) |
-| Autonomous coding lifecycle | Partial | Live local `CodingMissionRunner` harness proves lifecycle mechanics; opt-in provider-backed proof now verifies a configured provider can supply the edit for the disposable task, while broader arbitrary spec-to-PR autonomy remains expanding | [`scripts/dev/test-full-autonomous-coding-loop.sh`](scripts/dev/test-full-autonomous-coding-loop.sh), [`scripts/dev/test-provider-backed-autonomous-coding-loop.sh`](scripts/dev/test-provider-backed-autonomous-coding-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs) |
+| Autonomous coding lifecycle | Partial | Live local `CodingMissionRunner` harness proves lifecycle mechanics; provider-backed proof verifies configured-provider edit supply; real-repo harness now validates provider-compatible multi-file worktree commits and PR-ready output, while arbitrary issue selection, durable background recovery UX, and auto-merge remain expanding | [`scripts/dev/test-full-autonomous-coding-loop.sh`](scripts/dev/test-full-autonomous-coding-loop.sh), [`scripts/dev/test-provider-backed-autonomous-coding-loop.sh`](scripts/dev/test-provider-backed-autonomous-coding-loop.sh), [`scripts/dev/test-real-repo-autonomous-coding-harness.sh`](scripts/dev/test-real-repo-autonomous-coding-harness.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs) |
 | TUI | Integrated | Operator-shell + interactive `agent` mode + state-backed `shell-live` diagnostics | [`crates/tau-tui/src/main.rs`](crates/tau-tui/src/main.rs), [`crates/tau-tui/src/lib.rs`](crates/tau-tui/src/lib.rs), [`scripts/verify/m295-operator-maturity-wave.sh`](scripts/verify/m295-operator-maturity-wave.sh) |
 
 ## Current Gaps and Execution Plan

--- a/crates/tau-agent-core/src/coding_mission.rs
+++ b/crates/tau-agent-core/src/coding_mission.rs
@@ -163,6 +163,8 @@ pub struct CodingMissionControlledEdit {
 pub struct CodingMissionRunRequest {
     #[serde(default)]
     pub controlled_edit: Option<CodingMissionControlledEdit>,
+    #[serde(default)]
+    pub controlled_edits: Vec<CodingMissionControlledEdit>,
     pub commit_message: String,
     pub started_unix_ms: u64,
 }
@@ -223,6 +225,8 @@ pub struct CodingMissionResumeRequest {
     pub mission_id: String,
     #[serde(default)]
     pub controlled_edit: Option<CodingMissionControlledEdit>,
+    #[serde(default)]
+    pub controlled_edits: Vec<CodingMissionControlledEdit>,
     pub commit_message: String,
     pub started_unix_ms: u64,
     #[serde(default)]
@@ -937,6 +941,8 @@ impl CodingMissionRunner {
         state: &mut CodingMissionState,
         request: CodingMissionRunRequest,
     ) -> Result<CodingMissionRunOutcome, CodingMissionError> {
+        let controlled_edits =
+            requested_controlled_edits(&request.controlled_edit, &request.controlled_edits);
         if state.phase == CodingMissionPhase::Intake {
             state.transition_phase(
                 CodingMissionPhase::Planned,
@@ -982,13 +988,21 @@ impl CodingMissionRunner {
         }
         let mut verifier_passed = first.verifier_passed;
         if !verifier_passed {
-            if let Some(edit) = request.controlled_edit {
-                apply_controlled_edit_and_checkpoint(
+            if !controlled_edits.is_empty() {
+                if let Err(error) = apply_controlled_edits_and_checkpoint(
                     state,
-                    &edit,
+                    &controlled_edits,
                     branch.branch_name.as_str(),
                     request.started_unix_ms.saturating_add(200),
-                )?;
+                ) {
+                    return block_controlled_edit_error(
+                        state,
+                        error,
+                        false,
+                        iterations,
+                        request.started_unix_ms.saturating_add(299),
+                    );
+                }
                 iterations = iterations.saturating_add(1);
                 let second = run_coding_mission_verifiers(
                     state,
@@ -1179,29 +1193,36 @@ fn resume_from_apply_edit(
     checkpoint: &CodingMissionResumeCheckpoint,
     request: CodingMissionResumeRequest,
 ) -> Result<CodingMissionRunOutcome, CodingMissionError> {
-    let edit = match request.controlled_edit.clone() {
-        Some(edit) => edit,
-        None => {
-            return Ok(CodingMissionRunOutcome {
-                phase: state.phase,
-                verifier_passed: false,
-                committed: None,
-                blocked_reason: None,
-                iterations: 0,
-            });
-        }
-    };
+    let controlled_edits =
+        requested_controlled_edits(&request.controlled_edit, &request.controlled_edits);
+    if controlled_edits.is_empty() {
+        return Ok(CodingMissionRunOutcome {
+            phase: state.phase,
+            verifier_passed: false,
+            committed: None,
+            blocked_reason: None,
+            iterations: 0,
+        });
+    }
     let branch_name = checkpoint
         .branch_name
         .clone()
         .or_else(|| latest_prepared_branch_name(state))
         .unwrap_or_else(|| default_coding_git_branch_name(state));
-    apply_controlled_edit_and_checkpoint(
+    if let Err(error) = apply_controlled_edits_and_checkpoint(
         state,
-        &edit,
+        &controlled_edits,
         branch_name.as_str(),
         request.started_unix_ms.saturating_add(100),
-    )?;
+    ) {
+        return block_controlled_edit_error(
+            state,
+            error,
+            false,
+            1,
+            request.started_unix_ms.saturating_add(199),
+        );
+    }
     if request.stop_after == Some(CodingMissionResumeStopAfter::ControlledEdit) {
         return Ok(CodingMissionRunOutcome {
             phase: state.phase,
@@ -1403,13 +1424,27 @@ fn restore_resume_branch(
     Ok(Some(branch_name))
 }
 
-fn apply_controlled_edit_and_checkpoint(
+fn requested_controlled_edits(
+    controlled_edit: &Option<CodingMissionControlledEdit>,
+    controlled_edits: &[CodingMissionControlledEdit],
+) -> Vec<CodingMissionControlledEdit> {
+    let mut edits = Vec::with_capacity(
+        usize::from(controlled_edit.is_some()).saturating_add(controlled_edits.len()),
+    );
+    if let Some(edit) = controlled_edit.clone() {
+        edits.push(edit);
+    }
+    edits.extend(controlled_edits.iter().cloned());
+    edits
+}
+
+fn apply_controlled_edits_and_checkpoint(
     state: &mut CodingMissionState,
-    edit: &CodingMissionControlledEdit,
+    edits: &[CodingMissionControlledEdit],
     branch_name: &str,
     started_unix_ms: u64,
 ) -> Result<(), CodingMissionError> {
-    apply_controlled_edit(state, edit, started_unix_ms)?;
+    apply_controlled_edits(state, edits, started_unix_ms)?;
     let fingerprint = current_mutation_fingerprint(state, started_unix_ms.saturating_add(1))?;
     record_resume_checkpoint(
         state,
@@ -1419,6 +1454,28 @@ fn apply_controlled_edit_and_checkpoint(
         "resume_verify_after_edit",
         started_unix_ms.saturating_add(2),
     )
+}
+
+fn block_controlled_edit_error(
+    state: &mut CodingMissionState,
+    error: CodingMissionError,
+    verifier_passed: bool,
+    iterations: usize,
+    updated_unix_ms: u64,
+) -> Result<CodingMissionRunOutcome, CodingMissionError> {
+    match error {
+        CodingMissionError::GitLifecycle {
+            reason_code: "controlled_edit_outside_repo",
+            message: _,
+        } => block_coding_mission_run(
+            state,
+            "controlled_edit_outside_repo",
+            verifier_passed,
+            iterations,
+            updated_unix_ms,
+        ),
+        other => Err(other),
+    }
 }
 
 fn record_resume_checkpoint(
@@ -1587,11 +1644,57 @@ fn run_coding_mission_verifiers(
     })
 }
 
-fn apply_controlled_edit(
+fn apply_controlled_edits(
     state: &mut CodingMissionState,
-    edit: &CodingMissionControlledEdit,
+    edits: &[CodingMissionControlledEdit],
     created_unix_ms: u64,
 ) -> Result<(), CodingMissionError> {
+    let targets = validate_controlled_edit_targets(state, edits)?;
+    for (edit, target) in edits.iter().zip(targets.iter()) {
+        write_text_atomic(target, &edit.contents).map_err(|source| {
+            CodingMissionError::StateWrite {
+                path: target.clone(),
+                source,
+            }
+        })?;
+    }
+    for (edit, target) in edits.iter().zip(targets.iter()) {
+        let artifact_id = format!("controlled_edit:{}", edit.relative_path.display());
+        state.mission.artifacts.push(MissionArtifactRef {
+            artifact_id,
+            kind: "coding_mission_controlled_edit".to_string(),
+            path: Some(target.display().to_string()),
+            summary: Some(edit.reason_code.clone()),
+        });
+        state.events.push(CodingMissionEvent {
+            phase: state.phase,
+            reason_code: edit.reason_code.clone(),
+            message: format!("controlled edit wrote {}", edit.relative_path.display()),
+            created_unix_ms,
+        });
+    }
+    state.updated_unix_ms = created_unix_ms;
+    state.mission.latest_output_summary = match edits {
+        [edit] => format!("controlled edit wrote {}", edit.relative_path.display()),
+        _ => format!("controlled edit set wrote {} files", edits.len()),
+    };
+    save_coding_mission_state(state)
+}
+
+fn validate_controlled_edit_targets(
+    state: &CodingMissionState,
+    edits: &[CodingMissionControlledEdit],
+) -> Result<Vec<PathBuf>, CodingMissionError> {
+    edits
+        .iter()
+        .map(|edit| validate_controlled_edit_target(state, edit))
+        .collect()
+}
+
+fn validate_controlled_edit_target(
+    state: &CodingMissionState,
+    edit: &CodingMissionControlledEdit,
+) -> Result<PathBuf, CodingMissionError> {
     if edit.relative_path.is_absolute()
         || edit.relative_path.components().any(|component| {
             matches!(
@@ -1612,29 +1715,7 @@ fn apply_controlled_edit(
             message: target.display().to_string(),
         });
     }
-    write_text_atomic(&target, &edit.contents).map_err(|source| {
-        CodingMissionError::StateWrite {
-            path: target.clone(),
-            source,
-        }
-    })?;
-    let artifact_id = format!("controlled_edit:{}", edit.relative_path.display());
-    state.mission.artifacts.push(MissionArtifactRef {
-        artifact_id,
-        kind: "coding_mission_controlled_edit".to_string(),
-        path: Some(target.display().to_string()),
-        summary: Some(edit.reason_code.clone()),
-    });
-    state.events.push(CodingMissionEvent {
-        phase: state.phase,
-        reason_code: edit.reason_code.clone(),
-        message: format!("controlled edit wrote {}", edit.relative_path.display()),
-        created_unix_ms,
-    });
-    state.updated_unix_ms = created_unix_ms;
-    state.mission.latest_output_summary =
-        format!("controlled edit wrote {}", edit.relative_path.display());
-    save_coding_mission_state(state)
+    Ok(target)
 }
 
 fn block_coding_mission_run(
@@ -3050,6 +3131,23 @@ mod tests {
         config
     }
 
+    fn multi_file_verifier_config_for(root: &Path) -> CodingMissionConfig {
+        let mut config = committed_config_for(root);
+        std::fs::write(config.repo_path.join("status.txt"), "fail\n").expect("status file");
+        std::fs::create_dir_all(config.repo_path.join("docs")).expect("docs dir");
+        std::fs::write(config.repo_path.join("docs/notes.txt"), "missing\n").expect("notes file");
+        git(&config.repo_path, &["add", "status.txt", "docs/notes.txt"]);
+        git(
+            &config.repo_path,
+            &["commit", "-m", "add multi file fixture"],
+        );
+        config.verifier_commands = vec![
+            "grep -q pass status.txt".to_string(),
+            "grep -q helper docs/notes.txt".to_string(),
+        ];
+        config
+    }
+
     #[test]
     fn spec_c06_outer_loop_records_red_and_stays_executing() {
         let temp = tempdir().expect("tempdir");
@@ -3062,6 +3160,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "Make verifier green".to_string(),
                     started_unix_ms: 1_800_000_002_000,
                 },
@@ -3098,6 +3197,7 @@ mod tests {
                         contents: "pass\n".to_string(),
                         reason_code: "controlled_fix".to_string(),
                     }),
+                    controlled_edits: Vec::new(),
                     commit_message: "Make verifier green".to_string(),
                     started_unix_ms: 1_800_000_002_500,
                 },
@@ -3126,6 +3226,113 @@ mod tests {
     }
 
     #[test]
+    fn spec_c12_outer_loop_applies_multi_file_edits_and_commits() {
+        let temp = tempdir().expect("tempdir");
+        let config = multi_file_verifier_config_for(temp.path());
+        let mut state = CodingMissionState::create(config).expect("create state");
+        let runner = CodingMissionRunner::new();
+
+        let outcome = runner
+            .run(
+                &mut state,
+                CodingMissionRunRequest {
+                    controlled_edit: None,
+                    controlled_edits: vec![
+                        CodingMissionControlledEdit {
+                            relative_path: PathBuf::from("status.txt"),
+                            contents: "pass\n".to_string(),
+                            reason_code: "controlled_fix_status".to_string(),
+                        },
+                        CodingMissionControlledEdit {
+                            relative_path: PathBuf::from("docs/notes.txt"),
+                            contents: "helper\n".to_string(),
+                            reason_code: "controlled_fix_notes".to_string(),
+                        },
+                    ],
+                    commit_message: "Make multi-file verifier green".to_string(),
+                    started_unix_ms: 1_800_000_002_700,
+                },
+            )
+            .expect("run multi-file mission");
+
+        assert_eq!(outcome.phase, CodingMissionPhase::PrReady);
+        assert!(outcome.verifier_passed);
+        assert_eq!(
+            outcome
+                .committed
+                .as_ref()
+                .map(|commit| commit.changed_files.clone()),
+            Some(vec!["docs/notes.txt".to_string(), "status.txt".to_string()])
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.repo_path.join("status.txt")).expect("status"),
+            "pass\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.repo_path.join("docs/notes.txt")).expect("notes"),
+            "helper\n"
+        );
+        assert!(state
+            .mission
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_id == "controlled_edit:status.txt"));
+        assert!(state
+            .mission
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_id == "controlled_edit:docs/notes.txt"));
+    }
+
+    #[test]
+    fn regression_outer_loop_blocks_multi_file_escape_before_partial_write() {
+        let temp = tempdir().expect("tempdir");
+        let outside = tempdir().expect("outside");
+        let mut config = multi_file_verifier_config_for(temp.path());
+        config.allowed_roots.push(outside.path().to_path_buf());
+        let mut state = CodingMissionState::create(config).expect("create state");
+        let runner = CodingMissionRunner::new();
+
+        let outcome = runner
+            .run(
+                &mut state,
+                CodingMissionRunRequest {
+                    controlled_edit: None,
+                    controlled_edits: vec![
+                        CodingMissionControlledEdit {
+                            relative_path: PathBuf::from("status.txt"),
+                            contents: "pass\n".to_string(),
+                            reason_code: "controlled_fix_status".to_string(),
+                        },
+                        CodingMissionControlledEdit {
+                            relative_path: PathBuf::from("../escape.txt"),
+                            contents: "escape\n".to_string(),
+                            reason_code: "controlled_escape".to_string(),
+                        },
+                    ],
+                    commit_message: "Reject escaped edit".to_string(),
+                    started_unix_ms: 1_800_000_002_800,
+                },
+            )
+            .expect("run escaped multi-file mission");
+
+        assert_eq!(outcome.phase, CodingMissionPhase::Blocked);
+        assert_eq!(
+            outcome.blocked_reason.as_deref(),
+            Some("controlled_edit_outside_repo")
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.repo_path.join("status.txt")).expect("status"),
+            "fail\n"
+        );
+        assert!(!outside.path().join("escape.txt").exists());
+        assert!(!state
+            .git_evidence
+            .iter()
+            .any(|evidence| evidence.kind == CodingGitLifecycleEvidenceKind::CommitCreated));
+    }
+
+    #[test]
     fn regression_outer_loop_blocks_completion_without_mutation_evidence() {
         let temp = tempdir().expect("tempdir");
         let config = verifier_config_for(temp.path(), "pass\n", "grep -q pass status.txt");
@@ -3137,6 +3344,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "No mutation".to_string(),
                     started_unix_ms: 1_800_000_003_000,
                 },
@@ -3161,6 +3369,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "Impossible verifier".to_string(),
                     started_unix_ms: 1_800_000_003_500,
                 },
@@ -3191,6 +3400,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "Denied verifier".to_string(),
                     started_unix_ms: 1_800_000_004_000,
                 },
@@ -3222,6 +3432,7 @@ mod tests {
                         contents: "pass again\n".to_string(),
                         reason_code: "controlled_fix".to_string(),
                     }),
+                    controlled_edits: Vec::new(),
                     commit_message: "No verifier".to_string(),
                     started_unix_ms: 1_800_000_004_500,
                 },
@@ -3255,6 +3466,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "Make verifier green".to_string(),
                     started_unix_ms: 1_800_000_005_000,
                 },
@@ -3292,6 +3504,7 @@ mod tests {
                     contents: "pass\n".to_string(),
                     reason_code: "controlled_fix_after_red_resume".to_string(),
                 }),
+                controlled_edits: Vec::new(),
                 commit_message: "Make verifier green after resume".to_string(),
                 started_unix_ms: 1_800_000_005_500,
                 stop_after: None,
@@ -3346,6 +3559,7 @@ mod tests {
                 &mut state,
                 CodingMissionRunRequest {
                     controlled_edit: None,
+                    controlled_edits: Vec::new(),
                     commit_message: "Make verifier green".to_string(),
                     started_unix_ms: 1_800_000_006_000,
                 },
@@ -3361,6 +3575,7 @@ mod tests {
                     contents: "pass\n".to_string(),
                     reason_code: "controlled_fix_before_crash".to_string(),
                 }),
+                controlled_edits: Vec::new(),
                 commit_message: "Make verifier green after edit".to_string(),
                 started_unix_ms: 1_800_000_006_500,
                 stop_after: Some(CodingMissionResumeStopAfter::ControlledEdit),
@@ -3394,6 +3609,7 @@ mod tests {
                 state_root,
                 mission_id,
                 controlled_edit: None,
+                controlled_edits: Vec::new(),
                 commit_message: "Commit resumed edit".to_string(),
                 started_unix_ms: 1_800_000_007_000,
                 stop_after: None,
@@ -3417,6 +3633,84 @@ mod tests {
             .any(|evidence| evidence.kind == CodingGitLifecycleEvidenceKind::CommitCreated));
     }
 
+    #[test]
+    fn spec_c13_resume_after_multi_file_edit_completes_with_full_fingerprint() {
+        let temp = tempdir().expect("tempdir");
+        let config = multi_file_verifier_config_for(temp.path());
+        let state_root = config.state_root.clone();
+        let mission_id = config.mission_id.clone();
+        let mut state = CodingMissionState::create(config).expect("create state");
+        let runner = CodingMissionRunner::new();
+
+        runner
+            .run(
+                &mut state,
+                CodingMissionRunRequest {
+                    controlled_edit: None,
+                    controlled_edits: Vec::new(),
+                    commit_message: "Prepare multi-file resume".to_string(),
+                    started_unix_ms: 1_800_000_007_500,
+                },
+            )
+            .expect("run red mission");
+
+        let paused = runner
+            .resume(CodingMissionResumeRequest {
+                state_root: state_root.clone(),
+                mission_id: mission_id.clone(),
+                controlled_edit: None,
+                controlled_edits: vec![
+                    CodingMissionControlledEdit {
+                        relative_path: PathBuf::from("status.txt"),
+                        contents: "pass\n".to_string(),
+                        reason_code: "controlled_fix_status_after_resume".to_string(),
+                    },
+                    CodingMissionControlledEdit {
+                        relative_path: PathBuf::from("docs/notes.txt"),
+                        contents: "helper\n".to_string(),
+                        reason_code: "controlled_fix_notes_after_resume".to_string(),
+                    },
+                ],
+                commit_message: "Apply multi-file resume edit".to_string(),
+                started_unix_ms: 1_800_000_008_000,
+                stop_after: Some(CodingMissionResumeStopAfter::ControlledEdit),
+            })
+            .expect("resume through multi-file edit");
+
+        let fingerprint = paused
+            .state
+            .resume_checkpoint
+            .as_ref()
+            .and_then(|checkpoint| checkpoint.mutation_fingerprint.as_ref())
+            .expect("multi-file fingerprint");
+        assert_eq!(
+            fingerprint.changed_files,
+            vec!["docs/notes.txt".to_string(), "status.txt".to_string()]
+        );
+
+        let resumed = runner
+            .resume(CodingMissionResumeRequest {
+                state_root,
+                mission_id,
+                controlled_edit: None,
+                controlled_edits: Vec::new(),
+                commit_message: "Commit multi-file resumed edit".to_string(),
+                started_unix_ms: 1_800_000_008_500,
+                stop_after: None,
+            })
+            .expect("resume after multi-file edit");
+
+        assert_eq!(resumed.run.phase, CodingMissionPhase::PrReady);
+        assert_eq!(
+            resumed
+                .run
+                .committed
+                .as_ref()
+                .map(|commit| commit.changed_files.clone()),
+            Some(vec!["docs/notes.txt".to_string(), "status.txt".to_string()])
+        );
+    }
+
     fn pr_ready_state_for(root: &Path) -> (CodingMissionState, CodingGitLifecycleEvidence) {
         let config = verifier_config_for(root, "fail\n", "grep -q pass status.txt");
         let mut state = CodingMissionState::create(config).expect("create state");
@@ -3430,6 +3724,7 @@ mod tests {
                         contents: "pass\n".to_string(),
                         reason_code: "controlled_fix_for_pr_ready".to_string(),
                     }),
+                    controlled_edits: Vec::new(),
                     commit_message: "Make verifier green".to_string(),
                     started_unix_ms: 1_800_000_007_500,
                 },

--- a/crates/tau-browser-automation/src/browser_automation_live.rs
+++ b/crates/tau-browser-automation/src/browser_automation_live.rs
@@ -104,15 +104,27 @@ pub trait BrowserActionExecutor {
 /// Public struct `PlaywrightCliActionExecutor` used across Tau components.
 pub struct PlaywrightCliActionExecutor {
     cli_path: String,
+    cli_args: Vec<String>,
 }
 
 impl PlaywrightCliActionExecutor {
     pub fn new(cli_path: impl Into<String>) -> Result<Self> {
+        Self::with_args(cli_path, std::iter::empty::<String>())
+    }
+
+    pub fn with_args<I, S>(cli_path: impl Into<String>, cli_args: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         let cli_path = cli_path.into();
         if cli_path.trim().is_empty() {
             bail!("browser automation playwright cli path cannot be empty");
         }
-        Ok(Self { cli_path })
+        Ok(Self {
+            cli_path,
+            cli_args: cli_args.into_iter().map(Into::into).collect(),
+        })
     }
 
     fn invoke_command(
@@ -121,6 +133,7 @@ impl PlaywrightCliActionExecutor {
         payload: Option<&BrowserActionRequest>,
     ) -> Result<String> {
         let mut command = Command::new(self.cli_path.trim());
+        command.args(&self.cli_args);
         command.arg(subcommand);
         if let Some(payload) = payload {
             command.arg(
@@ -325,7 +338,8 @@ fn enforce_live_policy(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::io::Write;
+    use std::path::Path;
     use std::sync::{Arc, Mutex};
 
     use anyhow::Result;
@@ -419,8 +433,28 @@ mod tests {
         }
     }
 
-    fn write_mock_playwright_cli(path: &PathBuf) {
-        std::fs::write(
+    fn write_executable_fixture(path: &Path, body: &str) {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)
+            .expect("open executable fixture");
+        file.write_all(body.as_bytes())
+            .expect("write executable fixture");
+        file.sync_all().expect("sync executable fixture");
+        drop(file);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).expect("stat").permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).expect("chmod");
+        }
+    }
+
+    fn write_mock_playwright_cli(path: &Path) {
+        write_executable_fixture(
             path,
             r#"#!/usr/bin/env python3
 import json
@@ -507,19 +541,11 @@ print(json.dumps({
     "response_body": {"status": "rejected", "reason": "invalid_operation"}
 }))
 "#,
-        )
-        .expect("write mock playwright cli");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(path).expect("stat").permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(path, perms).expect("chmod");
-        }
+        );
     }
 
-    fn write_failing_playwright_cli(path: &PathBuf) {
-        std::fs::write(
+    fn write_failing_playwright_cli(path: &Path) {
+        write_executable_fixture(
             path,
             r#"#!/usr/bin/env python3
 import json
@@ -547,15 +573,15 @@ if command == "execute-action":
 print("unsupported command", file=sys.stderr)
 raise SystemExit(2)
 "#,
+        );
+    }
+
+    fn python_playwright_executor(script_path: &Path) -> PlaywrightCliActionExecutor {
+        PlaywrightCliActionExecutor::with_args(
+            "python3",
+            [script_path.to_string_lossy().to_string()],
         )
-        .expect("write failing playwright cli");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(path).expect("stat").permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(path, perms).expect("chmod");
-        }
+        .expect("executor")
     }
 
     #[test]
@@ -647,8 +673,7 @@ raise SystemExit(2)
         write_mock_playwright_cli(&script_path);
         let session_file = script_path.with_extension("session");
 
-        let executor = PlaywrightCliActionExecutor::new(script_path.to_string_lossy().to_string())
-            .expect("executor");
+        let executor = python_playwright_executor(&script_path);
         let mut manager = BrowserSessionManager::new(executor);
         let summary = run_browser_automation_live_fixture(
             &fixture,
@@ -692,8 +717,7 @@ raise SystemExit(2)
         )
         .expect("fixture parse");
 
-        let executor = PlaywrightCliActionExecutor::new(script_path.to_string_lossy().to_string())
-            .expect("executor");
+        let executor = python_playwright_executor(&script_path);
         let mut manager = BrowserSessionManager::new(executor);
         let summary = run_browser_automation_live_fixture(
             &fixture,
@@ -719,10 +743,7 @@ raise SystemExit(2)
         let session_file = script_path.with_extension("session");
 
         let case = sample_case("cleanup-case", &format!("file://{}", page_path.display()));
-        let mut manager = BrowserSessionManager::new(
-            PlaywrightCliActionExecutor::new(script_path.to_string_lossy().to_string())
-                .expect("executor"),
-        );
+        let mut manager = BrowserSessionManager::new(python_playwright_executor(&script_path));
         let result = manager
             .execute_case(&case, &BrowserAutomationLivePolicy::default())
             .expect("execute case");

--- a/crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs
+++ b/crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs
@@ -27,7 +27,10 @@ use tau_agent_core::{
 };
 use tau_ai::{ChatRequest, ChatUsage, LlmClient, Message, ModelRef, PromptCacheConfig, Provider};
 use tau_cli::Cli;
-use tau_provider::{build_provider_client, CodexCliClient, CodexCliConfig};
+use tau_provider::{
+    build_provider_client, provider_api_key_candidates_with_inputs, resolve_api_key,
+    CodexCliClient, CodexCliConfig,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -94,6 +97,10 @@ struct Args {
     /// Mock provider response used for deterministic provider parsing tests.
     #[arg(long)]
     mock_provider_response: Option<String>,
+
+    /// Verifier command(s) for real-repo mode. Repeat once per command.
+    #[arg(long = "verifier-command")]
+    verifier_commands: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -102,6 +109,7 @@ enum HarnessMode {
     Resume,
     Blocked,
     ProviderSuccess,
+    RealRepo,
 }
 
 impl HarnessMode {
@@ -111,6 +119,7 @@ impl HarnessMode {
             Self::Resume => "resume",
             Self::Blocked => "blocked",
             Self::ProviderSuccess => "provider_success",
+            Self::RealRepo => "real_repo",
         }
     }
 }
@@ -197,7 +206,16 @@ struct ProviderUsageReport {
 }
 
 #[derive(Debug, Deserialize)]
-struct ProviderEditPayload {
+#[serde(untagged)]
+enum ProviderEditPayload {
+    Single(ProviderEditPayloadEntry),
+    Multi {
+        edits: Vec<ProviderEditPayloadEntry>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderEditPayloadEntry {
     relative_path: String,
     contents: String,
     #[serde(default)]
@@ -205,7 +223,7 @@ struct ProviderEditPayload {
 }
 
 struct ProviderEditResolution {
-    edit: CodingMissionControlledEdit,
+    edits: Vec<CodingMissionControlledEdit>,
     report: ProviderProofReport,
 }
 
@@ -261,25 +279,45 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
         .with_context(|| format!("benchmark task '{}' not found", args.task_id))?;
     fs::create_dir_all(&args.state_root)
         .with_context(|| format!("create state root {}", args.state_root.display()))?;
-    prepare_disposable_repo(&args.repo_root)?;
+    if args.mode == HarnessMode::RealRepo {
+        if !args.repo_root.join(".git").exists() {
+            bail!("real-repo mode requires --repo-root to point at a git worktree");
+        }
+    } else {
+        prepare_disposable_repo(&args.repo_root)?;
+    }
 
     let mission_id = format!("{}-{}", args.run_id, args.mode.as_str());
-    let verifier_command = match args.mode {
-        HarnessMode::Success | HarnessMode::Resume | HarnessMode::ProviderSuccess => {
-            "grep -q pass status.txt"
+    let verifier_commands = match args.mode {
+        HarnessMode::RealRepo => {
+            if args.verifier_commands.is_empty() {
+                bail!("real-repo mode requires at least one --verifier-command");
+            }
+            args.verifier_commands.clone()
         }
-        HarnessMode::Blocked => "definitely-not-a-tau-command",
+        HarnessMode::Success | HarnessMode::Resume | HarnessMode::ProviderSuccess => {
+            vec!["grep -q pass status.txt".to_string()]
+        }
+        HarnessMode::Blocked => vec!["definitely-not-a-tau-command".to_string()],
     };
+    let base_branch = current_branch(&args.repo_root)
+        .with_context(|| format!("resolve current branch for {}", args.repo_root.display()))?;
     let config = CodingMissionConfig {
         state_root: args.state_root.clone(),
         mission_id: mission_id.clone(),
         session_key: format!("session-{mission_id}"),
         repo_path: args.repo_root.clone(),
-        issue_url: Some("https://github.com/njfio/Tau/issues/3654".to_string()),
+        issue_url: Some(match args.mode {
+            HarnessMode::RealRepo => "https://github.com/njfio/Tau/issues/3792".to_string(),
+            _ => "https://github.com/njfio/Tau/issues/3654".to_string(),
+        }),
         goal: task.goal.clone(),
-        base_branch: "master".to_string(),
-        branch_prefix: "codex/issue-3654-live-loop".to_string(),
-        verifier_commands: vec![verifier_command.to_string()],
+        base_branch,
+        branch_prefix: match args.mode {
+            HarnessMode::RealRepo => "codex/issue-3792-real-repo-harness".to_string(),
+            _ => "codex/issue-3654-live-loop".to_string(),
+        },
+        verifier_commands,
         pr_mode: CodingMissionPrMode::PrReady,
         allowed_roots: vec![args.repo_root.clone(), args.state_root.clone()],
         created_unix_ms: started_unix_ms,
@@ -311,14 +349,34 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
             &mut provider_report,
             started_unix_ms,
         )?,
+        HarnessMode::RealRepo => run_provider_success_case(
+            &runner,
+            &mut state,
+            &args,
+            &mission_id,
+            &mut provider_report,
+            started_unix_ms,
+        )?,
     };
     let pr_ready = if state.phase == CodingMissionPhase::PrReady {
+        let (title, risk_notes, rollback_notes) = match args.mode {
+            HarnessMode::RealRepo => (
+                "M334 real-repo autonomous coding harness".to_string(),
+                vec!["Risk: temporary real repository worktree validation only".to_string()],
+                vec!["Rollback: remove the harness branch/worktree".to_string()],
+            ),
+            _ => (
+                "M334 live coding loop fixture".to_string(),
+                vec!["Risk: disposable local fixture only".to_string()],
+                vec!["Rollback: delete the disposable repo".to_string()],
+            ),
+        };
         Some(
             state
                 .prepare_pr_ready_bundle(CodingMissionPrReadyRequest {
-                    title: Some("M334 live coding loop fixture".to_string()),
-                    risk_notes: vec!["Risk: disposable local fixture only".to_string()],
-                    rollback_notes: vec!["Rollback: delete the disposable repo".to_string()],
+                    title: Some(title),
+                    risk_notes,
+                    rollback_notes,
                     allow_draft_pr: false,
                     github_env: BTreeMap::new(),
                     gh_binary: None,
@@ -357,6 +415,7 @@ fn run_success_case(
             state,
             CodingMissionRunRequest {
                 controlled_edit: Some(edit),
+                controlled_edits: Vec::new(),
                 commit_message: commit_message.to_string(),
                 started_unix_ms: started_unix_ms + 1_000,
             },
@@ -374,6 +433,7 @@ fn run_resume_case(
             state,
             CodingMissionRunRequest {
                 controlled_edit: None,
+                controlled_edits: Vec::new(),
                 commit_message: "Make M334 live verifier green".to_string(),
                 started_unix_ms: started_unix_ms + 2_000,
             },
@@ -389,6 +449,7 @@ fn run_resume_case(
             state_root: state.state_root.clone(),
             mission_id: state.mission_id.clone(),
             controlled_edit: Some(pass_status_edit("controlled_fix_after_live_resume")),
+            controlled_edits: Vec::new(),
             commit_message: "Make M334 live verifier green after resume".to_string(),
             started_unix_ms: started_unix_ms + 3_000,
             stop_after: None,
@@ -415,6 +476,7 @@ fn run_blocked_case(
             state,
             CodingMissionRunRequest {
                 controlled_edit: None,
+                controlled_edits: Vec::new(),
                 commit_message: "Blocked verifier should not commit".to_string(),
                 started_unix_ms: started_unix_ms + 4_000,
             },
@@ -435,6 +497,7 @@ fn run_provider_success_case(
             state,
             CodingMissionRunRequest {
                 controlled_edit: None,
+                controlled_edits: Vec::new(),
                 commit_message: "Make M334 live verifier green with provider edit".to_string(),
                 started_unix_ms: started_unix_ms + 1_000,
             },
@@ -448,12 +511,14 @@ fn run_provider_success_case(
         .with_context(|| format!("resolve provider edit for {mission_id}"))?
     {
         ProviderEditOutcome::Ready(resolved) => {
-            *provider_report = Some(resolved.report);
+            let ProviderEditResolution { edits, report } = resolved;
+            *provider_report = Some(report);
             let resumed = runner
                 .resume(CodingMissionResumeRequest {
                     state_root: state.state_root.clone(),
                     mission_id: state.mission_id.clone(),
-                    controlled_edit: Some(resolved.edit),
+                    controlled_edit: None,
+                    controlled_edits: edits,
                     commit_message: "Make M334 live verifier green with provider edit".to_string(),
                     started_unix_ms: started_unix_ms + 2_000,
                     stop_after: None,
@@ -612,8 +677,17 @@ fn provider_cli(args: &Args, model_ref: &ModelRef) -> anyhow::Result<Cli> {
         "--provider-retry-budget-ms".to_string(),
         "0".to_string(),
     ];
-    if auth_mode != "api-key" {
+    if !provider_auth_mode_is_api_key(auth_mode) {
         cli_args.push("--provider-subscription-strict=true".to_string());
+    }
+    if provider_auth_mode_is_api_key(auth_mode) {
+        if let (Some(flag), Some(api_key)) = (
+            provider_api_key_flag(model_ref.provider),
+            provider_proof_api_key(model_ref.provider),
+        ) {
+            cli_args.push(flag.to_string());
+            cli_args.push(api_key);
+        }
     }
     match model_ref.provider {
         Provider::OpenAi | Provider::OpenRouter => {
@@ -665,19 +739,49 @@ fn provider_cli(args: &Args, model_ref: &ModelRef) -> anyhow::Result<Cli> {
     Cli::try_parse_from(cli_args).context("parse provider proof CLI config")
 }
 
+fn provider_auth_mode_is_api_key(auth_mode: &str) -> bool {
+    matches!(auth_mode.trim(), "api-key" | "api_key")
+}
+
+fn provider_api_key_flag(provider: Provider) -> Option<&'static str> {
+    match provider {
+        Provider::OpenAi | Provider::OpenRouter => Some("--openai-api-key"),
+        Provider::Anthropic => Some("--anthropic-api-key"),
+        Provider::Google => Some("--google-api-key"),
+    }
+}
+
+fn provider_proof_api_key(provider: Provider) -> Option<String> {
+    let candidates = provider_api_key_candidates_with_inputs(provider, None, None, None, None)
+        .into_iter()
+        .map(|(_source, value)| value)
+        .collect();
+    resolve_api_key(candidates)
+}
+
 fn provider_prompt(state: &CodingMissionState) -> anyhow::Result<String> {
     let status_path = state.repo_path.join("status.txt");
-    let current_status = fs::read_to_string(&status_path)
-        .with_context(|| format!("read fixture status {}", status_path.display()))?;
+    let current_status = match fs::read_to_string(&status_path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            format!("{} is absent in this repository.\n", status_path.display())
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("read fixture status {}", status_path.display()));
+        }
+    };
     Ok(format!(
-        "Goal:\n{}\n\nCurrent file status.txt contains:\n{}\n\nVerifier command:\n{}\n\nReturn exactly this JSON shape with the minimal edit needed to make the verifier pass:\n{{\"relative_path\":\"status.txt\",\"contents\":\"pass\\n\",\"reason_code\":\"provider_fix_for_live_loop\"}}",
+        "Goal:\n{}\n\nRepository root:\n{}\n\nCurrent file status.txt context:\n{}\n\nVerifier commands:\n{}\n\nReturn valid JSON only. Use either the legacy single-edit shape or this multi-edit shape:\n{{\"edits\":[{{\"relative_path\":\"path/from/repo/root\",\"contents\":\"file contents\",\"reason_code\":\"provider_fix\"}}]}}",
         state.goal,
+        state.repo_path.display(),
         current_status,
         state
             .verifier_commands
-            .first()
+            .iter()
             .map(String::as_str)
-            .unwrap_or("grep -q pass status.txt")
+            .collect::<Vec<_>>()
+            .join("\n")
     ))
 }
 
@@ -693,8 +797,10 @@ fn provider_edit_from_response(
     let response_text_sha256 = sha256_hex(response_text.as_bytes());
     let usage_report = usage.as_ref().map(provider_usage_report);
     match serde_json::from_str::<ProviderEditPayload>(response_text.trim()) {
-        Ok(payload) => match provider_payload_to_edit(payload) {
-            Ok(edit) => {
+        Ok(payload) => match provider_payload_to_edits(payload) {
+            Ok(edits) => {
+                let edit_relative_path = provider_edit_paths_summary(&edits);
+                let edit_reason_code = provider_edit_reason_summary(&edits);
                 let report = ProviderProofReport {
                     mode,
                     provider: model_ref.provider.as_str().to_string(),
@@ -706,11 +812,11 @@ fn provider_edit_from_response(
                     usage: usage_report,
                     response_text_bytes: Some(response_text_bytes),
                     response_text_sha256: Some(response_text_sha256),
-                    edit_relative_path: Some(edit.relative_path.display().to_string()),
-                    edit_reason_code: Some(edit.reason_code.clone()),
+                    edit_relative_path: Some(edit_relative_path),
+                    edit_reason_code: Some(edit_reason_code),
                     error: None,
                 };
-                ProviderEditOutcome::Ready(ProviderEditResolution { edit, report })
+                ProviderEditOutcome::Ready(ProviderEditResolution { edits, report })
             }
             Err(error) => {
                 ProviderEditOutcome::Failed(provider_failure_report(ProviderFailureReportInput {
@@ -740,15 +846,28 @@ fn provider_edit_from_response(
     }
 }
 
-fn provider_payload_to_edit(
+fn provider_payload_to_edits(
     payload: ProviderEditPayload,
+) -> Result<Vec<CodingMissionControlledEdit>, String> {
+    let entries = match payload {
+        ProviderEditPayload::Single(entry) => vec![entry],
+        ProviderEditPayload::Multi { edits } => edits,
+    };
+    if entries.is_empty() {
+        return Err("provider edit set must not be empty".to_string());
+    }
+    entries
+        .into_iter()
+        .map(provider_payload_entry_to_edit)
+        .collect()
+}
+
+fn provider_payload_entry_to_edit(
+    payload: ProviderEditPayloadEntry,
 ) -> Result<CodingMissionControlledEdit, String> {
     let relative_path = PathBuf::from(payload.relative_path.trim());
-    if relative_path.as_path() != Path::new("status.txt") {
-        return Err(format!(
-            "provider edit must target status.txt, got {}",
-            relative_path.display()
-        ));
+    if relative_path.as_os_str().is_empty() {
+        return Err("provider edit path must not be empty".to_string());
     }
     if relative_path.is_absolute()
         || relative_path.components().any(|component| {
@@ -763,7 +882,7 @@ fn provider_payload_to_edit(
         return Err("provider edit path escapes the disposable repo".to_string());
     }
     let mut contents = payload.contents;
-    if contents.trim() != "pass" {
+    if relative_path.as_path() == Path::new("status.txt") && contents.trim() != "pass" {
         return Err("provider edit contents must make status.txt contain pass".to_string());
     }
     if !contents.ends_with('\n') {
@@ -779,6 +898,22 @@ fn provider_payload_to_edit(
         contents,
         reason_code,
     })
+}
+
+fn provider_edit_paths_summary(edits: &[CodingMissionControlledEdit]) -> String {
+    edits
+        .iter()
+        .map(|edit| edit.relative_path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn provider_edit_reason_summary(edits: &[CodingMissionControlledEdit]) -> String {
+    edits
+        .iter()
+        .map(|edit| edit.reason_code.as_str())
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn provider_failure_report(input: ProviderFailureReportInput<'_>) -> ProviderProofReport {
@@ -846,6 +981,25 @@ fn redact_secret_like_tokens(text: &str) -> String {
         .join(" ")
 }
 
+fn provider_report_satisfies_mode(mode: HarnessMode, report: Option<&ProviderProofReport>) -> bool {
+    match mode {
+        HarnessMode::ProviderSuccess => report
+            .map(|report| {
+                report.dispatched
+                    && report.parse_status == "parsed"
+                    && matches!(
+                        report.edit_relative_path.as_deref(),
+                        Some(paths) if paths.split(',').any(|path| path == "status.txt")
+                    )
+            })
+            .unwrap_or(false),
+        HarnessMode::RealRepo => report
+            .map(|report| report.dispatched && report.parse_status == "parsed")
+            .unwrap_or(false),
+        HarnessMode::Success | HarnessMode::Resume | HarnessMode::Blocked => true,
+    }
+}
+
 fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
     let commit = input
         .state
@@ -883,7 +1037,10 @@ fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
     });
     let mut failure_reasons = Vec::new();
     let passed = match input.mode {
-        HarnessMode::Success | HarnessMode::Resume | HarnessMode::ProviderSuccess => {
+        HarnessMode::Success
+        | HarnessMode::Resume
+        | HarnessMode::ProviderSuccess
+        | HarnessMode::RealRepo => {
             let ok = input.state.phase == CodingMissionPhase::PrReady
                 && pr_ready_report.is_some()
                 && commit
@@ -895,21 +1052,14 @@ fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
                 && verifier_transcript
                     .iter()
                     .any(|evidence| evidence.status == "succeeded")
-                && (input.mode != HarnessMode::ProviderSuccess
-                    || input
-                        .provider
-                        .as_ref()
-                        .map(|report| {
-                            report.dispatched
-                                && report.parse_status == "parsed"
-                                && report.edit_relative_path.as_deref() == Some("status.txt")
-                        })
-                        .unwrap_or(false));
+                && provider_report_satisfies_mode(input.mode, input.provider.as_ref())
+                && (input.mode != HarnessMode::RealRepo || changed_files.len() >= 2);
             if !ok {
                 failure_reasons.push(match input.mode {
                     HarnessMode::ProviderSuccess => {
                         "provider_success_case_missing_required_evidence".to_string()
                     }
+                    HarnessMode::RealRepo => "real_repo_case_missing_required_evidence".to_string(),
                     HarnessMode::Success | HarnessMode::Resume => {
                         "success_or_resume_case_missing_required_evidence".to_string()
                     }
@@ -1078,7 +1228,42 @@ fn now_unix_ms() -> u64 {
 
 #[cfg(test)]
 mod provider_backed_tests {
+    use std::sync::{Mutex, OnceLock};
+
     use super::*;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env(name: &str, prior: Option<String>) {
+        match prior {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
+
+    fn provider_test_args(provider_model: &str) -> Args {
+        Args {
+            fixture: None,
+            task_id: "repo_spec_to_pr_feature_delivery".to_string(),
+            mode: HarnessMode::ProviderSuccess,
+            state_root: PathBuf::from("state"),
+            repo_root: PathBuf::from("repo"),
+            output: PathBuf::from("report.json"),
+            run_id: "provider-test".to_string(),
+            started_unix_ms: None,
+            provider_model: provider_model.to_string(),
+            provider_api_base: None,
+            provider_auth_mode: "api-key".to_string(),
+            provider_timeout_ms: 120_000,
+            provider_max_retries: 1,
+            provider_max_tokens: 1_024,
+            mock_provider_response: None,
+            verifier_commands: Vec::new(),
+        }
+    }
 
     #[test]
     fn provider_backed_parses_json_edit() {
@@ -1100,9 +1285,10 @@ mod provider_backed_tests {
         let ProviderEditOutcome::Ready(resolved) = outcome else {
             panic!("provider edit should parse");
         };
-        assert_eq!(resolved.edit.relative_path, PathBuf::from("status.txt"));
-        assert_eq!(resolved.edit.contents, "pass\n");
-        assert_eq!(resolved.edit.reason_code, "provider_test");
+        assert_eq!(resolved.edits.len(), 1);
+        assert_eq!(resolved.edits[0].relative_path, PathBuf::from("status.txt"));
+        assert_eq!(resolved.edits[0].contents, "pass\n");
+        assert_eq!(resolved.edits[0].reason_code, "provider_test");
         assert_eq!(resolved.report.parse_status, "parsed");
         assert_eq!(
             resolved.report.edit_relative_path.as_deref(),
@@ -1117,6 +1303,36 @@ mod provider_backed_tests {
             Some(18)
         );
         assert!(resolved.report.response_text_sha256.is_some());
+    }
+
+    #[test]
+    fn provider_backed_parses_json_edit_array() {
+        let model_ref = ModelRef::parse("openai/test-model").expect("model parses");
+        let outcome = provider_edit_from_response(
+            "mock",
+            &model_ref,
+            true,
+            Some("stop".to_string()),
+            None,
+            r#"{"edits":[{"relative_path":"status.txt","contents":"pass","reason_code":"provider_status"},{"relative_path":"docs/notes.txt","contents":"helper\n","reason_code":"provider_notes"}]}"#,
+        );
+
+        let ProviderEditOutcome::Ready(resolved) = outcome else {
+            panic!("provider edit array should parse");
+        };
+        assert_eq!(resolved.edits.len(), 2);
+        assert_eq!(resolved.edits[0].relative_path, PathBuf::from("status.txt"));
+        assert_eq!(resolved.edits[0].contents, "pass\n");
+        assert_eq!(
+            resolved.edits[1].relative_path,
+            PathBuf::from("docs/notes.txt")
+        );
+        assert_eq!(resolved.edits[1].contents, "helper\n");
+        assert_eq!(resolved.report.parse_status, "parsed");
+        assert_eq!(
+            resolved.report.edit_relative_path.as_deref(),
+            Some("status.txt,docs/notes.txt")
+        );
     }
 
     #[test]
@@ -1151,6 +1367,28 @@ mod provider_backed_tests {
         assert_eq!(report.parse_status, "invalid_edit");
         assert_eq!(report.reason_code, "provider_edit_invalid");
         assert!(report.edit_relative_path.is_none());
+    }
+
+    #[test]
+    fn provider_backed_openrouter_api_key_mode_injects_openrouter_key() {
+        let _guard = env_lock().lock().expect("env lock");
+        let prior_openrouter = std::env::var("OPENROUTER_API_KEY").ok();
+        let prior_tau_openrouter = std::env::var("TAU_OPENROUTER_API_KEY").ok();
+        let prior_openai = std::env::var("OPENAI_API_KEY").ok();
+
+        std::env::set_var("OPENROUTER_API_KEY", "test-openrouter-key");
+        std::env::remove_var("TAU_OPENROUTER_API_KEY");
+        std::env::remove_var("OPENAI_API_KEY");
+
+        let args = provider_test_args("openrouter/deepseek/deepseek-v4-flash");
+        let model_ref = ModelRef::parse(&args.provider_model).expect("model parses");
+        let cli = provider_cli(&args, &model_ref).expect("provider cli");
+
+        assert_eq!(cli.openai_api_key.as_deref(), Some("test-openrouter-key"));
+
+        restore_env("OPENROUTER_API_KEY", prior_openrouter);
+        restore_env("TAU_OPENROUTER_API_KEY", prior_tau_openrouter);
+        restore_env("OPENAI_API_KEY", prior_openai);
     }
 
     #[test]

--- a/docs/guides/canonical-product-proof.md
+++ b/docs/guides/canonical-product-proof.md
@@ -93,7 +93,9 @@ TAU_LIVE_PROVIDER_PROOF=1 ./scripts/dev/test-provider-backed-autonomous-coding-l
 ```
 
 By default the script uses `openai/gpt-4.1-mini` with API-key auth; override
-with `TAU_PROVIDER_PROOF_MODEL=provider/model`. Use
+with `TAU_PROVIDER_PROOF_MODEL=provider/model`. For OpenRouter-hosted models,
+include the OpenRouter provider prefix, for example
+`TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash`. Use
 `TAU_PROVIDER_PROOF_AUTH_MODE=codex-cli` with a Codex CLI-supported model such
 as `openai/gpt-5.5` when validating the local subscription-backed provider
 path. The

--- a/scripts/dev/test-real-repo-autonomous-coding-harness.sh
+++ b/scripts/dev/test-real-repo-autonomous-coding-harness.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+target_root="${TAU_REAL_REPO_HARNESS_TMP:-/tmp/tau-real-repo-autonomous-coding-harness}"
+worktree="${target_root}/worktree"
+state_root="${target_root}/state"
+report="${target_root}/real-repo-report.json"
+fixture_dir="tasks/tau-real-repo-harness-fixture"
+run_id="m334-real-repo-coding-loop-$$"
+base_branch="tau-real-repo-harness-base-$$"
+mission_branch="codex/issue-3792-real-repo-harness${run_id}-real_repo"
+
+rm -rf "${target_root}"
+mkdir -p "${target_root}"
+
+cleanup() {
+  git -C "${repo_root}" worktree remove --force "${worktree}" >/dev/null 2>&1 || true
+  git -C "${repo_root}" branch -D "${mission_branch}" >/dev/null 2>&1 || true
+  git -C "${repo_root}" branch -D "${base_branch}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git -C "${repo_root}" worktree add --detach "${worktree}" HEAD >/dev/null
+git -C "${worktree}" config user.email "tau-real-repo-harness@example.test"
+git -C "${worktree}" config user.name "Tau Real Repo Harness"
+git -C "${worktree}" switch -c "${base_branch}" >/dev/null
+
+mkdir -p "${worktree}/${fixture_dir}"
+printf 'fail\n' >"${worktree}/${fixture_dir}/status.txt"
+printf 'missing\n' >"${worktree}/${fixture_dir}/notes.txt"
+git -C "${worktree}" add "${fixture_dir}/status.txt" "${fixture_dir}/notes.txt"
+git -C "${worktree}" commit -m "seed real repo harness fixture" >/dev/null
+
+mock_provider_response='{"edits":[{"relative_path":"tasks/tau-real-repo-harness-fixture/status.txt","contents":"pass\n","reason_code":"provider_real_repo_status"},{"relative_path":"tasks/tau-real-repo-harness-fixture/notes.txt","contents":"helper\n","reason_code":"provider_real_repo_notes"}]}'
+
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/rust_pi-3792-real-repo-target}" \
+  cargo run -p tau-coding-agent --quiet --bin tau_live_coding_loop_harness -- \
+  --mode real-repo \
+  --repo-root "${worktree}" \
+  --state-root "${state_root}" \
+  --output "${report}" \
+  --run-id "${run_id}" \
+  --started-unix-ms 1800000090000 \
+  --verifier-command "grep -q pass ${fixture_dir}/status.txt" \
+  --verifier-command "grep -q helper ${fixture_dir}/notes.txt" \
+  --mock-provider-response "${mock_provider_response}" >/dev/null
+
+python3 - "${report}" "${fixture_dir}" <<'PY'
+import json
+import sys
+
+report_path = sys.argv[1]
+fixture_dir = sys.argv[2]
+with open(report_path, "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(report["passed"] is True, "real-repo report did not pass")
+require(report["mode"] == "real_repo", "mode mismatch")
+require(report["phase"] == "pr_ready", "mission did not reach pr_ready")
+require(report["pr_ready"]["status"] == "manual_ready", "PR status should be manual_ready")
+require(report["commit_hash"] and len(report["commit_hash"]) == 40, "missing commit hash")
+require(
+    report["changed_files"] == [
+        f"{fixture_dir}/notes.txt",
+        f"{fixture_dir}/status.txt",
+    ],
+    f"changed files mismatch: {report['changed_files']}",
+)
+provider = report["provider"]
+require(provider["parse_status"] == "parsed", "provider parse status mismatch")
+paths = set(provider["edit_relative_path"].split(","))
+require(
+    paths == {
+        f"{fixture_dir}/status.txt",
+        f"{fixture_dir}/notes.txt",
+    },
+    f"provider paths mismatch: {paths}",
+)
+statuses = [item["status"] for item in report["verifier_transcript"]]
+require("failed" in statuses, "missing red verifier evidence")
+require("succeeded" in statuses, "missing green verifier evidence")
+require(report["no_routine_human_steering_used"] is True, "unexpected human steering")
+PY
+
+echo "real-repo autonomous coding harness passed: ${report}"

--- a/specs/3648/spec.md
+++ b/specs/3648/spec.md
@@ -12,14 +12,15 @@ intended retryable backend-unavailable mapping path is exercised.
 Inputs:
 - `crates/tau-browser-automation/src/browser_automation_live.rs`
 - GitHub Actions failure evidence from PR `#3631`
+- GitHub Actions failure evidence from PR `#3793`
 - Existing local live-fixture helpers in the same test module
 
 Outputs:
-- The failing live-fixture integration test uses a deterministic temporary
-  executable pattern that is stable on Linux CI.
+- The live-fixture integration tests use a deterministic temporary executable
+  pattern that is stable on Linux CI.
 - The executor failure still maps to
   `browser_automation_backend_unavailable` with `503`.
-- Package-scoped validation on PR `#3631` advances beyond the
+- Package-scoped validation on PR `#3631` and PR `#3793` advances beyond the
   `Text file busy` failure in `tau-browser-automation`.
 
 ## Boundaries / Non-goals
@@ -43,25 +44,32 @@ Out of scope:
   `Text file busy (os error 26)`, so the test never reaches the intended error
   mapping assertion.
 - Neighboring live-fixture tests already use a Python-based temporary mock
-  executable and do not exhibit this launcher race.
+- PR `#3793` later exposed the same `Text file busy (os error 26)` failure in
+  `functional_live_fixture_runner_executes_navigation_and_action_sequence`
+  and `regression_drop_cleanup_shuts_down_active_session_without_orphan_marker`
+  against `mock-playwright-cli.py`, showing the Python helper must avoid direct
+  kernel execution of temporary scripts in Linux CI.
 
 ## Acceptance Criteria
 ### AC-1 The failing live-fixture test no longer relies on the unstable shell-script launcher path
 Given the retryable backend-unavailable integration test in
 `browser_automation_live.rs`,
 when it provisions its temporary executor fixture,
-then it uses a stable executable pattern already proven by neighboring tests
-instead of the ad hoc shell script that triggers `Text file busy` in CI.
+then it uses a stable executable pattern that writes, syncs, closes, and marks
+the temporary file executable, then launches it through a stable interpreter
+prefix instead of directly executing the temporary script path that triggers
+`Text file busy` in CI.
 
 ### AC-2 The behavioral contract remains unchanged
-Given the same failing-executor scenario,
+Given the same failing-executor scenario and the success-path mock executor,
 when the updated test runs,
 then `run_browser_automation_live_fixture(...)` still returns a summary with
-one retryable failure and the failure maps to
-`browser_automation_backend_unavailable` / HTTP `503`.
+one retryable failure for the failure fixture, two successes for the success
+fixture, and the failure maps to `browser_automation_backend_unavailable` /
+HTTP `503`.
 
 ### AC-3 Package-scoped CI advances beyond the launcher race
-Given the package-scoped validation path for PR `#3631`,
+Given the package-scoped validation path for PR `#3631` and PR `#3793`,
 when `tau-browser-automation` tests run under CI,
 then they no longer fail on `failed to launch browser automation executor` with
 `Text file busy (os error 26)`.
@@ -69,14 +77,17 @@ then they no longer fail on `failed to launch browser automation executor` with
 ## Conformance Cases
 - C-01 / AC-1 / Functional:
   The retryable backend-unavailable integration test no longer writes or
-  launches `failing-playwright-cli.sh`; it uses the stable mock-executable
-  helper pattern.
+  launches `failing-playwright-cli.sh`; shared mock-executable helpers use the
+  stable close-and-sync writer pattern plus interpreter-prefix execution.
 - C-02 / AC-2 / Regression:
   `cargo test -p tau-browser-automation --lib integration_live_fixture_maps_executor_failures_to_retryable_backend_unavailable -- --nocapture`
   passes and still asserts one retryable failure.
+- C-04 / AC-2 / Regression:
+  `cargo test -p tau-browser-automation --lib functional_live_fixture_runner_executes_navigation_and_action_sequence -- --nocapture`
+  passes and still asserts two successful live-fixture cases.
 - C-03 / AC-3 / Regression:
-  PR `#3631` no longer fails on the `Text file busy (os error 26)` launcher
-  race in `tau-browser-automation`.
+  PR `#3631` and PR `#3793` no longer fail on the
+  `Text file busy (os error 26)` launcher race in `tau-browser-automation`.
 
 ## Files To Touch
 - `specs/milestones/m330/index.md`
@@ -94,6 +105,7 @@ then they no longer fail on `failed to launch browser automation executor` with
 - Regression: rerun
   `./scripts/dev/fast-validate.sh --base 36dd1b5e417c68d6e8e49c276e3fccc297c502eb`
   locally and then on PR `#3631`.
+- Regression: rerun the PR `#3793` Quality gate after the shared helper fix.
 
 ## Success Metrics / Observable Signals
 - `tau-browser-automation` advances beyond the current Linux launcher race on

--- a/specs/3648/tasks.md
+++ b/specs/3648/tasks.md
@@ -10,3 +10,10 @@
       relevant crate tests, rerun the exact `fast-validate` reproduction, then
       push and watch PR `#3631` for advancement past the launcher race. Covers
       C-03.
+- [x] T4 Regression: capture the PR `#3793` Quality failure where
+      `functional_live_fixture_runner_executes_navigation_and_action_sequence`
+      and `regression_drop_cleanup_shuts_down_active_session_without_orphan_marker`
+      hit the same `Text file busy (os error 26)` launcher race, move both
+      Python mock fixture writers onto the close-and-sync executable writer,
+      execute temporary scripts through a `python3` prefix, and rerun the
+      browser-automation lib tests. Covers C-01, C-04, and C-03.

--- a/specs/3792-real-repo-autonomous-coding-harness/plan.md
+++ b/specs/3792-real-repo-autonomous-coding-harness/plan.md
@@ -1,0 +1,54 @@
+# Plan: Real-repo autonomous coding harness
+
+## Approach
+
+Extend the existing coding mission lifecycle instead of adding a parallel agent path. `CodingMissionRunner` already owns branch preparation, verifier evidence, controlled mutation, commit evidence, resume checkpoints, and PR-ready bundle generation. The product gap is that mutation input is single-file and fixture-shaped.
+
+Add a backward-compatible `controlled_edits` vector to run/resume requests. Normalize the legacy `controlled_edit` field and the vector into one validated edit list, apply all edits before recording the checkpoint, and compute the mutation fingerprint after the full edit set. If any edit is invalid, the runner blocks before commit. This keeps the existing safety policy and state machine intact.
+
+Update `tau_live_coding_loop_harness` so provider output may return either a legacy single edit or an `edits` array. Add a deterministic real-repo mode that runs against a repository worktree with a spec-derived verifier and emits PR-ready evidence. Real PR publication remains behind the existing draft-PR opt-in and GitHub auth check.
+
+## Affected Modules
+
+- `crates/tau-agent-core/src/coding_mission.rs`
+- `crates/tau-agent-core/src/lib.rs`
+- `crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`
+- `scripts/dev/test-full-autonomous-coding-loop.sh`
+- `scripts/dev/test-provider-backed-autonomous-coding-loop.sh`
+- `specs/3792-real-repo-autonomous-coding-harness/*`
+
+## Risks
+
+- Risk: multi-file edit support could partially write files before rejecting a later invalid path.
+  - Mitigation: pre-validate every target path before writing any file in the edit set.
+
+- Risk: resume fingerprints could miss one file and allow drift.
+  - Mitigation: fingerprint after applying the whole edit set and add resume coverage for two edited files.
+
+- Risk: provider schema expansion could break existing provider-proof responses.
+  - Mitigation: keep the legacy single-edit shape accepted and test both payload forms.
+
+- Risk: "real-repo" mode could accidentally mutate the developer's active checkout.
+  - Mitigation: require an explicit worktree/repo path and keep validation scripts on temporary worktrees.
+
+## Interfaces
+
+`CodingMissionRunRequest` and `CodingMissionResumeRequest` gain:
+
+- `controlled_edits: Vec<CodingMissionControlledEdit>`
+
+The existing `controlled_edit: Option<CodingMissionControlledEdit>` field remains accepted for compatibility.
+
+Provider edit JSON accepts either:
+
+```json
+{"relative_path":"path","contents":"...","reason_code":"..."}
+```
+
+or:
+
+```json
+{"edits":[{"relative_path":"path","contents":"...","reason_code":"..."}]}
+```
+
+The real-repo harness output must include verifier evidence, commit hash, PR-ready bundle path, and publication status. Draft PR creation remains opt-in through existing `allow_draft_pr` plus GitHub auth.

--- a/specs/3792-real-repo-autonomous-coding-harness/spec.md
+++ b/specs/3792-real-repo-autonomous-coding-harness/spec.md
@@ -1,0 +1,53 @@
+# Spec: Real-repo autonomous coding harness
+
+Status: Reviewed
+
+## Problem
+
+Tau's autonomous coding loop can prove a single-file disposable fixture and can call a provider for that fixture, but that does not yet make it a general coding-agent harness over a real repository. The next product slice must let a coding mission apply a provider-supplied multi-file repair plan against a real worktree, run spec-derived verifiers, commit the verified diff, and prepare auditable PR output without claiming unattended production auto-merge.
+
+## Scope
+
+In:
+- Accept multiple controlled edits in a single `CodingMissionRunner` run and resume path while preserving the legacy single-edit field.
+- Reject any multi-file edit set that escapes the repository root before committing.
+- Extend the live coding loop harness provider payload so providers can return either the legacy single edit or a multi-edit `edits` array.
+- Add a real-repo/worktree integration mode that runs red verifier, provider/controlled multi-file fix, green verifier, commit, and PR-ready bundle.
+- Record clear evidence for PR publication state: manual command or draft PR creation, depending on opt-in auth flags.
+
+Out:
+- Unattended production PR merge.
+- Running arbitrary destructive commands outside the existing workspace command policy.
+- A full long-running background scheduler UI.
+- Broad dashboard polish unrelated to coding missions.
+
+## Acceptance Criteria
+
+AC-1: Given a coding mission request contains two valid controlled edits, when the runner executes after a red verifier, then both files are written, the green verifier passes, and the mission reaches `PrReady` with one commit containing both files.
+
+AC-2: Given a multi-edit mission contains any path outside the repository root, when the runner executes, then the mission fail-closes without writing or committing the outside file.
+
+AC-3: Given provider output contains an `edits` array, when the live coding loop harness resolves provider instructions, then all edits are applied through `CodingMissionRunner` and legacy single-edit provider output remains accepted.
+
+AC-4: Given the harness is pointed at a real repository worktree with a spec-derived verifier, when it runs in real-repo mode, then it produces durable red/green verifier evidence, a commit, a PR-ready bundle, and a publication status that is honest about manual versus draft-PR creation.
+
+AC-5: Given a multi-edit mission pauses after edit application, when it resumes, then resume restores the prepared branch, verifies the multi-file mutation fingerprint, completes the commit, and reaches `PrReady`.
+
+## Conformance Cases
+
+C-01 maps AC-1: `CodingMissionRunRequest` with `controlled_edits=[src/lib.rs, tests/spec.rs]` starts from a failing verifier and exits with both files changed and verifier status passed.
+
+C-02 maps AC-2: `controlled_edits=[src/lib.rs, ../escape.txt]` returns a blocked outcome; `../escape.txt` is absent and no commit evidence is recorded.
+
+C-03 maps AC-3: provider JSON with `{"edits":[...]}` is accepted and converted into a multi-edit mission request; provider JSON with `{"relative_path":...,"contents":...}` remains accepted.
+
+C-04 maps AC-4: `tau_live_coding_loop_harness --mode real-repo` runs against a temporary worktree of this repository and writes an evidence report with red verifier failure, green verifier pass, commit hash, PR-ready body path, and publication status.
+
+C-05 maps AC-5: a run stopped after `ApplyEdit` stores a checkpoint whose mutation fingerprint covers all edited files; resume completes from that checkpoint and records a verified commit.
+
+## Success Signals
+
+- `cargo test -p tau-agent-core coding_mission -- --test-threads=1` covers multi-file run, escape rejection, and resume.
+- `cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` covers provider multi-edit parsing.
+- A deterministic real-repo harness script passes without provider credentials.
+- Provider-backed mode remains opt-in and can use OpenRouter/DeepSeek when `TAU_LIVE_PROVIDER_PROOF=1` and credentials are available.

--- a/specs/3792-real-repo-autonomous-coding-harness/tasks.md
+++ b/specs/3792-real-repo-autonomous-coding-harness/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Real-repo autonomous coding harness
+
+- [x] T1: Add red tests for multi-file mission run, outside-repo rejection, provider `edits` parsing, and multi-file resume.
+  - RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-agent-core coding_mission -- --test-threads=1` failed before implementation because `CodingMissionRunRequest` and `CodingMissionResumeRequest` had no `controlled_edits` field.
+  - RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` failed before implementation because `ProviderEditResolution` had no `edits` field.
+- [x] T2: Implement backward-compatible multi-edit support in `CodingMissionRunner`.
+  - Added serde-default `controlled_edits` vectors while preserving legacy `controlled_edit`.
+  - Added edit-set normalization, full target prevalidation, multi-file checkpoint fingerprinting, and blocked fail-closed handling for escaped paths.
+- [x] T3: Extend provider payload parsing and harness request construction for multi-file edit plans.
+  - Provider JSON now accepts either legacy single-edit shape or `{"edits":[...]}`.
+  - Provider resume path passes the edit vector into `CodingMissionRunner`.
+- [x] T4: Add deterministic real-repo/worktree harness coverage with PR-ready evidence.
+  - Added `tau_live_coding_loop_harness --mode real-repo` with explicit verifier commands and real worktree base-branch detection.
+  - Added `scripts/dev/test-real-repo-autonomous-coding-harness.sh`.
+- [x] T5: Run scoped unit, integration, formatting, and lint validation; update docs/status truthfully.
+  - GREEN: `cargo fmt --check`
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-agent-core coding_mission -- --test-threads=1` passed 27 mission tests.
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` passed 5 provider parser tests.
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-full-autonomous-coding-loop.sh`
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-real-repo-autonomous-coding-harness.sh`
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-agent-core --lib --tests -- -D warnings`
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-coding-agent --bin tau_live_coding_loop_harness -- -D warnings`
+  - RED: `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed_openrouter_api_key_mode_injects_openrouter_key -- --nocapture` failed before the provider proof auth fix because `provider_cli` left `cli.openai_api_key` unset when only `OPENROUTER_API_KEY` supplied the OpenRouter credential.
+  - GREEN: `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --nocapture` passed 6 provider-backed harness tests.
+  - GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-coding-agent --bin tau_live_coding_loop_harness -- -D warnings`
+  - LIVE GREEN: `TAU_LIVE_PROVIDER_PROOF=1 TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash TAU_PROVIDER_PROOF_REPORT_DIR=/tmp/tau-3792-provider-live-fixed CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-provider-backed-autonomous-coding-loop.sh` passed against OpenRouter/DeepSeek. Sanitized report: `passed=true`, `phase=pr_ready`, provider `openrouter`, model `deepseek/deepseek-v4-flash`, parsed edit path `status.txt`, response bytes `89`, response SHA-256 `cf341f4f557518800b7a0802d3e35f61d024dbcf144aa34855c07610843ef607`.


### PR DESCRIPTION
## Summary
Extends `CodingMissionRunner` from single-file controlled edits to safe multi-file edit sets, preserving the legacy `controlled_edit` field. Adds provider `edits` array parsing plus a `real-repo` harness mode and deterministic worktree script that drives a temporary Tau worktree through RED verifier, provider-compatible multi-file fix, GREEN verifier, commit, and PR-ready bundle evidence.

The provider-backed proof now explicitly resolves API-key credentials into the harness CLI config for API-key mode, so OpenRouter-hosted models use `OPENROUTER_API_KEY`/`TAU_OPENROUTER_API_KEY` through the OpenAI-compatible `--openai-api-key` path. The PR Quality gate also exposed the existing `tau-browser-automation` Linux `Text file busy (os error 26)` fixture race; this PR hardens that path under `specs/3648` by invoking temporary Python fixtures through a stable `python3` prefix.

## Links
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Closes #3792
- Parent epic: #3653
- Spec: `specs/3792-real-repo-autonomous-coding-harness/spec.md`
- Plan: `specs/3792-real-repo-autonomous-coding-harness/plan.md`
- Tasks: `specs/3792-real-repo-autonomous-coding-harness/tasks.md`
- CI repair spec: `specs/3648/spec.md`

## Spec Verification
| AC | Status | Test(s) |
|---|---|---|
| AC-1 multi-file mission reaches PR-ready commit | ✅ | `spec_c12_outer_loop_applies_multi_file_edits_and_commits` |
| AC-2 escaped edit set blocks before partial write | ✅ | `regression_outer_loop_blocks_multi_file_escape_before_partial_write` |
| AC-3 provider `edits` array and legacy single edit parse | ✅ | `provider_backed_parses_json_edit`, `provider_backed_parses_json_edit_array`, `provider_backed_openrouter_api_key_mode_injects_openrouter_key` |
| AC-4 real worktree harness emits PR-ready evidence | ✅ | `scripts/dev/test-real-repo-autonomous-coding-harness.sh` |
| AC-5 multi-file resume fingerprint completes | ✅ | `spec_c13_resume_after_multi_file_edit_completes_with_full_fingerprint` |

## TDD Evidence
RED core: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-agent-core coding_mission -- --test-threads=1` failed before implementation because `CodingMissionRunRequest`/`CodingMissionResumeRequest` had no `controlled_edits` field.

RED provider parser: `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` failed before implementation because `ProviderEditResolution` had no `edits` field.

RED provider auth: `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed_openrouter_api_key_mode_injects_openrouter_key -- --nocapture` failed before the provider proof auth fix because `provider_cli` left `cli.openai_api_key` unset when only `OPENROUTER_API_KEY` supplied the OpenRouter credential.

RED CI repair: PR `#3793` Quality failed in `browser_automation_live::tests::functional_live_fixture_runner_executes_navigation_and_action_sequence` and `browser_automation_live::tests::regression_drop_cleanup_shuts_down_active_session_without_orphan_marker` with `Text file busy (os error 26)` before the temporary Python fixture launch path was hardened.

GREEN:
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-agent-core coding_mission -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-full-autonomous-coding-loop.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-real-repo-autonomous-coding-harness.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-agent-core --lib --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-coding-agent --bin tau_live_coding_loop_harness -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-browser-automation --lib functional_live_fixture_runner_executes_navigation_and_action_sequence -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-browser-automation --lib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo clippy -p tau-browser-automation --lib --tests -- -D warnings`
- `RUST_MIN_STACK=8388608 CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --nocapture`
- `TAU_LIVE_PROVIDER_PROOF=1 TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash TAU_PROVIDER_PROOF_REPORT_DIR=/tmp/tau-3792-provider-live-fixed CARGO_TARGET_DIR=/tmp/rust_pi-3792-red-target ./scripts/dev/test-provider-backed-autonomous-coding-loop.sh`

## Live Provider Proof
Passed against OpenRouter/DeepSeek with local `.env` credentials and explicit OpenRouter-qualified model override. Sanitized report: `passed=true`, `phase=pr_ready`, provider `openrouter`, model `deepseek/deepseek-v4-flash`, parsed edit path `status.txt`, response bytes `89`, response SHA-256 `cf341f4f557518800b7a0802d3e35f61d024dbcf144aa34855c07610843ef607`.

For no-override runs, `.env` should use `TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash`; `deepseek/deepseek-v4-flash` does not select the OpenRouter provider route.

## Test Tiers
| Tier | Status | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | core runner/provider parser/provider auth/browser fixture tests | |
| Property | N/A | | no parser invariant/property surface changed; path safety covered by regression tests |
| Contract/DbC | N/A | | no contracts framework API added |
| Snapshot | N/A | | no snapshots used |
| Functional | ✅ | full autonomous loop + provider-backed proof + real-repo harness scripts | |
| Conformance | ✅ | AC-mapped spec tests above | |
| Integration | ✅ | `test-provider-backed-autonomous-coding-loop.sh`, `test-real-repo-autonomous-coding-harness.sh` | |
| Fuzz | N/A | | no untrusted parser beyond serde JSON shape plus path validation in this slice |
| Mutation | N/A | | not run; scoped branch is harness/runtime plumbing, not critical algorithm change |
| Regression | ✅ | legacy full loop, provider parser/auth tests, browser fixture race selectors | |
| Performance | N/A | | no perf-sensitive path changed |

## Mutation
Not run. No mutants claimed.

## Risks / Rollback
Risk: adding `controlled_edits` is a public struct shape change for Rust literal callers. Internal callers were updated; serde compatibility is preserved for legacy JSON. Rollback: revert this PR to restore single-edit-only behavior and remove the real-repo mode/script/provider-proof auth injection.

## Docs / ADR
Updated `README.md`, `docs/guides/canonical-product-proof.md`, `specs/3792-real-repo-autonomous-coding-harness/*`, and `specs/3648/*`. No ADR; this extends the existing coding mission lifecycle and stabilizes proof harness/auth/test fixture paths rather than introducing a new architecture.

## Human Review Note
This is P1/multi-module work. Spec status is `Reviewed`; please review the product boundary before merge.