### PR TITLE
Make blocked intake handoffs rerunnable

### DIFF
--- a/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
+++ b/crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs
@@ -288,6 +288,8 @@ pub struct AutonomousCodingIssueIntakeOutcome {
     pub clarifying_questions: Vec<AutonomousCodingIssueClarifyingQuestion>,
     pub issue_url: String,
     pub issue_title: String,
+    #[serde(default)]
+    pub issue_body: String,
     pub issue_body_summary: String,
     pub repo_path: PathBuf,
     pub base_branch: String,
@@ -1026,6 +1028,7 @@ impl AutonomousCodingJobRuntime {
         );
         let missing_inputs = verifier_plan.missing_inputs.clone();
         let next_action_summary = verifier_plan.next_action.clone();
+        let issue_body_summary = summarize_issue_body(&request.issue_body);
         let outcome = AutonomousCodingIssueIntakeOutcome {
             schema_version: AUTONOMOUS_CODING_JOB_SCHEMA_VERSION,
             intake_id: request.intake_id,
@@ -1037,7 +1040,8 @@ impl AutonomousCodingJobRuntime {
             clarifying_questions,
             issue_url: request.issue_url,
             issue_title: request.issue_title,
-            issue_body_summary: summarize_issue_body(&request.issue_body),
+            issue_body: request.issue_body,
+            issue_body_summary,
             repo_path,
             base_branch: request.base_branch,
             required_authority: issue_intake_required_authority(context),
@@ -2899,6 +2903,14 @@ mod tests {
         )
         .exists());
         assert_eq!(
+            outcome.issue_body,
+            "Make Tau solve this without verifier/edit authority."
+        );
+        let persisted = runtime
+            .issue_intake_status(outcome.intake_id.as_str())
+            .expect("persisted intake status");
+        assert_eq!(persisted.issue_body, outcome.issue_body);
+        assert_eq!(
             std::fs::read_to_string(fixture.repo.path().join("status.txt")).expect("status after"),
             before_status
         );
@@ -3092,6 +3104,10 @@ mod tests {
         );
         assert!(outcome.clarifying_questions.is_empty());
         assert!(outcome.missing_inputs.is_empty());
+        assert_eq!(
+            outcome.issue_body,
+            "Replay fails when a persisted checkpoint exists; verify with the focused tau-runtime replay test."
+        );
     }
 
     #[test]
@@ -3142,6 +3158,7 @@ mod tests {
             AutonomousCodingIssueIntakeDecision::Unknown
         );
         assert!(loaded.clarifying_questions.is_empty());
+        assert_eq!(loaded.issue_body, "");
     }
 
     #[tokio::test]

--- a/docs/guides/autonomous-coding-jobs.md
+++ b/docs/guides/autonomous-coding-jobs.md
@@ -111,7 +111,8 @@ auto-merge command state, heartbeat/lease, and the safe mark-blocked command.
 `intakes` lists persisted issue-intake decisions with classification, decision,
 question count, missing-input count, reason code, and next action. `intake
 <intake-id>` expands the verifier plan, suggested verifier commands, required
-authority, missing inputs, and clarifying questions.
+authority, missing inputs, clarifying questions, and a safe rerun command when
+one can be generated from concrete stored inputs.
 
 Ingest an arbitrary issue without verifier/edit authority:
 
@@ -315,6 +316,14 @@ parsing prose. For example, an underspecified issue records questions for
 `single_acceptance_criterion`. A `ready_to_run` decision only appears when the
 intake path already has verifier, edit/provider authority, and required
 credentials.
+
+For `needs_authority` records that already have the original issue body and a
+concrete verifier command, `tau-unified intake <intake-id>` also prints
+`rerun_command`. The command is shell-quoted, uses
+`tau-autonomous-coding-job issue-to-merge`, supplies the persisted issue fields
+and verifier command, and adds built-in OpenRouter provider-repair authority in
+draft PR mode. Vague, unsafe, broad, missing-verifier, legacy, or placeholder
+verifier records print `rerun_command=none`.
 
 Draft PR behavior is evidence-backed. In draft mode Tau checks for an existing
 PR for the job branch, updates it when found, creates a draft PR when GitHub auth

