### PR TITLE
Guard autonomous coding auto-merge authority

### DIFF
--- a/crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs
+++ b/crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs
@@ -15,8 +15,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde_json::json;
 use tau_agent_core::{CodingMissionControlledEdit, CodingMissionPrMode};
 use tau_runtime::{
+    AutonomousCodingAutoMergeRequest, AutonomousCodingIssueIntakeRequest,
     AutonomousCodingJobReplayRequest, AutonomousCodingJobRuntime, AutonomousCodingJobRuntimeConfig,
-    AutonomousCodingJobSubmitRequest,
+    AutonomousCodingJobSubmitRequest, AutonomousCodingMergeMethod,
 };
 
 #[derive(Debug, Parser)]
@@ -41,6 +42,12 @@ enum Command {
     Status(Box<JobStatusArgs>),
     /// Run the background-job stuck recovery sweep and refresh linked jobs.
     Recover(Box<JobRecoverArgs>),
+    /// Request GitHub auto-merge for a PR-ready autonomous coding job.
+    AutoMerge(Box<JobAutoMergeArgs>),
+    /// Ingest an arbitrary issue without verifier/edit authority.
+    IntakeIssue(Box<IssueIntakeArgs>),
+    /// Emit a persisted issue-intake authority plan.
+    IntakeStatus(Box<IssueIntakeStatusArgs>),
 }
 
 #[derive(Debug, Parser)]
@@ -118,6 +125,52 @@ struct JobRecoverArgs {
     runtime: RuntimeArgs,
 }
 
+#[derive(Debug, Parser)]
+struct JobAutoMergeArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    job_id: String,
+    #[arg(long)]
+    allow_auto_merge: bool,
+    #[arg(long, value_enum, default_value = "squash")]
+    merge_method: MergeMethodArg,
+    #[arg(long)]
+    delete_branch: bool,
+    #[arg(long)]
+    gh_binary: Option<PathBuf>,
+    #[arg(long)]
+    started_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+struct IssueIntakeArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    intake_id: String,
+    #[arg(long)]
+    issue_url: String,
+    #[arg(long)]
+    issue_title: String,
+    #[arg(long)]
+    issue_body: String,
+    #[arg(long)]
+    repo_path: PathBuf,
+    #[arg(long, default_value = "master")]
+    base_branch: String,
+    #[arg(long)]
+    started_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+struct IssueIntakeStatusArgs {
+    #[command(flatten)]
+    runtime: RuntimeArgs,
+    #[arg(long)]
+    intake_id: String,
+}
+
 #[derive(Debug, Clone, Parser)]
 struct RuntimeArgs {
     #[arg(long, default_value = ".tau/autonomous-coding")]
@@ -134,6 +187,13 @@ enum PrModeArg {
     #[value(name = "pr-ready")]
     PrReady,
     Draft,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum MergeMethodArg {
+    Merge,
+    Squash,
+    Rebase,
 }
 
 #[tokio::main]
@@ -219,6 +279,41 @@ async fn run(args: Args) -> Result<()> {
                 "recovered_jobs": outcome.recovered_jobs,
             }))?;
         }
+        Command::AutoMerge(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome = runtime.request_auto_merge(AutonomousCodingAutoMergeRequest {
+                job_id: args.job_id,
+                allow_auto_merge: args.allow_auto_merge,
+                merge_method: args.merge_method.into(),
+                delete_branch: args.delete_branch,
+                github_env: github_env_from_process(),
+                gh_binary: args.gh_binary,
+                started_unix_ms: args.started_unix_ms.unwrap_or_else(now_unix_ms),
+            })?;
+            print_json(&outcome)?;
+        }
+        Command::IntakeIssue(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome =
+                runtime.intake_issue_without_authority(AutonomousCodingIssueIntakeRequest {
+                    intake_id: args.intake_id,
+                    issue_url: args.issue_url,
+                    issue_title: args.issue_title,
+                    issue_body: args.issue_body,
+                    repo_path: args.repo_path,
+                    base_branch: args.base_branch,
+                    started_unix_ms: args.started_unix_ms.unwrap_or_else(now_unix_ms),
+                })?;
+            print_json(&outcome)?;
+        }
+        Command::IntakeStatus(args) => {
+            let args = *args;
+            let runtime = runtime_from_args(&args.runtime)?;
+            let outcome = runtime.issue_intake_status(args.intake_id.as_str())?;
+            print_json(&outcome)?;
+        }
     }
     Ok(())
 }
@@ -269,12 +364,34 @@ fn now_unix_ms() -> u64 {
         .unwrap_or_default()
 }
 
+fn github_env_from_process() -> std::collections::BTreeMap<String, String> {
+    ["GH_TOKEN", "GITHUB_TOKEN"]
+        .into_iter()
+        .filter_map(|key| {
+            std::env::var(key)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| (key.to_string(), value))
+        })
+        .collect()
+}
+
 impl From<PrModeArg> for CodingMissionPrMode {
     fn from(value: PrModeArg) -> Self {
         match value {
             PrModeArg::Disabled => Self::Disabled,
             PrModeArg::PrReady => Self::PrReady,
             PrModeArg::Draft => Self::Draft,
+        }
+    }
+}
+
+impl From<MergeMethodArg> for AutonomousCodingMergeMethod {
+    fn from(value: MergeMethodArg) -> Self {
+        match value {
+            MergeMethodArg::Merge => Self::Merge,
+            MergeMethodArg::Squash => Self::Squash,
+            MergeMethodArg::Rebase => Self::Rebase,
         }
     }
 }

