### PR TITLE
Add provider verifier repair loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These are the paths that operate as connected flows today.
 | Unified runtime lifecycle loop | `./scripts/dev/prove-tau-product.sh --check --report /tmp/tau-product-proof-check.json` for static proof evidence, then `./scripts/dev/prove-tau-product.sh --run --webchat-smoke --report /tmp/tau-product-proof-webchat.json` for opt-in live product-surface evidence | One-command runtime bring-up (`up/status/down`) for gateway/dashboard + interactive TUI agent (`tui`) with explicit live-shell fallback, optional webchat readiness smoke, and optional JSON evidence | [`scripts/dev/prove-tau-product.sh`](scripts/dev/prove-tau-product.sh), [`scripts/run/tau-unified.sh`](scripts/run/tau-unified.sh), [`docs/guides/canonical-product-proof.md`](docs/guides/canonical-product-proof.md) |
 | Live coding mission loop | `./scripts/dev/test-full-autonomous-coding-loop.sh` | Disposable-repo M334 `repo_spec_to_pr_feature_delivery` harness through `CodingMissionRunner`: RED verifier, controlled edit, GREEN verifier, commit, PR-ready bundle, crash/resume, and blocked-task fail-closed evidence | [`scripts/dev/test-full-autonomous-coding-loop.sh`](scripts/dev/test-full-autonomous-coding-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs), [`specs/3654/tasks.md`](specs/3654/tasks.md) |
 | Provider-backed coding loop | `TAU_LIVE_PROVIDER_PROOF=1 ./scripts/dev/test-provider-backed-autonomous-coding-loop.sh` | Opt-in disposable-repo proof that calls a configured provider using API-key or subscription auth, parses JSON edit instructions into `CodingMissionRunner`, records RED/GREEN verifier, commit, and PR-ready evidence, and fail-closes malformed provider output | [`scripts/dev/test-provider-backed-autonomous-coding-loop.sh`](scripts/dev/test-provider-backed-autonomous-coding-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs), [`specs/3788-provider-backed-coding-loop-proof/tasks.md`](specs/3788-provider-backed-coding-loop-proof/tasks.md) |
+| Provider verifier repair loop | `TAU_LIVE_PROVIDER_REPAIR_PROOF=1 ./scripts/dev/test-provider-verifier-repair-loop.sh` | Real-repo harness path that reruns provider attempts after verifier failure: captures failed verifier stdout/stderr and git diff, asks the next provider attempt for a targeted JSON patch, reruns verifiers, commits PR-ready output, and fail-closes exhausted repair budgets | [`scripts/dev/test-provider-verifier-repair-loop.sh`](scripts/dev/test-provider-verifier-repair-loop.sh), [`crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`](crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs), [`specs/3798-provider-verifier-repair-loop/spec.md`](specs/3798-provider-verifier-repair-loop/spec.md) |
 | Real-repo coding harness | `./scripts/dev/test-real-repo-autonomous-coding-harness.sh` | Temporary worktree of this repository through `CodingMissionRunner`: provider-compatible multi-file edit array, real git branch/commit, RED/GREEN verifier evidence, and manual PR-ready bundle | [`scripts/dev/test-real-repo-autonomous-coding-harness.sh`](scripts/dev/test-real-repo-autonomous-coding-harness.sh), [`crates/tau-agent-core/src/coding_mission.rs`](crates/tau-agent-core/src/coding_mission.rs), [`specs/3792-real-repo-autonomous-coding-harness/spec.md`](specs/3792-real-repo-autonomous-coding-harness/spec.md) |
 | Multi-channel ingress loop | `./scripts/demo/multi-channel.sh` | Multi-channel runtime, transport normalization, routing pipeline | [`docs/guides/multi-channel-event-pipeline.md`](docs/guides/multi-channel-event-pipeline.md), [`docs/guides/transports.md`](docs/guides/transports.md) |
 | Prompt optimization loop | [`docs/guides/training-ops.md`](docs/guides/training-ops.md) runbook flow | Training runner/store/tracer/proxy + rollout controls | [`docs/guides/training-ops.md`](docs/guides/training-ops.md), [`docs/guides/training-proxy-ops.md`](docs/guides/training-proxy-ops.md) |
@@ -54,6 +55,9 @@ These are the paths that operate as connected flows today.
 - Run a deterministic real-repo coding harness against a temporary worktree of
   this repository with provider-compatible multi-file edits, RED/GREEN verifier
   transcript, commit hash, and PR-ready bundle evidence.
+- Run a bounded provider verifier repair loop that converts verifier failure
+  evidence plus git diff into a follow-up provider patch attempt, then either
+  reruns to PR-ready or records an exhausted-repair blocked state.
 
 ## Capability Boundaries
 
@@ -104,6 +108,13 @@ Some surfaces are intentionally diagnostics-first or staged:
     `TAU_PROVIDER_PROOF_AUTH_MODE=codex-cli` with a
     Codex CLI-supported model such as `openai/gpt-5.5` to validate the
     local subscription-backed provider path.
+  - `TAU_LIVE_PROVIDER_REPAIR_PROOF=1 ./scripts/dev/test-provider-verifier-repair-loop.sh`
+    adds the repair-loop proof: the first provider-shaped edit can fail a
+    verifier, Tau captures failed verifier evidence plus git diff, sends that
+    context to the next configured provider attempt, reruns verification, and
+    commits only when the repaired worktree reaches PR-ready. Without
+    `TAU_LIVE_PROVIDER_REPAIR_PROOF=1`, the same script still runs deterministic
+    mock repair and exhausted-budget fail-closed checks.
   - `./scripts/dev/test-real-repo-autonomous-coding-harness.sh` runs the same
     lifecycle against a temporary worktree of this repository and validates a
     provider-compatible multi-file edit array. This is real git/worktree/commit

