### PR TITLE
Make verifier intake blockers actionable

### DIFF
--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
@@ -34,7 +34,7 @@ mod verifier_derivation;
 
 use verifier_derivation::{
     derive_concrete_docs_verifier_commands, derive_concrete_verifier_commands,
-    derive_repo_aware_code_verifier_commands,
+    derive_repo_aware_code_verifier_plan,
 };
 
 pub const AUTONOMOUS_CODING_JOB_SCHEMA_VERSION: u32 = 1;
@@ -2312,8 +2312,16 @@ fn issue_intake_verifier_plan(
             &["test", "panic", "rust", "crate", "compile", "clippy"],
         ) =>
         {
-            let mut commands = derive_repo_aware_code_verifier_commands(repo_path, title, body);
-            if commands.is_empty() {
+            let derivation = derive_repo_aware_code_verifier_plan(repo_path, title, body);
+            let derivation_missing_command = derivation.commands.is_empty();
+            let report_missing_derivation_inputs =
+                derivation_missing_command && !context.has_verifier;
+            let mut commands = derivation.commands;
+            let mut plan_missing_inputs = missing_inputs;
+            if report_missing_derivation_inputs {
+                append_missing_inputs(&mut plan_missing_inputs, derivation.missing_inputs);
+            }
+            if derivation_missing_command {
                 commands = vec![
                     "cargo fmt --check".to_string(),
                     "cargo test -p <affected-crate> <focused-test>".to_string(),
@@ -2327,9 +2335,12 @@ fn issue_intake_verifier_plan(
                 summary: "CLI issue should be verified with focused CLI tests and shell proof."
                     .to_string(),
                 suggested_verifier_commands: commands,
-                missing_inputs,
-                next_action: "Provide/approve the focused CLI verifier and mutation authority."
-                    .to_string(),
+                missing_inputs: plan_missing_inputs,
+                next_action: if report_missing_derivation_inputs {
+                    repo_aware_missing_verifier_next_action()
+                } else {
+                    "Provide/approve the focused CLI verifier and mutation authority.".to_string()
+                },
             }
         }
         _ if contains_any(
@@ -2337,25 +2348,35 @@ fn issue_intake_verifier_plan(
             &["test", "panic", "rust", "crate", "compile", "clippy"],
         ) =>
         {
-            let commands = derive_repo_aware_code_verifier_commands(repo_path, title, body);
-            let commands = if commands.is_empty() {
+            let derivation = derive_repo_aware_code_verifier_plan(repo_path, title, body);
+            let derivation_missing_command = derivation.commands.is_empty();
+            let report_missing_derivation_inputs =
+                derivation_missing_command && !context.has_verifier;
+            let mut plan_missing_inputs = missing_inputs;
+            if report_missing_derivation_inputs {
+                append_missing_inputs(&mut plan_missing_inputs, derivation.missing_inputs);
+            }
+            let commands = if derivation_missing_command {
                 vec![
                     "cargo fmt --check".to_string(),
                     "cargo test -p <affected-crate> <focused-test>".to_string(),
                     "cargo clippy -p <affected-crate> --lib --tests -- -D warnings".to_string(),
                 ]
             } else {
-                commands
+                derivation.commands
             };
             AutonomousCodingVerifierPlan {
                 plan_kind: "rust".to_string(),
                 summary: "Rust issue should be verified with focused tests before broader checks."
                     .to_string(),
                 suggested_verifier_commands: commands,
-                missing_inputs,
-                next_action:
+                missing_inputs: plan_missing_inputs,
+                next_action: if report_missing_derivation_inputs {
+                    repo_aware_missing_verifier_next_action()
+                } else {
                     "Provide the affected crate/test target or approve Tau's focused verifier plan."
-                        .to_string(),
+                        .to_string()
+                },
             }
         }
         AutonomousCodingIssueIntakeClassification::Solvable
@@ -2385,6 +2406,19 @@ fn issue_intake_verifier_plan(
             }
         }
     }
+}
+
+fn append_missing_inputs(missing_inputs: &mut Vec<String>, additions: Vec<String>) {
+    for addition in additions {
+        if !missing_inputs.iter().any(|input| input == &addition) {
+            missing_inputs.push(addition);
+        }
+    }
+}
+
+fn repo_aware_missing_verifier_next_action() -> String {
+    "Name an existing Cargo package and exact quoted/backticked test filter, or provide an explicit verifier command plus mutation authority."
+        .to_string()
 }
 
 fn ensure_pr_ready_bundle(

--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime/tests/repo_aware_verifier.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime/tests/repo_aware_verifier.rs
@@ -175,3 +175,108 @@ async fn spec_3810_c03_issue_to_merge_blocks_when_package_is_not_in_metadata() {
     assert!(outcome.submit.is_none());
     assert!(outcome.run.is_none());
 }
+
+#[tokio::test]
+async fn spec_3811_c01_missing_filter_plan_names_exact_test_filter_input() {
+    let fixture = CodingJobFixture::new();
+    fixture.install_rust_workspace_fixture("fail");
+    let runtime = fixture.runtime_without_background();
+    let provider = fixture.fake_provider_repair(
+        r#"{"files":{"crates/fixture-cli/src/lib.rs":"pub fn marker() -> &'static str {\n    \"pass\"\n}\n"},"reason_code":"provider_rust_fix"}"#,
+        0,
+    );
+
+    let outcome = runtime
+        .run_issue_to_merge(AutonomousCodingIssueToMergeRequest {
+            intake_id: "issue-3811-missing-filter-detail".to_string(),
+            mission_id: "issue-3811-missing-filter-detail-mission".to_string(),
+            session_key: "issue-3811-session".to_string(),
+            repo_path: fixture.repo.path().to_path_buf(),
+            issue_url: "https://github.com/njfio/Tau/issues/3811".to_string(),
+            issue_title: "Fix fixture-cli Rust failure".to_string(),
+            issue_body: "The fixture-cli crate has a failing Rust test, but the issue forgot to name the exact test filter."
+                .to_string(),
+            goal: "Should report the exact missing verifier ingredient.".to_string(),
+            base_branch: "master".to_string(),
+            branch_prefix: "codex/issue-to-merge-missing-filter-detail-".to_string(),
+            verifier_commands: Vec::new(),
+            pr_mode: CodingMissionPrMode::PrReady,
+            allowed_roots: vec![fixture.repo.path().to_path_buf()],
+            controlled_edits: Vec::new(),
+            provider_repair: provider.policy(2, "fake-provider", "repair-model"),
+            commit_message: "Should not be used".to_string(),
+            timeout_ms: Some(10_000),
+            allow_auto_merge: false,
+            merge_method: AutonomousCodingMergeMethod::Squash,
+            delete_branch: false,
+            github_env: BTreeMap::new(),
+            gh_binary: None,
+            started_unix_ms: 17_000,
+        })
+        .await
+        .expect("issue-to-merge blocks with missing filter detail");
+
+    assert_eq!(outcome.status, AutonomousCodingIssueToMergeStatus::Blocked);
+    let intake = outcome.intake.as_ref().expect("blocked intake");
+    assert!(intake.verifier_plan.missing_inputs.iter().any(|input| {
+        input == "exact quoted/backticked safe test filter token containing `spec`, `test`, `::`, or starting with `regression_`"
+    }));
+    assert!(intake
+        .verifier_plan
+        .next_action
+        .contains("quoted/backticked test filter"));
+}
+
+#[tokio::test]
+async fn spec_3811_c02_missing_package_plan_names_real_package_input() {
+    let fixture = CodingJobFixture::new();
+    fixture.install_rust_workspace_fixture("fail");
+    let runtime = fixture.runtime_without_background();
+    let provider = fixture.fake_provider_repair(
+        r#"{"files":{"crates/missing-crate/src/lib.rs":"pub fn marker() -> &'static str {\n    \"pass\"\n}\n"},"reason_code":"provider_rust_fix"}"#,
+        0,
+    );
+
+    let outcome = runtime
+        .run_issue_to_merge(AutonomousCodingIssueToMergeRequest {
+            intake_id: "issue-3811-missing-package-detail".to_string(),
+            mission_id: "issue-3811-missing-package-detail-mission".to_string(),
+            session_key: "issue-3811-session".to_string(),
+            repo_path: fixture.repo.path().to_path_buf(),
+            issue_url: "https://github.com/njfio/Tau/issues/3811".to_string(),
+            issue_title: "Fix missing-crate Rust test `spec_3810_repo_aware_verifier`"
+                .to_string(),
+            issue_body: "The missing-crate package has a failing Rust test named `spec_3810_repo_aware_verifier`, but that package is not in cargo metadata."
+                .to_string(),
+            goal: "Should report the unresolved package verifier ingredient.".to_string(),
+            base_branch: "master".to_string(),
+            branch_prefix: "codex/issue-to-merge-missing-package-detail-".to_string(),
+            verifier_commands: Vec::new(),
+            pr_mode: CodingMissionPrMode::PrReady,
+            allowed_roots: vec![fixture.repo.path().to_path_buf()],
+            controlled_edits: Vec::new(),
+            provider_repair: provider.policy(2, "fake-provider", "repair-model"),
+            commit_message: "Should not be used".to_string(),
+            timeout_ms: Some(10_000),
+            allow_auto_merge: false,
+            merge_method: AutonomousCodingMergeMethod::Squash,
+            delete_branch: false,
+            github_env: BTreeMap::new(),
+            gh_binary: None,
+            started_unix_ms: 18_000,
+        })
+        .await
+        .expect("issue-to-merge blocks with missing package detail");
+
+    assert_eq!(outcome.status, AutonomousCodingIssueToMergeStatus::Blocked);
+    let intake = outcome.intake.as_ref().expect("blocked intake");
+    assert!(intake
+        .verifier_plan
+        .missing_inputs
+        .iter()
+        .any(|input| input == "actual Cargo package name present in this repository (available: fixture-cli)"));
+    assert!(intake
+        .verifier_plan
+        .next_action
+        .contains("existing Cargo package"));
+}

--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime/verifier_derivation.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime/verifier_derivation.rs
@@ -1,5 +1,11 @@
 use std::{path::Path, process::Command};
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct RepoAwareVerifierDerivation {
+    pub commands: Vec<String>,
+    pub missing_inputs: Vec<String>,
+}
+
 pub(super) fn derive_concrete_docs_verifier_commands(title: &str, body: &str) -> Vec<String> {
     let combined = format!("{title}\n{body}");
     let normalized = combined.to_ascii_lowercase();
@@ -36,6 +42,14 @@ pub(super) fn derive_repo_aware_code_verifier_commands(
     title: &str,
     body: &str,
 ) -> Vec<String> {
+    derive_repo_aware_code_verifier_plan(repo_path, title, body).commands
+}
+
+pub(super) fn derive_repo_aware_code_verifier_plan(
+    repo_path: &Path,
+    title: &str,
+    body: &str,
+) -> RepoAwareVerifierDerivation {
     let combined = format!("{title}\n{body}");
     let normalized = combined.to_ascii_lowercase();
     if !contains_any(
@@ -54,22 +68,33 @@ pub(super) fn derive_repo_aware_code_verifier_commands(
             "clippy",
         ],
     ) {
-        return Vec::new();
+        return RepoAwareVerifierDerivation::default();
     }
 
     let package_names = repo_cargo_package_names(repo_path);
-    let Some(package_name) = resolve_referenced_package_name(&package_names, &combined) else {
-        return Vec::new();
-    };
-    if !is_safe_cargo_package_name(&package_name) {
-        return Vec::new();
+    let package_name = resolve_referenced_package_name(&package_names, &combined);
+    let test_filter = resolve_referenced_test_filter(&combined, &package_names);
+    let mut missing_inputs = Vec::new();
+    if package_name.is_none() {
+        missing_inputs.push(missing_package_input(&package_names));
+    }
+    if test_filter.is_none() {
+        missing_inputs.push(
+            "exact quoted/backticked safe test filter token containing `spec`, `test`, `::`, or starting with `regression_`"
+                .to_string(),
+        );
     }
 
-    let Some(test_filter) = resolve_referenced_test_filter(&combined, &package_names) else {
-        return Vec::new();
+    let commands = match (package_name, test_filter) {
+        (Some(package_name), Some(test_filter)) if is_safe_cargo_package_name(&package_name) => {
+            vec![format!("cargo test -p {package_name} {test_filter}")]
+        }
+        _ => Vec::new(),
     };
-
-    vec![format!("cargo test -p {package_name} {test_filter}")]
+    RepoAwareVerifierDerivation {
+        commands,
+        missing_inputs,
+    }
 }
 
 fn repo_cargo_package_names(repo_path: &Path) -> Vec<String> {
@@ -171,6 +196,29 @@ fn is_safe_test_filter_token(token: &str) -> bool {
             || token.contains("test")
             || token.contains("::")
             || token.starts_with("regression_"))
+}
+
+fn missing_package_input(package_names: &[String]) -> String {
+    if package_names.is_empty() {
+        return "Cargo workspace package metadata from `cargo metadata`".to_string();
+    }
+    format!(
+        "actual Cargo package name present in this repository (available: {})",
+        package_sample(package_names)
+    )
+}
+
+fn package_sample(package_names: &[String]) -> String {
+    const MAX_PACKAGE_SAMPLE: usize = 5;
+    let mut sample = package_names
+        .iter()
+        .take(MAX_PACKAGE_SAMPLE)
+        .cloned()
+        .collect::<Vec<_>>();
+    if package_names.len() > MAX_PACKAGE_SAMPLE {
+        sample.push("...".to_string());
+    }
+    sample.join(", ")
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {

--- a/docs/guides/autonomous-coding-jobs.md
+++ b/docs/guides/autonomous-coding-jobs.md
@@ -292,6 +292,11 @@ so a vague or no-authority issue becomes a concrete contract instead of a generi
 failure. These plans are intentionally not mutation authority; Tau still blocks
 until a verifier and edit/provider authority are supplied.
 
+For repo-aware Rust or CLI verifier planning, blocked records distinguish
+between a missing real Cargo package token and a missing exact safe test filter.
+That means an operator can supply the one missing ingredient instead of
+rewriting the whole verifier plan.
+
 Intake records also expose a queue-friendly clarifying contract:
 
 - `decision`: `ready_to_run`, `needs_authority`, `needs_clarification`,

--- a/specs/3811-actionable-verifier-missing-inputs/plan.md
+++ b/specs/3811-actionable-verifier-missing-inputs/plan.md
@@ -1,0 +1,39 @@
+# Plan 3811: Actionable Verifier Missing Inputs
+
+## Approach
+
+Keep the existing `AutonomousCodingVerifierPlan` schema and make the
+repo-aware verifier derivation helper return diagnostics alongside concrete
+commands.
+
+1. Add a small derivation outcome that contains `commands` and
+   `missing_inputs`.
+2. When Cargo metadata has no matching package token, report the missing real
+   package input and include available package context.
+3. When no exact safe quoted/backticked test filter is present, report the
+   missing filter contract.
+4. Preserve `derive_repo_aware_code_verifier_commands` as the command-only
+   wrapper used by the existing job path.
+5. Merge derivation diagnostics into the verifier plan without adding new
+   persisted fields.
+
+## Affected Files
+
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs`
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime/verifier_derivation.rs`
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime/tests/repo_aware_verifier.rs`
+- `docs/guides/autonomous-coding-jobs.md`
+- `specs/3811-actionable-verifier-missing-inputs/*`
+
+## Risks
+
+- Risk: missing-input strings become too noisy in large workspaces.
+  Mitigation: include only a short package sample.
+- Risk: diagnostics accidentally imply mutation authority.
+  Mitigation: command derivation remains fail-closed and blocked outcomes still
+  do not submit jobs.
+
+## Interfaces
+
+No CLI or JSON schema changes. This only improves `missing_inputs` and
+`next_action` content inside the existing verifier plan.

--- a/specs/3811-actionable-verifier-missing-inputs/spec.md
+++ b/specs/3811-actionable-verifier-missing-inputs/spec.md
@@ -1,0 +1,54 @@
+# Spec 3811: Actionable Verifier Missing Inputs
+
+Status: Reviewed
+
+## Problem Statement
+
+Tau now derives focused verifiers for narrow docs and Rust/CLI issues, but when
+repo-aware derivation fails the persisted verifier plan still falls back to
+generic placeholders. Operators need to know the exact missing ingredient:
+whether Tau needs a real Cargo package token, an exact safe test-filter token,
+or normal mutation/provider authority.
+
+## Scope
+
+In:
+
+- Preserve fail-closed behavior when verifier derivation cannot produce a
+  concrete command.
+- Add actionable repo-aware missing-input text for unresolved package names and
+  missing/unsafe test filters.
+- Keep the existing `missing_inputs` and `next_action` schema.
+
+Out:
+
+- Provider-based verifier invention.
+- New CLI flags or schema fields.
+- Guessing packages or test filters from broad issue text.
+
+## Acceptance Criteria
+
+AC-1: Given a Rust issue that names a real Cargo package but omits an exact safe
+test-filter token, when Tau blocks before mutation, then the persisted verifier
+plan names the missing exact quoted/backticked safe test filter.
+
+AC-2: Given a Rust issue that names a package absent from `cargo metadata`, when
+Tau blocks before mutation, then the persisted verifier plan names the missing
+real Cargo package input and shows available package context.
+
+AC-3: Given either blocked path, Tau must not create a job or run provider
+repair.
+
+## Conformance Cases
+
+| Case | Maps | Tier | Input | Expected |
+| --- | --- | --- | --- | --- |
+| C-01 | AC-1/AC-3 | Conformance | Fixture repo with package `fixture-cli`; issue names package but no test filter | Blocks and `missing_inputs` names the exact quoted/backticked safe test filter |
+| C-02 | AC-2/AC-3 | Conformance | Fixture repo with package `fixture-cli`; issue names `missing-crate` and exact test token | Blocks and `missing_inputs` names an actual Cargo package from metadata |
+
+## Success Signals
+
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1` passes.
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passes.
+- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo clippy -p tau-runtime --lib --tests -- -D warnings` passes.
+- `cargo fmt --check` and `git diff --check` pass.

--- a/specs/3811-actionable-verifier-missing-inputs/tasks.md
+++ b/specs/3811-actionable-verifier-missing-inputs/tasks.md
@@ -1,0 +1,19 @@
+# Tasks 3811: Actionable Verifier Missing Inputs
+
+- [x] T1 (RED): Add tests for missing filter and missing package verifier-plan
+  diagnostics.
+- [x] T2 (GREEN): Return repo-aware verifier derivation diagnostics.
+- [x] T3 (GREEN): Merge diagnostics into `AutonomousCodingVerifierPlan`.
+- [x] T4 (VERIFY): Run focused tests, runtime module tests, clippy, fmt, and
+  diff hygiene.
+
+## Evidence
+
+- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1` failed because the verifier plan did not name the exact missing filter/package inputs.
+- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1` passed: 2 passed.
+- REGRESSION: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3807_c03 -- --test-threads=1` passed after gating diagnostics to missing-verifier authority.
+- VERIFY: `cargo fmt --check` passed.
+- VERIFY: `python3 .github/scripts/oversized_file_guard.py --repo-root . --default-threshold 4000 --exemptions-file tasks/policies/oversized-file-exemptions.json --policy-guide docs/guides/oversized-file-policy.md --json-output-file /tmp/rust_pi-3811-oversized-file-guard.json` passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1` passed: 28 passed.
+- VERIFY: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo clippy -p tau-runtime --lib --tests -- -D warnings` passed.
+- VERIFY: `git diff --check` passed.


### PR DESCRIPTION
Summary:
Improves repo-aware verifier planning when Tau blocks before mutation. Missing verifier plans now distinguish between a missing real Cargo package token and a missing exact safe test-filter token, while preserving fail-closed behavior and the existing `missing_inputs`/`next_action` schema.

Links:
- Spec: `specs/3811-actionable-verifier-missing-inputs/spec.md`
- Plan: `specs/3811-actionable-verifier-missing-inputs/plan.md`
- Tasks: `specs/3811-actionable-verifier-missing-inputs/tasks.md`

Spec Verification:
| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: missing filter plan names exact safe test filter input | ✅ | `spec_3811_c01_missing_filter_plan_names_exact_test_filter_input` |
| AC-2: missing package plan names real Cargo package input | ✅ | `spec_3811_c02_missing_package_plan_names_real_package_input` |
| AC-3: blocked paths do not create jobs or run provider repair | ✅ | `spec_3811_c01_missing_filter_plan_names_exact_test_filter_input`, `spec_3811_c02_missing_package_plan_names_real_package_input` |

TDD Evidence:
- RED: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1` failed because the verifier plan did not name the exact missing filter/package inputs.
- GREEN: `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1` passed.
- REGRESSION: `spec_3807_c03` caught the ready-intake authority boundary and passed after gating diagnostics to missing-verifier authority.

Test Tiers:
| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | `cargo test -p tau-runtime spec_3811` | |
| Property | N/A | | No randomized invariant/parser behavior added. |
| Contract/DbC | N/A | | Existing JSON schema is unchanged. |
| Snapshot | N/A | | No snapshot output changed. |
| Functional | ✅ | `cargo test -p tau-runtime spec_3811` | |
| Conformance | ✅ | `spec_3811_c01`, `spec_3811_c02` | |
| Integration | ✅ | `cargo test -p tau-runtime autonomous_coding_jobs_runtime` | |
| Fuzz | N/A | | No untrusted parser or fuzz target added. |
| Mutation | N/A | | Not run for this bounded intake-planning slice. |
| Regression | ✅ | `cargo test -p tau-runtime spec_3807_c03`, `cargo test -p tau-runtime autonomous_coding_jobs_runtime` | |
| Performance | N/A | | No hot path or performance-sensitive path changed. |

Verification Commands:
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3811 -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime spec_3807_c03 -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo test -p tau-runtime autonomous_coding_jobs_runtime -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3811-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`
- `python3 .github/scripts/oversized_file_guard.py --repo-root . --default-threshold 4000 --exemptions-file tasks/policies/oversized-file-exemptions.json --policy-guide docs/guides/oversized-file-policy.md --json-output-file /tmp/rust_pi-3811-oversized-file-guard.json`
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
- `git diff --check`

Risks/Rollback:
- Risk is limited to text inside intake `missing_inputs` and `next_action`. Revert this PR to restore the generic missing-verifier text.

Docs/ADR:
- Updated `docs/guides/autonomous-coding-jobs.md` to document repo-aware package/filter missing-input behavior.
