### PR TITLE
Make coding missions recoverable as durable jobs

### DIFF
--- a/crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs
+++ b/crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs
@@ -1,0 +1,280 @@
+//! Standalone autonomous coding job operator binary.
+//!
+//! This is the narrow product surface for submitting, running, replaying, and
+//! inspecting durable coding jobs while the main control plane wiring catches
+//! up.
+
+use std::{
+    path::PathBuf,
+    process::ExitCode,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use serde_json::json;
+use tau_agent_core::{CodingMissionControlledEdit, CodingMissionPrMode};
+use tau_runtime::{
+    AutonomousCodingJobReplayRequest, AutonomousCodingJobRuntime, AutonomousCodingJobRuntimeConfig,
+    AutonomousCodingJobSubmitRequest,
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "tau-autonomous-coding-job",
+    about = "Submit, run, replay, recover, and inspect durable Tau coding jobs"
+)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Persist a coding mission job and optionally enqueue its background worker.
+    Submit(Box<JobSubmitArgs>),
+    /// Run or resume a persisted autonomous coding job.
+    Run(Box<JobRunArgs>),
+    /// Explicitly replay a checkpoint with optional updated edits/message.
+    Replay(Box<JobReplayArgs>),
+    /// Emit the operator status JSON for a persisted job.
+    Status(Box<JobStatusArgs>),
+    /// Run the background-job stuck recovery sweep and refresh linked jobs.
+    Recover(Box<JobRecoverArgs>),
+}
+
+#[derive(Debug, Parser)]
+struct JobSubmitArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+
+    #[arg(long)]
+    repo_path: PathBuf,
+    #[arg(long)]
+    mission_id: String,
+    #[arg(long, default_value = "local-session")]
+    session_key: String,
+    #[arg(long)]
+    issue_url: Option<String>,
+    #[arg(long)]
+    goal: String,
+    #[arg(long, default_value = "master")]
+    base_branch: String,
+    #[arg(long, default_value = "codex/autonomous-coding-job-")]
+    branch_prefix: String,
+    #[arg(long = "verifier-command", required = true)]
+    verifier_commands: Vec<String>,
+    #[arg(long = "allowed-root")]
+    allowed_roots: Vec<PathBuf>,
+    #[arg(long = "edit")]
+    edits: Vec<String>,
+    #[arg(long)]
+    commit_message: String,
+    #[arg(long, value_enum, default_value = "pr-ready")]
+    pr_mode: PrModeArg,
+    #[arg(long)]
+    enqueue_background_job: bool,
+    #[arg(long)]
+    timeout_ms: Option<u64>,
+    #[arg(long)]
+    started_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+struct JobRunArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    job_id: String,
+    #[arg(long)]
+    started_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+struct JobReplayArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    job_id: String,
+    #[arg(long = "edit")]
+    edits: Vec<String>,
+    #[arg(long)]
+    commit_message: Option<String>,
+    #[arg(long)]
+    started_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+struct JobStatusArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    job_id: String,
+}
+
+#[derive(Debug, Parser)]
+struct JobRecoverArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+}
+
+#[derive(Debug, Clone, Parser)]
+struct RuntimeArgs {
+    #[arg(long, default_value = ".tau/autonomous-coding")]
+    state_dir: PathBuf,
+    #[arg(long, default_value = ".tau/jobs")]
+    jobs_state_dir: PathBuf,
+    #[arg(long)]
+    runner_command: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PrModeArg {
+    Disabled,
+    #[value(name = "pr-ready")]
+    PrReady,
+    Draft,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run(Args::parse()).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("tau-autonomous-coding-job: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    match args.command {
+        Command::Submit(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let allowed_roots = if args.allowed_roots.is_empty() {
+                vec![args.repo_path.clone()]
+            } else {
+                args.allowed_roots
+            };
+            let outcome = runtime
+                .submit_job(AutonomousCodingJobSubmitRequest {
+                    mission_id: args.mission_id,
+                    session_key: args.session_key,
+                    repo_path: args.repo_path,
+                    issue_url: args.issue_url,
+                    goal: args.goal,
+                    base_branch: args.base_branch,
+                    branch_prefix: args.branch_prefix,
+                    verifier_commands: args.verifier_commands,
+                    pr_mode: args.pr_mode.into(),
+                    allowed_roots,
+                    controlled_edits: parse_edits(&args.edits)?,
+                    commit_message: args.commit_message,
+                    enqueue_background_job: args.enqueue_background_job,
+                    timeout_ms: args.timeout_ms,
+                    started_unix_ms: args.started_unix_ms.unwrap_or_else(now_unix_ms),
+                })
+                .await?;
+            print_json(&outcome)?;
+        }
+        Command::Run(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome = runtime.run_or_replay_job(
+                args.job_id.as_str(),
+                args.started_unix_ms.unwrap_or_else(now_unix_ms),
+            )?;
+            print_json(&outcome)?;
+        }
+        Command::Replay(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome = runtime.replay_job(AutonomousCodingJobReplayRequest {
+                job_id: args.job_id,
+                controlled_edits: parse_edits(&args.edits)?,
+                commit_message: args.commit_message,
+                started_unix_ms: args.started_unix_ms.unwrap_or_else(now_unix_ms),
+            })?;
+            print_json(&outcome)?;
+        }
+        Command::Status(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let status = runtime.status(args.job_id.as_str())?;
+            print_json(&status)?;
+        }
+        Command::Recover(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome = runtime.recover_stuck_background_jobs().await?;
+            print_json(&json!({
+                "background_report": {
+                    "scanned_running": outcome.background_report.scanned_running,
+                    "recovered": outcome.background_report.recovered,
+                    "skipped_fresh": outcome.background_report.skipped_fresh,
+                    "skipped_cancelled": outcome.background_report.skipped_cancelled,
+                    "recovered_job_ids": outcome.background_report.recovered_job_ids,
+                },
+                "recovered_jobs": outcome.recovered_jobs,
+            }))?;
+        }
+    }
+    Ok(())
+}
+
+fn runtime_from_args(args: &RuntimeArgs) -> Result<AutonomousCodingJobRuntime> {
+    let runner_command = match args.runner_command.clone() {
+        Some(path) => path,
+        None => {
+            std::env::current_exe().unwrap_or_else(|_| PathBuf::from("tau_autonomous_coding_job"))
+        }
+    };
+    AutonomousCodingJobRuntime::new(AutonomousCodingJobRuntimeConfig {
+        state_dir: args.state_dir.clone(),
+        background_jobs_state_dir: args.jobs_state_dir.clone(),
+        runner_command,
+        ..AutonomousCodingJobRuntimeConfig::default()
+    })
+}
+
+fn parse_edits(raw_edits: &[String]) -> Result<Vec<CodingMissionControlledEdit>> {
+    raw_edits
+        .iter()
+        .map(|raw| {
+            let (path, contents) = raw
+                .split_once('=')
+                .ok_or_else(|| anyhow!("--edit must use relative/path=contents"))?;
+            if path.trim().is_empty() {
+                return Err(anyhow!("--edit path must not be empty"));
+            }
+            Ok(CodingMissionControlledEdit {
+                relative_path: PathBuf::from(path),
+                contents: contents.to_string(),
+                reason_code: "operator_controlled_edit".to_string(),
+            })
+        })
+        .collect()
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or_default()
+}
+
+impl From<PrModeArg> for CodingMissionPrMode {
+    fn from(value: PrModeArg) -> Self {
+        match value {
+            PrModeArg::Disabled => Self::Disabled,
+            PrModeArg::PrReady => Self::PrReady,
+            PrModeArg::Draft => Self::Draft,
+        }
+    }
+}

--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
@@ -1,0 +1,1079 @@
+//! Durable autonomous coding job runtime.
+//!
+//! This layer links `CodingMissionRunner` with the generic background jobs
+//! runtime so coding work can be submitted, resumed, recovered, and inspected
+//! as one product loop.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use tau_agent_core::{
+    coding_mission_state_path, load_coding_mission_state, save_coding_mission_state,
+    CodingGitLifecycleEvidenceKind, CodingMissionConfig, CodingMissionControlledEdit,
+    CodingMissionPhase, CodingMissionPrMode, CodingMissionPrPublicationStatus,
+    CodingMissionPrReadyBundle, CodingMissionPrReadyRequest, CodingMissionResumeRequest,
+    CodingMissionRunRequest, CodingMissionRunner, CodingMissionState, CodingWorkspaceCommandStatus,
+};
+
+use crate::{
+    BackgroundJobCreateRequest, BackgroundJobRecord, BackgroundJobRecoveryReport,
+    BackgroundJobRuntime, BackgroundJobRuntimeConfig, BackgroundJobTraceContext,
+};
+
+pub const AUTONOMOUS_CODING_JOB_SCHEMA_VERSION: u32 = 1;
+
+const AUTONOMOUS_CODING_JOB_REASON_QUEUED: &str = "autonomous_coding_job_queued";
+const AUTONOMOUS_CODING_JOB_REASON_RUNNING: &str = "autonomous_coding_job_running";
+const AUTONOMOUS_CODING_JOB_REASON_WAITING_FOR_EDIT: &str =
+    "autonomous_coding_job_waiting_for_controlled_edit";
+const AUTONOMOUS_CODING_JOB_REASON_PR_READY: &str = "autonomous_coding_job_pr_ready";
+const AUTONOMOUS_CODING_JOB_REASON_BLOCKED: &str = "autonomous_coding_job_blocked";
+const AUTONOMOUS_CODING_JOB_REASON_FAILED: &str = "autonomous_coding_job_failed";
+const AUTONOMOUS_CODING_JOB_REASON_RECOVERED: &str = "autonomous_coding_job_background_recovered";
+const AUTONOMOUS_CODING_JOB_MAX_REPLAY_PASSES: usize = 6;
+
+static NEXT_AUTONOMOUS_CODING_JOB_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousCodingJobStatus {
+    Queued,
+    Running,
+    Recovering,
+    PrReady,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutonomousCodingJobRuntimeConfig {
+    pub state_dir: PathBuf,
+    pub background_jobs_state_dir: PathBuf,
+    pub runner_command: PathBuf,
+    pub runner_args_prefix: Vec<String>,
+    pub default_timeout_ms: u64,
+    pub max_timeout_ms: u64,
+    pub worker_poll_ms: u64,
+    pub stuck_recovery_poll_ms: u64,
+}
+
+impl Default for AutonomousCodingJobRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            state_dir: PathBuf::from(".tau/autonomous-coding"),
+            background_jobs_state_dir: PathBuf::from(".tau/jobs"),
+            runner_command: PathBuf::from("tau-autonomous-coding-job"),
+            runner_args_prefix: Vec::new(),
+            default_timeout_ms: 900_000,
+            max_timeout_ms: 3_600_000,
+            worker_poll_ms: 50,
+            stuck_recovery_poll_ms: 250,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobSubmitRequest {
+    pub mission_id: String,
+    pub session_key: String,
+    pub repo_path: PathBuf,
+    #[serde(default)]
+    pub issue_url: Option<String>,
+    pub goal: String,
+    pub base_branch: String,
+    pub branch_prefix: String,
+    pub verifier_commands: Vec<String>,
+    pub pr_mode: CodingMissionPrMode,
+    pub allowed_roots: Vec<PathBuf>,
+    #[serde(default)]
+    pub controlled_edits: Vec<CodingMissionControlledEdit>,
+    pub commit_message: String,
+    pub enqueue_background_job: bool,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    pub started_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobReplayRequest {
+    pub job_id: String,
+    #[serde(default)]
+    pub controlled_edits: Vec<CodingMissionControlledEdit>,
+    #[serde(default)]
+    pub commit_message: Option<String>,
+    pub started_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobRecord {
+    pub schema_version: u32,
+    pub job_id: String,
+    pub mission_id: String,
+    #[serde(default)]
+    pub background_job_id: Option<String>,
+    pub status: AutonomousCodingJobStatus,
+    pub reason_code: String,
+    pub state_root: PathBuf,
+    pub repo_path: PathBuf,
+    #[serde(default)]
+    pub issue_url: Option<String>,
+    pub goal: String,
+    pub verifier_commands: Vec<String>,
+    pub pr_mode: CodingMissionPrMode,
+    #[serde(default)]
+    pub controlled_edits: Vec<CodingMissionControlledEdit>,
+    pub commit_message: String,
+    pub created_unix_ms: u64,
+    pub updated_unix_ms: u64,
+    pub recovery_count: u64,
+    pub replay_count: u64,
+    #[serde(default)]
+    pub last_background_reason_code: Option<String>,
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobStatusSnapshot {
+    pub schema_version: u32,
+    pub job_id: String,
+    pub mission_id: String,
+    #[serde(default)]
+    pub background_job_id: Option<String>,
+    pub status: AutonomousCodingJobStatus,
+    pub phase: CodingMissionPhase,
+    pub reason_code: String,
+    pub repo_path: PathBuf,
+    #[serde(default)]
+    pub issue_url: Option<String>,
+    pub verifier_summary: String,
+    pub changed_files: Vec<String>,
+    pub resume_command: String,
+    pub pr_state: String,
+    #[serde(default)]
+    pub pr_ready_command: Option<String>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    pub recovery_count: u64,
+    pub replay_count: u64,
+    #[serde(default)]
+    pub last_background_reason_code: Option<String>,
+    #[serde(default)]
+    pub last_error: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobSubmitOutcome {
+    pub record: AutonomousCodingJobRecord,
+    #[serde(default)]
+    pub background_job: Option<BackgroundJobRecord>,
+    pub status: AutonomousCodingJobStatusSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingJobRunOutcome {
+    pub record: AutonomousCodingJobRecord,
+    pub status: AutonomousCodingJobStatusSnapshot,
+    #[serde(default)]
+    pub pr_ready_bundle: Option<CodingMissionPrReadyBundle>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutonomousCodingJobRecoveryOutcome {
+    pub background_report: BackgroundJobRecoveryReport,
+    pub recovered_jobs: Vec<AutonomousCodingJobStatusSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutonomousCodingJobRuntime {
+    config: AutonomousCodingJobRuntimeConfig,
+    background_runtime: BackgroundJobRuntime,
+}
+
+impl AutonomousCodingJobRuntime {
+    pub fn new(config: AutonomousCodingJobRuntimeConfig) -> Result<Self> {
+        ensure_autonomous_coding_job_layout(&config.state_dir)?;
+        let background_runtime = BackgroundJobRuntime::new(BackgroundJobRuntimeConfig {
+            state_dir: config.background_jobs_state_dir.clone(),
+            default_timeout_ms: config.default_timeout_ms.max(1),
+            max_timeout_ms: config.max_timeout_ms.max(config.default_timeout_ms.max(1)),
+            worker_poll_ms: config.worker_poll_ms,
+            stuck_recovery_poll_ms: config.stuck_recovery_poll_ms,
+        })?;
+        Ok(Self {
+            config,
+            background_runtime,
+        })
+    }
+
+    pub fn config(&self) -> &AutonomousCodingJobRuntimeConfig {
+        &self.config
+    }
+
+    pub async fn submit_job(
+        &self,
+        request: AutonomousCodingJobSubmitRequest,
+    ) -> Result<AutonomousCodingJobSubmitOutcome> {
+        ensure_autonomous_coding_job_layout(&self.config.state_dir)?;
+        let job_id = next_autonomous_coding_job_id();
+        let mission = CodingMissionState::create(CodingMissionConfig {
+            state_root: self.config.state_dir.clone(),
+            mission_id: request.mission_id.clone(),
+            session_key: request.session_key.clone(),
+            repo_path: request.repo_path.clone(),
+            issue_url: request.issue_url.clone(),
+            goal: request.goal.clone(),
+            base_branch: request.base_branch.clone(),
+            branch_prefix: request.branch_prefix.clone(),
+            verifier_commands: request.verifier_commands.clone(),
+            pr_mode: request.pr_mode,
+            allowed_roots: request.allowed_roots.clone(),
+            created_unix_ms: request.started_unix_ms,
+        })?;
+        save_coding_mission_state(&mission)?;
+
+        let mut record = AutonomousCodingJobRecord {
+            schema_version: AUTONOMOUS_CODING_JOB_SCHEMA_VERSION,
+            job_id,
+            mission_id: request.mission_id,
+            background_job_id: None,
+            status: AutonomousCodingJobStatus::Queued,
+            reason_code: AUTONOMOUS_CODING_JOB_REASON_QUEUED.to_string(),
+            state_root: self.config.state_dir.clone(),
+            repo_path: mission.repo_path.clone(),
+            issue_url: request.issue_url,
+            goal: request.goal,
+            verifier_commands: request.verifier_commands,
+            pr_mode: request.pr_mode,
+            controlled_edits: request.controlled_edits,
+            commit_message: request.commit_message,
+            created_unix_ms: request.started_unix_ms,
+            updated_unix_ms: request.started_unix_ms,
+            recovery_count: 0,
+            replay_count: 0,
+            last_background_reason_code: None,
+            last_error: None,
+        };
+
+        let mut background_job = None;
+        if request.enqueue_background_job {
+            let created = self
+                .background_runtime
+                .create_job(BackgroundJobCreateRequest {
+                    command: self.config.runner_command.display().to_string(),
+                    args: self.runner_args_for_job(record.job_id.as_str()),
+                    env: BTreeMap::new(),
+                    cwd: Some(record.repo_path.clone()),
+                    timeout_ms: request.timeout_ms,
+                    trace: BackgroundJobTraceContext::default(),
+                })
+                .await?;
+            record.background_job_id = Some(created.job_id.clone());
+            record.last_background_reason_code = Some(created.reason_code.clone());
+            background_job = Some(created);
+        }
+
+        persist_autonomous_coding_job_record(&record)?;
+        let status = self.refresh_status_snapshot(&record)?;
+        Ok(AutonomousCodingJobSubmitOutcome {
+            record,
+            background_job,
+            status,
+        })
+    }
+
+    pub fn run_or_replay_job(
+        &self,
+        job_id: &str,
+        started_unix_ms: u64,
+    ) -> Result<AutonomousCodingJobRunOutcome> {
+        self.execute_job(job_id, None, None, started_unix_ms, ReplayCounterMode::Auto)
+    }
+
+    pub fn replay_job(
+        &self,
+        request: AutonomousCodingJobReplayRequest,
+    ) -> Result<AutonomousCodingJobRunOutcome> {
+        self.execute_job(
+            request.job_id.as_str(),
+            Some(request.controlled_edits),
+            request.commit_message,
+            request.started_unix_ms,
+            ReplayCounterMode::Increment,
+        )
+    }
+
+    pub async fn recover_stuck_background_jobs(
+        &self,
+    ) -> Result<AutonomousCodingJobRecoveryOutcome> {
+        let background_report = self.background_runtime.recover_stuck_jobs().await?;
+        let mut recovered_jobs = Vec::new();
+        if background_report.recovered > 0 {
+            let recovered_ids = background_report
+                .recovered_job_ids
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            for mut record in load_autonomous_coding_job_records(&self.config.state_dir)? {
+                let Some(background_job_id) = record.background_job_id.as_deref() else {
+                    continue;
+                };
+                if !recovered_ids.contains(&background_job_id) {
+                    continue;
+                }
+                record.status = AutonomousCodingJobStatus::Recovering;
+                record.reason_code = AUTONOMOUS_CODING_JOB_REASON_RECOVERED.to_string();
+                record.updated_unix_ms = current_unix_timestamp_ms();
+                record.recovery_count = record.recovery_count.saturating_add(1);
+                record.last_background_reason_code =
+                    Some("job_recovered_after_stuck_timeout".to_string());
+                record.last_error = None;
+                persist_autonomous_coding_job_record(&record)?;
+                recovered_jobs.push(self.refresh_status_snapshot(&record)?);
+            }
+        }
+        Ok(AutonomousCodingJobRecoveryOutcome {
+            background_report,
+            recovered_jobs,
+        })
+    }
+
+    pub fn status(&self, job_id: &str) -> Result<AutonomousCodingJobStatusSnapshot> {
+        let record = load_autonomous_coding_job_record(&self.config.state_dir, job_id)?;
+        self.refresh_status_snapshot(&record)
+    }
+
+    fn execute_job(
+        &self,
+        job_id: &str,
+        controlled_edits_override: Option<Vec<CodingMissionControlledEdit>>,
+        commit_message_override: Option<String>,
+        started_unix_ms: u64,
+        replay_counter_mode: ReplayCounterMode,
+    ) -> Result<AutonomousCodingJobRunOutcome> {
+        let mut record = load_autonomous_coding_job_record(&self.config.state_dir, job_id)?;
+        let controlled_edits =
+            controlled_edits_override.unwrap_or_else(|| record.controlled_edits.clone());
+        if !controlled_edits.is_empty() {
+            record.controlled_edits = controlled_edits.clone();
+        }
+        if let Some(commit_message) = commit_message_override {
+            if !commit_message.trim().is_empty() {
+                record.commit_message = commit_message;
+            }
+        }
+
+        let state_before = load_coding_mission_state(&record.state_root, &record.mission_id)?;
+        let should_count_replay = match replay_counter_mode {
+            ReplayCounterMode::Increment => true,
+            ReplayCounterMode::Auto => {
+                state_before.resume_checkpoint.is_some()
+                    && state_before.phase != CodingMissionPhase::Intake
+            }
+        };
+        if should_count_replay {
+            record.replay_count = record.replay_count.saturating_add(1);
+        }
+        record.status = AutonomousCodingJobStatus::Running;
+        record.reason_code = AUTONOMOUS_CODING_JOB_REASON_RUNNING.to_string();
+        record.updated_unix_ms = started_unix_ms;
+        record.last_error = None;
+        persist_autonomous_coding_job_record(&record)?;
+        self.refresh_status_snapshot(&record)?;
+
+        let runner = CodingMissionRunner::new();
+        let mut pr_ready_bundle = None;
+        let mut last_phase = state_before.phase;
+        let mut final_state = state_before;
+        for pass in 0..AUTONOMOUS_CODING_JOB_MAX_REPLAY_PASSES {
+            let pass_started = started_unix_ms.saturating_add((pass as u64).saturating_mul(1_000));
+            let outcome = if final_state.phase == CodingMissionPhase::Intake {
+                runner.run(
+                    &mut final_state,
+                    CodingMissionRunRequest {
+                        controlled_edit: None,
+                        controlled_edits: controlled_edits.clone(),
+                        commit_message: record.commit_message.clone(),
+                        started_unix_ms: pass_started,
+                    },
+                )?
+            } else {
+                let resumed = runner.resume(CodingMissionResumeRequest {
+                    state_root: record.state_root.clone(),
+                    mission_id: record.mission_id.clone(),
+                    controlled_edit: None,
+                    controlled_edits: controlled_edits.clone(),
+                    commit_message: record.commit_message.clone(),
+                    started_unix_ms: pass_started,
+                    stop_after: None,
+                })?;
+                resumed.run
+            };
+
+            final_state = load_coding_mission_state(&record.state_root, &record.mission_id)?;
+            if final_state.phase == CodingMissionPhase::PrReady {
+                pr_ready_bundle = Some(ensure_pr_ready_bundle(
+                    &mut final_state,
+                    &record,
+                    pass_started.saturating_add(900),
+                )?);
+                record.status = AutonomousCodingJobStatus::PrReady;
+                record.reason_code = AUTONOMOUS_CODING_JOB_REASON_PR_READY.to_string();
+                record.updated_unix_ms = pass_started.saturating_add(999);
+                record.last_error = None;
+                persist_autonomous_coding_job_record(&record)?;
+                let status = self.refresh_status_snapshot(&record)?;
+                return Ok(AutonomousCodingJobRunOutcome {
+                    record,
+                    status,
+                    pr_ready_bundle,
+                });
+            }
+
+            if let Some(reason) = outcome.blocked_reason {
+                record.status = AutonomousCodingJobStatus::Blocked;
+                record.reason_code = AUTONOMOUS_CODING_JOB_REASON_BLOCKED.to_string();
+                record.updated_unix_ms = pass_started.saturating_add(999);
+                record.last_error = Some(reason);
+                persist_autonomous_coding_job_record(&record)?;
+                let status = self.refresh_status_snapshot(&record)?;
+                return Ok(AutonomousCodingJobRunOutcome {
+                    record,
+                    status,
+                    pr_ready_bundle,
+                });
+            }
+
+            let waiting_for_edit =
+                final_state
+                    .resume_checkpoint
+                    .as_ref()
+                    .is_some_and(|checkpoint| {
+                        checkpoint.next_action
+                            == tau_agent_core::CodingMissionResumeAction::ApplyEdit
+                            && controlled_edits.is_empty()
+                    });
+            if waiting_for_edit {
+                record.status = AutonomousCodingJobStatus::Running;
+                record.reason_code = AUTONOMOUS_CODING_JOB_REASON_WAITING_FOR_EDIT.to_string();
+                record.updated_unix_ms = pass_started.saturating_add(999);
+                persist_autonomous_coding_job_record(&record)?;
+                let status = self.refresh_status_snapshot(&record)?;
+                return Ok(AutonomousCodingJobRunOutcome {
+                    record,
+                    status,
+                    pr_ready_bundle,
+                });
+            }
+
+            if final_state.phase == last_phase
+                && final_state
+                    .resume_checkpoint
+                    .as_ref()
+                    .is_none_or(|checkpoint| {
+                        checkpoint.next_action == tau_agent_core::CodingMissionResumeAction::Blocked
+                    })
+            {
+                break;
+            }
+            last_phase = final_state.phase;
+        }
+
+        record.status = AutonomousCodingJobStatus::Failed;
+        record.reason_code = AUTONOMOUS_CODING_JOB_REASON_FAILED.to_string();
+        record.updated_unix_ms = started_unix_ms.saturating_add(9_999);
+        record.last_error = Some("replay_pass_limit_exhausted".to_string());
+        persist_autonomous_coding_job_record(&record)?;
+        let status = self.refresh_status_snapshot(&record)?;
+        Ok(AutonomousCodingJobRunOutcome {
+            record,
+            status,
+            pr_ready_bundle,
+        })
+    }
+
+    fn refresh_status_snapshot(
+        &self,
+        record: &AutonomousCodingJobRecord,
+    ) -> Result<AutonomousCodingJobStatusSnapshot> {
+        let state = load_coding_mission_state(&record.state_root, &record.mission_id)?;
+        let status = build_status_snapshot(record, &state);
+        persist_autonomous_coding_job_status(&self.config.state_dir, &status)?;
+        Ok(status)
+    }
+
+    fn runner_args_for_job(&self, job_id: &str) -> Vec<String> {
+        let mut args = self.config.runner_args_prefix.clone();
+        args.extend([
+            "run".to_string(),
+            "--state-dir".to_string(),
+            self.config.state_dir.display().to_string(),
+            "--job-id".to_string(),
+            job_id.to_string(),
+        ]);
+        args
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplayCounterMode {
+    Auto,
+    Increment,
+}
+
+pub fn autonomous_coding_job_record_path(state_dir: &Path, job_id: &str) -> PathBuf {
+    state_dir
+        .join("autonomous-coding-jobs")
+        .join(format!("{job_id}.json"))
+}
+
+pub fn autonomous_coding_job_status_path(state_dir: &Path, job_id: &str) -> PathBuf {
+    state_dir
+        .join("autonomous-coding-jobs")
+        .join(format!("{job_id}.status.json"))
+}
+
+fn ensure_autonomous_coding_job_layout(state_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(state_dir.join("autonomous-coding-jobs"))?;
+    std::fs::create_dir_all(state_dir.join("coding-missions"))?;
+    Ok(())
+}
+
+fn next_autonomous_coding_job_id() -> String {
+    let sequence = NEXT_AUTONOMOUS_CODING_JOB_SEQUENCE.fetch_add(1, Ordering::SeqCst);
+    format!(
+        "coding-job-{}-{sequence}",
+        current_unix_timestamp_ms().max(1)
+    )
+}
+
+fn current_unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or_default()
+}
+
+fn persist_autonomous_coding_job_record(record: &AutonomousCodingJobRecord) -> Result<()> {
+    let path = autonomous_coding_job_record_path(&record.state_root, &record.job_id);
+    write_json_atomic(&path, record)
+}
+
+fn persist_autonomous_coding_job_status(
+    state_dir: &Path,
+    status: &AutonomousCodingJobStatusSnapshot,
+) -> Result<()> {
+    let path = autonomous_coding_job_status_path(state_dir, &status.job_id);
+    write_json_atomic(&path, status)
+}
+
+fn load_autonomous_coding_job_record(
+    state_dir: &Path,
+    job_id: &str,
+) -> Result<AutonomousCodingJobRecord> {
+    let path = autonomous_coding_job_record_path(state_dir, job_id);
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let record = serde_json::from_str::<AutonomousCodingJobRecord>(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    if record.schema_version != AUTONOMOUS_CODING_JOB_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "unsupported autonomous coding job schema {} at {}; expected {}",
+            record.schema_version,
+            path.display(),
+            AUTONOMOUS_CODING_JOB_SCHEMA_VERSION
+        ));
+    }
+    Ok(record)
+}
+
+fn load_autonomous_coding_job_records(state_dir: &Path) -> Result<Vec<AutonomousCodingJobRecord>> {
+    let jobs_dir = state_dir.join("autonomous-coding-jobs");
+    if !jobs_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut records = Vec::new();
+    for entry in std::fs::read_dir(&jobs_dir)
+        .with_context(|| format!("failed to read {}", jobs_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.ends_with(".status.json"))
+        {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        records.push(
+            serde_json::from_str::<AutonomousCodingJobRecord>(&raw)
+                .with_context(|| format!("failed to parse {}", path.display()))?,
+        );
+    }
+    Ok(records)
+}
+
+fn build_status_snapshot(
+    record: &AutonomousCodingJobRecord,
+    state: &CodingMissionState,
+) -> AutonomousCodingJobStatusSnapshot {
+    let pr_ready_bundle = state.pr_ready_bundle.as_ref();
+    let changed_files = pr_ready_bundle
+        .map(|bundle| bundle.changed_files.clone())
+        .or_else(|| {
+            state
+                .git_evidence
+                .iter()
+                .rev()
+                .find(|evidence| evidence.kind == CodingGitLifecycleEvidenceKind::CommitCreated)
+                .map(|evidence| evidence.changed_files.clone())
+        })
+        .unwrap_or_default();
+    let verifier_summary = state
+        .command_evidence
+        .iter()
+        .rev()
+        .find(|evidence| evidence.reason_code.starts_with("coding_verifier"))
+        .map(|evidence| {
+            format!(
+                "{}:{}",
+                workspace_status_label(evidence.status),
+                evidence.reason_code
+            )
+        })
+        .unwrap_or_else(|| "none".to_string());
+    let resume_command = state
+        .resume_checkpoint
+        .as_ref()
+        .map(|checkpoint| checkpoint.operator_resume_command.clone())
+        .unwrap_or_else(|| "none".to_string());
+    let pr_state = pr_ready_bundle
+        .map(|bundle| pr_publication_status_label(bundle.status).to_string())
+        .unwrap_or_else(|| {
+            if state.phase == CodingMissionPhase::PrReady {
+                "pr_ready".to_string()
+            } else {
+                "none".to_string()
+            }
+        });
+    AutonomousCodingJobStatusSnapshot {
+        schema_version: AUTONOMOUS_CODING_JOB_SCHEMA_VERSION,
+        job_id: record.job_id.clone(),
+        mission_id: record.mission_id.clone(),
+        background_job_id: record.background_job_id.clone(),
+        status: record.status,
+        phase: state.phase,
+        reason_code: record.reason_code.clone(),
+        repo_path: record.repo_path.clone(),
+        issue_url: record.issue_url.clone(),
+        verifier_summary,
+        changed_files,
+        resume_command,
+        pr_state,
+        pr_ready_command: pr_ready_bundle.map(|bundle| bundle.manual_gh_pr_create_command.clone()),
+        pr_url: pr_ready_bundle.and_then(|bundle| bundle.pr_url.clone()),
+        recovery_count: record.recovery_count,
+        replay_count: record.replay_count,
+        last_background_reason_code: record.last_background_reason_code.clone(),
+        last_error: record.last_error.clone(),
+        metadata: BTreeMap::from([
+            (
+                "mission_state_path".to_string(),
+                coding_mission_state_path(&record.state_root, &record.mission_id)
+                    .display()
+                    .to_string(),
+            ),
+            (
+                "job_record_path".to_string(),
+                autonomous_coding_job_record_path(&record.state_root, &record.job_id)
+                    .display()
+                    .to_string(),
+            ),
+        ]),
+    }
+}
+
+fn ensure_pr_ready_bundle(
+    state: &mut CodingMissionState,
+    record: &AutonomousCodingJobRecord,
+    started_unix_ms: u64,
+) -> Result<CodingMissionPrReadyBundle> {
+    if let Some(bundle) = state.pr_ready_bundle.clone() {
+        return Ok(bundle);
+    }
+    let allow_draft_pr = record.pr_mode == CodingMissionPrMode::Draft;
+    state
+        .prepare_pr_ready_bundle(CodingMissionPrReadyRequest {
+            title: Some(format!(
+                "Autonomous coding job: {}",
+                first_goal_line(&record.goal)
+            )),
+            risk_notes: vec![
+                "Risk: verifier scope is configured by the autonomous coding job".to_string(),
+            ],
+            rollback_notes: vec!["Revert the autonomous coding mission commit".to_string()],
+            allow_draft_pr,
+            github_env: BTreeMap::new(),
+            gh_binary: None,
+            started_unix_ms,
+        })
+        .map_err(Into::into)
+}
+
+fn first_goal_line(goal: &str) -> String {
+    goal.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("coding mission")
+        .to_string()
+}
+
+fn workspace_status_label(status: CodingWorkspaceCommandStatus) -> &'static str {
+    match status {
+        CodingWorkspaceCommandStatus::Succeeded => "succeeded",
+        CodingWorkspaceCommandStatus::Failed => "failed",
+        CodingWorkspaceCommandStatus::Denied => "denied",
+    }
+}
+
+fn pr_publication_status_label(status: CodingMissionPrPublicationStatus) -> &'static str {
+    match status {
+        CodingMissionPrPublicationStatus::ManualReady => "manual_ready",
+        CodingMissionPrPublicationStatus::DraftCreated => "draft_created",
+        CodingMissionPrPublicationStatus::DraftFailed => "draft_failed",
+    }
+}
+
+fn write_json_atomic<T: Serialize + ?Sized>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(value)?;
+    let tmp_path = path.with_extension(format!(
+        "tmp.{}.{}",
+        std::process::id(),
+        NEXT_AUTONOMOUS_CODING_JOB_SEQUENCE.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::write(&tmp_path, json.as_bytes())
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to rename {} to {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::process::Command;
+
+    use serde_json::Value;
+    use tau_agent_core::{coding_mission_state_path, load_coding_mission_state};
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn spec_c01_submit_persists_mission_and_background_record_link() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_with_echo_runner();
+        let submitted = runtime
+            .submit_job(fixture.submit_request(true, Vec::new()))
+            .await
+            .expect("submit job");
+
+        assert!(autonomous_coding_job_record_path(
+            runtime.config().state_dir.as_path(),
+            submitted.record.job_id.as_str()
+        )
+        .exists());
+        assert!(coding_mission_state_path(
+            runtime.config().state_dir.as_path(),
+            submitted.record.mission_id.as_str()
+        )
+        .exists());
+        let background = submitted
+            .background_job
+            .as_ref()
+            .expect("background job linked");
+        assert_eq!(
+            submitted.record.background_job_id.as_deref(),
+            Some(background.job_id.as_str())
+        );
+        assert_eq!(
+            submitted.status.background_job_id.as_deref(),
+            Some(background.job_id.as_str())
+        );
+        assert_eq!(submitted.status.status, AutonomousCodingJobStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn spec_c02_run_applies_multi_file_edits_commits_and_reaches_pr_ready() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let submitted = runtime
+            .submit_job(fixture.submit_request(false, fixture.controlled_edits()))
+            .await
+            .expect("submit job");
+
+        let outcome = runtime
+            .run_or_replay_job(submitted.record.job_id.as_str(), 2_000)
+            .expect("run job");
+
+        assert_eq!(outcome.status.status, AutonomousCodingJobStatus::PrReady);
+        assert_eq!(outcome.status.phase, CodingMissionPhase::PrReady);
+        assert!(outcome
+            .status
+            .changed_files
+            .iter()
+            .any(|file| file == "status.txt"));
+        assert!(outcome
+            .status
+            .changed_files
+            .iter()
+            .any(|file| file == "docs/notes.txt"));
+        assert!(
+            outcome
+                .status
+                .pr_ready_command
+                .as_deref()
+                .unwrap_or_default()
+                .contains("gh pr create --draft"),
+            "missing actionable PR-ready command: {:?}",
+            outcome.status.pr_ready_command
+        );
+
+        let state = load_coding_mission_state(
+            runtime.config().state_dir.as_path(),
+            submitted.record.mission_id.as_str(),
+        )
+        .expect("mission state");
+        assert!(state.pr_ready_bundle.is_some());
+        assert_eq!(
+            git(fixture.repo.path(), &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "codex/autonomous-coding-job-mission-alpha"
+        );
+    }
+
+    #[tokio::test]
+    async fn spec_c03_replay_resumes_checkpoint_after_stale_background_recovery() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_with_echo_runner();
+        let submitted = runtime
+            .submit_job(fixture.submit_request(true, Vec::new()))
+            .await
+            .expect("submit job");
+        let first = runtime
+            .run_or_replay_job(submitted.record.job_id.as_str(), 2_000)
+            .expect("first run");
+        assert_eq!(first.status.phase, CodingMissionPhase::Executing);
+        assert_eq!(first.status.status, AutonomousCodingJobStatus::Running);
+        assert!(first.status.resume_command.contains("mission resume"));
+
+        mark_background_job_stale_running(
+            runtime.config().background_jobs_state_dir.as_path(),
+            submitted
+                .record
+                .background_job_id
+                .as_deref()
+                .expect("background job id"),
+        );
+        let recovery = runtime
+            .recover_stuck_background_jobs()
+            .await
+            .expect("recover stale background job");
+        assert_eq!(recovery.background_report.recovered, 1);
+        assert_eq!(recovery.recovered_jobs.len(), 1);
+        assert_eq!(recovery.recovered_jobs[0].recovery_count, 1);
+
+        let replayed = runtime
+            .replay_job(AutonomousCodingJobReplayRequest {
+                job_id: submitted.record.job_id.clone(),
+                controlled_edits: fixture.controlled_edits(),
+                commit_message: Some("Replay recovered mission to PR ready".to_string()),
+                started_unix_ms: 3_000,
+            })
+            .expect("replay recovered job");
+
+        assert_eq!(replayed.status.status, AutonomousCodingJobStatus::PrReady);
+        assert_eq!(replayed.status.recovery_count, 1);
+        assert!(replayed.status.replay_count >= 1);
+        assert!(
+            replayed.status.verifier_summary.contains("succeeded")
+                || replayed.status.verifier_summary.contains("failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn spec_c04_status_exposes_operator_action_fields() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let submitted = runtime
+            .submit_job(fixture.submit_request(false, fixture.controlled_edits()))
+            .await
+            .expect("submit job");
+        runtime
+            .run_or_replay_job(submitted.record.job_id.as_str(), 2_000)
+            .expect("run job");
+
+        let status = runtime
+            .status(submitted.record.job_id.as_str())
+            .expect("status");
+        assert_eq!(status.job_id, submitted.record.job_id);
+        assert_eq!(status.mission_id, submitted.record.mission_id);
+        assert_eq!(status.phase, CodingMissionPhase::PrReady);
+        assert_ne!(status.verifier_summary, "none");
+        assert!(!status.changed_files.is_empty());
+        assert_ne!(status.resume_command, "none");
+        assert_eq!(status.pr_state, "manual_ready");
+        assert!(status.pr_ready_command.is_some());
+    }
+
+    struct CodingJobFixture {
+        root: TempDir,
+        repo: TempDir,
+    }
+
+    impl CodingJobFixture {
+        fn new() -> Self {
+            let root = TempDir::new().expect("state root");
+            let repo = TempDir::new().expect("repo root");
+            git(repo.path(), &["init", "-b", "master"]);
+            git(repo.path(), &["config", "user.email", "tau@example.test"]);
+            git(repo.path(), &["config", "user.name", "Tau Test"]);
+            std::fs::write(repo.path().join("status.txt"), "fail\n").expect("status");
+            std::fs::create_dir_all(repo.path().join("docs")).expect("docs");
+            std::fs::write(repo.path().join("docs/notes.txt"), "draft\n").expect("notes");
+            git(repo.path(), &["add", "."]);
+            git(repo.path(), &["commit", "-m", "Initial fixture"]);
+            Self { root, repo }
+        }
+
+        fn runtime_without_background(&self) -> AutonomousCodingJobRuntime {
+            AutonomousCodingJobRuntime::new(AutonomousCodingJobRuntimeConfig {
+                state_dir: self.root.path().join("autonomous"),
+                background_jobs_state_dir: self.root.path().join("jobs"),
+                runner_command: PathBuf::from("/bin/echo"),
+                runner_args_prefix: Vec::new(),
+                default_timeout_ms: 5_000,
+                max_timeout_ms: 10_000,
+                worker_poll_ms: 10,
+                stuck_recovery_poll_ms: 0,
+            })
+            .expect("runtime")
+        }
+
+        fn runtime_with_echo_runner(&self) -> AutonomousCodingJobRuntime {
+            AutonomousCodingJobRuntime::new(AutonomousCodingJobRuntimeConfig {
+                state_dir: self.root.path().join("autonomous"),
+                background_jobs_state_dir: self.root.path().join("jobs"),
+                runner_command: PathBuf::from("/bin/echo"),
+                runner_args_prefix: Vec::new(),
+                default_timeout_ms: 5_000,
+                max_timeout_ms: 10_000,
+                worker_poll_ms: 10,
+                stuck_recovery_poll_ms: 0,
+            })
+            .expect("runtime")
+        }
+
+        fn submit_request(
+            &self,
+            enqueue_background_job: bool,
+            controlled_edits: Vec<CodingMissionControlledEdit>,
+        ) -> AutonomousCodingJobSubmitRequest {
+            AutonomousCodingJobSubmitRequest {
+                mission_id: "mission-alpha".to_string(),
+                session_key: "session-alpha".to_string(),
+                repo_path: self.repo.path().to_path_buf(),
+                issue_url: Some("https://github.com/njfio/Tau/issues/3794".to_string()),
+                goal: "Make the verifier pass and prepare PR-ready evidence".to_string(),
+                base_branch: "master".to_string(),
+                branch_prefix: "codex/autonomous-coding-job-".to_string(),
+                verifier_commands: vec![
+                    "grep -q pass status.txt".to_string(),
+                    "grep -q proof docs/notes.txt".to_string(),
+                ],
+                pr_mode: CodingMissionPrMode::PrReady,
+                allowed_roots: vec![self.repo.path().to_path_buf()],
+                controlled_edits,
+                commit_message: "Make autonomous verifier green".to_string(),
+                enqueue_background_job,
+                timeout_ms: Some(5_000),
+                started_unix_ms: 1_000,
+            }
+        }
+
+        fn controlled_edits(&self) -> Vec<CodingMissionControlledEdit> {
+            vec![
+                CodingMissionControlledEdit {
+                    relative_path: PathBuf::from("status.txt"),
+                    contents: "pass\n".to_string(),
+                    reason_code: "controlled_status_fix".to_string(),
+                },
+                CodingMissionControlledEdit {
+                    relative_path: PathBuf::from("docs/notes.txt"),
+                    contents: "proof\n".to_string(),
+                    reason_code: "controlled_notes_fix".to_string(),
+                },
+            ]
+        }
+    }
+
+    fn mark_background_job_stale_running(state_dir: &Path, background_job_id: &str) {
+        let path = state_dir
+            .join("jobs")
+            .join(format!("{background_job_id}.json"));
+        for _ in 0..50 {
+            if path.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let raw = std::fs::read_to_string(&path).expect("background manifest");
+        let mut value: Value = serde_json::from_str(&raw).expect("manifest json");
+        value["status"] = Value::String("running".to_string());
+        value["reason_code"] = Value::String("job_started".to_string());
+        value["started_unix_ms"] = Value::from(1_u64);
+        value["updated_unix_ms"] = Value::from(1_u64);
+        value["finished_unix_ms"] = Value::Null;
+        value["exit_code"] = Value::Null;
+        value["error"] = Value::Null;
+        std::fs::write(
+            path,
+            serde_json::to_string_pretty(&value).expect("serialized manifest"),
+        )
+        .expect("write stale manifest");
+    }
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+}

--- a/crates/tau-runtime/src/lib.rs
+++ b/crates/tau-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! runtime output, observability, and transport health modules reused across
 //! runtimes.
 
+pub mod autonomous_coding_jobs_runtime;
 pub mod background_jobs_runtime;
 pub mod channel_store;
 pub mod external_coding_agent_bridge_runtime;
@@ -19,6 +20,7 @@ pub mod transport_conformance_runtime;
 pub mod transport_health;
 pub mod wasm_sandbox_runtime;
 
+pub use autonomous_coding_jobs_runtime::*;
 pub use background_jobs_runtime::*;
 pub use channel_store::*;
 pub use external_coding_agent_bridge_runtime::*;

--- a/docs/guides/autonomous-coding-jobs.md
+++ b/docs/guides/autonomous-coding-jobs.md
@@ -1,0 +1,77 @@
+# Autonomous Coding Jobs
+
+Tau autonomous coding jobs link a durable job record, a `CodingMissionRunner`
+state file, and the background-job recovery runtime. The first product loop is
+bounded: operators provide the repo, issue/spec context, verifier commands, and
+controlled edits; Tau runs/replays the mission until it is blocked or PR-ready.
+
+## State Layout
+
+- Autonomous job records:
+  `.tau/autonomous-coding/autonomous-coding-jobs/<job-id>.json`
+- Operator status snapshots:
+  `.tau/autonomous-coding/autonomous-coding-jobs/<job-id>.status.json`
+- Mission state:
+  `.tau/autonomous-coding/coding-missions/<mission-id>.json`
+- Background job state:
+  `.tau/jobs`
+
+## CLI
+
+Submit a job:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- submit \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --repo-path /path/to/repo \
+  --mission-id issue-123 \
+  --issue-url https://github.com/owner/repo/issues/123 \
+  --goal "Make the spec verifier pass" \
+  --verifier-command "cargo test -p some-crate spec_c01" \
+  --edit "src/example.rs=updated contents" \
+  --commit-message "Make verifier green"
+```
+
+Run or resume the job:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- run \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --job-id <job-id>
+```
+
+Replay a checkpoint with updated edits:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- replay \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --job-id <job-id> \
+  --edit "src/example.rs=updated contents"
+```
+
+Inspect operator status:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- status \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --job-id <job-id>
+```
+
+Run stuck background-job recovery and refresh linked autonomous jobs:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- recover \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs
+```
+
+## Boundaries
+
+This loop prepares PR-ready evidence and can create a draft PR when the mission
+state is configured for draft PR mode and GitHub auth exists in the environment.
+It does not automatically merge protected branches, and it does not claim
+arbitrary issue solving without verifier commands and bounded edit authority.

--- a/scripts/dev/test-autonomous-coding-job-loop.sh
+++ b/scripts/dev/test-autonomous-coding-job-loop.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/rust_pi-3794-target}"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tau-autonomous-coding-job.XXXXXX")"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+export CARGO_TARGET_DIR="${TARGET_DIR}"
+
+run_cli() {
+  cargo run -q -p tau-coding-agent --bin tau_autonomous_coding_job -- "$@"
+}
+
+init_fixture_repo() {
+  local repo="$1"
+  mkdir -p "${repo}/docs"
+  git -C "${repo}" init -b master >/dev/null
+  git -C "${repo}" config user.email tau@example.test
+  git -C "${repo}" config user.name "Tau Test"
+  printf 'fail\n' >"${repo}/status.txt"
+  printf 'draft\n' >"${repo}/docs/notes.txt"
+  git -C "${repo}" add .
+  git -C "${repo}" commit -m "Initial fixture" >/dev/null
+}
+
+extract_json_field() {
+  local path="$1"
+  local expr="$2"
+  python3 - "$path" "$expr" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+value = payload
+for part in sys.argv[2].split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+assert_status_pr_ready() {
+  local status_path="$1"
+  python3 - "$status_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    status = json.load(handle)
+
+assert status["status"] == "pr_ready", status
+assert status["phase"] == "pr_ready", status
+assert status["pr_state"] == "manual_ready", status
+assert "gh pr create --draft" in status.get("pr_ready_command", ""), status
+assert "status.txt" in status["changed_files"], status
+assert "docs/notes.txt" in status["changed_files"], status
+assert status["verifier_summary"].startswith("succeeded:"), status
+PY
+}
+
+cd "${REPO_ROOT}"
+
+DIRECT_REPO="${WORK_DIR}/direct-repo"
+DIRECT_STATE="${WORK_DIR}/direct-state"
+DIRECT_JOBS="${WORK_DIR}/direct-jobs"
+mkdir -p "${DIRECT_REPO}"
+init_fixture_repo "${DIRECT_REPO}"
+
+run_cli submit \
+  --state-dir "${DIRECT_STATE}" \
+  --jobs-state-dir "${DIRECT_JOBS}" \
+  --repo-path "${DIRECT_REPO}" \
+  --mission-id direct-mission \
+  --session-key script-direct \
+  --issue-url https://github.com/njfio/Tau/issues/3794 \
+  --goal "Make direct autonomous coding verifier pass" \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q proof docs/notes.txt" \
+  --edit "status.txt=pass" \
+  --edit "docs/notes.txt=proof" \
+  --commit-message "Make direct autonomous verifier green" \
+  >"${WORK_DIR}/direct-submit.json"
+
+DIRECT_JOB_ID="$(extract_json_field "${WORK_DIR}/direct-submit.json" "record.job_id")"
+run_cli run \
+  --state-dir "${DIRECT_STATE}" \
+  --jobs-state-dir "${DIRECT_JOBS}" \
+  --job-id "${DIRECT_JOB_ID}" \
+  >"${WORK_DIR}/direct-run.json"
+run_cli status \
+  --state-dir "${DIRECT_STATE}" \
+  --jobs-state-dir "${DIRECT_JOBS}" \
+  --job-id "${DIRECT_JOB_ID}" \
+  >"${WORK_DIR}/direct-status.json"
+assert_status_pr_ready "${WORK_DIR}/direct-status.json"
+
+REPLAY_REPO="${WORK_DIR}/replay-repo"
+REPLAY_STATE="${WORK_DIR}/replay-state"
+REPLAY_JOBS="${WORK_DIR}/replay-jobs"
+mkdir -p "${REPLAY_REPO}"
+init_fixture_repo "${REPLAY_REPO}"
+
+run_cli submit \
+  --state-dir "${REPLAY_STATE}" \
+  --jobs-state-dir "${REPLAY_JOBS}" \
+  --repo-path "${REPLAY_REPO}" \
+  --mission-id replay-mission \
+  --session-key script-replay \
+  --issue-url https://github.com/njfio/Tau/issues/3794 \
+  --goal "Replay autonomous coding checkpoint to PR ready" \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q proof docs/notes.txt" \
+  --commit-message "Prepare replay checkpoint" \
+  >"${WORK_DIR}/replay-submit.json"
+
+REPLAY_JOB_ID="$(extract_json_field "${WORK_DIR}/replay-submit.json" "record.job_id")"
+run_cli run \
+  --state-dir "${REPLAY_STATE}" \
+  --jobs-state-dir "${REPLAY_JOBS}" \
+  --job-id "${REPLAY_JOB_ID}" \
+  >"${WORK_DIR}/replay-waiting.json"
+python3 - "${WORK_DIR}/replay-waiting.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+status = payload["status"]
+assert status["phase"] == "executing", status
+assert status["status"] == "running", status
+assert status["reason_code"] == "autonomous_coding_job_waiting_for_controlled_edit", status
+assert "mission resume" in status["resume_command"], status
+PY
+
+run_cli replay \
+  --state-dir "${REPLAY_STATE}" \
+  --jobs-state-dir "${REPLAY_JOBS}" \
+  --job-id "${REPLAY_JOB_ID}" \
+  --edit "status.txt=pass" \
+  --edit "docs/notes.txt=proof" \
+  --commit-message "Replay autonomous verifier green" \
+  >"${WORK_DIR}/replay-run.json"
+run_cli status \
+  --state-dir "${REPLAY_STATE}" \
+  --jobs-state-dir "${REPLAY_JOBS}" \
+  --job-id "${REPLAY_JOB_ID}" \
+  >"${WORK_DIR}/replay-status.json"
+assert_status_pr_ready "${WORK_DIR}/replay-status.json"
+
+printf 'autonomous_coding_job_loop=pass\n'
+printf 'direct_job_id=%s\n' "${DIRECT_JOB_ID}"
+printf 'replay_job_id=%s\n' "${REPLAY_JOB_ID}"

--- a/specs/3794-durable-autonomous-coding-job-loop/plan.md
+++ b/specs/3794-durable-autonomous-coding-job-loop/plan.md
@@ -1,0 +1,62 @@
+# Plan: Durable Autonomous Coding Job Loop
+
+GitHub Issue: #3794
+Status: Implemented
+
+## Approach
+
+Add a new `tau-runtime` autonomous coding job module that composes existing
+building blocks:
+
+- `CodingMissionState` and `CodingMissionRunner` remain the source of truth for
+  branch, verifier, resume, commit, and PR-ready behavior.
+- `BackgroundJobRuntime` remains the durable queue, timeout, restart-recovery,
+  and stuck-recovery substrate.
+- The new autonomous job record links those two records and stores the operator
+  summary needed to inspect or replay work.
+
+Add a small `tau-autonomous-coding-job` binary in `tau-coding-agent` for
+operator/test use:
+
+- `submit`: create mission/job records and enqueue a background job that calls
+  the same binary's `run` command.
+- `run`: run or replay a mission until it reaches `pr_ready` or a true blocker.
+- `status`: print the persisted operator status JSON.
+- `recover`: invoke the existing background-job stuck recovery sweep and refresh
+  the autonomous status.
+- `replay`: explicitly resume a mission checkpoint without requiring a queue
+  event.
+
+## Affected Modules
+
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs`
+- `crates/tau-runtime/src/lib.rs`
+- `crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs`
+- `scripts/dev/test-autonomous-coding-job-loop.sh`
+- `specs/3794-durable-autonomous-coding-job-loop/*`
+
+## Risks And Mitigations
+
+- Risk: duplicating mission state logic. Mitigation: delegate all branch,
+  verifier, edit, commit, and PR-ready work to `CodingMissionRunner` and
+  `CodingMissionState`.
+- Risk: overstating arbitrary autonomy. Mitigation: require verifier commands
+  and bounded controlled edits in this slice; status reports PR-ready handoff,
+  not automatic merge.
+- Risk: background worker races in tests. Mitigation: runtime unit tests call
+  the autonomous runner directly; CLI proof uses a disposable repo and explicit
+  status polling.
+
+## Interfaces
+
+- Autonomous job JSON records live under
+  `<state-dir>/autonomous-coding-jobs/<job-id>.json`.
+- Operator status snapshots live under
+  `<state-dir>/autonomous-coding-jobs/<job-id>.status.json`.
+- Mission state remains under `<state-dir>/coding-missions/<mission-id>.json`.
+- Background job state remains under the configured background jobs state dir.
+
+## ADR
+
+No new ADR: this composes existing mission and background-job architecture and
+does not introduce new dependencies, protocols, or scheduler semantics.

--- a/specs/3794-durable-autonomous-coding-job-loop/spec.md
+++ b/specs/3794-durable-autonomous-coding-job-loop/spec.md
@@ -1,0 +1,80 @@
+# Issue #3794: Durable Autonomous Coding Job Loop
+
+Status: Implemented
+GitHub Issue: #3794
+Priority: P1
+Milestone: M334 - Tau Ralph loop supervisor architecture
+
+## Problem
+
+Tau can run coding missions and durable background jobs, but the product path
+does not yet combine them into one recoverable issue-to-PR loop. A coding task
+should be submitted as a durable job, preserve mission checkpoints, recover
+from stale `running` background-job manifests, replay the mission from the last
+checkpoint, and expose operator-readable status through stable files/JSON.
+
+## Scope
+
+In scope:
+- Add a reusable autonomous coding job runtime that owns the durable job record
+  and delegates execution to `CodingMissionRunner`.
+- Submit coding jobs with repo, issue, verifier commands, controlled edits, and
+  PR mode metadata.
+- Queue the coding job through the existing background-job runtime.
+- Replay/resume mission checkpoints after recovery.
+- Persist status snapshots with mission phase, verifier state, changed files,
+  resume command, and PR-ready handoff evidence.
+- Add a dedicated CLI binary for submit/run/status/recover/replay validation.
+
+Out of scope:
+- Full arbitrary model planning over any issue without bounded inputs.
+- Automatic merge to protected branches.
+- Replacing `tau-unified` with a new command center in this slice.
+- New scheduler crates or new third-party dependencies.
+
+## Acceptance Criteria
+
+### AC-1: Durable Submit
+
+Given a repo path, issue URL, verifier commands, and controlled edits, when an
+autonomous coding job is submitted, then Tau persists a coding mission state, an
+autonomous job record, and a background-job record that points back to the
+mission.
+
+### AC-2: Multi-File Coding Execution
+
+Given a submitted job whose verifier fails until two files are changed, when
+the autonomous job runner executes, then it applies the controlled multi-file
+edit, reruns verifiers, commits the change, prepares PR-ready evidence, and
+marks the job `pr_ready`.
+
+### AC-3: Recovery Replays Mission Checkpoints
+
+Given a mission has a replay checkpoint and the background-job manifest is
+recovered from stale `running`, when the recovered job runs, then it resumes
+from the mission checkpoint and preserves earlier verifier evidence instead of
+starting over silently.
+
+### AC-4: Operator Status Is Complete Enough To Act
+
+Given an autonomous coding job has run or recovered, when status is inspected,
+then JSON/status files expose the background job id, mission id, phase, verifier
+summary, changed files, resume command, PR-ready command, PR URL if present,
+recovery count, replay count, and last reason code.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Conformance | temp repo, verifier commands, controlled edits | submit runs | mission/job/background records exist and are linked |
+| C-02 | AC-2 | Functional | verifier requires `status.txt` and `docs/notes.txt` edits | run/replay executes | mission reaches `pr_ready`, commit exists, changed files include both files |
+| C-03 | AC-3 | Regression | mission checkpoint plus stale recovered background manifest | recover and replay run | recovery count increments and mission resumes to `pr_ready` |
+| C-04 | AC-4 | Conformance | completed or blocked autonomous coding job | status runs | JSON includes actionable operator fields with no missing ids |
+
+## Success Signals
+
+- Focused runtime tests pass for the autonomous coding job runtime.
+- Dedicated CLI integration script passes over a disposable git repo.
+- Existing background-job recovery tests remain green.
+- `tau-unified status` can continue reading mission snapshots without schema
+  breakage.

--- a/specs/3794-durable-autonomous-coding-job-loop/tasks.md
+++ b/specs/3794-durable-autonomous-coding-job-loop/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Durable Autonomous Coding Job Loop
+
+GitHub Issue: #3794
+Status: Implemented
+
+- [x] T1 (RED): Add failing runtime tests for durable submit, multi-file run,
+  replay/resume, and status payload fields.
+- [x] T2 (GREEN): Implement the autonomous coding job runtime and persisted
+  record/status schema.
+- [x] T3 (GREEN): Add the dedicated CLI binary with submit/run/status/recover
+  and replay commands.
+- [x] T4 (GREEN): Add a disposable-repo integration script that proves the
+  full submit -> run/replay -> PR-ready loop.
+- [x] T5 (VERIFY): Run focused cargo tests, CLI integration script, fmt, diff
+  check, and clippy for touched crates.
+
+## TDD Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` failed with all four #3794 tests hitting `todo!("submit durable autonomous coding job")`.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passed after implementing submit, run/replay, recovery, and status snapshots.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target scripts/dev/test-autonomous-coding-job-loop.sh` passed and printed `autonomous_coding_job_loop=pass`.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-coding-agent --bin tau_autonomous_coding_job -- --test-threads=1` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo clippy -p tau-runtime --lib --tests -- -D warnings` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings` passed.
+- VERIFY: `cargo fmt --check` and `git diff --check` passed.
+
+## Test Tiers
+
+| Tier | Status | Tests | N/A Why |
+| --- | --- | --- | --- |
+| Unit | PASS | `tau-runtime` autonomous coding job tests | |
+| Property | N/A | | No randomized parser or invariant introduced in this slice |
+| Contract/DbC | N/A | | No formal contract macro surface changed |
+| Snapshot | N/A | | Status JSON uses field assertions rather than snapshots |
+| Functional | PASS | Multi-file run to PR-ready | |
+| Conformance | PASS | C-01..C-04 runtime and CLI coverage | |
+| Integration | PASS | `scripts/dev/test-autonomous-coding-job-loop.sh` | |
+| Fuzz | N/A | | No untrusted parser/fuzz target changed |
+| Mutation | N/A | | Follow-up for release gate; this slice uses focused regression coverage |
+| Regression | PASS | Recovery/replay checkpoint test | |
+| Performance | N/A | | No hot path or benchmarked runtime changed |


### PR DESCRIPTION
## Summary
Adds a durable autonomous coding job runtime that links `CodingMissionRunner` state with the existing background-job recovery runtime. Adds `tau_autonomous_coding_job` for submit/run/replay/status/recover, a disposable-repo integration proof, and operator docs.

## Links
Milestone: M334 - Tau Ralph loop supervisor architecture
Closes #3794
Spec: `specs/3794-durable-autonomous-coding-job-loop/spec.md`
Plan: `specs/3794-durable-autonomous-coding-job-loop/plan.md`
Tasks: `specs/3794-durable-autonomous-coding-job-loop/tasks.md`

P1 note: spec is marked Reviewed/Implemented and this PR should receive human review before merge.

## Spec Verification
| AC | Status | Test(s) |
|---|---|---|
| AC-1: Durable submit persists mission, autonomous job, and background job link | ✅ | `spec_c01_submit_persists_mission_and_background_record_link` |
| AC-2: Multi-file coding execution reaches PR-ready | ✅ | `spec_c02_run_applies_multi_file_edits_commits_and_reaches_pr_ready`; `scripts/dev/test-autonomous-coding-job-loop.sh` |
| AC-3: Recovery replays mission checkpoints | ✅ | `spec_c03_replay_resumes_checkpoint_after_stale_background_recovery`; CLI replay path in script |
| AC-4: Operator status exposes actionable fields | ✅ | `spec_c04_status_exposes_operator_action_fields`; CLI `status` assertions in script |

## TDD Evidence
RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` failed with all four tests hitting `todo!("submit durable autonomous coding job")`.

GREEN:
- `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target scripts/dev/test-autonomous-coding-job-loop.sh` printed `autonomous_coding_job_loop=pass`

VERIFY:
- `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo test -p tau-coding-agent --bin tau_autonomous_coding_job -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3794-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Test Tiers
| Tier | Status | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `tau-runtime` autonomous coding job tests | |
| Property | N/A | | No randomized parser or invariant introduced |
| Contract/DbC | N/A | | No formal contract macro surface changed |
| Snapshot | N/A | | Status JSON uses field assertions instead |
| Functional | ✅ | Multi-file run to PR-ready | |
| Conformance | ✅ | C-01..C-04 runtime and CLI coverage | |
| Integration | ✅ | `scripts/dev/test-autonomous-coding-job-loop.sh` | |
| Fuzz | N/A | | No untrusted parser/fuzz target changed |
| Mutation | N/A | | Follow-up for release gate; focused regression coverage in this slice |
| Regression | ✅ | Recovery/replay checkpoint test | |
| Performance | N/A | | No hot path or benchmarked runtime changed |

## Mutation
N/A for this slice; no release-critical algorithm gate was changed.

## Risks/Rollback
Risk: this introduces a new runtime wrapper and CLI surface, but it composes existing mission/background primitives rather than replacing them. Rollback: revert this PR; existing `CodingMissionRunner` and background-job behavior remain untouched.

## Docs/ADR
Docs: `docs/guides/autonomous-coding-jobs.md`
ADR: N/A; no new dependency, protocol, or scheduler decision.

## Boundaries
This prepares PR-ready evidence and can create draft PRs when configured/authenticated through mission PR mode. It does not automatically merge protected branches and does not claim arbitrary issue solving without verifier commands and bounded edit authority.