--- a/crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs
+++ b/crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs
@@ -94,9 +94,13 @@ struct Args {
     #[arg(long, default_value_t = 1_024)]
     provider_max_tokens: u32,
 
-    /// Mock provider response used for deterministic provider parsing tests.
-    #[arg(long)]
-    mock_provider_response: Option<String>,
+    /// Additional provider repair attempts after the initial provider edit.
+    #[arg(long, default_value_t = 2)]
+    provider_repair_attempts: usize,
+
+    /// Mock provider response for a specific provider attempt. Omitted attempts call the configured provider.
+    #[arg(long = "mock-provider-response")]
+    mock_provider_responses: Vec<String>,
 
     /// Verifier command(s) for real-repo mode. Repeat once per command.
     #[arg(long = "verifier-command")]
@@ -146,6 +150,7 @@ struct LiveLoopReport {
     blocked_reason: Option<String>,
     pr_ready: Option<PrReadyReport>,
     provider: Option<ProviderProofReport>,
+    provider_attempts: Vec<ProviderProofReport>,
     operator_interventions_used: Vec<String>,
     no_routine_human_steering_used: bool,
 }
@@ -180,8 +185,9 @@ struct PrReadyReport {
     pr_url: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct ProviderProofReport {
+    attempt_index: usize,
     mode: &'static str,
     provider: String,
     model: String,
@@ -194,10 +200,13 @@ struct ProviderProofReport {
     response_text_sha256: Option<String>,
     edit_relative_path: Option<String>,
     edit_reason_code: Option<String>,
+    repair_context_included: bool,
+    failed_verifier_count: usize,
+    diff_context_bytes: Option<usize>,
     error: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct ProviderUsageReport {
     input_tokens: u64,
     output_tokens: u64,
@@ -232,7 +241,28 @@ enum ProviderEditOutcome {
     Failed(ProviderProofReport),
 }
 
+#[derive(Debug, Clone, Default)]
+struct ProviderRepairContext {
+    failed_verifiers: Vec<ProviderVerifierFailureContext>,
+    changed_files: Vec<String>,
+    git_diff: String,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderVerifierFailureContext {
+    argv: Vec<String>,
+    exit_status: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+struct ProviderAttemptContext {
+    attempt_index: usize,
+    repair: Option<ProviderRepairContext>,
+}
+
 struct ProviderFailureReportInput<'a> {
+    attempt_index: usize,
     mode: &'static str,
     model_ref: &'a ModelRef,
     dispatched: bool,
@@ -241,6 +271,18 @@ struct ProviderFailureReportInput<'a> {
     response_text_bytes: Option<usize>,
     response_text_sha256: Option<String>,
     usage: Option<ProviderUsageReport>,
+    repair: Option<&'a ProviderRepairContext>,
+}
+
+struct ProviderEditResponseInput<'a> {
+    attempt_index: usize,
+    mode: &'static str,
+    model_ref: &'a ModelRef,
+    repair: Option<&'a ProviderRepairContext>,
+    dispatched: bool,
+    finish_reason: Option<String>,
+    usage: Option<ChatUsage>,
+    response_text: &'a str,
 }
 
 struct LiveLoopReportInput<'a> {
@@ -251,7 +293,7 @@ struct LiveLoopReportInput<'a> {
     outcome: &'a CodingMissionRunOutcome,
     resume: Option<ResumeReport>,
     pr_ready: Option<&'a CodingMissionPrReadyBundle>,
-    provider: Option<ProviderProofReport>,
+    provider_attempts: Vec<ProviderProofReport>,
 }
 
 fn main() -> ExitCode {
@@ -326,7 +368,7 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
     let runner = CodingMissionRunner::new();
 
     let mut resume_report = None;
-    let mut provider_report = None;
+    let mut provider_attempts = Vec::new();
     let outcome = match args.mode {
         HarnessMode::Success => run_success_case(
             &runner,
@@ -346,7 +388,7 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
             &mut state,
             &args,
             &mission_id,
-            &mut provider_report,
+            &mut provider_attempts,
             started_unix_ms,
         )?,
         HarnessMode::RealRepo => run_provider_success_case(
@@ -354,7 +396,7 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
             &mut state,
             &args,
             &mission_id,
-            &mut provider_report,
+            &mut provider_attempts,
             started_unix_ms,
         )?,
     };
@@ -395,7 +437,7 @@ fn run(args: Args, fixture_path: PathBuf, started_unix_ms: u64) -> anyhow::Resul
         outcome: &outcome,
         resume: resume_report,
         pr_ready: pr_ready.as_ref(),
-        provider: provider_report,
+        provider_attempts,
     });
     let passed = report.passed;
     write_report(&args.output, &report)?;
@@ -489,7 +531,7 @@ fn run_provider_success_case(
     state: &mut CodingMissionState,
     args: &Args,
     mission_id: &str,
-    provider_report: &mut Option<ProviderProofReport>,
+    provider_attempts: &mut Vec<ProviderProofReport>,
     started_unix_ms: u64,
 ) -> anyhow::Result<CodingMissionRunOutcome> {
     let red = runner
@@ -507,49 +549,90 @@ fn run_provider_success_case(
         return Ok(red);
     }
 
-    match resolve_provider_edit(args, state)
-        .with_context(|| format!("resolve provider edit for {mission_id}"))?
-    {
-        ProviderEditOutcome::Ready(resolved) => {
-            let ProviderEditResolution { edits, report } = resolved;
-            *provider_report = Some(report);
-            let resumed = runner
-                .resume(CodingMissionResumeRequest {
-                    state_root: state.state_root.clone(),
-                    mission_id: state.mission_id.clone(),
-                    controlled_edit: None,
-                    controlled_edits: edits,
-                    commit_message: "Make M334 live verifier green with provider edit".to_string(),
-                    started_unix_ms: started_unix_ms + 2_000,
-                    stop_after: None,
-                })
-                .context("resume provider-backed coding mission")?;
-            *state = resumed.state;
-            Ok(resumed.run)
-        }
-        ProviderEditOutcome::Failed(report) => {
-            let blocked_reason = report.reason_code.clone();
-            state
-                .transition_phase(
-                    CodingMissionPhase::Blocked,
-                    blocked_reason.as_str(),
-                    report
-                        .error
-                        .clone()
-                        .unwrap_or_else(|| blocked_reason.clone()),
-                    started_unix_ms + 2_000,
-                )
-                .context("record provider-backed blocked state")?;
-            *provider_report = Some(report);
-            Ok(CodingMissionRunOutcome {
-                phase: state.phase,
-                verifier_passed: false,
-                committed: None,
-                blocked_reason: Some(blocked_reason),
-                iterations: red.iterations,
-            })
+    let total_provider_attempts = args.provider_repair_attempts.saturating_add(1).max(1);
+    let mut latest_run = red;
+    for attempt_index in 1..=total_provider_attempts {
+        let repair = if attempt_index == 1 {
+            None
+        } else {
+            Some(provider_repair_context(state)?)
+        };
+        let attempt = ProviderAttemptContext {
+            attempt_index,
+            repair,
+        };
+        match resolve_provider_edit(args, state, &attempt).with_context(|| {
+            format!("resolve provider edit for {mission_id} attempt {attempt_index}")
+        })? {
+            ProviderEditOutcome::Ready(resolved) => {
+                let ProviderEditResolution { edits, report } = resolved;
+                provider_attempts.push(report);
+                let resumed = runner
+                    .resume(CodingMissionResumeRequest {
+                        state_root: state.state_root.clone(),
+                        mission_id: state.mission_id.clone(),
+                        controlled_edit: None,
+                        controlled_edits: edits,
+                        commit_message: "Make M334 live verifier green with provider edit"
+                            .to_string(),
+                        started_unix_ms: started_unix_ms
+                            .saturating_add(2_000)
+                            .saturating_add((attempt_index as u64).saturating_mul(1_000)),
+                        stop_after: None,
+                    })
+                    .context("resume provider-backed coding mission")?;
+                *state = resumed.state;
+                latest_run = resumed.run;
+                if latest_run.verifier_passed || state.phase == CodingMissionPhase::PrReady {
+                    return Ok(latest_run);
+                }
+                if latest_run.blocked_reason.is_some() || state.phase == CodingMissionPhase::Blocked
+                {
+                    return Ok(latest_run);
+                }
+            }
+            ProviderEditOutcome::Failed(report) => {
+                let blocked_reason = report.reason_code.clone();
+                state
+                    .transition_phase(
+                        CodingMissionPhase::Blocked,
+                        blocked_reason.as_str(),
+                        report
+                            .error
+                            .clone()
+                            .unwrap_or_else(|| blocked_reason.clone()),
+                        started_unix_ms
+                            .saturating_add(2_000)
+                            .saturating_add((attempt_index as u64).saturating_mul(1_000)),
+                    )
+                    .context("record provider-backed blocked state")?;
+                provider_attempts.push(report);
+                return Ok(CodingMissionRunOutcome {
+                    phase: state.phase,
+                    verifier_passed: false,
+                    committed: None,
+                    blocked_reason: Some(blocked_reason),
+                    iterations: latest_run.iterations,
+                });
+            }
         }
     }
+
+    state
+        .transition_phase(
+            CodingMissionPhase::Blocked,
+            "provider_repair_attempts_exhausted",
+            "provider verifier repair attempts exhausted before verifiers passed",
+            started_unix_ms.saturating_add(8_000),
+        )
+        .context("record exhausted provider repair state")?;
+    Ok(CodingMissionRunOutcome {
+        phase: state.phase,
+        verifier_passed: false,
+        committed: None,
+        blocked_reason: Some("provider_repair_attempts_exhausted".to_string()),
+        iterations: latest_run.iterations,
+    })
 }
 
 fn pass_status_edit(reason_code: &str) -> CodingMissionControlledEdit {
@@ -563,19 +646,22 @@ fn pass_status_edit(reason_code: &str) -> CodingMissionControlledEdit {
 fn resolve_provider_edit(
     args: &Args,
     state: &CodingMissionState,
+    attempt: &ProviderAttemptContext,
 ) -> anyhow::Result<ProviderEditOutcome> {
     let model_ref = ModelRef::parse(&args.provider_model)
         .with_context(|| format!("parse provider model '{}'", args.provider_model))?;
 
-    if let Some(mock_response) = args.mock_provider_response.as_ref() {
-        return Ok(provider_edit_from_response(
-            "mock",
-            &model_ref,
-            true,
-            None,
-            None,
-            mock_response,
-        ));
+    if let Some(mock_response) = mock_provider_response_for_attempt(args, attempt.attempt_index) {
+        return Ok(provider_edit_from_response(ProviderEditResponseInput {
+            attempt_index: attempt.attempt_index,
+            mode: "mock",
+            model_ref: &model_ref,
+            repair: attempt.repair.as_ref(),
+            dispatched: true,
+            finish_reason: None,
+            usage: None,
+            response_text: mock_response,
+        }));
     }
 
     let client = match provider_client(args, &model_ref) {
@@ -583,6 +669,7 @@ fn resolve_provider_edit(
         Err(error) => {
             return Ok(ProviderEditOutcome::Failed(provider_failure_report(
                 ProviderFailureReportInput {
+                    attempt_index: attempt.attempt_index,
                     mode: "live",
                     model_ref: &model_ref,
                     dispatched: false,
@@ -591,6 +678,7 @@ fn resolve_provider_edit(
                     response_text_bytes: None,
                     response_text_sha256: None,
                     usage: None,
+                    repair: attempt.repair.as_ref(),
                 },
             )));
         }
@@ -603,7 +691,7 @@ fn resolve_provider_edit(
                 "You generate one safe edit for a disposable Tau coding-loop proof. \
                  Return valid JSON only. No markdown, no prose.",
             ),
-            Message::user(provider_prompt(state)?),
+            Message::user(provider_prompt(state, attempt)?),
         ],
         tools: Vec::new(),
         tool_choice: None,
@@ -620,17 +708,20 @@ fn resolve_provider_edit(
     match runtime.block_on(client.complete(request)) {
         Ok(response) => {
             let text = response.message.text_content();
-            Ok(provider_edit_from_response(
-                "live",
-                &model_ref,
-                true,
-                response.finish_reason,
-                Some(response.usage),
-                &text,
-            ))
+            Ok(provider_edit_from_response(ProviderEditResponseInput {
+                attempt_index: attempt.attempt_index,
+                mode: "live",
+                model_ref: &model_ref,
+                repair: attempt.repair.as_ref(),
+                dispatched: true,
+                finish_reason: response.finish_reason,
+                usage: Some(response.usage),
+                response_text: &text,
+            }))
         }
         Err(error) => Ok(ProviderEditOutcome::Failed(provider_failure_report(
             ProviderFailureReportInput {
+                attempt_index: attempt.attempt_index,
                 mode: "live",
                 model_ref: &model_ref,
                 dispatched: true,
@@ -639,9 +730,16 @@ fn resolve_provider_edit(
                 response_text_bytes: None,
                 response_text_sha256: None,
                 usage: None,
+                repair: attempt.repair.as_ref(),
             },
         ))),
     }
+}
+
+fn mock_provider_response_for_attempt(args: &Args, attempt_index: usize) -> Option<&str> {
+    args.mock_provider_responses
+        .get(attempt_index.saturating_sub(1))
+        .map(String::as_str)
 }
 
 fn provider_client(args: &Args, model_ref: &ModelRef) -> anyhow::Result<Arc<dyn LlmClient>> {
@@ -759,7 +857,10 @@ fn provider_proof_api_key(provider: Provider) -> Option<String> {
     resolve_api_key(candidates)
 }
 
-fn provider_prompt(state: &CodingMissionState) -> anyhow::Result<String> {
+fn provider_prompt(
+    state: &CodingMissionState,
+    attempt: &ProviderAttemptContext,
+) -> anyhow::Result<String> {
     let status_path = state.repo_path.join("status.txt");
     let current_status = match fs::read_to_string(&status_path) {
         Ok(value) => value,
@@ -771,8 +872,13 @@ fn provider_prompt(state: &CodingMissionState) -> anyhow::Result<String> {
                 .with_context(|| format!("read fixture status {}", status_path.display()));
         }
     };
+    let repair_section = attempt
+        .repair
+        .as_ref()
+        .map(render_provider_repair_context)
+        .unwrap_or_default();
     Ok(format!(
-        "Goal:\n{}\n\nRepository root:\n{}\n\nCurrent file status.txt context:\n{}\n\nVerifier commands:\n{}\n\nReturn valid JSON only. Use either the legacy single-edit shape or this multi-edit shape:\n{{\"edits\":[{{\"relative_path\":\"path/from/repo/root\",\"contents\":\"file contents\",\"reason_code\":\"provider_fix\"}}]}}",
+        "Goal:\n{}\n\nRepository root:\n{}\n\nCurrent file status.txt context:\n{}\n\nVerifier commands:\n{}\n{}\n\nReturn valid JSON only. Use either the legacy single-edit shape or this multi-edit shape:\n{{\"edits\":[{{\"relative_path\":\"path/from/repo/root\",\"contents\":\"file contents\",\"reason_code\":\"provider_fix\"}}]}}",
         state.goal,
         state.repo_path.display(),
         current_status,
@@ -781,18 +887,130 @@ fn provider_prompt(state: &CodingMissionState) -> anyhow::Result<String> {
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>()
-            .join("\n")
+            .join("\n"),
+        repair_section
     ))
 }
 
-fn provider_edit_from_response(
-    mode: &'static str,
-    model_ref: &ModelRef,
-    dispatched: bool,
-    finish_reason: Option<String>,
-    usage: Option<ChatUsage>,
-    response_text: &str,
-) -> ProviderEditOutcome {
+fn provider_repair_context(state: &CodingMissionState) -> anyhow::Result<ProviderRepairContext> {
+    let failed_verifiers = state
+        .command_evidence
+        .iter()
+        .rev()
+        .filter(|evidence| {
+            evidence.reason_code.starts_with("coding_verifier")
+                && evidence.status == CodingWorkspaceCommandStatus::Failed
+        })
+        .take(4)
+        .map(|evidence| ProviderVerifierFailureContext {
+            argv: evidence.argv.clone(),
+            exit_status: evidence.exit_status,
+            stdout: read_artifact_snippet(evidence.stdout_path.as_path(), 2_000),
+            stderr: read_artifact_snippet(evidence.stderr_path.as_path(), 4_000),
+        })
+        .collect::<Vec<_>>();
+    let changed_files = git_lines(state.repo_path.as_path(), &["status", "--porcelain"])?;
+    let git_diff = git_snippet(state.repo_path.as_path(), &["diff", "--", "."], 12_000)?;
+    Ok(ProviderRepairContext {
+        failed_verifiers,
+        changed_files: parse_git_status_changed_file_names(&changed_files),
+        git_diff,
+    })
+}
+
+fn render_provider_repair_context(context: &ProviderRepairContext) -> String {
+    let failed = context
+        .failed_verifiers
+        .iter()
+        .enumerate()
+        .map(|(index, failure)| {
+            format!(
+                "Failure {}:\nargv: {}\nexit_status: {}\nstdout:\n{}\nstderr:\n{}",
+                index.saturating_add(1),
+                failure.argv.join(" "),
+                failure
+                    .exit_status
+                    .map(|status| status.to_string())
+                    .unwrap_or_else(|| "spawn_failed".to_string()),
+                failure.stdout,
+                failure.stderr
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let changed_files = if context.changed_files.is_empty() {
+        "none".to_string()
+    } else {
+        context.changed_files.join("\n")
+    };
+    format!(
+        "\n\nRepair attempt context:\nThe previous provider edit did not pass verification. Return a targeted JSON patch for the current dirty worktree.\n\nFailed verifier evidence:\n{}\n\nChanged files:\n{}\n\nCurrent git diff:\n{}\n",
+        failed,
+        changed_files,
+        context.git_diff
+    )
+}
+
+fn read_artifact_snippet(path: &Path, max_chars: usize) -> String {
+    let raw = fs::read_to_string(path).unwrap_or_default();
+    truncate_chars(redact_secret_like_tokens(&raw).as_str(), max_chars)
+}
+
+fn git_lines(repo_path: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .with_context(|| format!("run git {} in {}", args.join(" "), repo_path.display()))?;
+    if !output.status.success() {
+        return Ok(String::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn git_snippet(repo_path: &Path, args: &[&str], max_chars: usize) -> anyhow::Result<String> {
+    let raw = git_lines(repo_path, args)?;
+    Ok(truncate_chars(
+        redact_secret_like_tokens(&raw).as_str(),
+        max_chars,
+    ))
+}
+
+fn parse_git_status_changed_file_names(raw_status: &str) -> Vec<String> {
+    raw_status
+        .lines()
+        .filter_map(|line| line.get(3..))
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            line.rsplit_once(" -> ")
+                .map(|(_from, to)| to)
+                .unwrap_or(line)
+                .to_string()
+        })
+        .collect()
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value.chars().take(max_chars).collect::<String>();
+    truncated.push_str("\n[truncated]");
+    truncated
+}
+
+fn provider_edit_from_response(input: ProviderEditResponseInput<'_>) -> ProviderEditOutcome {
+    let ProviderEditResponseInput {
+        attempt_index,
+        mode,
+        model_ref,
+        repair,
+        dispatched,
+        finish_reason,
+        usage,
+        response_text,
+    } = input;
     let response_text_bytes = response_text.len();
     let response_text_sha256 = sha256_hex(response_text.as_bytes());
     let usage_report = usage.as_ref().map(provider_usage_report);
@@ -802,6 +1020,7 @@ fn provider_edit_from_response(
                 let edit_relative_path = provider_edit_paths_summary(&edits);
                 let edit_reason_code = provider_edit_reason_summary(&edits);
                 let report = ProviderProofReport {
+                    attempt_index,
                     mode,
                     provider: model_ref.provider.as_str().to_string(),
                     model: model_ref.model.clone(),
@@ -814,12 +1033,18 @@ fn provider_edit_from_response(
                     response_text_sha256: Some(response_text_sha256),
                     edit_relative_path: Some(edit_relative_path),
                     edit_reason_code: Some(edit_reason_code),
+                    repair_context_included: repair.is_some(),
+                    failed_verifier_count: repair
+                        .map(|context| context.failed_verifiers.len())
+                        .unwrap_or_default(),
+                    diff_context_bytes: repair.map(|context| context.git_diff.len()),
                     error: None,
                 };
                 ProviderEditOutcome::Ready(ProviderEditResolution { edits, report })
             }
             Err(error) => {
                 ProviderEditOutcome::Failed(provider_failure_report(ProviderFailureReportInput {
+                    attempt_index,
                     mode,
                     model_ref,
                     dispatched,
@@ -828,11 +1053,13 @@ fn provider_edit_from_response(
                     response_text_bytes: Some(response_text_bytes),
                     response_text_sha256: Some(response_text_sha256),
                     usage: usage_report,
+                    repair,
                 }))
             }
         },
         Err(error) => {
             ProviderEditOutcome::Failed(provider_failure_report(ProviderFailureReportInput {
+                attempt_index,
                 mode,
                 model_ref,
                 dispatched,
@@ -841,6 +1068,7 @@ fn provider_edit_from_response(
                 response_text_bytes: Some(response_text_bytes),
                 response_text_sha256: Some(response_text_sha256),
                 usage: usage_report,
+                repair,
             }))
         }
     }
@@ -918,6 +1146,7 @@ fn provider_edit_reason_summary(edits: &[CodingMissionControlledEdit]) -> String
 
 fn provider_failure_report(input: ProviderFailureReportInput<'_>) -> ProviderProofReport {
     ProviderProofReport {
+        attempt_index: input.attempt_index,
         mode: input.mode,
         provider: input.model_ref.provider.as_str().to_string(),
         model: input.model_ref.model.clone(),
@@ -936,6 +1165,12 @@ fn provider_failure_report(input: ProviderFailureReportInput<'_>) -> ProviderPro
         response_text_sha256: input.response_text_sha256,
         edit_relative_path: None,
         edit_reason_code: None,
+        repair_context_included: input.repair.is_some(),
+        failed_verifier_count: input
+            .repair
+            .map(|context| context.failed_verifiers.len())
+            .unwrap_or_default(),
+        diff_context_bytes: input.repair.map(|context| context.git_diff.len()),
         error: input.error,
     }
 }
@@ -1001,6 +1236,7 @@ fn provider_report_satisfies_mode(mode: HarnessMode, report: Option<&ProviderPro
 }
 
 fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
+    let final_provider = input.provider_attempts.last().cloned();
     let commit = input
         .state
         .git_evidence
@@ -1052,7 +1288,7 @@ fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
                 && verifier_transcript
                     .iter()
                     .any(|evidence| evidence.status == "succeeded")
-                && provider_report_satisfies_mode(input.mode, input.provider.as_ref())
+                && provider_report_satisfies_mode(input.mode, final_provider.as_ref())
                 && (input.mode != HarnessMode::RealRepo || changed_files.len() >= 2);
             if !ok {
                 failure_reasons.push(match input.mode {
@@ -1101,7 +1337,8 @@ fn build_report(input: LiveLoopReportInput<'_>) -> LiveLoopReport {
         resume: input.resume,
         blocked_reason: input.outcome.blocked_reason.clone(),
         pr_ready: pr_ready_report,
-        provider: input.provider,
+        provider: final_provider,
+        provider_attempts: input.provider_attempts,
         operator_interventions_used: Vec::new(),
         no_routine_human_steering_used: true,
     }
@@ -1260,7 +1497,8 @@ mod provider_backed_tests {
             provider_timeout_ms: 120_000,
             provider_max_retries: 1,
             provider_max_tokens: 1_024,
-            mock_provider_response: None,
+            provider_repair_attempts: 2,
+            mock_provider_responses: Vec::new(),
             verifier_commands: Vec::new(),
         }
     }
@@ -1268,19 +1506,21 @@ mod provider_backed_tests {
     #[test]
     fn provider_backed_parses_json_edit() {
         let model_ref = ModelRef::parse("openai/test-model").expect("model parses");
-        let outcome = provider_edit_from_response(
-            "mock",
-            &model_ref,
-            true,
-            Some("stop".to_string()),
-            Some(ChatUsage {
+        let outcome = provider_edit_from_response(ProviderEditResponseInput {
+            attempt_index: 1,
+            mode: "mock",
+            model_ref: &model_ref,
+            repair: None,
+            dispatched: true,
+            finish_reason: Some("stop".to_string()),
+            usage: Some(ChatUsage {
                 input_tokens: 10,
                 output_tokens: 8,
                 total_tokens: 18,
                 cached_input_tokens: 2,
             }),
-            r#"{"relative_path":"status.txt","contents":"pass","reason_code":"provider_test"}"#,
-        );
+            response_text: r#"{"relative_path":"status.txt","contents":"pass","reason_code":"provider_test"}"#,
+        });
 
         let ProviderEditOutcome::Ready(resolved) = outcome else {
             panic!("provider edit should parse");
@@ -1290,6 +1530,8 @@ mod provider_backed_tests {
         assert_eq!(resolved.edits[0].contents, "pass\n");
         assert_eq!(resolved.edits[0].reason_code, "provider_test");
         assert_eq!(resolved.report.parse_status, "parsed");
+        assert_eq!(resolved.report.attempt_index, 1);
+        assert!(!resolved.report.repair_context_included);
         assert_eq!(
             resolved.report.edit_relative_path.as_deref(),
             Some("status.txt")
@@ -1308,14 +1550,17 @@ mod provider_backed_tests {
     #[test]
     fn provider_backed_parses_json_edit_array() {
         let model_ref = ModelRef::parse("openai/test-model").expect("model parses");
-        let outcome = provider_edit_from_response(
-            "mock",
-            &model_ref,
-            true,
-            Some("stop".to_string()),
-            None,
-            r#"{"edits":[{"relative_path":"status.txt","contents":"pass","reason_code":"provider_status"},{"relative_path":"docs/notes.txt","contents":"helper\n","reason_code":"provider_notes"}]}"#,
-        );
+        let repair = repair_context_fixture();
+        let outcome = provider_edit_from_response(ProviderEditResponseInput {
+            attempt_index: 2,
+            mode: "mock",
+            model_ref: &model_ref,
+            repair: Some(&repair),
+            dispatched: true,
+            finish_reason: Some("stop".to_string()),
+            usage: None,
+            response_text: r#"{"edits":[{"relative_path":"status.txt","contents":"pass","reason_code":"provider_status"},{"relative_path":"docs/notes.txt","contents":"helper\n","reason_code":"provider_notes"}]}"#,
+        });
 
         let ProviderEditOutcome::Ready(resolved) = outcome else {
             panic!("provider edit array should parse");
@@ -1329,6 +1574,13 @@ mod provider_backed_tests {
         );
         assert_eq!(resolved.edits[1].contents, "helper\n");
         assert_eq!(resolved.report.parse_status, "parsed");
+        assert_eq!(resolved.report.attempt_index, 2);
+        assert!(resolved.report.repair_context_included);
+        assert_eq!(resolved.report.failed_verifier_count, 1);
+        assert_eq!(
+            resolved.report.diff_context_bytes,
+            Some(repair.git_diff.len())
+        );
         assert_eq!(
             resolved.report.edit_relative_path.as_deref(),
             Some("status.txt,docs/notes.txt")
@@ -1338,13 +1590,25 @@ mod provider_backed_tests {
     #[test]
     fn provider_backed_malformed_response_fails_closed() {
         let model_ref = ModelRef::parse("openai/test-model").expect("model parses");
-        let outcome = provider_edit_from_response("mock", &model_ref, true, None, None, "not-json");
+        let repair = repair_context_fixture();
+        let outcome = provider_edit_from_response(ProviderEditResponseInput {
+            attempt_index: 3,
+            mode: "mock",
+            model_ref: &model_ref,
+            repair: Some(&repair),
+            dispatched: true,
+            finish_reason: None,
+            usage: None,
+            response_text: "not-json",
+        });
 
         let ProviderEditOutcome::Failed(report) = outcome else {
             panic!("malformed provider output should fail");
         };
         assert_eq!(report.parse_status, "malformed");
         assert_eq!(report.reason_code, "provider_output_malformed");
+        assert_eq!(report.attempt_index, 3);
+        assert!(report.repair_context_included);
         assert!(report.edit_relative_path.is_none());
         assert!(report.response_text_sha256.is_some());
     }
@@ -1352,14 +1616,16 @@ mod provider_backed_tests {
     #[test]
     fn provider_backed_rejects_path_escape() {
         let model_ref = ModelRef::parse("openai/test-model").expect("model parses");
-        let outcome = provider_edit_from_response(
-            "mock",
-            &model_ref,
-            true,
-            None,
-            None,
-            r#"{"relative_path":"../status.txt","contents":"pass\n"}"#,
-        );
+        let outcome = provider_edit_from_response(ProviderEditResponseInput {
+            attempt_index: 1,
+            mode: "mock",
+            model_ref: &model_ref,
+            repair: None,
+            dispatched: true,
+            finish_reason: None,
+            usage: None,
+            response_text: r#"{"relative_path":"../status.txt","contents":"pass\n"}"#,
+        });
 
         let ProviderEditOutcome::Failed(report) = outcome else {
             panic!("escaping provider edit should fail");
@@ -1370,25 +1636,69 @@ mod provider_backed_tests {
     }
 
     #[test]
+    fn provider_repair_context_render_includes_verifier_and_diff() {
+        let rendered = render_provider_repair_context(&repair_context_fixture());
+
+        assert!(rendered.contains("Repair attempt context"));
+        assert!(rendered.contains("grep -q repaired notes.txt"));
+        assert!(rendered.contains("expected repaired"));
+        assert!(rendered.contains("status.txt"));
+        assert!(rendered.contains("+pass"));
+    }
+
+    fn repair_context_fixture() -> ProviderRepairContext {
+        ProviderRepairContext {
+            failed_verifiers: vec![ProviderVerifierFailureContext {
+                argv: vec![
+                    "grep".to_string(),
+                    "-q".to_string(),
+                    "repaired".to_string(),
+                    "notes.txt".to_string(),
+                ],
+                exit_status: Some(1),
+                stdout: String::new(),
+                stderr: "expected repaired notes.txt".to_string(),
+            }],
+            changed_files: vec!["status.txt".to_string()],
+            git_diff: "diff --git a/status.txt b/status.txt\n+pass\n".to_string(),
+        }
+    }
+
+    fn run_provider_cli_stack_test(f: impl FnOnce() + Send + 'static) {
+        std::thread::Builder::new()
+            .name("provider-cli-stack-test".to_string())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn provider cli stack test")
+            .join()
+            .expect("provider cli stack test should not panic");
+    }
+
+    #[test]
     fn provider_backed_openrouter_api_key_mode_injects_openrouter_key() {
-        let _guard = env_lock().lock().expect("env lock");
-        let prior_openrouter = std::env::var("OPENROUTER_API_KEY").ok();
-        let prior_tau_openrouter = std::env::var("TAU_OPENROUTER_API_KEY").ok();
-        let prior_openai = std::env::var("OPENAI_API_KEY").ok();
+        run_provider_cli_stack_test(|| {
+            let _guard = env_lock().lock().expect("env lock");
+            let prior_openrouter = std::env::var("OPENROUTER_API_KEY").ok();
+            let prior_tau_openrouter = std::env::var("TAU_OPENROUTER_API_KEY").ok();
+            let prior_openai = std::env::var("OPENAI_API_KEY").ok();
 
-        std::env::set_var("OPENROUTER_API_KEY", "test-openrouter-key");
-        std::env::remove_var("TAU_OPENROUTER_API_KEY");
-        std::env::remove_var("OPENAI_API_KEY");
+            std::env::set_var("OPENROUTER_API_KEY", "test-openrouter-key");
+            std::env::remove_var("TAU_OPENROUTER_API_KEY");
+            std::env::remove_var("OPENAI_API_KEY");
 
-        let args = provider_test_args("openrouter/deepseek/deepseek-v4-flash");
-        let model_ref = ModelRef::parse(&args.provider_model).expect("model parses");
-        let cli = provider_cli(&args, &model_ref).expect("provider cli");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let args = provider_test_args("openrouter/deepseek/deepseek-v4-flash");
+                let model_ref = ModelRef::parse(&args.provider_model).expect("model parses");
+                let cli = provider_cli(&args, &model_ref).expect("provider cli");
 
-        assert_eq!(cli.openai_api_key.as_deref(), Some("test-openrouter-key"));
+                assert_eq!(cli.openai_api_key.as_deref(), Some("test-openrouter-key"));
+            }));
 
-        restore_env("OPENROUTER_API_KEY", prior_openrouter);
-        restore_env("TAU_OPENROUTER_API_KEY", prior_tau_openrouter);
-        restore_env("OPENAI_API_KEY", prior_openai);
+            restore_env("OPENROUTER_API_KEY", prior_openrouter);
+            restore_env("TAU_OPENROUTER_API_KEY", prior_tau_openrouter);
+            restore_env("OPENAI_API_KEY", prior_openai);
+            result.expect("provider cli assertions should pass");
+        });
     }
 
     #[test]

--- a/docs/guides/canonical-product-proof.md
+++ b/docs/guides/canonical-product-proof.md
@@ -112,6 +112,28 @@ Boundary: this is a provider-backed disposable fixture for the M334 task. It is
 stronger than the controlled-edit lifecycle proof, but it is still not evidence
 that Tau can autonomously solve arbitrary repository issues without supervision.
 
+Run the provider verifier repair loop when the question is whether Tau can keep
+working after a provider edit fails verification:
+
+```bash
+TAU_LIVE_PROVIDER_REPAIR_PROOF=1 \
+  TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash \
+  ./scripts/dev/test-provider-verifier-repair-loop.sh
+```
+
+The script first runs deterministic checks for successful repair and exhausted
+repair-budget fail-closed behavior. With `TAU_LIVE_PROVIDER_REPAIR_PROOF=1`, it
+then deliberately applies a first provider-shaped edit that leaves one verifier
+failing, captures failed verifier evidence plus git diff, sends that repair
+context to the configured provider, reruns verification, and expects commit plus
+manual PR-ready output. Set `TAU_PROVIDER_PROOF_REPORT_DIR=/path/to/reports` to
+preserve sanitized JSON reports.
+
+Boundary: this proves a bounded verifier failure -> provider repair -> rerun ->
+PR-ready loop for a disposable M334 real-repo fixture. It still does not claim
+unattended arbitrary issue selection, merge authority, or protected-branch
+bypass.
+
 To also verify the Gateway sessions API readiness surface, add `--sessions-smoke`. This fetches `/gateway/sessions`, validates the JSON response shape, and records the sessions endpoint in the report:
 
 ```bash

--- a/scripts/dev/test-provider-verifier-repair-loop.sh
+++ b/scripts/dev/test-provider-verifier-repair-loop.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURE_PATH="${REPO_ROOT}/tasks/fixtures/m334/tranche-one-autonomy-benchmark.json"
+TASK_ID="repo_spec_to_pr_feature_delivery"
+TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/rust_pi-3798-repair-loop-target}"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tau-provider-repair-loop.XXXXXX")"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+export CARGO_TARGET_DIR="${TARGET_DIR}"
+
+load_repo_dotenv_if_present() {
+  local dotenv_path="${REPO_ROOT}/.env"
+  [[ -f "${dotenv_path}" ]] || return 0
+
+  local line key value
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -n "${line}" && "${line}" != \#* ]] || continue
+    if [[ "${line}" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="${line#"${line%%[![:space:]]*}"}"
+    fi
+    [[ "${line}" == *=* ]] || continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    [[ -z "${!key:-}" ]] || continue
+    if [[ "${#value}" -ge 2 ]]; then
+      if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+        value="${value:1:${#value}-2}"
+      elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+    fi
+    export "${key}=${value}"
+  done <"${dotenv_path}"
+}
+
+save_report() {
+  local source_path="$1"
+  local name="$2"
+  if [[ -n "${TAU_PROVIDER_PROOF_REPORT_DIR:-}" ]]; then
+    mkdir -p "${TAU_PROVIDER_PROOF_REPORT_DIR}"
+    cp "${source_path}" "${TAU_PROVIDER_PROOF_REPORT_DIR}/${name}"
+  fi
+}
+
+load_repo_dotenv_if_present
+
+MODEL="${TAU_PROVIDER_PROOF_MODEL:-openai/gpt-4.1-mini}"
+AUTH_MODE="${TAU_PROVIDER_PROOF_AUTH_MODE:-api-key}"
+MAX_TOKENS="${TAU_PROVIDER_PROOF_MAX_TOKENS:-1024}"
+LIVE_REPAIR_ENABLED="${TAU_LIVE_PROVIDER_REPAIR_PROOF:-0}"
+
+REPO="${WORK_DIR}/repo"
+STATE="${WORK_DIR}/state"
+REPORT="${WORK_DIR}/repair-report.json"
+EXHAUSTED_REPO="${WORK_DIR}/exhausted-repo"
+EXHAUSTED_STATE="${WORK_DIR}/exhausted-state"
+EXHAUSTED_REPORT="${WORK_DIR}/exhausted-report.json"
+
+mkdir -p "${REPO}"
+git -C "${REPO}" init -b master >/dev/null
+git -C "${REPO}" config user.email tau-repair@example.test
+git -C "${REPO}" config user.name "Tau Repair Test"
+printf 'fail\n' >"${REPO}/status.txt"
+printf 'missing\n' >"${REPO}/notes.txt"
+git -C "${REPO}" add .
+git -C "${REPO}" commit -m "Seed provider repair fixture" >/dev/null
+
+cd "${REPO_ROOT}"
+
+cargo run -q -p tau-coding-agent --bin tau_live_coding_loop_harness -- \
+  --fixture "${FIXTURE_PATH}" \
+  --task-id "${TASK_ID}" \
+  --mode real-repo \
+  --state-root "${STATE}" \
+  --repo-root "${REPO}" \
+  --output "${REPORT}" \
+  --run-id "m334-provider-repair-loop" \
+  --started-unix-ms 1800000700000 \
+  --provider-model openai/test-model \
+  --provider-auth-mode api-key \
+  --provider-repair-attempts 1 \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q repaired notes.txt" \
+  --mock-provider-response '{"relative_path":"status.txt","contents":"pass\n","reason_code":"provider_first_attempt"}' \
+  --mock-provider-response '{"relative_path":"notes.txt","contents":"repaired\n","reason_code":"provider_repair_attempt"}' >/dev/null
+
+python3 - "${REPORT}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(report["passed"] is True, report)
+require(report["phase"] == "pr_ready", report["phase"])
+require(report["commit_hash"] and len(report["commit_hash"]) == 40, report["commit_hash"])
+require(report["pr_ready"]["status"] == "manual_ready", report["pr_ready"])
+require(set(report["changed_files"]) == {"status.txt", "notes.txt"}, report["changed_files"])
+require(report["provider"]["edit_relative_path"] == "notes.txt", report["provider"])
+
+attempts = report["provider_attempts"]
+require(len(attempts) == 2, attempts)
+require(attempts[0]["attempt_index"] == 1, attempts)
+require(attempts[0]["repair_context_included"] is False, attempts[0])
+require(attempts[0]["edit_relative_path"] == "status.txt", attempts[0])
+require(attempts[1]["attempt_index"] == 2, attempts)
+require(attempts[1]["repair_context_included"] is True, attempts[1])
+require(attempts[1]["failed_verifier_count"] >= 1, attempts[1])
+require(attempts[1]["diff_context_bytes"] and attempts[1]["diff_context_bytes"] > 0, attempts[1])
+require(attempts[1]["edit_relative_path"] == "notes.txt", attempts[1])
+
+statuses = [item["status"] for item in report["verifier_transcript"]]
+require(statuses.count("failed") >= 2, statuses)
+require(statuses.count("succeeded") >= 3, statuses)
+PY
+
+save_report "${REPORT}" "provider-repair-report.json"
+echo "provider verifier repair loop passed: ${REPORT}"
+
+mkdir -p "${EXHAUSTED_REPO}"
+git -C "${EXHAUSTED_REPO}" init -b master >/dev/null
+git -C "${EXHAUSTED_REPO}" config user.email tau-repair@example.test
+git -C "${EXHAUSTED_REPO}" config user.name "Tau Repair Test"
+printf 'fail\n' >"${EXHAUSTED_REPO}/status.txt"
+printf 'missing\n' >"${EXHAUSTED_REPO}/notes.txt"
+git -C "${EXHAUSTED_REPO}" add .
+git -C "${EXHAUSTED_REPO}" commit -m "Seed exhausted provider repair fixture" >/dev/null
+
+if cargo run -q -p tau-coding-agent --bin tau_live_coding_loop_harness -- \
+  --fixture "${FIXTURE_PATH}" \
+  --task-id "${TASK_ID}" \
+  --mode real-repo \
+  --state-root "${EXHAUSTED_STATE}" \
+  --repo-root "${EXHAUSTED_REPO}" \
+  --output "${EXHAUSTED_REPORT}" \
+  --run-id "m334-provider-repair-loop-exhausted" \
+  --started-unix-ms 1800000800000 \
+  --provider-model openai/test-model \
+  --provider-auth-mode api-key \
+  --provider-repair-attempts 0 \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q repaired notes.txt" \
+  --mock-provider-response '{"relative_path":"status.txt","contents":"pass\n","reason_code":"provider_first_attempt"}' >/dev/null
+then
+  echo "expected exhausted provider repair loop to exit nonzero" >&2
+  exit 1
+fi
+
+python3 - "${EXHAUSTED_REPORT}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(report["passed"] is False, report)
+require(report["phase"] == "blocked", report["phase"])
+require(report["blocked_reason"] == "provider_repair_attempts_exhausted", report["blocked_reason"])
+require(report["commit_hash"] is None, report["commit_hash"])
+require(report["pr_ready"] is None, report["pr_ready"])
+attempts = report["provider_attempts"]
+require(len(attempts) == 1, attempts)
+require(attempts[0]["attempt_index"] == 1, attempts[0])
+require(attempts[0]["repair_context_included"] is False, attempts[0])
+require(attempts[0]["edit_relative_path"] == "status.txt", attempts[0])
+statuses = [item["status"] for item in report["verifier_transcript"]]
+require(statuses.count("failed") >= 2, statuses)
+require(statuses.count("succeeded") >= 1, statuses)
+PY
+
+save_report "${EXHAUSTED_REPORT}" "provider-repair-exhausted-report.json"
+echo "provider verifier repair loop exhausted safely: ${EXHAUSTED_REPORT}"
+
+if [[ "${LIVE_REPAIR_ENABLED}" != "1" ]]; then
+  echo "provider live repair proof skipped; set TAU_LIVE_PROVIDER_REPAIR_PROOF=1 to run provider-backed repair"
+  exit 0
+fi
+
+LIVE_REPO="${WORK_DIR}/live-repair-repo"
+LIVE_STATE="${WORK_DIR}/live-repair-state"
+LIVE_REPORT="${WORK_DIR}/live-repair-report.json"
+
+mkdir -p "${LIVE_REPO}"
+git -C "${LIVE_REPO}" init -b master >/dev/null
+git -C "${LIVE_REPO}" config user.email tau-repair@example.test
+git -C "${LIVE_REPO}" config user.name "Tau Repair Test"
+printf 'fail\n' >"${LIVE_REPO}/status.txt"
+printf 'missing\n' >"${LIVE_REPO}/notes.txt"
+git -C "${LIVE_REPO}" add .
+git -C "${LIVE_REPO}" commit -m "Seed live provider repair fixture" >/dev/null
+
+set +e
+cargo run -q -p tau-coding-agent --bin tau_live_coding_loop_harness -- \
+  --fixture "${FIXTURE_PATH}" \
+  --task-id "${TASK_ID}" \
+  --mode real-repo \
+  --state-root "${LIVE_STATE}" \
+  --repo-root "${LIVE_REPO}" \
+  --output "${LIVE_REPORT}" \
+  --run-id "m334-provider-live-repair-loop" \
+  --started-unix-ms 1800000900000 \
+  --provider-model "${MODEL}" \
+  --provider-auth-mode "${AUTH_MODE}" \
+  --provider-max-tokens "${MAX_TOKENS}" \
+  --provider-repair-attempts 1 \
+  --verifier-command "grep -q pass status.txt" \
+  --verifier-command "grep -q repaired notes.txt" \
+  --mock-provider-response '{"relative_path":"status.txt","contents":"pass\n","reason_code":"provider_first_attempt"}' >/dev/null
+live_status=$?
+set -e
+
+save_report "${LIVE_REPORT}" "provider-live-repair-report.json"
+if [[ "${live_status}" -ne 0 ]]; then
+  echo "provider live verifier repair loop failed; report saved to ${LIVE_REPORT}" >&2
+  exit "${live_status}"
+fi
+
+python3 - "${LIVE_REPORT}" "${MODEL}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+model = sys.argv[2]
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(report["passed"] is True, report)
+require(report["phase"] == "pr_ready", report["phase"])
+require(report["commit_hash"] and len(report["commit_hash"]) == 40, report["commit_hash"])
+require("notes.txt" in report["changed_files"], report["changed_files"])
+attempts = report["provider_attempts"]
+require(len(attempts) == 2, attempts)
+require(attempts[0]["mode"] == "mock", attempts[0])
+require(attempts[0]["repair_context_included"] is False, attempts[0])
+repair = attempts[1]
+require(repair["mode"] == "live", repair)
+require(repair["dispatched"] is True, repair)
+require(repair["parse_status"] == "parsed", repair)
+require(repair["repair_context_included"] is True, repair)
+require(repair["failed_verifier_count"] >= 1, repair)
+require(repair["diff_context_bytes"] and repair["diff_context_bytes"] > 0, repair)
+require("notes.txt" in (repair["edit_relative_path"] or ""), repair)
+require(repair["response_text_sha256"], repair)
+require(repair["provider"] == model.split("/", 1)[0], repair)
+require(repair["model"] == model.split("/", 1)[1], repair)
+statuses = [item["status"] for item in report["verifier_transcript"]]
+require(statuses.count("failed") >= 2, statuses)
+require(statuses.count("succeeded") >= 3, statuses)
+PY
+
+save_report "${LIVE_REPORT}" "provider-live-repair-report.json"
+echo "provider live verifier repair loop passed: ${LIVE_REPORT}"

--- a/specs/3798-provider-verifier-repair-loop/plan.md
+++ b/specs/3798-provider-verifier-repair-loop/plan.md
@@ -1,0 +1,54 @@
+# Plan: Provider Verifier Repair Loop
+
+GitHub Issue: #3798
+Status: Implemented
+
+## Approach
+
+Extend the existing provider-backed harness rather than adding a parallel agent:
+
+- Add a `provider_repair_attempts` CLI setting with a small bounded default.
+- Track each provider attempt in the JSON report.
+- Keep the first attempt prompt compatible with the existing proof path.
+- On verifier failure without a hard blocked reason, collect:
+  - failed verifier command argv,
+  - failed stdout/stderr snippets,
+  - current changed files,
+  - current git diff snippet.
+- Send that repair context to the provider prompt.
+- Apply the returned edit set with `CodingMissionRunner::resume`.
+- Stop immediately when the mission reaches PR-ready, when provider parsing
+  fails, when the verifier is hard-blocked, or when attempts are exhausted.
+
+## Affected Modules
+
+- `crates/tau-coding-agent/src/bin/tau_live_coding_loop_harness.rs`
+- `scripts/dev/test-provider-verifier-repair-loop.sh`
+- `README.md`
+- `docs/guides/canonical-product-proof.md`
+- `specs/3798-provider-verifier-repair-loop/*`
+
+## Risks And Mitigations
+
+- Risk: unbounded retry behavior hides bad model output. Mitigation: bounded
+  attempts and explicit exhausted-repair fail-closed reason.
+- Risk: repair prompt leaks secrets from command output. Mitigation: reuse
+  redaction before embedding stdout/stderr/diff snippets.
+- Risk: existing provider proof report consumers expect a single `provider`.
+  Mitigation: keep `provider` as the final attempt and add `provider_attempts`
+  as a backward-compatible field.
+
+## Interfaces
+
+- CLI: `--provider-repair-attempts <n>` controls additional provider repair
+  attempts after the first provider edit.
+- CLI: repeated `--mock-provider-response` values apply only to their matching
+  attempt; later attempts call the configured provider.
+- Report: `provider_attempts: ProviderProofReport[]`.
+- Provider prompt: repair attempts include failed verifier and diff context.
+
+## ADR
+
+No ADR required: this is bounded harness behavior and does not change provider
+protocols, transport semantics, schemas outside the harness report, or
+dependencies.

--- a/specs/3798-provider-verifier-repair-loop/spec.md
+++ b/specs/3798-provider-verifier-repair-loop/spec.md
@@ -1,0 +1,80 @@
+# Issue #3798: Provider Verifier Repair Loop
+
+Status: Implemented
+GitHub Issue: #3798
+Priority: P1
+Milestone: M334 - Tau Ralph loop supervisor architecture
+
+## Problem
+
+Tau's provider-backed coding loop can request a provider edit, apply it, run
+verifiers, and produce PR-ready output when the first edit succeeds. When the
+post-edit verifier fails, the loop currently stops in an executing state without
+feeding the verifier failure back into the provider.
+
+That makes Tau a one-shot code generator rather than a functional autonomous
+coding harness. The product loop needs a bounded repair cycle: inspect failed
+verifier evidence and the current diff, ask the provider for a targeted patch,
+rerun verifiers, and only commit/prepare PR-ready output after verification is
+green.
+
+## Scope
+
+In scope:
+- Add a bounded provider repair loop to `tau_live_coding_loop_harness`.
+- Include failed verifier stdout/stderr, current changed files, and current diff
+  context in repair prompts.
+- Persist per-attempt provider evidence in the harness report.
+- Add deterministic coverage where the first provider edit fails a verifier and
+  a second provider repair reaches PR-ready.
+- Preserve fail-closed behavior for malformed provider output, invalid edits,
+  missing provider client/auth, and exhausted repair attempts.
+
+Out of scope:
+- Changing provider transport semantics or adding new model providers.
+- Launching a live browser/game inspection loop.
+- Automatically opening or merging GitHub PRs from this harness.
+- Adding unbounded retries.
+
+## Acceptance Criteria
+
+### AC-1: Failed Verifier Triggers Provider Repair
+
+Given a provider edit is parsed and applied but a verifier fails, when repair
+attempts remain, then Tau builds a repair prompt containing failed verifier
+evidence and current diff context and asks the provider for a targeted patch.
+
+### AC-2: Repair Can Reach PR-Ready
+
+Given the second provider response fixes the verifier failure, when Tau applies
+the repair and reruns verifiers, then the mission commits the verified changes
+and prepares PR-ready output.
+
+### AC-3: Attempts Are Durable And Observable
+
+Given a provider-backed run uses multiple provider attempts, when the report is
+written, then it includes the final provider report plus an ordered attempt list
+with parse status, reason code, edit paths, response hash, and repair context
+flags.
+
+### AC-4: Exhausted Repairs Fail Closed
+
+Given verifier failures persist until the configured repair attempt limit is
+exhausted, when the loop exits, then Tau does not commit, does not prepare
+PR-ready output, records the exhausted repair reason, and keeps verifier
+evidence available.
+
+## Conformance Cases
+
+| Case | AC | Tier | Given | When | Then |
+| --- | --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | first provider edit fails verifier | provider loop continues | second prompt includes verifier stderr and git diff context |
+| C-02 | AC-2 | Integration | second provider edit fixes verifier | provider loop reruns | report passes, commit exists, PR-ready bundle exists |
+| C-03 | AC-3 | Functional | two provider attempts run | report is written | `provider_attempts` contains two sanitized attempts |
+| C-04 | AC-4 | Regression | provider attempts do not satisfy verifier | attempt limit reached | report blocks without commit or PR-ready bundle |
+
+## Success Signals
+
+- Focused harness tests cover C-01, C-03, and C-04.
+- A shell integration script covers C-02 against a disposable repo.
+- Existing provider-backed proof scripts continue to pass.

--- a/specs/3798-provider-verifier-repair-loop/tasks.md
+++ b/specs/3798-provider-verifier-repair-loop/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Provider Verifier Repair Loop
+
+GitHub Issue: #3798
+Status: Implemented
+
+- [x] T1 (RED): Add deterministic provider repair tests/script where first
+  provider edit fails and second provider edit reaches PR-ready.
+- [x] T2 (GREEN): Add bounded provider attempt loop and per-attempt report
+  fields.
+- [x] T3 (GREEN): Add repair prompt context from verifier stderr/stdout and git
+  diff.
+- [x] T4 (GREEN): Preserve malformed/invalid/exhausted repair fail-closed
+  behavior.
+- [x] T5 (VERIFY): Run focused tests, scripts, fmt, diff check, and clippy.
+
+## Test Tiers
+
+| Tier | Status | Tests | N/A Why |
+| --- | --- | --- | --- |
+| Unit | Done | `cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` | |
+| Property | N/A | | No randomized parser or invariant introduced |
+| Contract/DbC | N/A | | No formal contract macro surface changed |
+| Snapshot | N/A | | JSON report fields asserted directly |
+| Functional | Done | repair prompt render test; deterministic repair and exhausted report assertions | |
+| Conformance | Done | `provider_attempts` report assertions in unit tests and shell proof | |
+| Integration | Done | `scripts/dev/test-provider-verifier-repair-loop.sh`; opt-in live OpenRouter repair proof | |
+| Fuzz | N/A | | No untrusted parser/fuzz target changed |
+| Mutation | N/A | | Follow-up release gate; focused repair-loop regression coverage in this slice |
+| Regression | Done | malformed provider output test; exhausted repair budget script path | |
+| Performance | N/A | | Bounded attempts only; no hot path benchmarked |
+
+## Verification Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh`
+  initially failed before implementation because
+  `--provider-repair-attempts` was not a recognized argument.
+- Unit: `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1`
+  passed with 7 tests.
+- Deterministic integration:
+  `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh`
+  passed successful repair and exhausted-budget fail-closed cases.
+- Live provider repair:
+  `TAU_LIVE_PROVIDER_REPAIR_PROOF=1 TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash TAU_PROVIDER_PROOF_REPORT_DIR=/tmp/tau-3798-repair-proof CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh`
+  passed. The live report recorded attempt 1 as mock, attempt 2 as live
+  OpenRouter, parsed repair context, `notes.txt,status.txt` edit paths, GREEN
+  verifier rerun, commit hash, and manual PR-ready output.


### PR DESCRIPTION
## Summary
Adds a bounded provider verifier repair loop to `tau_live_coding_loop_harness`: verifier failure after a provider edit now captures failed verifier evidence plus git diff, asks the next provider attempt for a targeted JSON patch, reruns verification, and only commits/marks PR-ready when verifiers pass. Also adds deterministic and opt-in live OpenRouter repair-loop proof coverage.

Human review requested: this is a P1 multi-module spec slice per the repository contract.

## Links
- Milestone: M334 - Tau Ralph loop supervisor architecture
- Closes #3798
- Spec: `specs/3798-provider-verifier-repair-loop/spec.md`
- Plan: `specs/3798-provider-verifier-repair-loop/plan.md`
- Tasks: `specs/3798-provider-verifier-repair-loop/tasks.md`

## Spec Verification (AC -> tests)

| AC | Status | Test(s) |
|---|---|---|
| AC-1: Failed verifier triggers provider repair | ✅ | `provider_repair_context_render_includes_verifier_and_diff`; `scripts/dev/test-provider-verifier-repair-loop.sh` |
| AC-2: Repair can reach PR-ready | ✅ | deterministic repair case; live OpenRouter repair case with `TAU_LIVE_PROVIDER_REPAIR_PROOF=1` |
| AC-3: Attempts are durable and observable | ✅ | provider unit tests and script assertions for `provider_attempts`, final `provider`, hashes, edit paths, repair flags |
| AC-4: Exhausted repairs fail closed | ✅ | exhausted-budget path in `scripts/dev/test-provider-verifier-repair-loop.sh` |

## TDD Evidence
- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh` initially failed because `--provider-repair-attempts` was not recognized.
- GREEN: focused provider-backed unit tests passed with 7 tests, deterministic repair script passed, and live OpenRouter repair reached `pr_ready`.
- REGRESSION: malformed provider output still fail-closes; existing real-repo harness still passes.

## Test Tiers

| Tier | Status | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1` | |
| Property | N/A | | No randomized parser or invariant introduced |
| Contract/DbC | N/A | | No formal contract macro surface changed |
| Snapshot | N/A | | JSON report fields asserted directly |
| Functional | ✅ | repair context render unit; deterministic repair/exhausted script paths | |
| Conformance | ✅ | `provider_attempts` report assertions in unit and shell proof | |
| Integration | ✅ | `scripts/dev/test-provider-verifier-repair-loop.sh`; opt-in live OpenRouter repair proof | |
| Fuzz | N/A | | No fuzz target changed |
| Mutation | N/A | | Follow-up release gate; focused repair-loop regression coverage in this slice |
| Regression | ✅ | malformed provider output script; existing real-repo harness | |
| Performance | N/A | | Bounded attempts only; no hot path benchmarked |

## Commands Run
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target cargo test -p tau-coding-agent --bin tau_live_coding_loop_harness provider_backed -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target cargo clippy -p tau-coding-agent --bin tau_live_coding_loop_harness -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh`
- `TAU_LIVE_PROVIDER_REPAIR_PROOF=1 TAU_PROVIDER_PROOF_MODEL=openrouter/deepseek/deepseek-v4-flash TAU_PROVIDER_PROOF_REPORT_DIR=/tmp/tau-3798-repair-proof CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-verifier-repair-loop.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-provider-backed-autonomous-coding-loop.sh --mock-malformed`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3798-repair-loop-target scripts/dev/test-real-repo-autonomous-coding-harness.sh`

## Mutation
N/A for this slice. No `cargo-mutants` run; focused repair-loop regression and integration coverage added.

## Risks/Rollback
Risk is moderate because the harness report shape now includes `provider_attempts` while preserving the existing final `provider` field. Rollback is reverting this commit; it removes the repair attempts and returns the harness to one-shot provider behavior.

## Docs/ADR
Updated `README.md`, `docs/guides/canonical-product-proof.md`, and `specs/3798-provider-verifier-repair-loop/*`. No ADR required because this is bounded harness behavior and does not change provider protocols, transports, dependencies, or non-harness schemas.