--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    process::Command,
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -110,6 +111,109 @@ pub struct AutonomousCodingJobReplayRequest {
     pub started_unix_ms: u64,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousCodingMergeMethod {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+impl AutonomousCodingMergeMethod {
+    fn gh_flag(self) -> &'static str {
+        match self {
+            Self::Merge => "--merge",
+            Self::Squash => "--squash",
+            Self::Rebase => "--rebase",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousCodingAutoMergeStatus {
+    Requested,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingAutoMergeRequest {
+    pub job_id: String,
+    pub allow_auto_merge: bool,
+    pub merge_method: AutonomousCodingMergeMethod,
+    pub delete_branch: bool,
+    #[serde(default)]
+    pub github_env: BTreeMap<String, String>,
+    #[serde(default)]
+    pub gh_binary: Option<PathBuf>,
+    pub started_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingAutoMergeEvidence {
+    pub status: AutonomousCodingAutoMergeStatus,
+    pub reason_code: String,
+    pub pr_url: Option<String>,
+    pub command_argv: Vec<String>,
+    #[serde(default)]
+    pub stdout_path: Option<PathBuf>,
+    #[serde(default)]
+    pub stderr_path: Option<PathBuf>,
+    #[serde(default)]
+    pub exit_status: Option<i32>,
+    #[serde(default)]
+    pub error_summary: Option<String>,
+    pub created_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingAutoMergeOutcome {
+    pub record: AutonomousCodingJobRecord,
+    pub status: AutonomousCodingJobStatusSnapshot,
+    pub evidence: AutonomousCodingAutoMergeEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingIssueIntakeRequest {
+    pub intake_id: String,
+    pub issue_url: String,
+    pub issue_title: String,
+    pub issue_body: String,
+    pub repo_path: PathBuf,
+    pub base_branch: String,
+    pub started_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomousCodingIssueIntakeStatus {
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingAuthorityRequirement {
+    pub reason_code: String,
+    pub summary: String,
+    pub required_input: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomousCodingIssueIntakeOutcome {
+    pub schema_version: u32,
+    pub intake_id: String,
+    pub status: AutonomousCodingIssueIntakeStatus,
+    pub reason_code: String,
+    pub issue_url: String,
+    pub issue_title: String,
+    pub issue_body_summary: String,
+    pub repo_path: PathBuf,
+    pub base_branch: String,
+    pub required_authority: Vec<AutonomousCodingAuthorityRequirement>,
+    pub created_unix_ms: u64,
+    pub updated_unix_ms: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AutonomousCodingJobRecord {
     pub schema_version: u32,
@@ -137,6 +241,8 @@ pub struct AutonomousCodingJobRecord {
     pub last_background_reason_code: Option<String>,
     #[serde(default)]
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub auto_merge_evidence: Option<AutonomousCodingAutoMergeEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -166,6 +272,14 @@ pub struct AutonomousCodingJobStatusSnapshot {
     pub last_background_reason_code: Option<String>,
     #[serde(default)]
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub auto_merge_status: Option<String>,
+    #[serde(default)]
+    pub auto_merge_reason_code: Option<String>,
+    #[serde(default)]
+    pub auto_merge_command: Option<String>,
+    #[serde(default)]
+    pub auto_merge_pr_url: Option<String>,
     #[serde(default)]
     pub metadata: BTreeMap<String, String>,
 }
@@ -261,6 +375,7 @@ impl AutonomousCodingJobRuntime {
             replay_count: 0,
             last_background_reason_code: None,
             last_error: None,
+            auto_merge_evidence: None,
         };
 
         let mut background_job = None;
@@ -349,6 +464,208 @@ impl AutonomousCodingJobRuntime {
     pub fn status(&self, job_id: &str) -> Result<AutonomousCodingJobStatusSnapshot> {
         let record = load_autonomous_coding_job_record(&self.config.state_dir, job_id)?;
         self.refresh_status_snapshot(&record)
+    }
+
+    pub fn request_auto_merge(
+        &self,
+        request: AutonomousCodingAutoMergeRequest,
+    ) -> Result<AutonomousCodingAutoMergeOutcome> {
+        let mut record =
+            load_autonomous_coding_job_record(&self.config.state_dir, &request.job_id)?;
+        let state = load_coding_mission_state(&record.state_root, &record.mission_id)?;
+        let status = build_status_snapshot(&record, &state);
+
+        if !request.allow_auto_merge {
+            return self.block_auto_merge(
+                record,
+                "auto_merge_policy_disabled",
+                "auto-merge policy is disabled for this request",
+                status.pr_url,
+                request.started_unix_ms,
+            );
+        }
+        if record.status != AutonomousCodingJobStatus::PrReady
+            || state.phase != CodingMissionPhase::PrReady
+        {
+            return self.block_auto_merge(
+                record,
+                "auto_merge_job_not_pr_ready",
+                "job must be pr_ready before auto-merge can be requested",
+                status.pr_url,
+                request.started_unix_ms,
+            );
+        }
+        let Some(pr_url) = status.pr_url.clone() else {
+            return self.block_auto_merge(
+                record,
+                "auto_merge_missing_pr_url",
+                "PR URL is required before auto-merge can be requested",
+                None,
+                request.started_unix_ms,
+            );
+        };
+        if !github_auth_present_for_auto_merge(&request.github_env) {
+            return self.block_auto_merge(
+                record,
+                "auto_merge_missing_github_auth",
+                "GH_TOKEN or GITHUB_TOKEN is required for auto-merge",
+                Some(pr_url),
+                request.started_unix_ms,
+            );
+        }
+
+        let gh_binary = request.gh_binary.unwrap_or_else(|| PathBuf::from("gh"));
+        let mut argv = vec![
+            "pr".to_string(),
+            "merge".to_string(),
+            pr_url.clone(),
+            "--auto".to_string(),
+            request.merge_method.gh_flag().to_string(),
+        ];
+        if request.delete_branch {
+            argv.push("--delete-branch".to_string());
+        }
+        debug_assert!(!argv.iter().any(|arg| arg == "--admin"));
+
+        let artifact_dir = autonomous_coding_job_artifact_dir(&record.state_root, &record.job_id);
+        std::fs::create_dir_all(&artifact_dir)?;
+        let stdout_path = artifact_dir.join("auto-merge.stdout.log");
+        let stderr_path = artifact_dir.join("auto-merge.stderr.log");
+        let output = Command::new(&gh_binary)
+            .args(&argv)
+            .envs(&request.github_env)
+            .current_dir(&record.repo_path)
+            .output();
+
+        let evidence = match output {
+            Ok(output) => {
+                std::fs::write(&stdout_path, &output.stdout)?;
+                std::fs::write(&stderr_path, &output.stderr)?;
+                if output.status.success() {
+                    AutonomousCodingAutoMergeEvidence {
+                        status: AutonomousCodingAutoMergeStatus::Requested,
+                        reason_code: "auto_merge_requested".to_string(),
+                        pr_url: Some(pr_url),
+                        command_argv: auto_merge_command_argv(&gh_binary, &argv),
+                        stdout_path: Some(stdout_path),
+                        stderr_path: Some(stderr_path),
+                        exit_status: output.status.code(),
+                        error_summary: None,
+                        created_unix_ms: request.started_unix_ms,
+                    }
+                } else {
+                    AutonomousCodingAutoMergeEvidence {
+                        status: AutonomousCodingAutoMergeStatus::Failed,
+                        reason_code: "auto_merge_command_failed".to_string(),
+                        pr_url: Some(pr_url),
+                        command_argv: auto_merge_command_argv(&gh_binary, &argv),
+                        stdout_path: Some(stdout_path),
+                        stderr_path: Some(stderr_path),
+                        exit_status: output.status.code(),
+                        error_summary: Some(format!(
+                            "gh pr merge exited with status {}",
+                            output.status.code().unwrap_or(-1)
+                        )),
+                        created_unix_ms: request.started_unix_ms,
+                    }
+                }
+            }
+            Err(error) => AutonomousCodingAutoMergeEvidence {
+                status: AutonomousCodingAutoMergeStatus::Failed,
+                reason_code: "auto_merge_command_spawn_failed".to_string(),
+                pr_url: Some(pr_url),
+                command_argv: auto_merge_command_argv(&gh_binary, &argv),
+                stdout_path: None,
+                stderr_path: None,
+                exit_status: None,
+                error_summary: Some(error.to_string()),
+                created_unix_ms: request.started_unix_ms,
+            },
+        };
+
+        record.reason_code = evidence.reason_code.clone();
+        record.updated_unix_ms = request.started_unix_ms;
+        record.auto_merge_evidence = Some(evidence.clone());
+        persist_autonomous_coding_job_record(&record)?;
+        let status = self.refresh_status_snapshot(&record)?;
+        Ok(AutonomousCodingAutoMergeOutcome {
+            record,
+            status,
+            evidence,
+        })
+    }
+
+    pub fn intake_issue_without_authority(
+        &self,
+        request: AutonomousCodingIssueIntakeRequest,
+    ) -> Result<AutonomousCodingIssueIntakeOutcome> {
+        ensure_autonomous_coding_job_layout(&self.config.state_dir)?;
+        let repo_path = canonicalize_existing_dir(request.repo_path.as_path())?;
+        let outcome = AutonomousCodingIssueIntakeOutcome {
+            schema_version: AUTONOMOUS_CODING_JOB_SCHEMA_VERSION,
+            intake_id: request.intake_id,
+            status: AutonomousCodingIssueIntakeStatus::Blocked,
+            reason_code: "issue_intake_authority_required".to_string(),
+            issue_url: request.issue_url,
+            issue_title: request.issue_title,
+            issue_body_summary: summarize_issue_body(&request.issue_body),
+            repo_path,
+            base_branch: request.base_branch,
+            required_authority: vec![
+                AutonomousCodingAuthorityRequirement {
+                    reason_code: "verifier_authority_required".to_string(),
+                    summary: "A verifier command or acceptance test must be provided before code can be changed.".to_string(),
+                    required_input: "--verifier-command or spec-derived test command".to_string(),
+                },
+                AutonomousCodingAuthorityRequirement {
+                    reason_code: "edit_authority_required".to_string(),
+                    summary: "An edit plan, provider edit authority, or controlled edit set must be provided before mutation.".to_string(),
+                    required_input: "--edit, provider edit plan, or approved mutation authority".to_string(),
+                },
+            ],
+            created_unix_ms: request.started_unix_ms,
+            updated_unix_ms: request.started_unix_ms,
+        };
+        persist_autonomous_coding_issue_intake(&self.config.state_dir, &outcome)?;
+        Ok(outcome)
+    }
+
+    pub fn issue_intake_status(
+        &self,
+        intake_id: &str,
+    ) -> Result<AutonomousCodingIssueIntakeOutcome> {
+        load_autonomous_coding_issue_intake(&self.config.state_dir, intake_id)
+    }
+
+    fn block_auto_merge(
+        &self,
+        mut record: AutonomousCodingJobRecord,
+        reason_code: &str,
+        error_summary: &str,
+        pr_url: Option<String>,
+        started_unix_ms: u64,
+    ) -> Result<AutonomousCodingAutoMergeOutcome> {
+        let evidence = AutonomousCodingAutoMergeEvidence {
+            status: AutonomousCodingAutoMergeStatus::Blocked,
+            reason_code: reason_code.to_string(),
+            pr_url,
+            command_argv: Vec::new(),
+            stdout_path: None,
+            stderr_path: None,
+            exit_status: None,
+            error_summary: Some(error_summary.to_string()),
+            created_unix_ms: started_unix_ms,
+        };
+        record.reason_code = reason_code.to_string();
+        record.updated_unix_ms = started_unix_ms;
+        record.auto_merge_evidence = Some(evidence.clone());
+        persist_autonomous_coding_job_record(&record)?;
+        let status = self.refresh_status_snapshot(&record)?;
+        Ok(AutonomousCodingAutoMergeOutcome {
+            record,
+            status,
+            evidence,
+        })
     }
 
     fn execute_job(
@@ -541,9 +858,20 @@ pub fn autonomous_coding_job_status_path(state_dir: &Path, job_id: &str) -> Path
         .join(format!("{job_id}.status.json"))
 }
 
+pub fn autonomous_coding_issue_intake_path(state_dir: &Path, intake_id: &str) -> PathBuf {
+    state_dir
+        .join("issue-intake")
+        .join(format!("{intake_id}.json"))
+}
+
+fn autonomous_coding_job_artifact_dir(state_dir: &Path, job_id: &str) -> PathBuf {
+    state_dir.join("autonomous-coding-jobs").join(job_id)
+}
+
 fn ensure_autonomous_coding_job_layout(state_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(state_dir.join("autonomous-coding-jobs"))?;
     std::fs::create_dir_all(state_dir.join("coding-missions"))?;
+    std::fs::create_dir_all(state_dir.join("issue-intake"))?;
     Ok(())
 }
 
@@ -573,6 +901,34 @@ fn persist_autonomous_coding_job_status(
 ) -> Result<()> {
     let path = autonomous_coding_job_status_path(state_dir, &status.job_id);
     write_json_atomic(&path, status)
+}
+
+fn persist_autonomous_coding_issue_intake(
+    state_dir: &Path,
+    outcome: &AutonomousCodingIssueIntakeOutcome,
+) -> Result<()> {
+    let path = autonomous_coding_issue_intake_path(state_dir, &outcome.intake_id);
+    write_json_atomic(&path, outcome)
+}
+
+fn load_autonomous_coding_issue_intake(
+    state_dir: &Path,
+    intake_id: &str,
+) -> Result<AutonomousCodingIssueIntakeOutcome> {
+    let path = autonomous_coding_issue_intake_path(state_dir, intake_id);
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let outcome = serde_json::from_str::<AutonomousCodingIssueIntakeOutcome>(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    if outcome.schema_version != AUTONOMOUS_CODING_JOB_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "unsupported issue intake schema {} at {}; expected {}",
+            outcome.schema_version,
+            path.display(),
+            AUTONOMOUS_CODING_JOB_SCHEMA_VERSION
+        ));
+    }
+    Ok(outcome)
 }
 
 fn load_autonomous_coding_job_record(
@@ -689,6 +1045,23 @@ fn build_status_snapshot(
         replay_count: record.replay_count,
         last_background_reason_code: record.last_background_reason_code.clone(),
         last_error: record.last_error.clone(),
+        auto_merge_status: record
+            .auto_merge_evidence
+            .as_ref()
+            .map(|evidence| auto_merge_status_label(evidence.status).to_string()),
+        auto_merge_reason_code: record
+            .auto_merge_evidence
+            .as_ref()
+            .map(|evidence| evidence.reason_code.clone()),
+        auto_merge_command: record
+            .auto_merge_evidence
+            .as_ref()
+            .filter(|evidence| !evidence.command_argv.is_empty())
+            .map(|evidence| evidence.command_argv.join(" ")),
+        auto_merge_pr_url: record
+            .auto_merge_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.pr_url.clone()),
         metadata: BTreeMap::from([
             (
                 "mission_state_path".to_string(),
@@ -703,6 +1076,51 @@ fn build_status_snapshot(
                     .to_string(),
             ),
         ]),
+    }
+}
+
+fn github_auth_present_for_auto_merge(env: &BTreeMap<String, String>) -> bool {
+    env.get("GH_TOKEN")
+        .or_else(|| env.get("GITHUB_TOKEN"))
+        .is_some_and(|value| !value.trim().is_empty())
+        || std::env::var("GH_TOKEN").is_ok_and(|value| !value.trim().is_empty())
+        || std::env::var("GITHUB_TOKEN").is_ok_and(|value| !value.trim().is_empty())
+}
+
+fn auto_merge_command_argv(gh_binary: &Path, args: &[String]) -> Vec<String> {
+    let mut argv = Vec::with_capacity(args.len().saturating_add(1));
+    argv.push(gh_binary.display().to_string());
+    argv.extend(args.iter().cloned());
+    argv
+}
+
+fn auto_merge_status_label(status: AutonomousCodingAutoMergeStatus) -> &'static str {
+    match status {
+        AutonomousCodingAutoMergeStatus::Requested => "requested",
+        AutonomousCodingAutoMergeStatus::Blocked => "blocked",
+        AutonomousCodingAutoMergeStatus::Failed => "failed",
+    }
+}
+
+fn canonicalize_existing_dir(path: &Path) -> Result<PathBuf> {
+    let canonical = std::fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize {}", path.display()))?;
+    if !canonical.is_dir() {
+        return Err(anyhow!("{} must be a directory", canonical.display()));
+    }
+    Ok(canonical)
+}
+
+fn summarize_issue_body(body: &str) -> String {
+    let summary = body
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("no issue body supplied");
+    if summary.chars().count() <= 240 {
+        summary.to_string()
+    } else {
+        summary.chars().take(240).collect()
     }
 }
 
@@ -944,6 +1362,116 @@ mod tests {
         assert!(status.pr_ready_command.is_some());
     }
 
+    #[tokio::test]
+    async fn spec_3796_c01_auto_merge_requests_gh_auto_merge_when_authorized() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let submitted = make_pr_ready_job_with_pr_url(&fixture, &runtime).await;
+        let gh = fixture.fake_gh("auto-merge-enabled\n", 0);
+        let outcome = runtime
+            .request_auto_merge(AutonomousCodingAutoMergeRequest {
+                job_id: submitted.record.job_id.clone(),
+                allow_auto_merge: true,
+                merge_method: AutonomousCodingMergeMethod::Squash,
+                delete_branch: true,
+                github_env: BTreeMap::from([("GH_TOKEN".to_string(), "test-token".to_string())]),
+                gh_binary: Some(gh.binary.clone()),
+                started_unix_ms: 4_000,
+            })
+            .expect("request auto merge");
+
+        assert_eq!(
+            outcome.evidence.status,
+            AutonomousCodingAutoMergeStatus::Requested
+        );
+        assert_eq!(
+            outcome.status.auto_merge_status.as_deref(),
+            Some("requested")
+        );
+        assert_eq!(
+            outcome.status.auto_merge_reason_code.as_deref(),
+            Some("auto_merge_requested")
+        );
+        let argv = std::fs::read_to_string(&gh.argv_path).expect("captured argv");
+        assert!(argv.contains("pr\nmerge\nhttps://github.com/njfio/Tau/pull/3796"));
+        assert!(argv.contains("--auto\n"));
+        assert!(argv.contains("--squash\n"));
+        assert!(argv.contains("--delete-branch\n"));
+        assert!(!argv.contains("--admin"));
+    }
+
+    #[tokio::test]
+    async fn spec_3796_c02_auto_merge_blocks_without_policy_or_pr_url() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let submitted = runtime
+            .submit_job(fixture.submit_request(false, fixture.controlled_edits()))
+            .await
+            .expect("submit job");
+        runtime
+            .run_or_replay_job(submitted.record.job_id.as_str(), 2_000)
+            .expect("run job");
+        let gh = fixture.fake_gh("should-not-run\n", 0);
+
+        let outcome = runtime
+            .request_auto_merge(AutonomousCodingAutoMergeRequest {
+                job_id: submitted.record.job_id.clone(),
+                allow_auto_merge: false,
+                merge_method: AutonomousCodingMergeMethod::Merge,
+                delete_branch: false,
+                github_env: BTreeMap::from([("GH_TOKEN".to_string(), "test-token".to_string())]),
+                gh_binary: Some(gh.binary.clone()),
+                started_unix_ms: 4_000,
+            })
+            .expect("blocked auto merge");
+
+        assert_eq!(
+            outcome.evidence.status,
+            AutonomousCodingAutoMergeStatus::Blocked
+        );
+        assert_eq!(outcome.evidence.reason_code, "auto_merge_policy_disabled");
+        assert!(!gh.argv_path.exists(), "blocked merge should not invoke gh");
+    }
+
+    #[tokio::test]
+    async fn spec_3796_c04_issue_intake_without_authority_persists_blocked_plan() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let before_status =
+            std::fs::read_to_string(fixture.repo.path().join("status.txt")).expect("status before");
+
+        let outcome = runtime
+            .intake_issue_without_authority(AutonomousCodingIssueIntakeRequest {
+                intake_id: "issue-3796-intake".to_string(),
+                issue_url: "https://github.com/njfio/Tau/issues/3796".to_string(),
+                issue_title: "Solve arbitrary issue".to_string(),
+                issue_body: "Make Tau solve this without verifier/edit authority.".to_string(),
+                repo_path: fixture.repo.path().to_path_buf(),
+                base_branch: "master".to_string(),
+                started_unix_ms: 5_000,
+            })
+            .expect("issue intake");
+
+        assert_eq!(outcome.status, AutonomousCodingIssueIntakeStatus::Blocked);
+        assert!(outcome
+            .required_authority
+            .iter()
+            .any(|item| item.reason_code == "verifier_authority_required"));
+        assert!(outcome
+            .required_authority
+            .iter()
+            .any(|item| item.reason_code == "edit_authority_required"));
+        assert!(autonomous_coding_issue_intake_path(
+            runtime.config().state_dir.as_path(),
+            outcome.intake_id.as_str()
+        )
+        .exists());
+        assert_eq!(
+            std::fs::read_to_string(fixture.repo.path().join("status.txt")).expect("status after"),
+            before_status
+        );
+    }
+
     struct CodingJobFixture {
         root: TempDir,
         repo: TempDir,
@@ -1033,6 +1561,56 @@ mod tests {
                 },
             ]
         }
+
+        fn fake_gh(&self, stdout: &str, exit_code: i32) -> FakeGh {
+            let binary = self.root.path().join("fake-gh.sh");
+            let argv_path = self.root.path().join("fake-gh-argv.txt");
+            let script = format!(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > '{}'\nprintf '{}'\nexit {}\n",
+                shell_single_quote(argv_path.display().to_string().as_str()),
+                stdout.replace('\'', "'\"'\"'"),
+                exit_code
+            );
+            std::fs::write(&binary, script).expect("fake gh");
+            let mut perms = std::fs::metadata(&binary).expect("metadata").permissions();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&binary, perms).expect("chmod");
+            }
+            FakeGh { binary, argv_path }
+        }
+    }
+
+    struct FakeGh {
+        binary: PathBuf,
+        argv_path: PathBuf,
+    }
+
+    async fn make_pr_ready_job_with_pr_url(
+        fixture: &CodingJobFixture,
+        runtime: &AutonomousCodingJobRuntime,
+    ) -> AutonomousCodingJobRunOutcome {
+        let submitted = runtime
+            .submit_job(fixture.submit_request(false, fixture.controlled_edits()))
+            .await
+            .expect("submit job");
+        let outcome = runtime
+            .run_or_replay_job(submitted.record.job_id.as_str(), 2_000)
+            .expect("run job");
+        let mut state = load_coding_mission_state(
+            runtime.config().state_dir.as_path(),
+            outcome.record.mission_id.as_str(),
+        )
+        .expect("mission state");
+        state
+            .pr_ready_bundle
+            .as_mut()
+            .expect("pr-ready bundle")
+            .pr_url = Some("https://github.com/njfio/Tau/pull/3796".to_string());
+        save_coding_mission_state(&state).expect("save pr url");
+        outcome
     }
 
     fn mark_background_job_stale_running(state_dir: &Path, background_job_id: &str) {
@@ -1075,5 +1653,9 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn shell_single_quote(value: &str) -> String {
+        value.replace('\'', "'\"'\"'")
     }
 }

--- a/docs/guides/autonomous-coding-jobs.md
+++ b/docs/guides/autonomous-coding-jobs.md
@@ -69,9 +69,41 @@ cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- recover \
   --jobs-state-dir .tau/jobs
 ```
 
+Request protected-branch-safe GitHub auto-merge for a PR-ready job:
+
+```bash
+GH_TOKEN=... cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- auto-merge \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --job-id <job-id> \
+  --allow-auto-merge \
+  --merge-method squash \
+  --delete-branch
+```
+
+This invokes normal GitHub auto-merge behavior. It honors branch protections and
+required checks; it does not use admin bypass flags.
+
+Ingest an arbitrary issue without verifier/edit authority:
+
+```bash
+cargo run -p tau-coding-agent --bin tau_autonomous_coding_job -- intake-issue \
+  --state-dir .tau/autonomous-coding \
+  --jobs-state-dir .tau/jobs \
+  --intake-id issue-123 \
+  --issue-url https://github.com/owner/repo/issues/123 \
+  --issue-title "Issue title" \
+  --issue-body "Issue body" \
+  --repo-path /path/to/repo
+```
+
+This creates a blocked authority plan that lists the verifier and edit authority
+needed before Tau can mutate the repository.
+
 ## Boundaries
 
-This loop prepares PR-ready evidence and can create a draft PR when the mission
-state is configured for draft PR mode and GitHub auth exists in the environment.
-It does not automatically merge protected branches, and it does not claim
-arbitrary issue solving without verifier commands and bounded edit authority.
+This loop prepares PR-ready evidence, can create a draft PR when the mission
+state is configured for draft PR mode and GitHub auth exists in the environment,
+and can request GitHub auto-merge when explicit policy/auth/PR URL gates pass.
+It does not bypass protected branches, and it does not claim arbitrary issue
+solving without verifier commands and bounded edit authority.

--- a/scripts/dev/test-autonomous-coding-automerge-intake.sh
+++ b/scripts/dev/test-autonomous-coding-automerge-intake.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/rust_pi-3796-target}"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tau-automerge-intake.XXXXXX")"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+export CARGO_TARGET_DIR="${TARGET_DIR}"
+
+run_cli() {
+  cargo run -q -p tau-coding-agent --bin tau_autonomous_coding_job -- "$@"
+}
+
+init_fixture_repo() {
+  local repo="$1"
+  mkdir -p "${repo}/docs"
+  git -C "${repo}" init -b master >/dev/null
+  git -C "${repo}" config user.email tau@example.test
+  git -C "${repo}" config user.name "Tau Test"
+  printf 'fail\n' >"${repo}/status.txt"
+  printf 'draft\n' >"${repo}/docs/notes.txt"
+  git -C "${repo}" add .
+  git -C "${repo}" commit -m "Initial fixture" >/dev/null
+}
+
+extract_json_field() {
+  local path="$1"
+  local expr="$2"
+  python3 - "$path" "$expr" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+value = payload
+for part in sys.argv[2].split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+cd "${REPO_ROOT}"
+
+STATE="${WORK_DIR}/state"
+JOBS="${WORK_DIR}/jobs"
+REPO="${WORK_DIR}/repo"
+mkdir -p "${REPO}"
+init_fixture_repo "${REPO}"
+
+run_cli submit \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --repo-path "${REPO}" \
+  --mission-id automerge-mission \
+  --session-key script-automerge \
+  --issue-url https://github.com/njfio/Tau/issues/3796 \
+  --goal "Make guarded auto-merge fixture pass" \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q proof docs/notes.txt" \
+  --edit "status.txt=pass" \
+  --edit "docs/notes.txt=proof" \
+  --commit-message "Make guarded automerge verifier green" \
+  >"${WORK_DIR}/submit.json"
+
+JOB_ID="$(extract_json_field "${WORK_DIR}/submit.json" "record.job_id")"
+run_cli run \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --job-id "${JOB_ID}" \
+  >"${WORK_DIR}/run.json"
+
+python3 - "${STATE}/coding-missions/automerge-mission.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    state = json.load(handle)
+
+assert state["phase"] == "pr_ready", state["phase"]
+state["pr_ready_bundle"]["pr_url"] = "https://github.com/njfio/Tau/pull/3796"
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(state, handle, indent=2)
+    handle.write("\n")
+PY
+
+FAKE_GH="${WORK_DIR}/fake-gh.sh"
+FAKE_GH_ARGV="${WORK_DIR}/fake-gh-argv.txt"
+cat >"${FAKE_GH}" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${FAKE_GH_ARGV}"
+printf 'auto-merge-enabled\n'
+SH
+chmod +x "${FAKE_GH}"
+
+GH_TOKEN=test-token run_cli auto-merge \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --job-id "${JOB_ID}" \
+  --allow-auto-merge \
+  --merge-method squash \
+  --delete-branch \
+  --gh-binary "${FAKE_GH}" \
+  >"${WORK_DIR}/auto-merge.json"
+
+python3 - "${WORK_DIR}/auto-merge.json" "${FAKE_GH_ARGV}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["evidence"]["status"] == "requested", payload
+assert payload["evidence"]["reason_code"] == "auto_merge_requested", payload
+assert payload["status"]["auto_merge_status"] == "requested", payload
+assert payload["status"]["auto_merge_pr_url"] == "https://github.com/njfio/Tau/pull/3796", payload
+
+with open(sys.argv[2], "r", encoding="utf-8") as handle:
+    argv = handle.read().splitlines()
+
+assert argv[:3] == ["pr", "merge", "https://github.com/njfio/Tau/pull/3796"], argv
+assert "--auto" in argv, argv
+assert "--squash" in argv, argv
+assert "--delete-branch" in argv, argv
+assert "--admin" not in argv, argv
+PY
+
+rm -f "${FAKE_GH_ARGV}"
+GH_TOKEN=test-token run_cli auto-merge \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --job-id "${JOB_ID}" \
+  --merge-method squash \
+  --gh-binary "${FAKE_GH}" \
+  >"${WORK_DIR}/auto-merge-blocked.json"
+
+python3 - "${WORK_DIR}/auto-merge-blocked.json" "${FAKE_GH_ARGV}" <<'PY'
+import json
+import os
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["evidence"]["status"] == "blocked", payload
+assert payload["evidence"]["reason_code"] == "auto_merge_policy_disabled", payload
+assert not os.path.exists(sys.argv[2]), "blocked auto-merge invoked gh"
+PY
+
+BEFORE_STATUS="$(cat "${REPO}/status.txt")"
+run_cli intake-issue \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --intake-id issue-3796-intake \
+  --issue-url https://github.com/njfio/Tau/issues/3796 \
+  --issue-title "Arbitrary issue without authority" \
+  --issue-body "Solve this without verifier or edit authority." \
+  --repo-path "${REPO}" \
+  --base-branch master \
+  >"${WORK_DIR}/intake.json"
+
+run_cli intake-status \
+  --state-dir "${STATE}" \
+  --jobs-state-dir "${JOBS}" \
+  --intake-id issue-3796-intake \
+  >"${WORK_DIR}/intake-status.json"
+
+python3 - "${WORK_DIR}/intake-status.json" "${REPO}/status.txt" "${BEFORE_STATUS}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    intake = json.load(handle)
+
+assert intake["status"] == "blocked", intake
+reasons = {item["reason_code"] for item in intake["required_authority"]}
+assert "verifier_authority_required" in reasons, intake
+assert "edit_authority_required" in reasons, intake
+
+with open(sys.argv[2], "r", encoding="utf-8") as handle:
+    after = handle.read().strip()
+assert after == sys.argv[3], (after, sys.argv[3])
+PY
+
+printf 'autonomous_coding_automerge_intake=pass\n'
+printf 'job_id=%s\n' "${JOB_ID}"

--- a/specs/3796-guarded-automerge-issue-intake/plan.md
+++ b/specs/3796-guarded-automerge-issue-intake/plan.md
@@ -1,0 +1,57 @@
+# Plan: Guarded Auto-Merge And Issue Intake
+
+GitHub Issue: #3796
+Status: Implemented
+
+## Approach
+
+Extend the autonomous coding job runtime rather than adding a separate merger:
+
+- Add `request_auto_merge` to the runtime with explicit policy/auth/PR URL
+  gates.
+- Store merge evidence under the existing autonomous job record/status JSON.
+- Execute `gh pr merge <pr-url> --auto --<method>` only after all gates pass.
+- Keep the command free of admin/protection bypass flags.
+
+Add arbitrary issue intake as a durable non-mutating path:
+
+- Persist issue context and authority requirements under
+  `<state-dir>/issue-intake/<intake-id>.json`.
+- Emit status JSON that says the intake is blocked until verifier and edit
+  authority are provided.
+- Do not create a coding mission or write to the repo in this path.
+
+Extend `tau_autonomous_coding_job` with:
+
+- `auto-merge`
+- `intake-issue`
+- `intake-status`
+
+## Affected Modules
+
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs`
+- `crates/tau-coding-agent/src/bin/tau_autonomous_coding_job.rs`
+- `scripts/dev/test-autonomous-coding-automerge-intake.sh`
+- `docs/guides/autonomous-coding-jobs.md`
+- `specs/3796-guarded-automerge-issue-intake/*`
+
+## Risks And Mitigations
+
+- Risk: auto-merge is mistaken for branch-protection bypass. Mitigation:
+  require `--auto`, reject missing auth/policy, never emit `--admin`, and
+  document the boundary.
+- Risk: arbitrary issue intake is overstated as code-solving. Mitigation:
+  persist a blocked authority plan unless verifier/edit authority is present.
+- Risk: shell integration depends on live GitHub. Mitigation: use a fake `gh`
+  executable that captures argv for deterministic proof.
+
+## Interfaces
+
+- `request_auto_merge(request) -> AutonomousCodingAutoMergeOutcome`
+- `intake_issue_without_authority(request) -> AutonomousCodingIssueIntakeOutcome`
+- CLI JSON output remains machine-readable and includes status reason codes.
+
+## ADR
+
+No ADR required: this uses existing GitHub CLI behavior and adds no new
+dependency or protocol.

--- a/specs/3796-guarded-automerge-issue-intake/spec.md
+++ b/specs/3796-guarded-automerge-issue-intake/spec.md
@@ -1,0 +1,78 @@
+# Issue #3796: Guarded Auto-Merge And Arbitrary Issue Intake
+
+Status: Implemented
+GitHub Issue: #3796
+Priority: P1
+Milestone: M334 - Tau Ralph loop supervisor architecture
+
+## Problem
+
+Durable autonomous coding jobs can reach PR-ready state, but the product loop
+still stops at a manual handoff. Operators need Tau to request auto-merge when
+the repository's protected-branch rules allow it, and they need Tau to ingest
+arbitrary issue context even when verifier/edit authority has not been granted.
+
+The unsafe version of this request would bypass protected branches or mutate
+repositories without authority. That is out of scope. The product behavior must
+honor GitHub protections and block with an actionable authority plan when
+required verifier/edit authority is missing.
+
+## Scope
+
+In scope:
+- Add policy-gated auto-merge request support to autonomous coding jobs.
+- Require PR-ready state, explicit policy, a PR URL, and GitHub auth before a
+  merge request is attempted.
+- Use `gh pr merge <url> --auto --<method>` without admin/protection bypass.
+- Persist auto-merge evidence and expose it in job status.
+- Add issue intake without verifier/edit authority that persists an authority
+  plan and status instead of mutating code.
+- Add CLI and integration coverage for blocked and successful guarded paths.
+
+Out of scope:
+- Bypassing protected branch rules, required reviews, or required checks.
+- Blind arbitrary repo mutation without verifier/edit authority.
+- Automatically merging directly to protected branches with admin override.
+
+## Acceptance Criteria
+
+### AC-1: Auto-Merge Requires Explicit Authority
+
+Given a PR-ready autonomous coding job has a PR URL, GitHub auth, and
+`allow_auto_merge=true`, when auto-merge is requested, then Tau invokes a GitHub
+auto-merge command that honors branch protection and persists merge evidence.
+
+### AC-2: Missing Authority Blocks Safely
+
+Given a job is not PR-ready, has no PR URL, lacks GitHub auth, or does not have
+auto-merge policy enabled, when auto-merge is requested, then Tau does not run a
+merge command and records an operator-visible blocked reason.
+
+### AC-3: Protected Branches Are Not Bypassed
+
+Given auto-merge is requested, when the command is assembled, then it includes
+`--auto` and a merge method but never includes `--admin` or another branch
+protection bypass flag.
+
+### AC-4: Arbitrary Issue Intake Without Authority Produces A Plan
+
+Given an arbitrary issue URL/body is ingested without verifier or edit
+authority, when intake runs, then Tau persists a durable issue-intake plan with
+required verifier/edit authority and marks the intake blocked without changing
+the repository.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | PR-ready job with PR URL, auth, and policy enabled | auto-merge request runs | fake `gh` receives `pr merge <url> --auto --squash` and status records requested |
+| C-02 | AC-2 | Regression | PR-ready job without PR URL or policy | auto-merge request runs | command is not executed and status records blocked reason |
+| C-03 | AC-3 | Conformance | fake `gh` captures argv | auto-merge request runs | argv has no `--admin` |
+| C-04 | AC-4 | Functional | issue URL/body without verifier/edit authority | issue intake runs | authority plan exists and repo files are unchanged |
+
+## Success Signals
+
+- Focused `tau-runtime` tests cover C-01..C-04.
+- CLI integration script proves guarded merge and no-authority issue intake over
+  disposable fixtures.
+- Existing autonomous coding job loop proof continues to pass.

--- a/specs/3796-guarded-automerge-issue-intake/tasks.md
+++ b/specs/3796-guarded-automerge-issue-intake/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Guarded Auto-Merge And Issue Intake
+
+GitHub Issue: #3796
+Status: Implemented
+
+- [x] T1 (RED): Add failing runtime tests for merge success, merge blocked,
+  no bypass flags, and no-authority issue intake.
+- [x] T2 (GREEN): Implement auto-merge policy/auth/PR URL gates and persisted
+  merge evidence.
+- [x] T3 (GREEN): Implement durable issue intake authority plans without repo
+  mutation.
+- [x] T4 (GREEN): Add CLI commands and disposable integration proof.
+- [x] T5 (VERIFY): Run focused tests, scripts, fmt, diff check, and clippy.
+
+## Test Tiers
+
+| Tier | Status | Tests | N/A Why |
+| --- | --- | --- | --- |
+| Unit | Done | `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` | |
+| Property | N/A | | No randomized parser or invariant introduced |
+| Contract/DbC | N/A | | No formal contract macro surface changed |
+| Snapshot | N/A | | JSON status uses field assertions |
+| Functional | Done | `spec_3796_c01_auto_merge_requests_gh_auto_merge_when_authorized`; `spec_3796_c04_issue_intake_without_authority_persists_blocked_plan` | |
+| Conformance | Done | `scripts/dev/test-autonomous-coding-automerge-intake.sh` asserts `--auto`, merge method, and no `--admin` | |
+| Integration | Done | `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-automerge-intake.sh`; `scripts/dev/test-autonomous-coding-job-loop.sh` | |
+| Fuzz | N/A | | No untrusted parser/fuzz target changed |
+| Mutation | N/A | | Follow-up for release gate; focused regression coverage in this slice |
+| Regression | Done | `spec_3796_c02_auto_merge_blocks_without_policy_or_pr_url`; existing autonomous job loop proof | |
+| Performance | N/A | | No hot path or benchmarked runtime changed |
+
+## Verification Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` failed before implementation because `AutonomousCodingAutoMergeRequest`, `AutonomousCodingMergeMethod`, `AutonomousCodingAutoMergeStatus`, `AutonomousCodingIssueIntakeRequest`, `AutonomousCodingIssueIntakeStatus`, `request_auto_merge`, `intake_issue_without_authority`, and `autonomous_coding_issue_intake_path` were missing.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passed: 7 tests.
+- CLI: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-coding-agent --bin tau_autonomous_coding_job -- --test-threads=1` passed.
+- Integration: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-automerge-intake.sh` passed with `autonomous_coding_automerge_intake=pass`.
+- Regression: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-job-loop.sh` passed with `autonomous_coding_job_loop=pass`.
+- Lint: `cargo fmt --check`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`, and `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings` passed.


### PR DESCRIPTION
## Summary
Adds guarded auto-merge and no-authority issue intake to the autonomous coding job runtime. Tau can now request GitHub auto-merge only for PR-ready jobs with explicit policy, PR URL, and GitHub auth, and it persists blocked authority plans for arbitrary issue intake without verifier/edit authority.

## Links
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Closes #3796
- Spec: `specs/3796-guarded-automerge-issue-intake/spec.md`
- Plan: `specs/3796-guarded-automerge-issue-intake/plan.md`
- Tasks: `specs/3796-guarded-automerge-issue-intake/tasks.md`

## Spec Verification
| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: Auto-merge requires explicit authority | ✅ | `spec_3796_c01_auto_merge_requests_gh_auto_merge_when_authorized`; `scripts/dev/test-autonomous-coding-automerge-intake.sh` |
| AC-2: Missing authority blocks safely | ✅ | `spec_3796_c02_auto_merge_blocks_without_policy_or_pr_url`; blocked script path |
| AC-3: Protected branches are not bypassed | ✅ | fake `gh` argv assertion includes `--auto`/method and excludes `--admin` |
| AC-4: Arbitrary issue intake without authority produces a plan | ✅ | `spec_3796_c04_issue_intake_without_authority_persists_blocked_plan`; intake/status script path |

## TDD Evidence
RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` failed before implementation because the #3796 auto-merge/intake types, methods, and persisted path helper were missing.

GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passed with 7 tests.

REGRESSION: `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-job-loop.sh` passed with `autonomous_coding_job_loop=pass`.

## Test Tiers
| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | `cargo test -p tau-runtime autonomous_coding_jobs_runtime` | |
| Property | N/A | | No randomized parser or invariant introduced |
| Contract/DbC | N/A | | No formal contract macro surface changed |
| Snapshot | N/A | | JSON status uses field assertions |
| Functional | ✅ | #3796 runtime tests and CLI script | |
| Conformance | ✅ | fake `gh` argv has `--auto`/method and no `--admin` | |
| Integration | ✅ | `scripts/dev/test-autonomous-coding-automerge-intake.sh`; `scripts/dev/test-autonomous-coding-job-loop.sh` | |
| Fuzz | N/A | | No untrusted parser/fuzz target changed |
| Mutation | N/A | | Follow-up release gate; focused regression coverage in this slice |
| Regression | ✅ | missing policy/PR URL block test; existing job loop proof | |
| Performance | N/A | | No hot path or benchmarked runtime changed |

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo test -p tau-coding-agent --bin tau_autonomous_coding_job -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-automerge-intake.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target scripts/dev/test-autonomous-coding-job-loop.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3796-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings`

## Mutation
N/A for this slice; no release mutation run. Focused conformance/regression tests lock the safety gates.

## Risks/Rollback
Risk: auto-merge can be overstated as branch-protection bypass. It is intentionally just `gh pr merge <url> --auto --<method>` and never emits `--admin`.

Rollback: revert this PR; autonomous coding jobs fall back to PR-ready handoff behavior.

## Docs/ADR
- Updated `docs/guides/autonomous-coding-jobs.md`
- No ADR: no new dependency or protocol; uses existing GitHub CLI behavior.
