### PR TITLE
Let bounded docs issues derive safe verifiers

### DIFF
--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
@@ -670,18 +670,25 @@ impl AutonomousCodingJobRuntime {
     ) -> Result<AutonomousCodingIssueToMergeOutcome> {
         ensure_autonomous_coding_job_layout(&self.config.state_dir)?;
         let provider_repair_configured = request.provider_repair.is_configured();
-        let has_verifier = !request.verifier_commands.is_empty();
+        let verifier_commands = if request.verifier_commands.is_empty() {
+            derive_concrete_docs_verifier_commands(&request.issue_title, &request.issue_body)
+        } else {
+            request.verifier_commands.clone()
+        };
+        let has_verifier = !verifier_commands.is_empty();
         let has_edit_or_provider_authority =
             !request.controlled_edits.is_empty() || provider_repair_configured;
-        if !has_verifier || !has_edit_or_provider_authority {
+        let needs_intake = request.verifier_commands.is_empty() || !has_edit_or_provider_authority;
+        let mut intake_for_outcome = None;
+        if needs_intake {
             let intake = self.intake_issue_with_context(
                 AutonomousCodingIssueIntakeRequest {
-                    intake_id: request.intake_id,
-                    issue_url: request.issue_url,
-                    issue_title: request.issue_title,
-                    issue_body: request.issue_body,
-                    repo_path: request.repo_path,
-                    base_branch: request.base_branch,
+                    intake_id: request.intake_id.clone(),
+                    issue_url: request.issue_url.clone(),
+                    issue_title: request.issue_title.clone(),
+                    issue_body: request.issue_body.clone(),
+                    repo_path: request.repo_path.clone(),
+                    base_branch: request.base_branch.clone(),
                     started_unix_ms: request.started_unix_ms,
                 },
                 IssueIntakeAuthorityContext {
@@ -690,14 +697,20 @@ impl AutonomousCodingJobRuntime {
                     has_required_credentials: true,
                 },
             )?;
-            return Ok(AutonomousCodingIssueToMergeOutcome {
-                status: AutonomousCodingIssueToMergeStatus::Blocked,
-                reason_code: intake.reason_code.clone(),
-                intake: Some(intake),
-                submit: None,
-                run: None,
-                auto_merge: None,
-            });
+            if !has_verifier
+                || !has_edit_or_provider_authority
+                || intake.decision != AutonomousCodingIssueIntakeDecision::ReadyToRun
+            {
+                return Ok(AutonomousCodingIssueToMergeOutcome {
+                    status: AutonomousCodingIssueToMergeStatus::Blocked,
+                    reason_code: intake.reason_code.clone(),
+                    intake: Some(intake),
+                    submit: None,
+                    run: None,
+                    auto_merge: None,
+                });
+            }
+            intake_for_outcome = Some(intake);
         }
 
         let allowed_roots = if request.allowed_roots.is_empty() {
@@ -714,7 +727,7 @@ impl AutonomousCodingJobRuntime {
                 goal: request.goal,
                 base_branch: request.base_branch,
                 branch_prefix: request.branch_prefix,
-                verifier_commands: request.verifier_commands,
+                verifier_commands,
                 pr_mode: request.pr_mode,
                 allowed_roots,
                 controlled_edits: request.controlled_edits,
@@ -746,7 +759,7 @@ impl AutonomousCodingJobRuntime {
             return Ok(AutonomousCodingIssueToMergeOutcome {
                 status,
                 reason_code: run.status.reason_code.clone(),
-                intake: None,
+                intake: intake_for_outcome,
                 submit: Some(submit),
                 run: Some(run),
                 auto_merge: None,
@@ -777,7 +790,7 @@ impl AutonomousCodingJobRuntime {
             return Ok(AutonomousCodingIssueToMergeOutcome {
                 status,
                 reason_code: auto_merge.evidence.reason_code.clone(),
-                intake: None,
+                intake: intake_for_outcome,
                 submit: Some(submit),
                 run: Some(run),
                 auto_merge: Some(auto_merge),
@@ -787,7 +800,7 @@ impl AutonomousCodingJobRuntime {
         Ok(AutonomousCodingIssueToMergeOutcome {
             status: AutonomousCodingIssueToMergeStatus::PrReady,
             reason_code: run.status.reason_code.clone(),
-            intake: None,
+            intake: intake_for_outcome,
             submit: Some(submit),
             run: Some(run),
             auto_merge: None,
@@ -2148,6 +2161,50 @@ fn intake_question(
     }
 }
 
+fn derive_concrete_docs_verifier_commands(title: &str, body: &str) -> Vec<String> {
+    let combined = format!("{title}\n{body}");
+    let normalized = combined.to_ascii_lowercase();
+    if !contains_any(&normalized, &["readme", "docs", "documentation", "guide"]) {
+        return Vec::new();
+    }
+
+    let Some(token) = extract_safe_docs_verifier_token(&combined) else {
+        return Vec::new();
+    };
+
+    let grep_command = if normalized.contains("readme") {
+        format!("grep -n {token} README.md")
+    } else {
+        format!("grep -R -n {token} docs")
+    };
+    vec!["git diff --check".to_string(), grep_command]
+}
+
+fn extract_safe_docs_verifier_token(text: &str) -> Option<String> {
+    for delimiter in ['`', '"'] {
+        let mut parts = text.split(delimiter);
+        while let Some(_) = parts.next() {
+            let Some(candidate) = parts.next() else {
+                break;
+            };
+            let token = candidate.trim();
+            if is_safe_docs_verifier_token(token) {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn is_safe_docs_verifier_token(token: &str) -> bool {
+    let len = token.len();
+    (3..=96).contains(&len)
+        && !token.starts_with('-')
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':'))
+}
+
 fn issue_intake_required_authority(
     context: IssueIntakeAuthorityContext,
 ) -> Vec<AutonomousCodingAuthorityRequirement> {
@@ -2248,12 +2305,22 @@ fn issue_intake_verifier_plan(
             next_action: "Provide expected/current behavior and an affected surface.".to_string(),
         },
         _ if contains_any(&normalized, &["readme", "docs", "documentation", "guide"]) => {
-            let mut commands = vec!["git diff --check".to_string()];
-            if normalized.contains("readme") {
-                commands.push("grep -n <expected-text> README.md".to_string());
+            let commands = derive_concrete_docs_verifier_commands(title, body);
+            let commands = if commands.is_empty() {
+                if normalized.contains("readme") {
+                    vec![
+                        "git diff --check".to_string(),
+                        "grep -n <expected-text> README.md".to_string(),
+                    ]
+                } else {
+                    vec![
+                        "git diff --check".to_string(),
+                        "grep -R -n <expected-text> docs".to_string(),
+                    ]
+                }
             } else {
-                commands.push("grep -R -n <expected-text> docs specs README.md".to_string());
-            }
+                commands
+            };
             AutonomousCodingVerifierPlan {
                 plan_kind: "docs".to_string(),
                 summary: "Docs issue can be verified with text assertions and diff hygiene."
@@ -3422,6 +3489,127 @@ mod tests {
         assert_eq!(run.status.status, AutonomousCodingJobStatus::PrReady);
         assert_eq!(run.status.provider_repair_attempts, 1);
         assert!(outcome.intake.is_none());
+    }
+
+    #[tokio::test]
+    async fn spec_3809_c01_issue_to_merge_derives_concrete_docs_verifier() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let provider = fixture.fake_provider_repair(
+            r#"{"files":{"docs/notes.txt":"tau_derived_docs_verifier\n"},"reason_code":"provider_docs_marker"}"#,
+            0,
+        );
+
+        let outcome = runtime
+            .run_issue_to_merge(AutonomousCodingIssueToMergeRequest {
+                intake_id: "issue-3809-derived-docs".to_string(),
+                mission_id: "issue-3809-derived-docs-mission".to_string(),
+                session_key: "issue-3809-session".to_string(),
+                repo_path: fixture.repo.path().to_path_buf(),
+                issue_url: "https://github.com/njfio/Tau/issues/3809".to_string(),
+                issue_title: "Document `tau_derived_docs_verifier` in docs".to_string(),
+                issue_body:
+                    "Add documentation that includes the exact marker `tau_derived_docs_verifier`."
+                        .to_string(),
+                goal: "Let Tau derive the docs verifier from intake.".to_string(),
+                base_branch: "master".to_string(),
+                branch_prefix: "codex/issue-to-merge-derived-docs-".to_string(),
+                verifier_commands: Vec::new(),
+                pr_mode: CodingMissionPrMode::PrReady,
+                allowed_roots: vec![fixture.repo.path().to_path_buf()],
+                controlled_edits: Vec::new(),
+                provider_repair: provider.policy(2, "fake-provider", "repair-model"),
+                commit_message: "Document derived verifier marker".to_string(),
+                timeout_ms: Some(5_000),
+                allow_auto_merge: false,
+                merge_method: AutonomousCodingMergeMethod::Squash,
+                delete_branch: false,
+                github_env: BTreeMap::new(),
+                gh_binary: None,
+                started_unix_ms: 12_000,
+            })
+            .await
+            .expect("issue-to-merge derived docs verifier");
+
+        assert_eq!(outcome.status, AutonomousCodingIssueToMergeStatus::PrReady);
+        let intake = outcome.intake.as_ref().expect("derived intake");
+        assert_eq!(
+            intake.decision,
+            AutonomousCodingIssueIntakeDecision::ReadyToRun
+        );
+        assert_eq!(intake.verifier_plan.plan_kind, "docs");
+        assert!(intake
+            .verifier_plan
+            .suggested_verifier_commands
+            .iter()
+            .any(|command| command == "grep -R -n tau_derived_docs_verifier docs"));
+
+        let submit = outcome.submit.as_ref().expect("submit");
+        assert!(submit
+            .record
+            .verifier_commands
+            .iter()
+            .any(|command| command == "grep -R -n tau_derived_docs_verifier docs"));
+        let run = outcome.run.as_ref().expect("run");
+        assert_eq!(run.status.status, AutonomousCodingJobStatus::PrReady);
+        assert!(run
+            .status
+            .changed_files
+            .iter()
+            .any(|file| file == "docs/notes.txt"));
+    }
+
+    #[tokio::test]
+    async fn spec_3809_c02_issue_to_merge_without_concrete_docs_verifier_still_blocks() {
+        let fixture = CodingJobFixture::new();
+        let runtime = fixture.runtime_without_background();
+        let provider = fixture.fake_provider_repair(
+            r#"{"files":{"docs/notes.txt":"operator recovery evidence\n"},"reason_code":"provider_docs_text"}"#,
+            0,
+        );
+
+        let outcome = runtime
+            .run_issue_to_merge(AutonomousCodingIssueToMergeRequest {
+                intake_id: "issue-3809-missing-docs-verifier".to_string(),
+                mission_id: "issue-3809-missing-docs-verifier-mission".to_string(),
+                session_key: "issue-3809-session".to_string(),
+                repo_path: fixture.repo.path().to_path_buf(),
+                issue_url: "https://github.com/njfio/Tau/issues/3809".to_string(),
+                issue_title: "Update the docs".to_string(),
+                issue_body: "Explain the operator recovery evidence workflow in documentation."
+                    .to_string(),
+                goal: "Should not mutate without a concrete verifier assertion.".to_string(),
+                base_branch: "master".to_string(),
+                branch_prefix: "codex/issue-to-merge-missing-docs-verifier-".to_string(),
+                verifier_commands: Vec::new(),
+                pr_mode: CodingMissionPrMode::PrReady,
+                allowed_roots: vec![fixture.repo.path().to_path_buf()],
+                controlled_edits: Vec::new(),
+                provider_repair: provider.policy(2, "fake-provider", "repair-model"),
+                commit_message: "Should not be used".to_string(),
+                timeout_ms: Some(5_000),
+                allow_auto_merge: false,
+                merge_method: AutonomousCodingMergeMethod::Squash,
+                delete_branch: false,
+                github_env: BTreeMap::new(),
+                gh_binary: None,
+                started_unix_ms: 13_000,
+            })
+            .await
+            .expect("issue-to-merge blocks without concrete docs verifier");
+
+        assert_eq!(outcome.status, AutonomousCodingIssueToMergeStatus::Blocked);
+        let intake = outcome.intake.as_ref().expect("blocked intake");
+        assert_eq!(
+            intake.classification,
+            AutonomousCodingIssueIntakeClassification::MissingVerifier
+        );
+        assert!(intake
+            .required_authority
+            .iter()
+            .any(|authority| authority.reason_code == "verifier_authority_required"));
+        assert!(outcome.submit.is_none());
+        assert!(outcome.run.is_none());
     }
 
     struct CodingJobFixture {

--- a/docs/guides/autonomous-coding-jobs.md
+++ b/docs/guides/autonomous-coding-jobs.md
@@ -155,6 +155,13 @@ auto-merge request. If verifier commands or edit authority are missing, it
 falls back to a blocked issue-intake authority plan and does not mutate the
 repository.
 
+For bounded docs/readme issues, `issue-to-merge` can derive a verifier only when
+the issue includes an exact quoted or backticked single-token marker such as
+`tau_docs_marker`. In that narrow case, Tau records the intake plan and uses
+`git diff --check` plus a concrete `grep` command for the marker. Multi-word
+phrases, placeholders, broad requests, unsafe requests, and normal code changes
+still require an explicit `--verifier-command`.
+
 Run the same loop with built-in OpenRouter-compatible repair authority instead
 of manual edits:
 

--- a/specs/3809-derived-docs-verifier/plan.md
+++ b/specs/3809-derived-docs-verifier/plan.md
@@ -1,0 +1,44 @@
+# Plan 3809: Derived Docs Verifier for Issue-to-Merge
+
+## Approach
+
+Keep verifier derivation deliberately narrow. `issue-to-merge` may auto-derive a
+verifier only when all of these are true:
+
+- The request omits explicit verifier commands.
+- The issue text looks like docs/readme/documentation/guide work.
+- The issue contains a quoted or backticked marker that is safe as one argv
+  token: ASCII alphanumeric plus `_`, `-`, `.`, or `:`, length 3..96, not
+  starting with `-`.
+- Edit or provider repair authority is present.
+- Intake classification is still `ready_to_run`.
+
+When these hold, Tau uses:
+
+- `git diff --check`
+- `grep -n <token> README.md` for README issues, or
+  `grep -R -n <token> docs` for docs issues
+
+Everything else continues through the existing blocked intake path.
+
+## Affected Files
+
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs`
+- `docs/guides/autonomous-coding-jobs.md`
+- `specs/3809-derived-docs-verifier/*`
+
+## Risks
+
+- Risk: Tau overstates this as arbitrary verifier generation.
+  Mitigation: docs and tests state this is single-token docs verification only.
+- Risk: unsafe tokens become shell injection.
+  Mitigation: commands are split by argv, not shell, and the accepted marker is
+  limited to safe single-token characters.
+- Risk: broad/vague issues sneak through.
+  Mitigation: intake classification still runs and must produce
+  `ready_to_run`.
+
+## Interfaces
+
+No CLI flag changes. This is a runtime behavior improvement for
+`tau-autonomous-coding-job issue-to-merge` when `verifier_commands` are empty.

--- a/specs/3809-derived-docs-verifier/spec.md
+++ b/specs/3809-derived-docs-verifier/spec.md
@@ -1,0 +1,63 @@
+# Spec 3809: Derived Docs Verifier for Issue-to-Merge
+
+Status: Reviewed
+
+## Problem Statement
+
+`issue-to-merge` currently blocks whenever `--verifier-command` is omitted,
+even when the issue is a bounded docs request and contains a concrete text
+marker Tau can verify safely. That keeps the loop too manual for simple
+documentation fixes. Tau should be able to derive a small docs verifier only
+when the issue supplies an exact argv-safe marker, while preserving fail-closed
+behavior for vague docs work and all broader coding work.
+
+## Scope
+
+In:
+
+- Derive verifier commands for docs/readme issues that include a quoted or
+  backticked single-token marker.
+- Persist the intake record that explains the derived verifier plan.
+- Run the normal durable issue-to-merge path using the derived verifier when
+  provider/edit authority is present.
+- Keep blocking when no concrete marker exists.
+
+Out:
+
+- General verifier invention for arbitrary coding tasks.
+- Shell-quoted multi-word grep phrases.
+- Provider-generated verifier plans.
+- Live provider or live GitHub validation.
+
+## Acceptance Criteria
+
+AC-1: Given a docs issue with a concrete backticked marker and provider repair
+authority, when `issue-to-merge` is called without `--verifier-command`, then Tau
+derives `git diff --check` plus a concrete `grep` verifier and can reach
+PR-ready through the normal durable job loop.
+
+AC-2: Given the same successful path, when the outcome is inspected, then it
+includes a persisted intake record with `decision=ready_to_run`, `plan_kind=docs`,
+and the derived verifier commands.
+
+AC-3: Given a docs issue without a quoted/backticked safe marker, when
+`issue-to-merge` is called without `--verifier-command`, then Tau blocks before
+creating a job and records `verifier_authority_required`.
+
+AC-4: Given an unsafe, broad, or underspecified issue, the derived-docs verifier
+path must not override the existing fail-closed intake classification.
+
+## Conformance Cases
+
+| Case | Maps | Tier | Input | Expected |
+| --- | --- | --- | --- | --- |
+| C-01 | AC-1/AC-2 | Conformance | Docs issue containing `tau_derived_docs_verifier`, provider repair authority, no verifier command | Job reaches PR-ready; intake records derived docs verifier |
+| C-02 | AC-3 | Regression | Docs issue with no concrete marker, provider repair authority, no verifier command | Blocks before mutation with verifier authority required |
+| C-03 | AC-4 | Regression | Existing broad/unsafe/underspecified intake tests | Existing classifications remain authoritative |
+
+## Success Signals
+
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime spec_3809 -- --test-threads=1` passes.
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passes.
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo clippy -p tau-runtime --lib --tests -- -D warnings` passes.
+- `cargo fmt --check` and `git diff --check` pass.

--- a/specs/3809-derived-docs-verifier/tasks.md
+++ b/specs/3809-derived-docs-verifier/tasks.md
@@ -1,0 +1,19 @@
+# Tasks 3809: Derived Docs Verifier for Issue-to-Merge
+
+- [x] T1 (RED): Add failing runtime tests for concrete docs verifier derivation
+  and missing-marker fail-closed behavior.
+- [x] T2 (GREEN): Derive safe docs verifier commands from quoted/backticked
+  single-token markers.
+- [x] T3 (GREEN): Persist the intake record for auto-derived verifier runs.
+- [x] T4 (DOCS): Document the narrow derived-docs verifier boundary.
+- [x] T5 (VERIFY): Run focused runtime tests, module tests, clippy, fmt, and
+  diff hygiene.
+
+## Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime spec_3809 -- --test-threads=1` failed before implementation with `Blocked` instead of `PrReady`.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime spec_3809 -- --test-threads=1` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo clippy -p tau-runtime --lib --tests -- -D warnings` passed.
+- VERIFY: `cargo fmt --check` passed.
+- VERIFY: `git diff --check` passed.


### PR DESCRIPTION
Summary:
- Allows issue-to-merge to derive a verifier only for docs/readme issues with a quoted/backticked single-token marker.
- Persists the intake record for derived-verifier runs so operators can see the plan Tau auto-adopted.
- Preserves fail-closed behavior when a docs issue lacks a concrete marker.

Links:
- Spec: specs/3809-derived-docs-verifier/spec.md
- Plan: specs/3809-derived-docs-verifier/plan.md

Spec Verification:
| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1 derive concrete docs verifier and reach PR-ready | ✅ | cargo test -p tau-runtime spec_3809 |
| AC-2 persisted intake explains derived docs verifier | ✅ | cargo test -p tau-runtime spec_3809 |
| AC-3 docs issue without concrete marker blocks before mutation | ✅ | cargo test -p tau-runtime spec_3809 |
| AC-4 broad/unsafe/underspecified intake remains fail-closed | ✅ | cargo test -p tau-runtime autonomous_coding_jobs_runtime |

TDD Evidence:
- RED: CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime spec_3809 -- --test-threads=1 failed before implementation with Blocked instead of PrReady.
- GREEN: CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo test -p tau-runtime spec_3809 -- --test-threads=1 passed.

Test Tiers:
| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | cargo test -p tau-runtime spec_3809 | |
| Property | N/A | | No randomized parser/invariant added |
| Contract/DbC | N/A | | No public API contract changed |
| Snapshot | N/A | | No snapshot output changed |
| Functional | ✅ | cargo test -p tau-runtime autonomous_coding_jobs_runtime | |
| Conformance | ✅ | spec_3809 tests cover C-01/C-02 | |
| Integration | ✅ | autonomous_coding_jobs_runtime exercises durable issue-to-merge fixture repo | |
| Fuzz | N/A | | Marker parser is bounded deterministic token extraction |
| Mutation | N/A | | Narrow intake/verifier routing, not a critical algorithm path for this slice |
| Regression | ✅ | missing-marker test preserves blocked behavior | |
| Performance | N/A | | Small string inspection only |

Additional Verification:
- CARGO_TARGET_DIR=/tmp/rust_pi-3809-target cargo clippy -p tau-runtime --lib --tests -- -D warnings
- cargo fmt --check
- git diff --check

Risks/Rollback:
- Narrow runtime behavior change. Roll back this PR to restore mandatory explicit verifier commands for all issue-to-merge requests.

Known Gaps:
- Not a general arbitrary verifier generator. Multi-word docs assertions and normal code changes still require explicit verifier commands.
- Not live-tested against OpenRouter/GitHub; deterministic fake provider and fixture repo were used.