--- a/scripts/run/tau-unified.sh
+++ b/scripts/run/tau-unified.sh
@@ -1214,6 +1214,7 @@ cmd_intake() {
   python3 - "${autonomous_coding_state_dir}" "${intake_id}" <<'PY'
 import json
 import os
+import shlex
 import sys
 
 state_dir, intake_id = sys.argv[1:]
@@ -1228,6 +1229,64 @@ def clean(value, default="none"):
         value = ",".join(clean(item, "") for item in value if clean(item, ""))
     value = str(value).replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
     return value if value else default
+
+def concrete_verifier_commands(commands):
+    concrete = []
+    for command in commands or []:
+        command = str(command).strip()
+        if not command:
+            continue
+        if "<" in command or ">" in command:
+            continue
+        concrete.append(command)
+    return concrete
+
+def intake_rerun_command(intake, state_dir):
+    if intake.get("decision") != "needs_authority":
+        return "none"
+    verifier_plan = intake.get("verifier_plan") or {}
+    verifier_commands = concrete_verifier_commands(verifier_plan.get("suggested_verifier_commands"))
+    if not verifier_commands:
+        return "none"
+    issue_body = str(intake.get("issue_body") or "").strip()
+    repo_path = str(intake.get("repo_path") or "").strip()
+    issue_url = str(intake.get("issue_url") or "").strip()
+    issue_title = str(intake.get("issue_title") or "").strip()
+    intake_id = str(intake.get("intake_id") or "").strip()
+    if not issue_body or not repo_path or not issue_url or not issue_title or not intake_id:
+        return "none"
+    argv = [
+        "tau-autonomous-coding-job",
+        "issue-to-merge",
+        "--state-dir",
+        state_dir,
+        "--intake-id",
+        intake_id,
+        "--repo-path",
+        repo_path,
+        "--mission-id",
+        f"{intake_id}-mission",
+        "--issue-url",
+        issue_url,
+        "--issue-title",
+        issue_title,
+        "--issue-body",
+        issue_body,
+        "--base-branch",
+        str(intake.get("base_branch") or "master"),
+    ]
+    for command in verifier_commands:
+        argv.extend(["--verifier-command", command])
+    argv.extend([
+        "--allowed-root",
+        repo_path,
+        "--provider-repair-openrouter",
+        "--provider-repair-attempts",
+        "3",
+        "--pr-mode",
+        "draft",
+    ])
+    return shlex.join(argv)
 
 if not os.path.exists(path):
     print(f"tau-unified: autonomous_coding.intake.error=not_found intake_id={clean(intake_id)}")
@@ -1255,6 +1314,7 @@ fields = {
     "verifier_plan.suggested_verifier_commands": verifier_plan.get("suggested_verifier_commands") or [],
     "verifier_plan.missing_inputs": verifier_plan.get("missing_inputs") or [],
     "verifier_plan.next_action": verifier_plan.get("next_action"),
+    "rerun_command": intake_rerun_command(intake, state_dir),
 }
 for key, value in fields.items():
     print(f"tau-unified: autonomous_coding.intake.{key}={clean(value)}")

--- a/scripts/run/test-tau-unified.sh
+++ b/scripts/run/test-tau-unified.sh
@@ -392,6 +392,48 @@ JSON
   "updated_unix_ms": 12
 }
 JSON
+  cat >"${test_autonomous_coding_state_dir}/issue-intake/issue-3807-intake-rerun-command.json" <<JSON
+{
+  "schema_version": 1,
+  "intake_id": "issue-3807-intake-rerun-command",
+  "status": "blocked",
+  "reason_code": "issue_intake_missing_edit_or_provider_authority",
+  "classification": "missing_edit_or_provider_authority",
+  "classification_summary": "Issue has a concrete verifier but still needs edit or provider repair authority.",
+  "decision": "needs_authority",
+  "clarifying_questions": [
+    {
+      "reason_code": "mutation_authority",
+      "question": "Should Tau use provider repair, controlled edits, or wait for an operator-supplied patch?",
+      "required_input": "--edit, --provider-repair-openrouter, --provider-repair-command, or approved mutation authority"
+    }
+  ],
+  "issue_url": "https://github.com/njfio/Tau/issues/3807",
+  "issue_title": "Fix fixture-cli Rust test",
+  "issue_body": "The fixture-cli crate has a failing Rust test named spec_3810_repo_aware_verifier and should use the focused verifier.",
+  "issue_body_summary": "The fixture-cli crate has a failing Rust test named spec_3810_repo_aware_verifier and should use the focused verifier.",
+  "repo_path": "${tmp_dir}/fixture-repo",
+  "base_branch": "master",
+  "required_authority": [
+    {
+      "reason_code": "edit_authority_required",
+      "summary": "An edit plan, provider edit authority, or controlled edit set must be provided before mutation.",
+      "required_input": "--edit, --provider-repair-openrouter, --provider-repair-command, or approved mutation authority"
+    }
+  ],
+  "verifier_plan": {
+    "plan_kind": "rust",
+    "summary": "Rust issue should be verified with focused tests before broader checks.",
+    "suggested_verifier_commands": ["cargo test -p fixture-cli spec_3810_repo_aware_verifier"],
+    "missing_inputs": ["controlled edit, provider repair adapter, or explicit mutation authority"],
+    "next_action": "Provide provider repair or controlled edit authority before mutation."
+  },
+  "missing_inputs": ["controlled edit, provider repair adapter, or explicit mutation authority"],
+  "next_action_summary": "Provide provider repair or controlled edit authority before mutation.",
+  "created_unix_ms": 21,
+  "updated_unix_ms": 22
+}
+JSON
   cat >"${test_autonomous_coding_state_dir}/autonomous-coding-jobs/stale-job.status.json" <<JSON
 {
   "schema_version": 1,
@@ -554,7 +596,8 @@ JSON
 
   local intakes_output
   intakes_output="$("${LAUNCHER_SCRIPT}" intakes --autonomous-coding-state-dir "${test_autonomous_coding_state_dir}" 2>&1)"
-  assert_contains "${intakes_output}" "tau-unified: autonomous_coding.intakes.count=1" "intakes list count"
+  assert_contains "${intakes_output}" "tau-unified: autonomous_coding.intakes.count=2" "intakes list count"
+  assert_contains "${intakes_output}" "tau-unified: autonomous_coding.intake=issue-3807-intake-rerun-command status=blocked classification=missing_edit_or_provider_authority decision=needs_authority reason_code=issue_intake_missing_edit_or_provider_authority question_count=1 missing_input_count=1" "intakes list needs authority summary"
   assert_contains "${intakes_output}" "tau-unified: autonomous_coding.intake=issue-3808-vague status=blocked classification=underspecified decision=needs_clarification reason_code=issue_intake_underspecified question_count=2 missing_input_count=2" "intakes list summary"
   assert_contains "${intakes_output}" "tau-unified: autonomous_coding.intake.issue-3808-vague.next_action=Ask for expected behavior and verifier command." "intakes list next action"
 
@@ -566,6 +609,18 @@ JSON
   assert_contains "${intake_output}" "tau-unified: autonomous_coding.intake.verifier_plan.suggested_verifier_commands=cargo test -p tau-runtime spec_3808" "intake inspect suggested verifier"
   assert_contains "${intake_output}" "tau-unified: autonomous_coding.intake.required_authority.verifier_authority_required=A verifier command is required before mutation. required_input=verifier command" "intake inspect authority"
   assert_contains "${intake_output}" "tau-unified: autonomous_coding.intake.question.expected_behavior=What should happen after the fix? required_input=expected behavior" "intake inspect question"
+  assert_contains "${intake_output}" "tau-unified: autonomous_coding.intake.rerun_command=none" "vague intake has no rerun command"
+
+  local intake_rerun_output
+  intake_rerun_output="$("${LAUNCHER_SCRIPT}" intake issue-3807-intake-rerun-command --autonomous-coding-state-dir "${test_autonomous_coding_state_dir}" 2>&1)"
+  assert_contains "${intake_rerun_output}" "tau-unified: autonomous_coding.intake.id=issue-3807-intake-rerun-command" "intake rerun inspect id"
+  assert_contains "${intake_rerun_output}" "tau-unified: autonomous_coding.intake.rerun_command=tau-autonomous-coding-job issue-to-merge" "intake rerun command marker"
+  assert_contains "${intake_rerun_output}" "--state-dir ${test_autonomous_coding_state_dir}" "intake rerun state dir"
+  assert_contains "${intake_rerun_output}" "--intake-id issue-3807-intake-rerun-command" "intake rerun intake id"
+  assert_contains "${intake_rerun_output}" "--issue-body 'The fixture-cli crate has a failing Rust test named spec_3810_repo_aware_verifier and should use the focused verifier.'" "intake rerun issue body"
+  assert_contains "${intake_rerun_output}" "--verifier-command 'cargo test -p fixture-cli spec_3810_repo_aware_verifier'" "intake rerun verifier command"
+  assert_contains "${intake_rerun_output}" "--provider-repair-openrouter" "intake rerun provider flag"
+  assert_contains "${intake_rerun_output}" "--provider-repair-attempts 3" "intake rerun provider attempts"
 
   local fake_cli="${tmp_dir}/fake-autonomous-coding-job.sh"
   local fake_cli_args="${tmp_dir}/fake-autonomous-coding-job.args"

--- a/specs/3807-intake-rerun-command/plan.md
+++ b/specs/3807-intake-rerun-command/plan.md
@@ -1,0 +1,38 @@
+# Plan 3807: Intake Rerun Command
+
+## Approach
+
+Use persisted intake JSON as the operator handoff. Add only the missing
+ingredient needed for an exact rerun command: the original issue body.
+
+1. Add backward-compatible `issue_body` to
+   `AutonomousCodingIssueIntakeOutcome`.
+2. Populate it from `AutonomousCodingIssueIntakeRequest`.
+3. Extend `tau-unified intake` to compute, not persist, a rerun command.
+4. Gate command generation to `decision=needs_authority`, non-empty issue body,
+   and concrete verifier commands that do not contain placeholder brackets.
+5. Shell-quote every argv part with Python `shlex.join`.
+
+## Affected Files
+
+- `crates/tau-runtime/src/autonomous_coding_jobs_runtime.rs`
+- `scripts/run/tau-unified.sh`
+- `scripts/run/test-tau-unified.sh`
+- `docs/guides/autonomous-coding-jobs.md`
+- `specs/3807-intake-rerun-command/*`
+
+## Risks
+
+- Risk: command output could encourage mutation from underspecified intake.
+  Mitigation: emit only for `needs_authority` records with concrete verifier
+  commands and original body.
+- Risk: shell quoting mistakes in issue text.
+  Mitigation: build argv and use `shlex.join` in the Python renderer.
+- Risk: schema drift for older intake JSON.
+  Mitigation: `issue_body` uses a serde default and legacy test coverage.
+
+## Interfaces
+
+No new CLI command. `tau-unified intake <id>` gains one line:
+
+`tau-unified: autonomous_coding.intake.rerun_command=<command|none>`

--- a/specs/3807-intake-rerun-command/spec.md
+++ b/specs/3807-intake-rerun-command/spec.md
@@ -1,0 +1,67 @@
+# Spec 3807: Intake Rerun Command
+
+Status: Implemented
+
+## Problem Statement
+
+Tau can persist verifier plans and structured clarifying questions for blocked
+issue intake, but `tau-unified intake` still leaves the operator to manually
+reconstruct the next `issue-to-merge` command. That is brittle because the
+command needs the original issue body, concrete verifier command, repo path,
+state directory, and safe provider/edit authority.
+
+## Scope
+
+In:
+
+- Persist the original issue body in intake records, with legacy JSON loading
+  defaulting to an empty body.
+- Have `tau-unified intake <id>` print a shell-quoted rerun command when the
+  intake is `needs_authority`, has the original issue body, and has concrete
+  verifier commands.
+- Use the existing OpenRouter provider-repair flag in the suggested rerun
+  command; do not auto-merge.
+- Keep vague, unsafe, broad, missing-verifier, or placeholder-verifier intakes
+  blocked without a rerun command.
+
+Out:
+
+- Live provider calls during intake inspection.
+- New persisted command fields.
+- Auto-merge or branch-protection behavior.
+- Inferring verifier commands from prose placeholders.
+
+## Acceptance Criteria
+
+AC-1: Given an intake record with `decision=needs_authority`, an original issue
+body, and concrete verifier commands, when `tau-unified intake <id>` runs, then
+it prints `rerun_command` with a shell-quoted
+`tau-autonomous-coding-job issue-to-merge` command containing state dir, intake
+id, repo path, issue URL/title/body, base branch, verifier command, allowed root,
+OpenRouter provider repair, and draft PR mode.
+
+AC-2: Given an underspecified intake or an intake without a concrete verifier
+command, when `tau-unified intake <id>` runs, then it prints
+`rerun_command=none`.
+
+AC-3: Given a newly recorded intake, when it is persisted, then the original
+issue body is stored in the intake JSON.
+
+AC-4: Given legacy intake JSON without `issue_body`, when Tau loads it, then it
+defaults to an empty body without breaking old records.
+
+## Conformance Cases
+
+| Case | Maps | Tier | Input | Expected |
+| --- | --- | --- | --- | --- |
+| C-01 | AC-1 | Functional | Needs-authority intake with concrete Rust verifier | `tau-unified intake` emits shell-quoted rerun command |
+| C-02 | AC-2 | Functional | Underspecified intake with questions | `rerun_command=none` |
+| C-03 | AC-3 | Conformance | Runtime intake request with issue body | Persisted status contains full `issue_body` |
+| C-04 | AC-4 | Regression | Legacy intake JSON without `issue_body` | Deserializes with empty issue body |
+
+## Success Signals
+
+- `bash scripts/run/test-tau-unified.sh status_contract` passes.
+- Focused `tau-runtime` tests cover persisted `issue_body` and legacy default.
+- `cargo fmt --check`, shell syntax checks, clippy, roadmap sync, oversized-file
+  guard, and diff hygiene pass.

--- a/specs/3807-intake-rerun-command/tasks.md
+++ b/specs/3807-intake-rerun-command/tasks.md
@@ -1,0 +1,33 @@
+# Tasks 3807: Intake Rerun Command
+
+- [x] T1 (RED): Add spec, plan, tasks, and failing `tau-unified` status-contract
+  assertions for `rerun_command`.
+- [x] T2 (GREEN): Persist `issue_body` in intake records with legacy default.
+- [x] T3 (GREEN): Generate shell-quoted rerun command in `tau-unified intake`.
+- [x] T4 (DOCS): Document the rerun command behavior and safety gate.
+- [x] T5 (VERIFY): Run focused shell/Rust tests, clippy, fmt, shell syntax,
+  oversized-file guard, roadmap sync, and diff hygiene.
+
+## Evidence
+
+- RED:
+  `bash scripts/run/test-tau-unified.sh status_contract` failed before
+  implementation because `tau-unified intake` did not print
+  `rerun_command=none` for vague intake and had no concrete rerun command for
+  needs-authority intake.
+- GREEN:
+  `bash scripts/run/test-tau-unified.sh status_contract` passed after adding
+  shell-quoted rerun command generation.
+- RUNTIME:
+  `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo test -p tau-runtime spec_3807 -- --test-threads=1`
+  passed 4 intake contract tests, including legacy `issue_body` default.
+  `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo test -p tau-runtime spec_3796_c04 -- --test-threads=1`
+  passed persisted no-authority intake coverage.
+- STATIC:
+  `cargo fmt --check`; `bash -n scripts/run/tau-unified.sh scripts/run/test-tau-unified.sh`;
+  `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`;
+  `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings`.
+- GUARDS:
+  `python3 .github/scripts/oversized_file_guard.py --repo-root . --default-threshold 4000 --exemptions-file tasks/policies/oversized-file-exemptions.json --policy-guide docs/guides/oversized-file-policy.md --json-output-file /tmp/rust_pi-3807-rerun-oversized-file-guard.json`
+  passed with 453 checked files and 0 issues;
+  `scripts/dev/roadmap-status-sync.sh --check --quiet`; `git diff --check`.


### PR DESCRIPTION
## Summary
Adds a safe operator handoff for blocked autonomous coding intake. Intake records now persist the original issue body, and `tau-unified intake <id>` prints a shell-quoted `tau-autonomous-coding-job issue-to-merge` rerun command only when the record is `needs_authority` and already has concrete verifier commands.

## Links
Milestone: M334 - Tau Ralph loop supervisor architecture
Closes #3807
Spec: specs/3807-intake-rerun-command/spec.md
Plan: specs/3807-intake-rerun-command/plan.md
Tasks: specs/3807-intake-rerun-command/tasks.md

## Spec Verification (AC -> tests)
| AC | Status | Test(s) |
| --- | --- | --- |
| AC-1: Needs-authority intake emits shell-quoted rerun command | ✅ | `bash scripts/run/test-tau-unified.sh status_contract` |
| AC-2: Vague/no-concrete-verifier intake emits `rerun_command=none` | ✅ | `bash scripts/run/test-tau-unified.sh status_contract` |
| AC-3: Newly recorded intake persists original issue body | ✅ | `spec_3796_c04_issue_intake_without_authority_persists_blocked_plan`, `spec_3807_c03_ready_intake_with_authority_is_machine_readable` |
| AC-4: Legacy intake JSON without `issue_body` loads with default | ✅ | `spec_3807_c04_legacy_intake_json_defaults_new_fields` |

## TDD Evidence
RED: `bash scripts/run/test-tau-unified.sh status_contract` failed before implementation because `tau-unified intake` did not print `rerun_command=none` and had no concrete rerun command for needs-authority intake.

GREEN: `bash scripts/run/test-tau-unified.sh status_contract` passed after adding shell-quoted rerun command generation.

REGRESSION: `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo test -p tau-runtime spec_3807 -- --test-threads=1` passed 4 tests. `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo test -p tau-runtime spec_3796_c04 -- --test-threads=1` passed.

## Test Tiers
| Tier | Status | Tests | N/A Why |
| --- | --- | --- | --- |
| Unit | ✅ | `spec_3807`, `spec_3796_c04` | |
| Property | N/A | | No randomized invariant/parser behavior changed. |
| Contract/DbC | ✅ | `bash scripts/run/test-tau-unified.sh status_contract` | |
| Snapshot | N/A | | Line-oriented marker assertions used instead. |
| Functional | ✅ | `status_contract` launcher test | |
| Conformance | ✅ | C-01..C-04 via shell/Rust tests | |
| Integration | ✅ | Runtime intake persistence plus launcher fixture JSON | |
| Fuzz | N/A | | No fuzz-targeted untrusted parser changed. |
| Mutation | N/A | | Narrow operator handoff mapping; no cargo-mutants run for this P2 slice. |
| Regression | ✅ | Legacy JSON default and old no-authority intake tests | |
| Performance | N/A | | Not performance-sensitive. |

## Additional Verification
- `cargo fmt --check`
- `bash -n scripts/run/tau-unified.sh scripts/run/test-tau-unified.sh`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo clippy -p tau-runtime --lib --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rust_pi-3807-rerun-target cargo clippy -p tau-coding-agent --bin tau_autonomous_coding_job -- -D warnings`
- `python3 .github/scripts/oversized_file_guard.py --repo-root . --default-threshold 4000 --exemptions-file tasks/policies/oversized-file-exemptions.json --policy-guide docs/guides/oversized-file-policy.md --json-output-file /tmp/rust_pi-3807-rerun-oversized-file-guard.json` passed with 453 checked files and 0 issues
- `scripts/dev/roadmap-status-sync.sh --check --quiet`
- `git diff --check`; `git diff --cached --check`

## Mutation
Not run. This is a narrow CLI/runtime handoff slice covered by focused conformance and regression tests.

## Risks/Rollback
Risk is limited to `tau-unified intake` output and a backward-compatible `issue_body` field on intake records. Rollback removes the renderer helper and leaves old intake behavior intact.

## Docs/ADR
Updated docs/guides/autonomous-coding-jobs.md. No ADR; no new dependency, protocol, or merge behavior change.